### PR TITLE
spacecmd: Convert %-formatting and .format() to f-strings

### DIFF
--- a/spacecmd/src/spacecmd/activationkey.py
+++ b/spacecmd/src/spacecmd/activationkey.py
@@ -572,8 +572,7 @@ def do_activationkey_listpackages(self, args):
         details.get("packages"), key=lambda x: (x["name"]), reverse=True
     ):
         if "arch" in package:
-            # pylint: disable-next=consider-using-f-string
-            print("%s.%s" % (package["name"], package["arch"]))
+            print(f"{package['name']}.{package['arch']}")
         else:
             print(package["name"])
 
@@ -772,8 +771,7 @@ def do_activationkey_setconfigchannelorder(self, args):
     print("")
     print(_("New Configuration Channels:"))
     for i, new_channel in enumerate(new_channels, 1):
-        # pylint: disable-next=consider-using-f-string
-        print("[%i] %s" % (i, new_channel))
+        print(f"[{i}] {new_channel}")
 
     self.client.activationkey.setConfigChannels(self.session, [key], new_channels)
 
@@ -889,8 +887,7 @@ def do_activationkey_delete(self, args):
 
     # allow globbing of activationkey names
     keys = filter_results(self.do_activationkey_list("", True), args)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("activationkey_delete called with args %s, keys=%s" % (args, keys))
+    logging.debug(f"activationkey_delete called with args {args}, keys={keys}")
 
     if not keys:
         logging.error(_N("No keys matched argument %s") % args)
@@ -903,8 +900,7 @@ def do_activationkey_delete(self, args):
         return 1
 
     for key in keys:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Deleting key %s" % key)
+        logging.debug(f"Deleting key {key}")
         self.client.activationkey.delete(self.session, key)
 
     return 0
@@ -1043,8 +1039,7 @@ def do_activationkey_details(self, args):
         result.append(details.get("base_channel_label"))
 
         for channel in sorted(details.get("child_channel_labels")):
-            # pylint: disable-next=consider-using-f-string
-            result.append(" |-- %s" % channel)
+            result.append(f" |-- {channel}")
 
         result.append("")
         result.append(_("Configuration Channels"))
@@ -1071,8 +1066,7 @@ def do_activationkey_details(self, args):
             name = package.get("name")
 
             if package.get("arch"):
-                # pylint: disable-next=consider-using-f-string
-                name += ".%s" % package.get("arch")
+                name += f".{package.get('arch')}"
 
             result.append(name)
     for entry in result:
@@ -1106,8 +1100,7 @@ def do_activationkey_enableconfigdeployment(self, args):
         return 1
 
     for key in args:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Enabling config file deployment for %s" % key)
+        logging.debug(f"Enabling config file deployment for {key}")
         self.client.activationkey.enableConfigDeployment(self.session, key)
 
     return 0
@@ -1141,8 +1134,7 @@ def do_activationkey_disableconfigdeployment(self, args):
         return 1
 
     for key in args:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Disabling config file deployment for %s" % key)
+        logging.debug(f"Disabling config file deployment for {key}")
         self.client.activationkey.disableConfigDeployment(self.session, key)
 
     return 0
@@ -1243,19 +1235,18 @@ def do_activationkey_setusagelimit(self, args):
     key = args.pop(0)
     usage_limit = -1
     if args[0] == "unlimited":
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Setting usage for key %s unlimited" % key)
+        logging.debug(f"Setting usage for key {key} unlimited")
     else:
         try:
             usage_limit = int(args[0])
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("Setting usage for key %s to %d" % (key, usage_limit))
+            logging.debug(f"Setting usage for key {key} to {usage_limit}")
         except ValueError:
             logging.error(_N("Couldn't convert argument %s to an integer") % args[0])
             self.help_activationkey_setusagelimit()
             return 1
 
     current_details = self.client.activationkey.getDetails(self.session, key)
+
     details = {
         "description": current_details.get("description"),
         "base_channel_label": current_details.get("base_channel_label"),
@@ -1342,13 +1333,11 @@ def complete_activationkey_export(self, text, line, beg, end):
 
 def export_activationkey_getdetails(self, key):
     # Get the key details
-    # pylint: disable-next=consider-using-f-string
     logging.info(_N("Getting activation key details for %s" % key))
     details = self.client.activationkey.getDetails(self.session, key)
 
     # Get the key config-channel data, add it to the existing details
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("activationkey.listConfigChannels %s" % key)
+    logging.debug(f"activationkey.listConfigChannels {key}")
     ccdlist = []
     try:
         ccdlist = self.client.activationkey.listConfigChannels(self.session, key)
@@ -1358,12 +1347,10 @@ def export_activationkey_getdetails(self, key):
         )
 
     cclist = [c["label"] for c in ccdlist]
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Got config channel label list of %s" % cclist)
+    logging.debug(f"Got config channel label list of {cclist}")
     details["config_channels"] = cclist
 
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("activationkey.checkConfigDeployment %s" % key)
+    logging.debug(f"activationkey.checkConfigDeployment {key}")
     details["config_deploy"] = self.client.activationkey.checkConfigDeployment(
         self.session, key
     )
@@ -1393,8 +1380,7 @@ def do_activationkey_export(self, args):
 
     filename = ""
     if options.file is not None:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Passed filename do_activationkey_export %s" % options.file)
+        logging.debug(f"Passed filename do_activationkey_export {options.file}")
         filename = options.file
 
     # Get the list of keys to export and sort out the filename if required
@@ -1408,9 +1394,7 @@ def do_activationkey_export(self, args):
         # allow globbing of activationkey names
         keys = filter_results(self.do_activationkey_list("", True), args)
         logging.debug(
-            # pylint: disable-next=consider-using-f-string
-            "activationkey_export called with args %s, keys=%s"
-            % (args, keys)
+            f"activationkey_export called with args {args}, keys={keys}"
         )
 
         if not keys:
@@ -1422,8 +1406,7 @@ def do_activationkey_export(self, args):
             # If we are exporting exactly one key, we default to keyname.json
             # otherwise, generic akeys.json name
             if len(keys) == 1:
-                # pylint: disable-next=consider-using-f-string
-                filename = "%s.json" % keys[0]
+                filename = f"{keys[0]}.json"
             else:
                 filename = "akeys.json"
 
@@ -1433,8 +1416,7 @@ def do_activationkey_export(self, args):
         logging.info(_N("Exporting key %s to %s") % (k, filename))
         keydetails_list.append(self.export_activationkey_getdetails(k))
 
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("About to dump %d keys to %s" % (len(keydetails_list), filename))
+    logging.debug(f"About to dump {len(keydetails_list)} keys to {filename}")
 
     # Check if filepath exists, if it is an existing file
     # we prompt the user for confirmation
@@ -1471,8 +1453,7 @@ def do_activationkey_import(self, args):
         return 1
 
     for filename in args:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Passed filename do_activationkey_import %s" % filename)
+        logging.debug(f"Passed filename do_activationkey_import {filename}")
         keydetails_list = json_read_from_file(filename)
 
         if not keydetails_list:
@@ -1500,8 +1481,7 @@ def import_activationkey_fromdetails(self, keydetails):
     else:
         # create the key, we need to drop the org prefix from the key name
         keyname = re.sub("^[0-9]-", "", keydetails["key"])
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Found key %s, importing as %s" % (keydetails["key"], keyname))
+        logging.debug(f"Found key {keydetails['key']}, importing as {keyname}")
 
         # Channel label must be an empty-string for "Red Hat Satellite Default"
         # The export to json maps this to a unicode string "none"
@@ -1558,8 +1538,7 @@ def import_activationkey_fromdetails(self, keydetails):
             gids.append(grpdetails.get("id"))
 
         if gids:
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("Adding groups %s to key %s" % (gids, newkey))
+            logging.debug(f"Adding groups {gids} to key {newkey}")
             self.client.activationkey.addServerGroups(self.session, newkey, gids)
 
         # Finally add the package list
@@ -1636,17 +1615,13 @@ def do_activationkey_clone(self, args):
         self.help_activationkey_clone()
         return 1
 
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Got args=%s %d" % (args, len(args)))
+    logging.debug(f"Got args={args} {len(args)}")
     # allow globbing of configchannel channel names
     akeys = filter_results(allkeys, args)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Filtered akeys %s" % akeys)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("all akeys %s" % allkeys)
+    logging.debug(f"Filtered akeys {akeys}")
+    logging.debug(f"all akeys {allkeys}")
     for ak in akeys:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Cloning %s" % ak)
+        logging.debug(f"Cloning {ak}")
         # Replace the key-name with the clonename specified by the user
         keydetails = self.export_activationkey_getdetails(ak)
 
@@ -1658,9 +1633,7 @@ def do_activationkey_clone(self, args):
             findstr = options.regex.split("/")[1]
             replacestr = options.regex.split("/")[2]
             logging.debug(
-                # pylint: disable-next=consider-using-f-string
-                "Regex option with %s, replacing %s with %s"
-                % (options.regex, findstr, replacestr)
+                f"Regex option with {options.regex}, replacing {findstr} with {replacestr}"
             )
 
             # First we do the key name
@@ -1688,11 +1661,8 @@ def do_activationkey_clone(self, args):
                     newc = re.sub(findstr, replacestr, c)
                     if newc in all_childch:
                         logging.debug(
-                            # pylint: disable-next=consider-using-f-string
-                            "Found child channel %s for key %s, "
-                            % (c, keydetails["key"])
-                            # pylint: disable-next=consider-using-f-string
-                            + "replacing with %s" % newc
+                            f"Found child channel {c} for key {keydetails['key']}, "
+                            f"replacing with {newc}"
                         )
 
                         new_child_channel_labels.append(newc)
@@ -1704,9 +1674,7 @@ def do_activationkey_clone(self, args):
                         )
 
                 logging.debug(
-                    "Processed all child channels, "
-                    # pylint: disable-next=consider-using-f-string
-                    + "new_child_channel_labels=%s" % new_child_channel_labels
+                    f"Processed all child channels, new_child_channel_labels={new_child_channel_labels}"
                 )
 
                 keydetails["child_channel_labels"] = new_child_channel_labels
@@ -1727,10 +1695,8 @@ def do_activationkey_clone(self, args):
 
                 if newcc in allccs:
                     logging.debug(
-                        # pylint: disable-next=consider-using-f-string
-                        "Found config channel %s for key %s, " % (cc, keydetails["key"])
-                        # pylint: disable-next=consider-using-f-string
-                        + "replacing with %s" % newcc
+                        f"Found config channel {cc} for key {keydetails['key']}, "
+                        f"replacing with {newcc}"
                     )
 
                     new_config_channels.append(newcc)
@@ -1742,9 +1708,7 @@ def do_activationkey_clone(self, args):
                     )
 
             logging.debug(
-                "Processed all config channels, "
-                # pylint: disable-next=consider-using-f-string
-                + "new_config_channels = %s" % new_config_channels
+                f"Processed all config channels, new_config_channels = {new_config_channels}"
             )
 
             keydetails["config_channels"] = new_config_channels

--- a/spacecmd/src/spacecmd/configchannel.py
+++ b/spacecmd/src/spacecmd/configchannel.py
@@ -395,30 +395,20 @@ def do_configchannel_backup(self, args):
         dumpfile = outputpath_base + details.get("path")
         dumpdir = dumpfile
         print(_("Output Path:   %s") % dumpfile)
-        # pylint: disable-next=consider-using-f-string
-        fh.write("[%s]\n" % details.get("path"))
-        # pylint: disable-next=consider-using-f-string
-        fh.write("type = %s\n" % details.get("type"))
-        # pylint: disable-next=consider-using-f-string
-        fh.write("revision = %s\n" % details.get("revision"))
-        # pylint: disable-next=consider-using-f-string
-        fh.write("creation = %s\n" % details.get("creation"))
-        # pylint: disable-next=consider-using-f-string
-        fh.write("modified = %s\n" % details.get("modified"))
+        fh.write(f"[{details.get('path')}]\n")
+        fh.write(f"type = {details.get('type')}\n")
+        fh.write(f"revision = {details.get('revision')}\n")
+        fh.write(f"creation = {details.get('creation')}\n")
+        fh.write(f"modified = {details.get('modified')}\n")
 
         if details.get("type") == "symlink":
-            # pylint: disable-next=consider-using-f-string
-            fh.write("target_path = %s\n" % details.get("target_path"))
+            fh.write(f"target_path = {details.get('target_path')}\n")
         else:
-            # pylint: disable-next=consider-using-f-string
-            fh.write("owner = %s\n" % details.get("owner"))
-            # pylint: disable-next=consider-using-f-string
-            fh.write("group = %s\n" % details.get("group"))
-            # pylint: disable-next=consider-using-f-string
-            fh.write("permissions_mode = %s\n" % details.get("permissions_mode"))
+            fh.write(f"owner = {details.get('owner')}\n")
+            fh.write(f"group = {details.get('group')}\n")
+            fh.write(f"permissions_mode = {details.get('permissions_mode')}\n")
 
-        # pylint: disable-next=consider-using-f-string
-        fh.write("selinux_ctx = %s\n" % details.get("selinux_ctx"))
+        fh.write(f"selinux_ctx = {details.get('selinux_ctx')}\n")
 
         if details.get("type") in ("file", "sls"):
             dumpdir = os.path.dirname(dumpfile)
@@ -427,10 +417,8 @@ def do_configchannel_backup(self, args):
             os.makedirs(dumpdir)
 
         if details.get("type") in ("file", "sls"):
-            # pylint: disable-next=consider-using-f-string
-            fh.write("sha256 = %s\n" % details.get("sha256"))
-            # pylint: disable-next=consider-using-f-string
-            fh.write("binary = %s\n" % details.get("binary"))
+            fh.write(f"sha256 = {details.get('sha256')}\n")
+            fh.write(f"binary = {details.get('binary')}\n")
             # pylint: disable-next=unspecified-encoding
             of = open(dumpfile, "w")
             of.write(details.get("contents") or "")
@@ -580,9 +568,7 @@ def do_configchannel_delete(self, args):
     # allow globbing of configchannel names
     channels = filter_results(self.do_configchannel_list("", True), args)
     logging.debug(
-        # pylint: disable-next=consider-using-f-string
-        "configchannel_delete called with args %s, channels=%s"
-        % (args, channels)
+        f"configchannel_delete called with args {args}, channels={channels}"
     )
 
     if not channels:
@@ -899,8 +885,7 @@ def do_configchannel_addfile(self, args, update_path=""):
                 self.session, options.channel, [options.path]
             )
         except xmlrpclib.Fault:
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("No existing file information found for %s" % options.path)
+            logging.debug(f"No existing file information found for {options.path}")
             file_info = None
 
     file_info = self.configfile_getinfo(args, options, file_info, interactive)
@@ -1220,8 +1205,7 @@ def export_configchannel_getdetails(self, channel):
     # we can iterate over each file, then we just error on individual files
     # instead of failing to export anything at all...
     for p in paths:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Found file %s for %s" % (p, channel))
+        logging.debug(f"Found file {p} for {channel}")
         try:
             pinfo = self.client.configchannel.lookupFileInfo(self.session, channel, [p])
             if pinfo:
@@ -1347,8 +1331,7 @@ def do_configchannel_export(self, args):
             # If we are exporting exactly one cc, we default to ccname.json
             # otherwise, generic ccs.json name
             if len(ccs) == 1:
-                # pylint: disable-next=consider-using-f-string
-                filename = "%s.json" % ccs[0]
+                filename = f"{ccs[0]}.json"
             else:
                 filename = "ccs.json"
 
@@ -1443,8 +1426,7 @@ def import_configchannel_fromdetails(self, ccdetails):
             ret = None
             if filedetails["type"] == "symlink":
                 del filedetails["type"]
-                # pylint: disable-next=consider-using-f-string
-                logging.debug("Adding symlink %s" % filedetails)
+                logging.debug(f"Adding symlink {filedetails}")
                 ret = self.client.configchannel.createOrUpdateSymlink(
                     self.session, ccdetails["label"], path, filedetails
                 )
@@ -1489,8 +1471,7 @@ def import_configchannel_fromdetails(self, ccdetails):
                         filedetails["contents"] = filedetails["contents"].decode("utf8")
                         filedetails["contents_enc64"] = True
 
-                # pylint: disable-next=consider-using-f-string
-                logging.debug("Creating %s %s" % (filedetails["type"], filedetails))
+                logging.debug(f"Creating {filedetails['type']} {filedetails}")
                 if "type" in filedetails:
                     del filedetails["type"]
 
@@ -1498,8 +1479,7 @@ def import_configchannel_fromdetails(self, ccdetails):
                     self.session, ccdetails["label"], path, isdir, filedetails
                 )
             if ret is not None:
-                # pylint: disable-next=consider-using-f-string
-                logging.debug("Added file %s to %s" % (ret["path"], ccdetails["name"]))
+                logging.debug(f"Added file {ret['path']} to {ccdetails['name']}")
             else:
                 logging.error(
                     _N("Error adding file %s to %s")
@@ -1583,8 +1563,7 @@ def do_configchannel_clone(self, args):
         logging.error(_N("No suitable channels to clone has been found."))
 
     for cc in ccs:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Cloning %s" % cc)
+        logging.debug(f"Cloning {cc}")
         ccdetails = self.export_configchannel_getdetails(cc)
 
         # If the -x/--regex option is passed, do a sed-style replacement over

--- a/spacecmd/src/spacecmd/cryptokey.py
+++ b/spacecmd/src/spacecmd/cryptokey.py
@@ -183,8 +183,7 @@ def do_cryptokey_delete(self, args):
 
     # allow globbing of cryptokey names
     keys = filter_results(self.do_cryptokey_list("", True), args)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("cryptokey_delete called with args %s, keys=%s" % (args, keys))
+    logging.debug(f"cryptokey_delete called with args {args}, keys={keys}")
 
     if not keys:
         logging.error(_N("No keys matched argument %s") % args)
@@ -245,8 +244,7 @@ def do_cryptokey_details(self, args):
 
     # allow globbing of cryptokey names
     keys = filter_results(self.do_cryptokey_list("", True), args)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("cryptokey_details called with args %s, keys=%s" % (args, keys))
+    logging.debug(f"cryptokey_details called with args {args}, keys={keys}")
 
     if not keys:
         logging.error(_N("No keys matched argument %s") % args)

--- a/spacecmd/src/spacecmd/custominfo.py
+++ b/spacecmd/src/spacecmd/custominfo.py
@@ -93,8 +93,7 @@ def do_custominfo_deletekey(self, args):
 
     # allow globbing of custominfo key names
     keys = filter_results(self.do_custominfo_listkeys("", True), args)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("customkey_deletekey called with args %s, keys=%s" % (args, keys))
+    logging.debug(f"customkey_deletekey called with args {args}, keys={keys}")
 
     if not keys:
         logging.error(_N("No keys matched argument %s") % args)
@@ -156,12 +155,10 @@ def do_custominfo_details(self, args):
 
     # allow globbing of custominfo key names
     keys = filter_results(self.do_custominfo_listkeys("", True), args)
-    logging.debug(
-        # pylint: disable-next=consider-using-f-string
-        "customkey_details called with args: '{}', keys: '{}'.".format(
-            ", ".join(args), ", ".join(keys)
-        )
-    )
+    args_str = ", ".join(args)
+    keys_str = ", ".join(keys)
+    logging.debug(f"customkey_details called with args: '{args_str}', keys: '{keys_str}'.")
+
 
     if not keys:
         logging.error(_N("No keys matched argument '{}'.").format(", ".join(args)))

--- a/spacecmd/src/spacecmd/distribution.py
+++ b/spacecmd/src/spacecmd/distribution.py
@@ -217,8 +217,7 @@ def do_distribution_delete(self, args):
 
     # allow globbing of distribution names
     dists = filter_results(self.do_distribution_list("", True), args)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("distribution_delete called with args %s, dists=%s" % (args, dists))
+    logging.debug(f"distribution_delete called with args {args}, dists={dists}")
 
     if not dists:
         logging.error(_N("No distributions matched argument %s") % args)
@@ -258,8 +257,7 @@ def do_distribution_details(self, args):
 
     # allow globbing of distribution names
     dists = filter_results(self.do_distribution_list("", True), args)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("distribution_details called with args %s, dists=%s" % (args, dists))
+    logging.debug(f"distribution_details called with args {args}, dists={dists}")
 
     if not dists:
         logging.error(_N("No distributions matched argument %s") % args)

--- a/spacecmd/src/spacecmd/errata.py
+++ b/spacecmd/src/spacecmd/errata.py
@@ -158,20 +158,16 @@ def do_errata_apply(self, args, errata_list=None, only_systems=None):
                     if system.get("name") not in to_apply_by_name[erratum]:
                         to_apply_by_name[erratum].append(system.get("name"))
         except xmlrpclib.Fault:
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("%s does not affect any systems" % erratum)
+            logging.debug(f"{erratum} does not affect any systems")
             continue
 
         # make a summary list to show the user
         if erratum in to_apply_by_name:
             summary.append(
-                # pylint: disable-next=consider-using-f-string
-                "%s        %s"
-                % (erratum.ljust(15), str(len(to_apply_by_name[erratum])).rjust(3))
+                f"{erratum.ljust(15)}        {str(len(to_apply_by_name[erratum])).rjust(3)}"
             )
         else:
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("%s does not affect any systems" % erratum)
+            logging.debug(f"{erratum} does not affect any systems")
 
     # get a unique list of all systems we need to touch
     for systemlist in to_apply_by_name.values():
@@ -296,8 +292,7 @@ def do_errata_listaffectedsystems(self, args):
                 print(self.SEPARATOR)
             add_separator = True
 
-            # pylint: disable-next=consider-using-f-string
-            print("%s:" % erratum)
+            print(f"{erratum}:")
             print("\n".join(sorted([s.get("name") for s in systems])))
 
     return 0
@@ -340,8 +335,7 @@ def do_errata_listcves(self, args):
                         print(self.SEPARATOR)
                     add_separator = True
 
-                    # pylint: disable-next=consider-using-f-string
-                    print("%s:" % erratum)
+                    print(f"{erratum}:")
 
                 print("\n".join(sorted(cves)))
         return 0
@@ -369,8 +363,7 @@ def do_errata_findbycve(self, args):
         self.help_errata_findbycve()
         return 1
 
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Got CVE list %s" % cve_list)
+    logging.debug(f"Got CVE list {cve_list}")
     add_separator = False
 
     # Then iterate over the requested CVEs and dump the errata which match
@@ -379,13 +372,11 @@ def do_errata_findbycve(self, args):
             print(self.SEPARATOR)
         add_separator = True
 
-        # pylint: disable-next=consider-using-f-string
-        print("%s:" % c)
+        print(f"{c}:")
         errata = self.client.errata.findByCve(self.session, c)
         if errata:
             for e in errata:
-                # pylint: disable-next=consider-using-f-string
-                print("%s" % e.get("advisory_name"))
+                print(f"{e.get('advisory_name')}")
 
     return 0
 
@@ -523,8 +514,7 @@ def do_errata_delete(self, args):
     # tell the user how many channels each erratum affects
     for erratum in sorted(errata):
         channels = self.client.errata.applicableToChannels(self.session, erratum)
-        # pylint: disable-next=consider-using-f-string
-        print("%s    %s" % (erratum.ljust(20), str(len(channels)).rjust(3)))
+        print(f"{erratum.ljust(20)}    {str(len(channels)).rjust(3)}")
 
     if not self.options.yes and not self.user_confirm(_("Delete these patches [y/N]:")):
         return 1

--- a/spacecmd/src/spacecmd/group.py
+++ b/spacecmd/src/spacecmd/group.py
@@ -354,16 +354,14 @@ def do_group_restore(self, args):
         return 1
 
     inputdir = os.path.abspath(inputdir)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Input Directory: %s" % (inputdir))
+    logging.debug(f"Input Directory: {inputdir}")
 
     # make a list of file items in the input dir
     if os.path.isdir(inputdir):
         d_content = os.listdir(inputdir)
         for d_item in d_content:
             if os.path.isfile(inputdir + "/" + d_item):
-                # pylint: disable-next=consider-using-f-string
-                logging.debug("Found file %s" % inputdir + "/" + d_item)
+                logging.debug(f"Found file {inputdir}/{d_item}")
                 files[d_item] = inputdir + "/" + d_item
     else:
         logging.error(
@@ -417,17 +415,12 @@ def do_group_restore(self, args):
             if current[groupname] == backup:
                 logging.error(_N("Group %s already restored") % groupname)
             else:
-                # pylint: disable-next=consider-using-f-string
-                logging.debug("Already have %s but the data have changed" % groupname)
+                logging.debug(f"Already have {groupname} but the data have changed")
 
                 if is_interactive(options):
                     if current[groupname]["description"] != backup["description"]:
                         print(_("Changing description from:"))
-                        print(
-                            # pylint: disable-next=consider-using-f-string
-                            '\n"%s"\nto\n"%s"\n'
-                            % (current[groupname]["description"], backup["description"])
-                        )
+                        print(f'\n"{current[groupname]["description"]}"\nto\n"{backup["description"]}"\n')
                         userinput = prompt_user(_("Continue [y/N]:"))
 
                         if userinput.lower() == "y":

--- a/spacecmd/src/spacecmd/kickstart.py
+++ b/spacecmd/src/spacecmd/kickstart.py
@@ -246,8 +246,7 @@ def do_kickstart_delete(self, args):
     # allow globbing of kickstart labels
     all_labels = self.do_kickstart_list("", True)
     labels = filter_results(all_labels, args)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Got labels to delete of %s" % labels)
+    logging.debug(f"Got labels to delete of {labels}")
 
     if not labels:
         logging.error(_N("No valid kickstart labels passed as arguments!"))
@@ -484,8 +483,7 @@ def do_kickstart_details(self, args):
     result.append(base_channel.get("label"))
 
     for channel in sorted(child_channels):
-        # pylint: disable-next=consider-using-f-string
-        result.append("  |-- %s" % channel)
+        result.append(f"  |-- {channel}")
 
     if advanced_options:
         result.append("")
@@ -493,8 +491,7 @@ def do_kickstart_details(self, args):
         result.append("----------------")
         for o in sorted(advanced_options, key=itemgetter("name")):
             if o.get("arguments"):
-                # pylint: disable-next=consider-using-f-string
-                result.append("%s %s" % (o.get("name"), o.get("arguments")))
+                result.append(f"{o.get('name')} {o.get('arguments')}")
 
     if custom_options:
         result.append("")
@@ -535,16 +532,14 @@ def do_kickstart_details(self, args):
         for fp in sorted(file_preservations, key=itemgetter("name")):
             result.append(fp.get("name"))
             for profile_name in sorted(fp.get("file_names")):
-                # pylint: disable-next=consider-using-f-string
-                result.append("    |-- %s" % profile_name)
+                result.append(f"    |-- {profile_name}")
 
     if variables:
         result.append("")
         result.append(_("Variables"))
         result.append("---------")
         for k in sorted(variables.keys()):
-            # pylint: disable-next=consider-using-f-string
-            result.append("%s = %s" % (k, str(variables[k])))
+            result.append(f"{k} = {str(variables[k])}")
 
     if scripts:
         result.append("")
@@ -1449,8 +1444,7 @@ def do_kickstart_listvariables(self, args):
     variables = self.client.kickstart.profile.getVariables(self.session, profile)
 
     for v in variables:
-        # pylint: disable-next=consider-using-f-string
-        print("%s = %s" % (v, variables[v]))
+        print(f"{v} = {variables[v]}")
 
     return 0
 
@@ -1601,8 +1595,7 @@ def do_kickstart_listoptions(self, args):
 
     for o in sorted(options, key=itemgetter("name")):
         if o.get("arguments"):
-            # pylint: disable-next=consider-using-f-string
-            print("%s %s" % (o.get("name"), o.get("arguments")))
+            print(f"{o.get('name')} {o.get('arguments')}")
 
     return 0
 
@@ -2392,15 +2385,13 @@ def export_kickstart_getdetails(self, profile, kickstarts):
 
     # Get the initial ks details struct from the kickstarts list-of-struct,
     # which is returned from kickstart.listKickstarts()
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Getting kickstart profile details for %s" % profile)
+    logging.debug(f"Getting kickstart profile details for {profile}")
     details = None
     for k in kickstarts:
         if k.get("label") == profile:
             details = k
             break
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Got basic details for %s : %s" % (profile, details))
+    logging.debug(f"Got basic details for {profile} : {details}")
 
     # Now use the various other API functions to build up a more complete
     # details struct for export.  Note there are a some ommisions from the API
@@ -2423,15 +2414,12 @@ def export_kickstart_getdetails(self, profile, kickstarts):
     details["ip_ranges"] = self.client.kickstart.profile.listIpRanges(
         self.session, profile
     )
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("About to get variable_list for %s" % profile)
+    logging.debug(f"About to get variable_list for {profile}")
     details["variable_list"] = self.client.kickstart.profile.getVariables(
         self.session, profile
     )
     logging.debug(
-        # pylint: disable-next=consider-using-f-string
-        "done variable_list for %s = %s"
-        % (profile, details["variable_list"])
+        f"done variable_list for {profile} = {details['variable_list']}"
     )
     # just export the key names, then look for one with the same name on import
     details["activation_keys"] = [
@@ -2494,8 +2482,7 @@ def export_kickstart_getdetails(self, profile, kickstarts):
         post_kopts = kscontents.split("`/sbin/grubby --default-kernel` --args=")[
             1
         ].split('"')[1]
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Post kernel options %s detected" % post_kopts)
+        logging.debug(f"Post kernel options {post_kopts} detected")
         details["post_kopts"] = post_kopts
 
     # and now sort all the lists
@@ -2520,8 +2507,7 @@ def do_kickstart_export(self, args):
 
     filename = ""
     if options.file is not None:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Passed filename do_kickstart_export %s" % options.file)
+        logging.debug(f"Passed filename do_kickstart_export {options.file}")
         filename = options.file
 
     # Get the list of profiles to export and sort out the filename if required
@@ -2535,9 +2521,7 @@ def do_kickstart_export(self, args):
         # allow globbing of kickstart kickstart names
         profiles = filter_results(self.do_kickstart_list("", True), args)
         logging.debug(
-            # pylint: disable-next=consider-using-f-string
-            "kickstart_export called with args %s, profiles=%s"
-            % (args, profiles)
+            f"kickstart_export called with args {args}, profiles={profiles}"
         )
         if not profiles:
             logging.error(
@@ -2552,8 +2536,7 @@ def do_kickstart_export(self, args):
             # If we are exporting exactly one ks, we default to ksname.json
             # otherwise, generic ks_profiles.json name
             if len(profiles) == 1:
-                # pylint: disable-next=consider-using-f-string
-                filename = "%s.json" % profiles[0]
+                filename = f"{profiles[0]}.json"
             else:
                 filename = "ks_profiles.json"
 
@@ -2569,9 +2552,7 @@ def do_kickstart_export(self, args):
         ksdetails_list.append(self.export_kickstart_getdetails(p, kickstarts))
 
     logging.debug(
-        # pylint: disable-next=consider-using-f-string
-        "About to dump %d ks profiles to %s"
-        % (len(ksdetails_list), filename)
+        f"About to dump {len(ksdetails_list)} ks profiles to {filename}"
     )
     # Check if filepath exists, if an existing file we prompt for confirmation
     if os.path.isfile(filename):
@@ -2606,8 +2587,7 @@ def do_kickstart_importjson(self, args):
         return 1
 
     for filename in args:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Passed filename do_kickstart_import %s" % filename)
+        logging.debug(f"Passed filename do_kickstart_import {filename}")
         ksdetails_list = json_read_from_file(filename)
         if not ksdetails_list:
             logging.error(_N("Error, could not read json data from %s") % filename)
@@ -2715,8 +2695,7 @@ def import_kickstart_fromdetails(self, ksdetails):
                 script["chroot"],
             )
         if ret:
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("Added %s script to profile" % script["script_type"])
+            logging.debug(f"Added {script['script_type']} script to profile")
         else:
             logging.error(_N("Error adding %s script") % script["script_type"])
     # Specify ip ranges
@@ -2724,8 +2703,7 @@ def import_kickstart_fromdetails(self, ksdetails):
         if self.client.kickstart.profile.addIpRange(
             self.session, ksdetails["label"], iprange["min"], iprange["max"]
         ):
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("added ip range %s-%s" % iprange["min"], iprange["max"])
+            logging.debug(f"added ip range {iprange['min']}-{iprange['max']}")
         else:
             logging.warning(
                 _N("failed to add ip range %s-%s, continuing") % iprange["min"],
@@ -2745,8 +2723,7 @@ def import_kickstart_fromdetails(self, ksdetails):
                 if self.client.kickstart.profile.system.addFilePreservations(
                     self.session, ksdetails["label"], [fp]
                 ):
-                    # pylint: disable-next=consider-using-f-string
-                    logging.debug("added file preservation '%s'" % fp)
+                    logging.debug(f"added file preservation '{fp}'")
                 else:
                     logging.warning(
                         _N("failed to add file preservation %s, skipping") % fp
@@ -2762,8 +2739,7 @@ def import_kickstart_fromdetails(self, ksdetails):
     ]
     for akey in ksdetails["activation_keys"]:
         if akey in existing_act_keys:
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("Adding activation key %s to profile" % akey)
+            logging.debug(f"Adding activation key {akey} to profile")
             self.client.kickstart.profile.keys.addActivationKey(
                 self.session, ksdetails["label"], akey
             )
@@ -2779,8 +2755,7 @@ def import_kickstart_fromdetails(self, ksdetails):
     ]
     for key in ksdetails["gpg_ssl_keys"]:
         if key in existing_gpg_ssl_keys:
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("Adding GPG/SSL key %s to profile" % key)
+            logging.debug(f"Adding GPG/SSL key {key} to profile")
             self.client.kickstart.profile.system.addKeys(
                 self.session, ksdetails["label"], [key]
             )
@@ -2939,8 +2914,7 @@ def do_kickstart_getupdatetype(self, args):
     # allow globbing of kickstart labels
     all_labels = self.do_kickstart_list("", True)
     labels = filter_results(all_labels, args)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Got labels to list the update type %s" % labels)
+    logging.debug(f"Got labels to list the update type {labels}")
 
     if not labels:
         logging.error(_N("No valid kickstart labels passed as arguments!"))
@@ -3001,8 +2975,7 @@ def do_kickstart_setupdatetype(self, args):
     # allow globbing of kickstart labels
     all_labels = self.do_kickstart_list("", True)
     labels = filter_results(all_labels, args)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Got labels to set the update type %s" % labels)
+    logging.debug(f"Got labels to set the update type {labels}")
 
     if not labels:
         logging.error(_N("No valid kickstart labels passed as arguments!"))
@@ -3050,8 +3023,7 @@ def do_kickstart_getsoftwaredetails(self, args):
     # allow globbing of kickstart labels
     all_labels = self.do_kickstart_list("", True)
     labels = filter_results(all_labels, args)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Got labels to set the update type %s" % labels)
+    logging.debug(f"Got labels to set the update type {labels}")
 
     if not labels:
         logging.error(_N("No valid kickstart labels passed as arguments!"))

--- a/spacecmd/src/spacecmd/misc.py
+++ b/spacecmd/src/spacecmd/misc.py
@@ -231,8 +231,7 @@ def help_history(self):
 
 def do_history(self, args):
     for i in range(1, readline.get_current_history_length()):
-        # pylint: disable-next=consider-using-f-string
-        print("%s  %s" % (str(i).rjust(4), readline.get_history_item(i)))
+        print(f"{str(i).rjust(4)}  {readline.get_history_item(i)}")
     return 0
 
 
@@ -304,8 +303,7 @@ def do_login(self, args):
     else:
         proto = "https"
 
-    # pylint: disable-next=consider-using-f-string
-    server_url = "%s://%s/rpc/api" % (proto, server)
+    server_url = f"{proto}://{server}/rpc/api"
 
     # this will enable spewing out all client/server traffic
     verbose_xmlrpc = False
@@ -420,8 +418,7 @@ def do_login(self, args):
                 os.mkdir(conf_dir, int("0700", 8))
 
             # add the new cache to the file
-            # pylint: disable-next=consider-using-f-string
-            line = "%s:%s\n" % (username, self.session)
+            line = f"{username}:{self.session}\n"
 
             # write the new cache file out
             # pylint: disable-next=unspecified-encoding
@@ -526,20 +523,17 @@ def tab_complete_errata(self, text):
 def tab_complete_systems(self, text):
     if re.match("group:", text):
         # prepend 'group' to each item for tab completion
-        # pylint: disable-next=consider-using-f-string
-        groups = ["group:%s" % g for g in self.do_group_list("", True)]
+        groups = [f"group:{g}" for g in self.do_group_list("", True)]
 
         return tab_completer(groups, text)
     if re.match("channel:", text):
         # prepend 'channel' to each item for tab completion
-        # pylint: disable-next=consider-using-f-string
-        channels = ["channel:%s" % s for s in self.do_softwarechannel_list("", True)]
+        channels = [f"channel:{s}" for s in self.do_softwarechannel_list("", True)]
 
         return tab_completer(channels, text)
     if re.match("search:", text):
         # prepend 'search' to each item for tab completion
-        # pylint: disable-next=consider-using-f-string
-        fields = ["search:%s:" % f for f in self.SYSTEM_SEARCH_FIELDS]
+        fields = [f"search:{f}:" for f in self.SYSTEM_SEARCH_FIELDS]
         return tab_completer(fields, text)
 
     options = self.get_system_names()
@@ -669,9 +663,8 @@ def generate_package_cache(self, force=False):
             # Alert in case of non-unique ID is detected.
             if i in self.all_packages_by_id:
                 logging.debug(  # pylint: disable=logging-not-lazy
-                    # pylint: disable-next=consider-using-f-string
-                    'Non-unique package id "%s" is detected. Taking "%s" '
-                    'instead of "%s"' % (i, k, self.all_packages_by_id[i])
+                    f'Non-unique package id "{i}" is detected. Taking "{k}" '
+                    f'instead of "{self.all_packages_by_id[i]}"'
                 )
 
             self.all_packages_by_id[i] = k
@@ -845,8 +838,7 @@ def get_system_names_ids(self):
 
 # check for duplicate system names and return the system ID
 def get_system_id(self, name):
-    # pylint: disable-next=consider-using-f-string
-    name = "%s" % name
+    name = f"{name}"
     self.generate_system_cache()
     systems = []
 
@@ -876,12 +868,10 @@ def get_system_id(self, name):
         logging.warning(_N("Please reference systems by ID or resolve the"))
         logging.warning(_N("underlying issue with 'system_delete' or 'system_rename'"))
 
-        # pylint: disable-next=consider-using-f-string
-        id_list = "%s = " % name
+        id_list = f"{name} = "
 
         for system_id in sorted(systems):
-            # pylint: disable-next=consider-using-f-string
-            id_list = id_list + "%i, " % system_id
+            id_list = id_list + f"{system_id}, "
 
         logging.warning("")
         logging.warning(id_list[:-2])
@@ -939,8 +929,7 @@ def expand_systems(self, args):
             systems.extend(self.ssm)
         elif re.match("group:", item):
             item = re.sub("group:", "", item)
-            # pylint: disable-next=consider-using-f-string
-            members = self.do_group_listsystems("'%s'" % item, True)
+            members = self.do_group_listsystems(f"'{item}'", True)
 
             if members:
                 systems.extend([re.escape(m) for m in members])
@@ -971,8 +960,7 @@ def expand_systems(self, args):
 
     matches = filter_results(self.get_system_names(), systems)
 
-    # pylint: disable-next=consider-using-f-string
-    return ["%s" % x for x in list(set(matches + system_ids))]
+    return [f"{x}" for x in list(set(matches + system_ids))]
 
 
 def list_base_channels(self):
@@ -1027,11 +1015,9 @@ def user_confirm(
         return True
 
     if nospacer:
-        # pylint: disable-next=consider-using-f-string
-        answer = prompt_user("%s" % prompt)
+        answer = prompt_user(f"{prompt}")
     else:
-        # pylint: disable-next=consider-using-f-string
-        answer = prompt_user("\n%s" % prompt)
+        answer = prompt_user(f"\n{prompt}")
 
     if re.match("y", answer, re.I):
         if integer:
@@ -1077,19 +1063,16 @@ def replace_line_buffer(self, msg=None):
 
     # don't print(a prompt if there wasn't one to begin with)
     if readline.get_line_buffer():
-        # pylint: disable-next=consider-using-f-string
-        new_line = "%s%s" % (self.prompt, msg)
+        new_line = f"{self.prompt}{msg}"
     else:
-        # pylint: disable-next=consider-using-f-string
-        new_line = "%s" % msg
+        new_line = f"{msg}"
 
     # clear the current line
     self.stdout.write("\r".ljust(len(self.current_line) + 1))
     self.stdout.flush()
 
     # write the new line
-    # pylint: disable-next=consider-using-f-string
-    self.stdout.write("\r%s" % new_line)
+    self.stdout.write(f"\r{new_line}")
     self.stdout.flush()
 
     # keep track of what is displayed so we can clear it later

--- a/spacecmd/src/spacecmd/org.py
+++ b/spacecmd/src/spacecmd/org.py
@@ -165,19 +165,17 @@ def help_org_create(self):
     print(_("org_create: Create an organization"))
     print(
         _(
-            # pylint: disable-next=consider-using-f-string
-            """usage: org_create [options])
+            f"""usage: org_create [options])
 
 options:
   -n ORG_NAME
   -u USERNAME
-  -P PREFIX (%s)
+  -P PREFIX ({", ".join(_PREFIXES)})
   -f FIRST_NAME
   -l LAST_NAME
   -e EMAIL
   -p PASSWORD
   --pam enable PAM authentication"""
-            % ", ".join(_PREFIXES)
         )
     )
 

--- a/spacecmd/src/spacecmd/package.py
+++ b/spacecmd/src/spacecmd/package.py
@@ -96,37 +96,22 @@ def do_package_details(self, args):
                 self.session, package_id
             )
 
-            # pylint: disable-next=consider-using-f-string
-            print(_("Name:      %s" % details.get("name")))
-            # pylint: disable-next=consider-using-f-string
-            print(_("Version:   %s" % details.get("version")))
-            # pylint: disable-next=consider-using-f-string
-            print(_("Release:   %s" % details.get("release")))
-            # pylint: disable-next=consider-using-f-string
-            print(_("Epoch:     %s" % details.get("epoch")))
-            # pylint: disable-next=consider-using-f-string
-            print(_("Arch:      %s" % details.get("arch_label")))
+            print(_(f"Name:      {details.get('name')}"))
+            print(_(f"Version:   {details.get('version')}"))
+            print(_(f"Release:   {details.get('release')}"))
+            print(_(f"Epoch:     {details.get('epoch')}"))
+            print(_(f"Arch:      {details.get('arch_label')}"))
             print("")
-            # pylint: disable-next=consider-using-f-string
-            print(_("File:      %s" % details.get("file")))
-            # pylint: disable-next=consider-using-f-string
-            print(_("Path:      %s" % details.get("path")))
-            # pylint: disable-next=consider-using-f-string
-            print(_("Size:      %s" % details.get("size")))
+            print(_(f"File:      {details.get('file')}"))
+            print(_(f"Path:      {details.get('path')}"))
+            print(_(f"Size:      {details.get('size')}"))
             print(
                 _(
-                    # pylint: disable-next=consider-using-f-string
-                    "Retracted: %s"
-                    % (_("Yes") if details.get("part_of_retracted_patch") else _("No"))
+                    f"Retracted: {_('Yes') if details.get('part_of_retracted_patch') else _('No')}"
                 )
             )
             print(
-                # pylint: disable-next=consider-using-f-string
-                "%s%s"
-                % (
-                    (details.get("checksum_type").upper() + ":").ljust(11),
-                    details.get("checksum"),
-                )
+                f"{(details.get('checksum_type').upper() + ':').ljust(11)}{details.get('checksum')}"
             )
             print("")
             print(_("Installed Systems: %i") % len(installed_systems))
@@ -151,13 +136,10 @@ def help_package_search(
     command="package_search",
     description="Find packages that meet the given criteria",
 ):
-    # pylint: disable-next=consider-using-f-string
-    print("%s: %s" % (command, description))
-    # pylint: disable-next=consider-using-f-string
-    print(_("usage: %s NAME|QUERY" % command))
+    print(f"{command}: {description}")
+    print(_(f"usage: {command} NAME|QUERY"))
     print("")
-    # pylint: disable-next=consider-using-f-string
-    print(_("Example: %s kernel" % command))
+    print(_(f"Example: {command} kernel"))
     print("")
     print(_("Advanced Search:"))
     print(
@@ -370,8 +352,7 @@ def do_package_listinstalledsystems(self, args):
         if systems:
             print(
                 "\n".join(
-                    # pylint: disable-next=consider-using-f-string
-                    sorted(["%s : %s" % (s.get("name"), s.get("id")) for s in systems])
+                    sorted([f"{s.get('name')} : {s.get('id')}" for s in systems])
                 )
             )
 

--- a/spacecmd/src/spacecmd/repo.py
+++ b/spacecmd/src/spacecmd/repo.py
@@ -144,8 +144,7 @@ def do_repo_listfilters(self, args):
     filters = self.client.channel.software.listRepoFilters(self.session, args[0])
     if filters:
         for flt in filters:
-            # pylint: disable-next=consider-using-f-string
-            print("%s%s" % (flt.get("flag"), flt.get("filter")))
+            print(f"{flt.get('flag')}{flt.get('filter')}")
     else:
         print(_("No filters found"))
         return 1

--- a/spacecmd/src/spacecmd/report.py
+++ b/spacecmd/src/spacecmd/report.py
@@ -71,15 +71,12 @@ def do_report_inactivesystems(self, args):
     if systems:
         max_size = max_length([s.get("name") for s in systems])
 
-        # pylint: disable-next=consider-using-f-string
-        print("%s  %s  %s" % ("System ID ", "System".ljust(max_size), "Last Checkin"))
-        print(("----------  " + "-" * max_size) + "  ------------")
+        print(f"{'System ID '}  {'System'.ljust(max_size)}  {'Last Checkin'}")
+        print(f"----------  " + "-" * max_size + "  ------------")
 
         for s in sorted(systems, key=itemgetter("name")):
             print(
-                # pylint: disable-next=consider-using-f-string
-                "%s  %s  %s"
-                % (s.get("id"), s.get("name").ljust(max_size), s.get("last_checkin"))
+                f"{s.get('id')}  {s.get('name').ljust(max_size)}  {s.get('last_checkin')}"
             )
         return 0
     else:
@@ -104,15 +101,12 @@ def do_report_outofdatesystems(self, args):
         report[system.get("name")] = system.get("outdated_pkg_count")
 
     if report:
-        # pylint: disable-next=consider-using-f-string
-        print("%s  %s" % ("System".ljust(max_size), "Packages"))
+        print(f"{'System'.ljust(max_size)}  {'Packages'}")
         print(("-" * max_size) + "  --------")
 
         for system in sorted(report):
             print(
-                # pylint: disable-next=consider-using-f-string
-                "%s       %s"
-                % (system.ljust(max_size), str(report[system]).rjust(3))
+                f"{system.ljust(max_size)}       {str(report[system]).rjust(3)}"
             )
         return 0
     else:
@@ -166,8 +160,7 @@ def do_report_errata(self, args):
 
     report = {}
     for erratum in errata_list:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Getting affected systems for %s" % erratum)
+        logging.debug(f"Getting affected systems for {erratum}")
 
         affected = self.client.errata.listAffectedSystems(self.session, erratum)
 
@@ -183,14 +176,11 @@ def do_report_errata(self, args):
             max_size = size
 
     if report:
-        print(_("%s  # Systems") % _(("Errata").ljust(max_size)))
-        # pylint: disable-next=consider-using-f-string
-        print("%s  ---------" % ("------".ljust(max_size)))
+        print(_("%s  # Systems") % (_("Errata").ljust(max_size)))
+        print(f"{'------'.ljust(max_size)}  ---------")
         for erratum in sorted(report):
             print(
-                # pylint: disable-next=consider-using-f-string
-                "%s        %s"
-                % (erratum.ljust(max_size), str(report[erratum]).rjust(3))
+                f"{erratum.ljust(max_size)}        {str(report[erratum]).rjust(3)}"
             )
         return 0
     elif partial_errata:
@@ -251,26 +241,18 @@ def do_report_ipaddresses(self, args):
 
     if report:
         print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  IP"
-            % ("System".ljust(system_max_size), "Hostname".ljust(hostname_max_size))
+            f"{'System'.ljust(system_max_size)}  {'Hostname'.ljust(hostname_max_size)}  IP"
         )
 
         print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  --"
-            % ("------".ljust(system_max_size), "--------".ljust(hostname_max_size))
+            f"{'------'.ljust(system_max_size)}  {'--------'.ljust(hostname_max_size)}  --"
         )
 
         for system in sorted(report):
             print(
-                # pylint: disable-next=consider-using-f-string
-                "%s  %s  %s"
-                % (
-                    system.ljust(system_max_size),
-                    report[system]["hostname"].ljust(hostname_max_size),
-                    report[system]["ip"].ljust(15).strip(),
-                )
+                f"{system.ljust(system_max_size)}  "
+                f"{report[system]['hostname'].ljust(hostname_max_size)}  "
+                f"{report[system]['ip'].ljust(15).strip()}"
             )
         return 0
     else:
@@ -322,12 +304,10 @@ def do_report_kernels(self, args):
     if report:
         print(_("%s  Kernel") % (_("System").ljust(system_max_size)))
 
-        # pylint: disable-next=consider-using-f-string
-        print("%s  ------" % ("------".ljust(system_max_size)))
+        print(f"{'------'.ljust(system_max_size)}  ------")
 
         for system in sorted(report):
-            # pylint: disable-next=consider-using-f-string
-            print("%s  %s" % (system.ljust(system_max_size), report[system]))
+            print(f"{system.ljust(system_max_size)}  {report[system]}")
         return 0
     else:
         return 1
@@ -354,19 +334,16 @@ def do_report_duplicates(self, args):
         add_separator = True
 
         for item in dupes_by_profile:
-            # pylint: disable-next=consider-using-f-string
-            print("%s:" % item)
+            print(f"{item}:")
 
             # get some details for each duplicate
-            # pylint: disable-next=consider-using-f-string
-            systems = self.client.system.searchByName(self.session, "^%s$" % item)
+            systems = self.client.system.searchByName(self.session, f"^{item}$")
 
             print(_("System ID   Last Checkin"))
             print("----------  -----------------")
 
             for dupe in systems:
-                # pylint: disable-next=consider-using-f-string
-                print("%i  %s" % (dupe.get("id"), dupe.get("last_checkin")))
+                print(f"{dupe.get('id')}  {dupe.get('last_checkin')}")
 
             if len(dupes_by_profile) > 1:
                 print("")
@@ -382,15 +359,13 @@ def do_report_duplicates(self, args):
             add_separator = True
 
             for item in dupes_by_ip:
-                # pylint: disable-next=consider-using-f-string
-                print("%s:" % item.get("ip"))
+                print(f"{item.get('ip')}:")
 
                 print(_("System ID   Last Checkin"))
                 print("----------  -----------------")
 
                 for dupe in item.get("systems"):
-                    # pylint: disable-next=consider-using-f-string
-                    print("%i  %s" % (dupe.get("systemId"), dupe.get("last_checkin")))
+                    print(f"{dupe.get('systemId')}  {dupe.get('last_checkin')}")
 
                 if len(dupes_by_ip) > 1:
                     print("")
@@ -401,15 +376,13 @@ def do_report_duplicates(self, args):
             add_separator = True
 
             for item in dupes_by_mac:
-                # pylint: disable-next=consider-using-f-string
-                print("%s:" % item.get("mac").upper())
+                print(f"{item.get('mac').upper()}:")
 
                 print(_("System ID   Last Checkin"))
                 print("----------  -----------------")
 
                 for dupe in item.get("systems"):
-                    # pylint: disable-next=consider-using-f-string
-                    print("%i  %s" % (dupe.get("systemId"), dupe.get("last_checkin")))
+                    print(f"{dupe.get('systemId')}  {dupe.get('last_checkin')}")
 
                 if len(dupes_by_mac) > 1:
                     print("")
@@ -420,15 +393,13 @@ def do_report_duplicates(self, args):
             add_separator = True
 
             for item in dupes_by_hostname:
-                # pylint: disable-next=consider-using-f-string
-                print("%s:" % item.get("hostname"))
+                print(f"{item.get('hostname')}:")
 
                 print(_("System ID   Last Checkin"))
                 print("----------  -----------------")
 
                 for dupe in item.get("systems"):
-                    # pylint: disable-next=consider-using-f-string
-                    print("%i  %s" % (dupe.get("systemId"), dupe.get("last_checkin")))
+                    print(f"{dupe.get('systemId')}  {dupe.get('last_checkin')}")
 
                 if len(dupes_by_hostname) > 1:
                     print("")

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -53,15 +53,13 @@ def print_schedule_summary(self, action_type, args):
 
     if args:
         begin_date = parse_time_input(args[0])
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Begin Date: %s" % begin_date)
+        logging.debug(f"Begin Date: {begin_date}")
     else:
         begin_date = None
 
     if len(args) > 1:
         end_date = parse_time_input(args[1])
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("End Date:   %s" % end_date)
+        logging.debug(f"End Date:   {end_date}")
     else:
         end_date = None
 
@@ -105,16 +103,11 @@ def print_schedule_summary(self, action_type, args):
 
         if self.check_api_version("10.11"):
             print(
-                # pylint: disable-next=consider-using-f-string
-                "%s  %s   %s  %s  %s    %s"
-                % (
-                    str(action.get("id")).ljust(6),
-                    action.get("earliest"),
-                    str(action.get("completedSystems")).rjust(3),
-                    str(action.get("failedSystems")).rjust(3),
-                    str(action.get("inProgressSystems")).rjust(3),
-                    action.get("name"),
-                )
+                f"{str(action.get('id')).ljust(6)}  {action.get('earliest')}   "
+                f"{str(action.get('completedSystems')).rjust(3)}  "
+                f"{str(action.get('failedSystems')).rjust(3)}  "
+                f"{str(action.get('inProgressSystems')).rjust(3)}    "
+                f"{action.get('name')}"
             )
         else:
             # Satellite 5.3 compatibility
@@ -131,16 +124,11 @@ def print_schedule_summary(self, action_type, args):
             )
 
             print(
-                # pylint: disable-next=consider-using-f-string
-                "%s  %s   %s  %s  %s    %s"
-                % (
-                    str(action.get("id")).ljust(6),
-                    action.get("earliest"),
-                    str(len(completed)).rjust(3),
-                    str(len(failed)).rjust(3),
-                    str(len(in_progress)).rjust(3),
-                    action.get("name"),
-                )
+                f"{str(action.get('id')).ljust(6)}  {action.get('earliest')}   "
+                f"{str(len(completed)).rjust(3)}  "
+                f"{str(len(failed)).rjust(3)}  "
+                f"{str(len(in_progress)).rjust(3)}    "
+                f"{action.get('name')}"
             )
 
 
@@ -518,8 +506,7 @@ def do_schedule_deletearchived(self, args):
 
     if args:
         date_limit = parse_time_input(args[0])
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Date limit: %s" % date_limit)
+        logging.debug(f"Date limit: {date_limit}")
     else:
         date_limit = None
 
@@ -529,8 +516,7 @@ def do_schedule_deletearchived(self, args):
     if date_limit:
         actions = [action for action in actions if action.get("earliest") < date_limit]
 
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("actions: {}".format(actions))
+    logging.debug(f"actions: {actions}")
     if actions:
         if not _options.yes:
             user_answer = prompt_user(
@@ -561,8 +547,7 @@ def do_schedule_deletearchived(self, args):
                     if i + BATCH_SIZE <= len(action_ids)
                     else len(action_ids)
                 )
-                # pylint: disable-next=consider-using-f-string
-                print("Deleted {} actions of {}".format(processed, len(action_ids)))
+                print(f"Deleted {processed} actions of {len(action_ids)}")
     else:
         print(_("No archived actions found."))
 
@@ -600,8 +585,7 @@ def do_schedule_archivecompleted(self, args):
 
     if args:
         date_limit = parse_time_input(args[0])
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Date limit: %s" % date_limit)
+        logging.debug(f"Date limit: {date_limit}")
     else:
         date_limit = None
 
@@ -611,8 +595,7 @@ def do_schedule_archivecompleted(self, args):
     if date_limit:
         actions = [action for action in actions if action.get("earliest") < date_limit]
 
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("actions: {}".format(actions))
+    logging.debug(f"actions: {actions}")
     if actions:
         if not _options.yes:
             user_answer = prompt_user(
@@ -643,7 +626,6 @@ def do_schedule_archivecompleted(self, args):
                     if i + BATCH_SIZE <= len(action_ids)
                     else len(action_ids)
                 )
-                # pylint: disable-next=consider-using-f-string
-                print("Archived {} actions of {}".format(processed, len(action_ids)))
+                print(f"Archived {processed} actions of {len(action_ids)}")
     else:
         print(_("No completed actions found."))

--- a/spacecmd/src/spacecmd/shell.py
+++ b/spacecmd/src/spacecmd/shell.py
@@ -89,8 +89,7 @@ class SpacewalkShell(Cmd):
 
     # a SyntaxError is thrown if we don't wrap this in an 'exec'
     for module in __module_list:
-        # pylint: disable-next=consider-using-f-string
-        exec("from spacecmd.%s import *" % module)
+        exec(f"from spacecmd.{module} import *")
 
     # maximum length of history file
     HISTORY_LENGTH = 1024
@@ -196,8 +195,7 @@ class SpacewalkShell(Cmd):
 
         # print(the help message for a command if the user passed --help)
         if "--help" in parts or "-h" in parts:
-            # pylint: disable-next=consider-using-f-string
-            return "help %s" % command
+            return f"help {command}"
 
         # should we look for an item in the history?
         if command[0] != "!" or len(command) < 2:
@@ -250,8 +248,7 @@ class SpacewalkShell(Cmd):
         if history_match:
             if parts[1:]:
                 for arg in parts[1:]:
-                    # pylint: disable-next=consider-using-f-string
-                    line += " '%s'" % arg
+                    line += f" '{arg}'"
 
             readline.add_history(line)
             print(line)

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -96,23 +96,19 @@ def do_softwarechannel_list(self, args, doreturn=False):
         if options.verbose:
             for l in labels:
                 details = self.client.channel.software.getDetails(self.session, l)
-                # pylint: disable-next=consider-using-f-string
-                print("%s : %s" % (l, details["summary"]))
+                print(f"{l} : {details['summary']}")
                 if options.tree:
                     for c in self.list_child_channels(parent=l):
                         cdetails = self.client.channel.software.getDetails(
                             self.session, c
                         )
-                        # pylint: disable-next=consider-using-f-string
-                        print(" |-%s : %s" % (c, cdetails["summary"]))
+                        print(f" |-{c} : {cdetails['summary']}")
         else:
             for l in labels:
-                # pylint: disable-next=consider-using-f-string
-                print("%s" % l)
+                print(f"{l}")
                 if options.tree:
                     for c in self.list_child_channels(parent=l):
-                        # pylint: disable-next=consider-using-f-string
-                        print(" |-%s" % c)
+                        print(f" |-{c}")
 
     return None
 
@@ -157,12 +153,10 @@ def do_softwarechannel_listmanageablechannels(self, args, doreturn=False):
         if options.verbose:
             for l in labels:
                 details = self.client.channel.software.getDetails(self.session, l)
-                # pylint: disable-next=consider-using-f-string
-                print("%s : %s" % (l, details["summary"]))
+                print(f"{l} : {details['summary']}")
         else:
             for l in labels:
-                # pylint: disable-next=consider-using-f-string
-                print("%s" % l)
+                print(f"{l}")
 
     return None
 
@@ -193,8 +187,7 @@ def do_softwarechannel_listbasechannels(self, args):
         if options.verbose:
             for c in sorted(channels):
                 details = self.client.channel.software.getDetails(self.session, c)
-                # pylint: disable-next=consider-using-f-string
-                print("%s : %s" % (c, details["summary"]))
+                print(f"{c} : {details['summary']}")
         else:
             print("\n".join(sorted(channels)))
 
@@ -233,8 +226,7 @@ def do_softwarechannel_listchildchannels(self, args):
         if options.verbose:
             for c in channels:
                 details = self.client.channel.software.getDetails(self.session, c)
-                # pylint: disable-next=consider-using-f-string
-                print("%s : %s" % (c, details["summary"]))
+                print(f"{c} : {details['summary']}")
         else:
             print("\n".join(channels))
 
@@ -432,13 +424,13 @@ def help_softwarechannel_setdetails(self):
     print(_("softwarechannel_setdetails: Modify details of a software channel"))
     print(
         _(
-            """usage: softwarechannel_setdetails [options] <CHANNEL ...>)
+            f"""usage: softwarechannel_setdetails [options] <CHANNEL ...>)
 
 options, at least one of which must be given:
   -n NAME
   -d DESCRIPTION
   -s SUMMARY
-  -c CHECKSUM %s
+  -c CHECKSUM {CHECKSUM}
   -m MAINTAINER_NAME
   -e MAINTAINER_EMAIL
   -p MAINTAINER_PHONE
@@ -446,7 +438,6 @@ options, at least one of which must be given:
   -i GPG_ID
   -f GPG_FINGERPRINT"""
         )
-        % CHECKSUM
     )
 
 
@@ -519,8 +510,7 @@ def do_softwarechannel_setdetails(self, args):
                 _N("Setting same name for more than " + "one channel will fail")
             )
             return 1
-        # pylint: disable-next=consider-using-f-string
-        logging.debug('checking other channels for name "%s"' % new_details.get("name"))
+        logging.debug(f'checking other channels for name "{new_details.get("name")}"')
         for c in self.list_base_channels() + self.list_child_channels():
             cd = self.client.channel.software.getDetails(self.session, c)
             if cd.get("name") == new_details.get("name"):
@@ -564,8 +554,7 @@ def do_softwarechannel_setdetails(self, args):
     logging.debug(new_details)
     num_changed = 0
     for channel in channels:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("getting ID for channel %s" % channel)
+        logging.debug(f"getting ID for channel {channel}")
         try:
             details = self.client.channel.software.getDetails(self.session, channel)
         except xmlrpclib.Fault as e:
@@ -573,8 +562,7 @@ def do_softwarechannel_setdetails(self, args):
             logging.error(e)
             return 1
         channel_id = details.get("id")
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("setting details for channel %s (%d)" % (channel, channel_id))
+        logging.debug(f"setting details for channel {channel} ({channel_id})")
         try:
             self.client.channel.software.setDetails(
                 self.session, channel_id, new_details
@@ -764,11 +752,9 @@ def do_softwarechannel_listarches(self, args):
 
     for arch in sorted(arches):
         if options.verbose:
-            # pylint: disable-next=consider-using-f-string
-            print("%s (%s)" % (arch["label"], arch["name"]))
+            print(f"{arch['label']} ({arch['name']})")
         else:
-            # pylint: disable-next=consider-using-f-string
-            print("%s" % arch["label"])
+            print(f"{arch['label']}")
 
     return 0
 
@@ -836,18 +822,17 @@ def help_softwarechannel_update(self):
     print(_("softwarechannel_update: Update a software channel"))
     print(
         _(
-            """usage: softwarechannel_update LABEL(To identify the channel) [options]
+            f"""usage: softwarechannel_update LABEL(To identify the channel) [options]
 options:
   -l LABEL(Required)
   -n NAME
   -s SUMMARY
   -d DESCRIPTION
-  -c CHECKSUM %s
+  -c CHECKSUM {CHECKSUM}
   -u GPG-URL
   -i GPG-ID
   -f GPG-FINGERPRINT
   -g DISABLE-GPG-CHECK"""
-            % CHECKSUM
         )
     )
 
@@ -971,7 +956,7 @@ def help_softwarechannel_create(self):
     print(_("softwarechannel_create: Create a software channel"))
     print(
         _(
-            """usage: softwarechannel_create [options])
+            f"""usage: softwarechannel_create [options])
 
 options:
   -n NAME
@@ -979,12 +964,11 @@ options:
   -s SUMMARY
   -p PARENT_CHANNEL
   -a ARCHITECTURE
-  -c CHECKSUM %s
+  -c CHECKSUM {CHECKSUM}
   -u GPG_URL
   -i GPG_ID
   -f GPG_FINGERPRINT
   -g DISABLE_GPG_CHECK"""
-            % CHECKSUM
         )
     )
 
@@ -1068,8 +1052,7 @@ def do_softwarechannel_create(self, args):
             options.label,
             options.name,
             options.summary,
-            # pylint: disable-next=consider-using-f-string
-            "channel-%s" % options.arch,
+            f"channel-{options.arch}",
             options.parent_channel,
             options.checksum,
             gpgData,
@@ -1344,22 +1327,17 @@ def do_softwarechannel_clonetree(
         self.help_softwarechannel_clonetree()
         return 1
     logging.debug(
-        # pylint: disable-next=consider-using-f-string
-        "--child mode specified, finding children of %s\n"
-        % options.source_channel
+        f"--child mode specified, finding children of {options.source_channel}\n"
     )
     children = self.list_child_channels(parent=options.source_channel)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Found children %s\n" % children)
+    logging.debug(f"Found children {children}\n")
     for c in children:
         channels.append(c)
 
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("channels=%s" % channels)
+    logging.debug(f"channels={channels}")
     parent_channel = None
     for ch in channels:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Cloning %s" % ch)
+        logging.debug(f"Cloning {ch}")
         label = None
         name = None
         if options.regex:
@@ -1439,20 +1417,16 @@ def clone_channel(self, channel, options, details):
 def copy_gpg_values_from_source(details, srcdetails):
     if srcdetails["gpg_key_url"]:
         details["gpg_key_url"] = srcdetails["gpg_key_url"]
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("copying gpg_key_url=%s" % srcdetails["gpg_key_url"])
+        logging.debug(f"copying gpg_key_url={srcdetails['gpg_key_url']}")
     if srcdetails["gpg_key_id"]:
         details["gpg_key_id"] = srcdetails["gpg_key_id"]
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("copying gpg_key_id=%s" % srcdetails["gpg_key_id"])
+        logging.debug(f"copying gpg_key_id={srcdetails['gpg_key_id']}")
     if srcdetails["gpg_key_fp"]:
         details["gpg_key_fp"] = srcdetails["gpg_key_fp"]
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("copying gpg_key_fp=%s" % srcdetails["gpg_key_fp"])
+        logging.debug(f"copying gpg_key_fp={srcdetails['gpg_key_fp']}")
     if srcdetails["gpg_check"]:
         details["gpg_check"] = str(srcdetails["gpg_check"])
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("copying gpg_check=%s" % srcdetails["gpg_check"])
+        logging.debug(f"copying gpg_check={srcdetails['gpg_check']}")
 
 
 ####################
@@ -1468,18 +1442,14 @@ def do_regx_replacement(self, channel, options):
     findstr = options.regex.split("/")[1]
     replacestr = options.regex.split("/")[2]
     logging.debug(
-        # pylint: disable-next=consider-using-f-string
-        "--regex selected with %s, replacing %s with %s"
-        % (options.regex, findstr, replacestr)
+        f"--regex selected with {options.regex}, replacing {findstr} with {replacestr}"
     )
     srcdetails = self.client.channel.software.getDetails(self.session, channel)
 
     newvalues["name"] = re.sub(findstr, replacestr, srcdetails["name"])
     newvalues["label"] = re.sub(findstr, replacestr, channel)
     logging.debug(
-        # pylint: disable-next=consider-using-f-string
-        "regex mode : %s %s %s"
-        % (options.source_channel, newvalues["name"], newvalues["label"])
+        f"regex mode : {options.source_channel} {newvalues['name']} {newvalues['label']}"
     )
 
     return newvalues
@@ -1628,8 +1598,7 @@ def do_softwarechannel_removeerrata(self, args):
     # to the channel afterwards
     package_ids = []
     for erratum in errata:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Retrieving packages for patch %s" % erratum)
+        logging.debug(f"Retrieving packages for patch {erratum}")
 
         # get the packages affected by this errata
         packages = self.client.errata.listPackages(self.session, erratum)
@@ -1832,13 +1801,8 @@ def do_softwarechannel_adderratabydate(self, args):
         # call adderrata with the list of errata from the date range
         # this clones the errata and adds it to the channel
         return self.do_softwarechannel_adderrata(
-            # pylint: disable-next=consider-using-f-string
-            "%s %s %s"
-            % (
-                source_channel,
-                dest_channel,
-                " ".join([e.get("advisory_name") for e in errata]),
-            )
+            f"{source_channel} {dest_channel} "
+            f"{' '.join([e.get('advisory_name') for e in errata])}"
         )
 
     return 0
@@ -1892,8 +1856,7 @@ def do_softwarechannel_listerratabydate(self, args):
         return 1
 
     # get the errata that are in the given date range
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Retrieving list of errata from channel %s" % channel)
+    logging.debug(f"Retrieving list of errata from channel {channel}")
     errata = self.client.channel.software.listErrata(
         self.session, channel, parse_time_input(begin_date), parse_time_input(end_date)
     )
@@ -1967,29 +1930,23 @@ def do_softwarechannel_adderrata(self, args):
     errata = filter_results(
         [e.get("advisory_name") for e in source_errata], errata_wanted
     )
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("errata = %s" % errata)
+    logging.debug(f"errata = {errata}")
     if options.skip:
         # We just match the NNNN:MMMM of the XXXX-NNNN:MMMM as the
         # source errata will be RH[BES]A and the DEST errata will be CLA
         dest_errata_suffix = [x.get("advisory_name").split("-")[1] for x in dest_errata]
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("dest_errata_suffix = %s" % dest_errata_suffix)
+        logging.debug(f"dest_errata_suffix = {dest_errata_suffix}")
         toremove = []
         for e in errata:
             if e.split("-")[1] in dest_errata_suffix:
                 logging.debug(
-                    # pylint: disable-next=consider-using-f-string
-                    "Skipping errata %s as it seems to be in %s"
-                    % (e, dest_channel)
+                    f"Skipping errata {e} as it seems to be in {dest_channel}"
                 )
                 toremove.append(e)
         for e in toremove:
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("Removing %s from errata to be added" % e)
+            logging.debug(f"Removing {e} from errata to be added")
             errata.remove(e)
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("skip-mode : reduced errata = %s" % errata)
+        logging.debug(f"skip-mode : reduced errata = {errata}")
 
     # keep the details for our matching errata so we can use them later
     errata_details = []
@@ -2002,8 +1959,7 @@ def do_softwarechannel_adderrata(self, args):
         # to the channel afterwards
         package_ids = []
         for erratum in errata:
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("Retrieving packages for patch %s" % erratum)
+            logging.debug(f"Retrieving packages for patch {erratum}")
 
             # get the packages affected by this errata
             packages = self.client.errata.listPackages(self.session, erratum)
@@ -2038,8 +1994,7 @@ def do_softwarechannel_adderrata(self, args):
     # clone each erratum individually because the process is slow and it can
     # lead to timeouts on the server
     for erratum in errata:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Cloning %s" % erratum)
+        logging.debug(f"Cloning {erratum}")
         if self.check_api_version("10.11"):
             # This call is poorly documented, but it stops errata.clone
             # pushing EL6 packages into EL5 channels when the errata
@@ -2093,17 +2048,14 @@ def do_softwarechannel_getorgaccess(self, args):
         )
 
     for channel in channels:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Getting org-access for channel %s" % channel)
+        logging.debug(f"Getting org-access for channel {channel}")
         sharing = self.client.channel.access.getOrgSharing(self.session, channel)
-        # pylint: disable-next=consider-using-f-string
-        print("%s : %s" % (channel, sharing))
+        print(f"{channel} : {sharing}")
         if sharing == "protected":
             # for protected channels list each organization's access status
             channel_orgs = self.client.channel.org.list(self.session, channel)
             for org in channel_orgs:
-                # pylint: disable-next=consider-using-f-string
-                print("\t%s : %s" % (org["org_name"], org["access_enabled"]))
+                print(f"\t{org['org_name']} : {org['access_enabled']}")
 
     return 0
 
@@ -2341,8 +2293,7 @@ def do_softwarechannel_regenerateyumcache(self, args):
     channels = filter_results(self.do_softwarechannel_list("", True), args)
 
     for channel in channels:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Regenerating YUM cache for %s" % channel)
+        logging.debug(f"Regenerating YUM cache for {channel}")
         self.client.channel.software.regenerateYumCache(
             self.session, channel, _options.force
         )
@@ -2440,12 +2391,8 @@ def dump_softwarechannel_errata(self, name):
     result = []
     for erratum in errata:
         result.append(
-            # pylint: disable-next=consider-using-f-string
-            "%s %s"
-            % (
-                erratum.get("advisory_name").ljust(14),
-                wrap(erratum.get("advisory_synopsis"), 50)[0],
-            )
+            f"{erratum.get('advisory_name').ljust(14)} "
+            f"{wrap(erratum.get('advisory_synopsis'), 50)[0]}"
         )
     result.sort()
     return result
@@ -3006,8 +2953,7 @@ def do_softwarechannel_syncrepos(self, args):
     channels = filter_results(self.do_softwarechannel_list("", True), args)
 
     for channel in channels:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Syncing repos for %s" % channel)
+        logging.debug(f"Syncing repos for {channel}")
         self.client.channel.software.syncRepo(self.session, channel, params)
 
     return 0

--- a/spacecmd/src/spacecmd/ssm.py
+++ b/spacecmd/src/spacecmd/ssm.py
@@ -97,12 +97,10 @@ def do_ssm_add(self, args):
             logging.warning(_N("%s is already in the list") % system)
             continue
         self.ssm[system] = self.get_system_id(system)
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Added %s" % system)
+        logging.debug(f"Added {system}")
 
     if self.ssm:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Systems Selected: %i" % len(self.ssm))
+        logging.debug(f"Systems Selected: {len(self.ssm)}")
 
     # save the SSM for use between sessions
     save_cache(self.ssm_cache_file, self.ssm)
@@ -149,8 +147,7 @@ def do_ssm_intersect(self, args):
     tmp_ssm = {}
     for system in systems:
         if system in self.ssm:
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("%s is in both groups: leaving in SSM" % system)
+            logging.debug(f"{system} is in both groups: leaving in SSM")
             tmp_ssm[system] = self.ssm[system]
 
     # set self.ssm to tmp_ssm, which now holds the intersection
@@ -160,8 +157,7 @@ def do_ssm_intersect(self, args):
     save_cache(self.ssm_cache_file, self.ssm)
 
     if self.ssm:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Systems Selected: %i" % len(self.ssm))
+        logging.debug(f"Systems Selected: {len(self.ssm)}")
 
     return 0
 
@@ -201,12 +197,10 @@ def do_ssm_remove(self, args):
     for system in systems:
         # double-check for existance in case of duplicate names
         if system in self.ssm:
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("Removed %s" % system)
+            logging.debug(f"Removed {system}")
             del self.ssm[system]
 
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Systems Selected: %i" % len(self.ssm))
+    logging.debug(f"Systems Selected: {len(self.ssm)}")
 
     # save the SSM for use between sessions
     save_cache(self.ssm_cache_file, self.ssm)
@@ -229,8 +223,7 @@ def do_ssm_list(self, args):
 
     if systems:
         print("\n".join(systems))
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Systems Selected: %i" % len(systems))
+        logging.debug(f"Systems Selected: {len(systems)}")
         return 0
     else:
         return 1

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -77,20 +77,17 @@ def print_package_comparison(self, results):
 
     # print(headers)
     print(
-        # pylint: disable-next=consider-using-f-string
-        "%s  %s  %s  %s"
-        % (
-            _("Package").ljust(max_name),
-            _("This System").ljust(max_this),
-            _("Other System").ljust(max_other),
-            _("Difference").ljust(max_comparison),
-        )
+        f"{_('Package').ljust(max_name)}  "
+        f"{_('This System').ljust(max_this)}  "
+        f"{_('Other System').ljust(max_other)}  "
+        f"{_('Difference').ljust(max_comparison)}"
     )
 
     print(
-        # pylint: disable-next=consider-using-f-string
-        "%s  %s  %s  %s"
-        % ("-" * max_name, "-" * max_this, "-" * max_other, "-" * max_comparison)
+        f"{'-' * max_name}  "
+        f"{'-' * max_this}  "
+        f"{'-' * max_other}  "
+        f"{'-' * max_comparison}"
     )
 
     for item in results:
@@ -99,14 +96,10 @@ def print_package_comparison(self, results):
             continue
 
         print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  %s  %s"
-            % (
-                item.get("package_name").ljust(max_name),
-                str(item.get("this_system")).ljust(max_this),
-                str(item.get("other_system")).ljust(max_other),
-                __PKG_COMPARISONS[item.get("comparison")],
-            )
+            f"{item.get('package_name').ljust(max_name)}  "
+            f"{str(item.get('this_system')).ljust(max_this)}  "
+            f"{str(item.get('other_system')).ljust(max_other)}  "
+            f"{__PKG_COMPARISONS[item.get('comparison')]}"
         )
 
 
@@ -136,8 +129,7 @@ def manipulate_child_channels(self, args, remove=False):
 
     print(_("Systems"))
     print("-------")
-    # pylint: disable-next=consider-using-f-string
-    print("\n".join(sorted(["%s" % x for x in systems])))
+    print("\n".join(sorted([f"{x}" for x in systems])))
     print("")
 
     if remove:
@@ -193,11 +185,7 @@ def do_system_list(self, args, doreturn=False):
             print(
                 "\n".join(
                     sorted(
-                        [
-                            # pylint: disable-next=consider-using-f-string
-                            "%s : %s" % (v, k)
-                            for k, v in self.get_system_names_ids().items()
-                        ]
+                        [f"{v} : {k}" for k, v in self.get_system_names_ids().items()]
                     )
                 )
             )
@@ -358,8 +346,7 @@ def do_system_search(self, args, doreturn=False):
     max_size = 0
     for s in results:
         # only use real matches, not the fuzzy ones we get back
-        # pylint: disable-next=consider-using-f-string
-        if re.search(value, "%s" % s.get(key), re.I):
+        if re.search(value, f"{s.get(key)}", re.I):
             if len(s.get("name")) > max_size:
                 max_size = len(s.get("name"))
 
@@ -373,8 +360,7 @@ def do_system_search(self, args, doreturn=False):
                 if key == "name":
                     print(s[0])
                 else:
-                    # pylint: disable-next=consider-using-f-string
-                    print("%s  %s" % (s[0].ljust(max_size), str(s[1]).strip()))
+                    print(f"{s[0].ljust(max_size)}  {str(s[1]).strip()}")
 
     return 0
 
@@ -809,8 +795,7 @@ def do_system_installpackage(self, args):
 
     if self.check_api_version("10.11"):
         for package in packages_to_install:
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("Finding the latest version of %s" % package)
+            logging.debug(f"Finding the latest version of {package}")
 
             avail_packages = self.client.system.listLatestAvailablePackage(
                 self.session, system_ids, package
@@ -827,9 +812,7 @@ def do_system_installpackage(self, args):
         # XXX: Satellite 5.3 compatibility
         for system_id in system_ids:
             logging.debug(
-                # pylint: disable-next=consider-using-f-string
-                "Getting available packages for %s"
-                % self.get_system_name(system_id)
+                f"Getting available packages for {self.get_system_name(system_id)}"
             )
 
             avail_packages = self.client.system.listLatestInstallablePackages(
@@ -861,8 +844,7 @@ def do_system_installpackage(self, args):
             # stash the warnings and show at the end so the user can see them
             warnings.append(system_id)
 
-        # pylint: disable-next=consider-using-f-string
-        print("%s:" % self.get_system_name(system_id))
+        print(f"{self.get_system_name(system_id)}:")
         for package_id in jobs[system_id]:
             print(self.get_package_name(package_id))
 
@@ -972,8 +954,7 @@ def do_system_removepackage(self, args):
 
     jobs = {}
     for package_name in matching_packages:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("Finding systems with %s" % package_name)
+        logging.debug(f"Finding systems with {package_name}")
 
         installed_systems = {}
         for package_id in self.get_package_id(package_name):
@@ -1001,8 +982,7 @@ def do_system_removepackage(self, args):
             print(self.SEPARATOR)
         add_separator = True
 
-        # pylint: disable-next=consider-using-f-string
-        print("%s:" % system)
+        print(f"{system}:")
         for package in jobs[system]:
             print(self.get_package_name(package))
 
@@ -1169,8 +1149,7 @@ def do_system_upgradepackage(self, args):
         hdr = _("Full package update on systems:")
         print(hdr)
         print("-" * len(hdr))
-        # pylint: disable-next=consider-using-f-string
-        print("- {}".format(system))
+        print(f"- {system}")
 
     print("")
     print(_("Start Time: %s") % options.start_time)
@@ -1413,27 +1392,18 @@ def print_configfiles(self, quiet, filelist):
     # print(header when not in quiet mode)
     if not quiet:
         print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  %s"
-            % (
-                "path".ljust(max_path),
-                "type".ljust(max_type),
-                "label/type".ljust(max_label),
-            )
+            f"{'path'.ljust(max_path)}  "
+            f"{'type'.ljust(max_type)}  "
+            f"{'label/type'.ljust(max_label)}"
         )
 
-        # pylint: disable-next=consider-using-f-string
-        print("%s  %s  %s" % ("-" * max_path, "-" * max_type, "-" * max_label))
+        print(f"{'-' * max_path}  {'-' * max_type}  {'-' * max_label}")
 
     for f in filelist:
         print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  %s"
-            % (
-                f["path"].ljust(max_path),
-                f["type"].ljust(max_type),
-                f["channel_label"].ljust(max_label),
-            )
+            f"{f['path'].ljust(max_path)}  "
+            f"{f['type'].ljust(max_type)}  "
+            f"{f['channel_label'].ljust(max_label)}"
         )
 
 
@@ -1652,8 +1622,7 @@ def do_system_addconfigfile(self, args, update_path=""):
         return 1
 
     system_id = self.get_system_id(options.system)
-    # pylint: disable-next=consider-using-f-string
-    logging.debug("Got ID %s for system %s" % (system_id, options.system))
+    logging.debug(f"Got ID {system_id} for system {options.system}")
 
     # check if this file already exists
     try:
@@ -1661,11 +1630,9 @@ def do_system_addconfigfile(self, args, update_path=""):
             self.session, system_id, [options.path], localopt
         )
         if file_info:
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("Found existing file_info %s" % file_info)
+            logging.debug(f"Found existing file_info {file_info}")
     except xmlrpclib.Fault:
-        # pylint: disable-next=consider-using-f-string
-        logging.debug("No existing file information found for %s" % options.path)
+        logging.debug(f"No existing file information found for {options.path}")
 
     file_info = self.configfile_getinfo(args, options, file_info, interactive)
 
@@ -1865,8 +1832,7 @@ def do_system_setconfigchannelorder(self, args):
     print(_("New Configuration Channels"))
     print("--------------------------")
     for i, new_channel in enumerate(new_channels, 1):
-        # pylint: disable-next=consider-using-f-string
-        print("[%i] %s" % (i, new_channel))
+        print(f"[{i}] {new_channel}")
 
     if not self.user_confirm():
         return 1
@@ -2020,13 +1986,11 @@ def do_system_delete(self, args):
         colsize = 7
 
     print(_("%s  System ID") % _("Profile").ljust(colsize))
-    # pylint: disable-next=consider-using-f-string
-    print("%s  ---------" % ("-" * colsize))
+    print(f"{'-' * colsize}  ---------")
 
     # print(a summary for the user)
     for system_id in system_ids:
-        # pylint: disable-next=consider-using-f-string
-        print("%s  %i" % (self.get_system_name(system_id).ljust(colsize), system_id))
+        print(f"{self.get_system_name(system_id).ljust(colsize)}  {system_id}")
 
     if not self.user_confirm(_("Delete these systems [y/N]:")):
         return 1
@@ -2171,8 +2135,7 @@ def do_system_rename(self, args):
     if not system_id:
         return 1
 
-    # pylint: disable-next=consider-using-f-string
-    print("%s (%s) -> %s" % (old_name, system_id, new_name))
+    print(f"{old_name} ({system_id}) -> {new_name}")
     if not self.user_confirm():
         return 1
 
@@ -2225,12 +2188,10 @@ def do_system_refreshpillar(self, args):
 
     self.client.system.refreshPillar(self.session, sids)
 
-    # pylint: disable-next=consider-using-f-string
-    num = "%s" % len(sids)
+    num = f"{len(sids)}"
     if num == "0":
         num = "all"
-    # pylint: disable-next=consider-using-f-string
-    print('Refreshed Pillar data for "%s" systems' % (num))
+    print(f'Refreshed Pillar data for "{num}" systems')
     return 0
 
 
@@ -2286,8 +2247,7 @@ def do_system_listcustomvalues(self, args):
         values = self.client.system.getCustomValues(self.session, system_id)
 
         for v in values:
-            # pylint: disable-next=consider-using-f-string
-            print("%s = %s" % (v, values[v]))
+            print(f"{v} = {values[v]}")
 
     return 0
 
@@ -2624,15 +2584,12 @@ def do_system_listnotes(self, args):
         notes = self.client.system.listNotes(self.session, system_id)
 
         for n in notes:
-            # pylint: disable-next=consider-using-f-string
-            print("%d. %s (%s)" % (n["id"], n["subject"], n["creator"]))
+            print(f"{n['id']}. {n['subject']} ({n['creator']})")
             print(n["note"])
             print("")
 
     return 0
 
-
-####################
 
 ####################
 
@@ -3157,8 +3114,7 @@ def do_system_details(self, args, short=False):
         print(base_channel.get("label"))
 
         for channel in child_channels:
-            # pylint: disable-next=consider-using-f-string
-            print("  |-- %s" % channel.get("label"))
+            print(f"  |-- {channel.get('label')}")
 
         if ranked_config_channels:
             print("")
@@ -3569,9 +3525,7 @@ def do_system_eventdetails(self, args):
         except xmlrpclib.Fault:
             print(
                 _(
-                    # pylint: disable-next=consider-using-f-string
-                    "No event %s found in the history of system %s"
-                    % (event_id, system_id)
+                    f"No event {event_id} found in the history of system {system_id}"
                 )
             )
             continue
@@ -3974,8 +3928,7 @@ def do_system_comparepackageprofile(self, args):
             print(self.SEPARATOR)
         add_separator = True
 
-        # pylint: disable-next=consider-using-f-string
-        print("%s:" % system)
+        print(f"{system}:")
         self.print_package_comparison(results)
 
     return 0
@@ -4067,8 +4020,7 @@ def do_system_syncpackages(self, args):
             options.start_time = parse_time_input(options.start_time)
 
     # show a comparison and ask for confirmation
-    # pylint: disable-next=consider-using-f-string
-    self.do_system_comparepackages("%s %s" % (source_id, target_id))
+    self.do_system_comparepackages(f"{source_id} {target_id}")
 
     print("")
     print(_("Start Time: %s") % options.start_time)
@@ -4143,19 +4095,16 @@ def print_comparison_withchannel(
     tmp_system = []
     tmp_channel = []
     for item in results:
-        # pylint: disable-next=consider-using-f-string
-        name_string = "%(name)s.%(arch)s" % item
+        name_string = f"{item['name']}.{item['arch']}"
         tmp_names.append(name_string)
         # Create two version-string lists, one for the version in the results
         # list, and another with the version string from the channel_latest
         # dict, if the channel contains a matching package
-        # pylint: disable-next=consider-using-f-string
-        version_string = "%(version)s-%(release)s" % item
+        version_string = f"{item['version']}-{item['release']}"
         tmp_system.append(version_string)
         key = item["name"], item["arch"]
         if key in channel_latest:
-            # pylint: disable-next=consider-using-f-string
-            version_string = "%(version)s-%(release)s" % channel_latest[key]
+            version_string = f"{channel_latest[key]['version']}-{channel_latest[key]['release']}"
             tmp_channel.append(version_string)
 
     max_name = max_length(tmp_names, minimum=7)
@@ -4165,80 +4114,57 @@ def print_comparison_withchannel(
 
     # print(headers)
     print(
-        # pylint: disable-next=consider-using-f-string
-        "%s  %s  %s  %s"
-        % (
-            _("Package").ljust(max_name),
-            _("System Version").ljust(max_system),
-            _("Channel Version").ljust(max_channel),
-            _("Difference").ljust(max_comparison),
-        )
+        f"{_('Package').ljust(max_name)}  "
+        f"{_('System Version').ljust(max_system)}  "
+        f"{_('Channel Version').ljust(max_channel)}  "
+        f"{_('Difference').ljust(max_comparison)}"
     )
 
     print(
-        # pylint: disable-next=consider-using-f-string
-        "%s  %s  %s  %s"
-        % ("-" * max_name, "-" * max_system, "-" * max_channel, "-" * max_comparison)
+        f"{'-' * max_name}  "
+        f"{'-' * max_system}  "
+        f"{'-' * max_channel}  "
+        f"{'-' * max_comparison}"
     )
 
     # Then print(the packages)
     for item in channelnewer:
-        # pylint: disable-next=consider-using-f-string
-        name_string = "%(name)s.%(arch)s" % item
-        # pylint: disable-next=consider-using-f-string
-        version_string = "%(version)s-%(release)s" % item
+        name_string = f"{item['name']}.{item['arch']}"
+        version_string = f"{item['version']}-{item['release']}"
         key = item["name"], item["arch"]
         if key in channel_latest:
-            # pylint: disable-next=consider-using-f-string
-            channel_version = "%(version)s-%(release)s" % channel_latest[key]
+            channel_version = f"{channel_latest[key]['version']}-{channel_latest[key]['release']}"
         else:
             channel_version = "-"
         print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  %s  %s"
-            % (
-                name_string.ljust(max_name),
-                version_string.ljust(max_system),
-                channel_version.ljust(max_channel),
-                _("Channel_newer_than_system").ljust(max_comparison),
-            )
+            f"{name_string.ljust(max_name)}  "
+            f"{version_string.ljust(max_system)}  "
+            f"{channel_version.ljust(max_channel)}  "
+            f"{_('Channel_newer_than_system').ljust(max_comparison)}"
         )
     for item in systemnewer:
-        # pylint: disable-next=consider-using-f-string
-        name_string = "%(name)s.%(arch)s" % item
-        # pylint: disable-next=consider-using-f-string
-        version_string = "%(version)s-%(release)s" % item
+        name_string = f"{item['name']}.{item['arch']}"
+        version_string = f"{item['version']}-{item['release']}"
         key = item["name"], item["arch"]
         if key in channel_latest:
-            # pylint: disable-next=consider-using-f-string
-            channel_version = "%(version)s-%(release)s" % channel_latest[key]
+            channel_version = f"{channel_latest[key]['version']}-{channel_latest[key]['release']}"
         else:
             channel_version = "-"
         print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  %s  %s"
-            % (
-                name_string.ljust(max_name),
-                version_string.ljust(max_system),
-                channel_version.ljust(max_channel),
-                _("System_newer_than_channel").ljust(max_comparison),
-            )
+            f"{name_string.ljust(max_name)}  "
+            f"{version_string.ljust(max_system)}  "
+            f"{channel_version.ljust(max_channel)}  "
+            f"{_('System_newer_than_channel').ljust(max_comparison)}"
         )
     for item in channelmissing:
-        # pylint: disable-next=consider-using-f-string
-        name_string = "%(name)s.%(arch)s" % item
-        # pylint: disable-next=consider-using-f-string
-        version_string = "%(version)s-%(release)s" % item
+        name_string = f"{item['name']}.{item['arch']}"
+        version_string = f"{item['version']}-{item['release']}"
         channel_version = "-"
         print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  %s  %s"
-            % (
-                name_string.ljust(max_name),
-                version_string.ljust(max_system),
-                channel_version.ljust(max_channel),
-                _("Missing_in_channel").ljust(max_comparison),
-            )
+            f"{name_string.ljust(max_name)}  "
+            f"{version_string.ljust(max_system)}  "
+            f"{channel_version.ljust(max_channel)}  "
+            f"{_('Missing_in_channel').ljust(max_comparison)}"
         )
 
 
@@ -4288,17 +4214,13 @@ def do_system_comparewithchannel(self, args):
 
         instpkgs = self.client.system.listPackages(self.session, system_id)
         logging.debug(
-            # pylint: disable-next=consider-using-f-string
-            "Got %d packages installed in system %s"
-            % (len(instpkgs), system)
+            f"Got {len(instpkgs)} packages installed in system {system}"
         )
         # We need to filter to get only the latest installed packages,
         # because multiple versions (e.g kernel) can be installed
         packages = filter_latest_packages(instpkgs)
         logging.debug(
-            # pylint: disable-next=consider-using-f-string
-            "Got latest %d packages installed in system %s"
-            % (len(packages.keys()), system)
+            f"Got latest {len(packages.keys())} packages installed in system {system}"
         )
 
         channels = []
@@ -4311,8 +4233,7 @@ def do_system_comparewithchannel(self, args):
                 self.help_system_comparewithchannel()
                 return None
             channels = [options.channel]
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("User specified channel %s" % options.channel)
+            logging.debug(f"User specified channel {options.channel}")
         else:
             # No specified channel, so we create a list of all channels the
             # system is subscribed to
@@ -4330,8 +4251,7 @@ def do_system_comparewithchannel(self, args):
                     )
                 )
                 return 1
-            # pylint: disable-next=consider-using-f-string
-            logging.debug("base channel %s for %s" % (basech["name"], system))
+            logging.debug(f"base channel {basech['name']} for {system}")
             childch = self.client.system.listSubscribedChildChannels(
                 self.session, system_id
             )
@@ -4343,8 +4263,7 @@ def do_system_comparewithchannel(self, args):
         latestpkgs = {}
         for c in channels:
             if c not in channel_latest:
-                # pylint: disable-next=consider-using-f-string
-                logging.debug("Getting packages for channel %s" % c)
+                logging.debug(f"Getting packages for channel {c}")
                 pkgs = self.client.channel.software.listAllPackages(self.session, c)
                 # filter_latest_packages Returns a dict of latest packages
                 # indexed by name,arch tuple, which we add to the dict-of-dict
@@ -4580,16 +4499,12 @@ def do_system_show_packageversion(self, args):
         for pkg in instpkgs:
             if pkg.get("name") == searchpkg:
                 print(
-                    # pylint: disable-next=consider-using-f-string
-                    "%s\t%s\t%s\t%s\t%s\t%s"
-                    % (
-                        pkg.get("name"),
-                        pkg.get("version"),
-                        pkg.get("release"),
-                        pkg.get("epoch"),
-                        pkg.get("arch_label"),
-                        system,
-                    )
+                    f"{pkg.get('name')}\t"
+                    f"{pkg.get('version')}\t"
+                    f"{pkg.get('release')}\t"
+                    f"{pkg.get('epoch')}\t"
+                    f"{pkg.get('arch_label')}\t"
+                    f"{system}"
                 )
 
     return 0
@@ -5014,8 +4929,7 @@ def do_system_bootstrap(self, args):
         args.append(int(options.proxyid))
     args.append(options.saltssh)
 
-    # pylint: disable-next=consider-using-f-string
-    print(_("Bootstrapping '{}'. This may take a while.".format(options.hostname)))
+    print(_(f"Bootstrapping '{options.hostname}'. This may take a while."))
     if options.ssh_password:
         self.client.system.bootstrap(
             self.session,
@@ -5101,23 +5015,15 @@ def do_system_needrebootafterupdate(self, args, short=False):
 
         if system_needs_reboot:
             if self.options.quiet:
-                # pylint: disable-next=consider-using-f-string
-                print("{}: 1".format(system))
+                print(f"{system}: 1")
             else:
-                # pylint: disable-next=consider-using-f-string
-                print(_("System '{}' needs to be rebooted after update".format(system)))
+                print(_(f"System '{system}' needs to be rebooted after update"))
         else:
             if self.options.quiet:
-                # pylint: disable-next=consider-using-f-string
-                print("{}: 0".format(system))
+                print(f"{system}: 0")
             else:
                 print(
-                    _(
-                        # pylint: disable-next=consider-using-f-string
-                        "No reboot needed for system '{}' after applying available updates".format(
-                            system
-                        )
-                    )
+                    _(f"No reboot needed for system '{system}' after applying available updates")
                 )
     return 0
 

--- a/spacecmd/src/spacecmd/user.py
+++ b/spacecmd/src/spacecmd/user.py
@@ -384,12 +384,7 @@ def do_user_details(self, args):
             )
         except xmlrpclib.Fault as exc:
             logging.warning(_N("%s is not a valid user") % user)
-            logging.debug(
-                # pylint: disable-next=consider-using-f-string
-                "Error '{}' while getting data about user '{}': {}".format(
-                    exc.faultCode, user, exc.faultString
-                )
-            )
+            logging.debug(f"Error '{exc.faultCode}' while getting data about user '{user}': {exc.faultString}")
             continue
 
         org_name = self.client.org.getDetails(self.session, details.get("org_id")).get(

--- a/spacecmd/src/spacecmd/utils.py
+++ b/spacecmd/src/spacecmd/utils.py
@@ -130,8 +130,7 @@ def is_interactive(options):
 
 def load_cache(cachefile):
     data = {}
-    # pylint: disable-next=consider-using-f-string
-    cachefile = "{}.json".format(cachefile)
+    cachefile = f"{cachefile}.json"
     expire = datetime.now()
 
     logging.debug("Loading cache from %s", cachefile)
@@ -175,16 +174,12 @@ def save_cache(cachefile, data, expire=None):
         except ValueError:
             # pylint: disable-next=raise-missing-from
             raise ValueError(
-                # pylint: disable-next=consider-using-f-string
-                "Provided expire parameter must conform to {}".format(
-                    _CACHE_DATE_FORMAT
-                )
+                f"Provided expire parameter must conform to {_CACHE_DATE_FORMAT}"
             )
 
     if expire:
         data["expire"] = expire
-    # pylint: disable-next=consider-using-f-string
-    cachefile = "{}.json".format(cachefile)
+    cachefile = f"{cachefile}.json"
 
     try:
         with open(cachefile, "w", encoding="utf-8") as f:
@@ -295,13 +290,11 @@ def prompt_user(prompt, noblank=False, multiline=False):
                     # python 2 must call raw_input() because input()
                     # also evaluates the user input and that causes
                     # problems.
-                    # pylint: disable-next=consider-using-f-string
-                    userinput = raw_input("%s " % prompt)
+                    userinput = raw_input(f"{prompt} ")
                 except NameError:
                     # python 3 replaced raw_input() with input()...
                     # it no longer evaulates the user input.
-                    # pylint: disable-next=consider-using-f-string
-                    userinput = input("%s " % prompt)
+                    userinput = input(f"{prompt} ")
             if noblank:
                 if userinput != "":
                     break
@@ -337,8 +330,7 @@ def parse_time_input(userinput=""):
             # YYYYMMDD
             if not match.group(4) and not match.group(5):
                 timestamp = time.strptime(
-                    # pylint: disable-next=consider-using-f-string
-                    "%s%s%s" % (match.group(1), match.group(2), match.group(3)),
+                    f"{match.group(1)}{match.group(2)}{match.group(3)}",
                     date_format,
                 )
             # YYYYMMDDHH
@@ -346,9 +338,7 @@ def parse_time_input(userinput=""):
                 date_format += "%H"
 
                 timestamp = time.strptime(
-                    # pylint: disable-next=consider-using-f-string
-                    "%s%s%s%s"
-                    % (match.group(1), match.group(2), match.group(3), match.group(4)),
+                    f"{match.group(1)}{match.group(2)}{match.group(3)}{match.group(4)}",
                     date_format,
                 )
             # YYYYMMDDHHMM
@@ -356,15 +346,7 @@ def parse_time_input(userinput=""):
                 date_format += "%H%M"
 
                 timestamp = time.strptime(
-                    # pylint: disable-next=consider-using-f-string
-                    "%s%s%s%s%s"
-                    % (
-                        match.group(1),
-                        match.group(2),
-                        match.group(3),
-                        match.group(4),
-                        match.group(5),
-                    ),
+                    f"{match.group(1)}{match.group(2)}{match.group(3)}{match.group(4)}{match.group(5)}",
                     date_format,
                 )
             # YYYYMMDDHHMMSS
@@ -372,16 +354,7 @@ def parse_time_input(userinput=""):
                 date_format += "%H%M%S"
 
                 timestamp = time.strptime(
-                    # pylint: disable-next=consider-using-f-string
-                    "%s%s%s%s%s%s"
-                    % (
-                        match.group(1),
-                        match.group(2),
-                        match.group(3),
-                        match.group(4),
-                        match.group(5),
-                        match.group(6),
-                    ),
+                    f"{match.group(1)}{match.group(2)}{match.group(3)}{match.group(4)}{match.group(5)}{match.group(6)}",
                     date_format,
                 )
             if timestamp:
@@ -458,30 +431,22 @@ def build_package_name(package):
     Args:
       packages: A single package object.
     """
-    # pylint: disable-next=consider-using-f-string
-    name = "{name}-{version}-{release}".format(
-        name=package.get("name"),
-        version=package.get("version"),
-        release=package.get("release"),
-    )
+    name = f"{package.get('name')}-{package.get('version')}-{package.get('release')}"
     epoch = package.get("epoch", "").strip()
     # NOTE: normally it's "name-epoch:version-release.arch", but in spacecmd
     # "name-version-release:epoch.arch" is used. Such strings can be supplied
     # by users, therefore we need to stick to it.
     if epoch:
-        # pylint: disable-next=consider-using-f-string
-        name += ":{epoch}".format(epoch=epoch)
+        name += f":{epoch}"
 
     arch = package.get("arch", "").strip()
     arch_label = package.get("arch_label", "").strip()
     if arch:
         # system.listPackages uses AMD64 instead of x86_64
         arch = re.sub("amd64", "x86_64", arch.lower())
-        # pylint: disable-next=consider-using-f-string
-        name += ".{arch}".format(arch=arch)
+        name += f".{arch}"
     elif arch_label:
-        # pylint: disable-next=consider-using-f-string
-        name += ".{arch}".format(arch=arch_label)
+        name += f".{arch_label}"
 
     return name
 
@@ -524,14 +489,10 @@ def print_errata_summary(erratum):
         erratum["date"] = date_parts[0]
 
     print(
-        # pylint: disable-next=consider-using-f-string
-        "%s  %s  %s  %s"
-        % (
-            erratum.get("advisory_name").ljust(14),
-            wrap(erratum.get("advisory_synopsis"), 49)[0].ljust(49),
-            (erratum.get("advisory_status") or "").ljust(9),
-            erratum.get("date").rjust(8),
-        )
+        f"{erratum.get('advisory_name').ljust(14)}  "
+        f"{wrap(erratum.get('advisory_synopsis'), 49)[0].ljust(49)}  "
+        f"{(erratum.get('advisory_status') or '').ljust(9)}  "
+        f"{erratum.get('date').rjust(8)}"
     )
 
 
@@ -588,8 +549,7 @@ def config_channel_order(all_channels=None, new_channels=None):
         print(_("Current Selections"))
         print("------------------")
         for i, new_channel in enumerate(new_channels, 1):
-            # pylint: disable-next=consider-using-f-string
-            print("%i. %s" % (i, new_channel))
+            print(f"{i}. {new_channel}")
 
         print("")
         action = prompt_user("a[dd], r[emove], c[lear], d[one]:")

--- a/spacecmd/tests/helpers.py
+++ b/spacecmd/tests/helpers.py
@@ -77,10 +77,7 @@ def assert_expect(calls, *expectations):
     expectations = list(expectations)
     for call in calls:
         expectation = next(iter(expectations))
-        # pylint: disable-next=consider-using-f-string
-        assert call[0][0] == expectation, "Expected '{}', got '{}'".format(
-            expectation, call[0][0]
-        )
+        assert call[0][0] == expectation, f"Expected '{expectation}', got '{call[0][0]}'"
         expectations.pop(0)
     assert not expectations
 
@@ -116,10 +113,8 @@ def assert_args_expect(calls, expectations):
         args, kw = call
         # pylint: disable-next=invalid-name,invalid-name
         _args, _kw = next(iter(expectations))
-        # pylint: disable-next=consider-using-f-string
-        assert args == _args, "{} is not as expected {}".format(str(args), str(_args))
-        # pylint: disable-next=consider-using-f-string
-        assert kw == _kw, "{} is not as expected {}".format(str(kw), str(_kw))
+        assert args == _args, f"{args} is not as expected {_args}"
+        assert kw == _kw, f"{kw} is not as expected {_kw}"
         expectations.pop(0)
     assert not expectations
 

--- a/spacecmd/tests/test_errata.py
+++ b/spacecmd/tests/test_errata.py
@@ -1280,8 +1280,7 @@ class TestSCErrata:
         shell.get_system_id = (
             lambda data: zlib.adler32(data.encode("utf-8")) & 0xFFFFFFFF
         )
-        # pylint: disable-next=unnecessary-lambda,consider-using-f-string
-        shell.get_erratum_name = lambda data: "CVE-{}-name".format(data)
+        shell.get_erratum_name = lambda data: f"CVE-{data}-name"
         shell.expand_errata = MagicMock(return_value=["CVE-1", "CVE-2"])
         shell.client.errata.listAffectedSystems = MagicMock(
             side_effect=[
@@ -1376,8 +1375,7 @@ class TestSCErrata:
         shell.get_system_id = (
             lambda data: zlib.adler32(data.encode("utf-8")) & 0xFFFFFFFF
         )
-        # pylint: disable-next=unnecessary-lambda,consider-using-f-string
-        shell.get_erratum_name = lambda data: "CVE-{}-name".format(data)
+        shell.get_erratum_name = lambda data: f"CVE-{data}-name"
         shell.expand_errata = MagicMock(return_value=["CVE-1", "CVE-2"])
         shell.client.errata.listAffectedSystems = MagicMock(
             side_effect=[

--- a/spacecmd/tests/test_group.py
+++ b/spacecmd/tests/test_group.py
@@ -355,9 +355,7 @@ class TestSCGroup:
         prompter = MagicMock(return_value=msg)
 
         with patch("spacecmd.group.prompt_user", prompter):
-            # pylint: disable-next=consider-using-f-string
-            spacecmd.group.do_group_create(shell, "Jeff {}".format(msg))
-
+            spacecmd.group.do_group_create(shell, f"Jeff {msg}")
         assert not prompter.called
         assert shell.client.systemgroup.create.called
 

--- a/spacecmd/tests/test_kickstart.py
+++ b/spacecmd/tests/test_kickstart.py
@@ -208,10 +208,8 @@ class TestSCKickStart:
             # pylint: disable-next=unused-variable,unused-variable
         ) as lgr, patch("spacecmd.kickstart.prompt_user", prompter) as pmt:
             spacecmd.kickstart.do_kickstart_clone(
-                # pylint: disable-next=consider-using-f-string
                 shell,
-                # pylint: disable-next=consider-using-f-string
-                "-n {} -c {}".format(name, clone),
+                f"-n {name} -c {clone}",
             )
 
         assert not prompter.called

--- a/spacecmd/tests/test_package.py
+++ b/spacecmd/tests/test_package.py
@@ -616,10 +616,8 @@ class TestSCPackage:
                 # pylint: disable-next=unused-variable
             ) as lgr:
                 out = spacecmd.package.do_package_search(
-                    # pylint: disable-next=consider-using-f-string
                     shell,
-                    # pylint: disable-next=consider-using-f-string
-                    "{}emacs*".format(field),
+                    f"{field}emacs*",
                     doreturn=True,
                 )
 
@@ -627,7 +625,7 @@ class TestSCPackage:
             assert logger.debug.called
             assert shell.client.packages.search.advanced.called
             assert out is not None
-
+            
     # pylint: disable-next=redefined-outer-name
     def test_package_remove_noarg(self, shell):
         """

--- a/spacecmd/tests/test_shell.py
+++ b/spacecmd/tests/test_shell.py
@@ -34,8 +34,7 @@ class TestSCShell:
         Test shell delimieters are set without hyphens
         or colons during the tab completion.
         """
-        # pylint: disable-next=consider-using-f-string
-        cfg_dir = "/tmp/shell/{}/conf".format(int(time.time()))
+        cfg_dir = f"/tmp/shell/{int(time.time())}/conf"
         m_logger = MagicMock()
 
         cpl_setter = MagicMock()
@@ -47,8 +46,7 @@ class TestSCShell:
             options.nohistory = True
             shell = SpacewalkShell(options, cfg_dir, None)
 
-            # pylint: disable-next=consider-using-f-string
-            assert shell.history_file == "{}/history".format(cfg_dir)
+            assert shell.history_file == f"{cfg_dir}/history"
             assert not m_logger.error.called
             assert cpl_setter.call_args[0][0] != readline.get_completer_delims()
             assert cpl_setter.call_args[0][0] == " \t\n`~!@#$%^&*()=+[{]}\\|;'\",<>?"
@@ -67,8 +65,7 @@ class TestSCShell:
         """
         Test shell no history file should capture IOError and log it.
         """
-        # pylint: disable-next=consider-using-f-string
-        cfg_dir = "/tmp/shell/{}/conf".format(int(time.time()))
+        cfg_dir = f"/tmp/shell/{int(time.time())}/conf"
         m_logger = MagicMock()
         # pylint: disable-next=unused-variable
         cpl_setter = MagicMock()
@@ -77,8 +74,7 @@ class TestSCShell:
             options.nohistory = False
             shell = SpacewalkShell(options, cfg_dir, None)
 
-            # pylint: disable-next=consider-using-f-string
-            assert shell.history_file == "{}/history".format(cfg_dir)
+            assert shell.history_file == f"{cfg_dir}/history"
             assert not os.path.exists(shell.history_file)
             assert m_logger.error.call_args[0][0] == "Could not read history file"
 

--- a/spacecmd/tests/test_utils.py
+++ b/spacecmd/tests/test_utils.py
@@ -55,10 +55,9 @@ class TestSCUtilsCacheIntegration:
         spacecmd.utils.save_cache(
             cachefile=self.cachefile, data=self.data, expire=self.expiration
         )
-        # pylint: disable-next=consider-using-f-string
-        assert os.path.exists("{}.json".format(self.cachefile))
-        # pylint: disable-next=unspecified-encoding,consider-using-f-string
-        with open("{}.json".format(self.cachefile), "r") as f:
+        assert os.path.exists(f"{self.cachefile}.json")
+        # pylint: disable-next=unspecified-encoding
+        with open(f"{self.cachefile}.json", "r") as f:
             out = json.loads(f.read())
 
         assert "expire" in out
@@ -89,8 +88,7 @@ class TestSCUtilsCacheIntegration:
                 (
                     (
                         "Couldn't write to %s",
-                        # pylint: disable-next=consider-using-f-string
-                        "{}.json".format(self.cachefile),
+                        f"{self.cachefile}.json",
                     ),
                     {},
                 )
@@ -107,8 +105,7 @@ class TestSCUtilsCacheIntegration:
             cachefile=self.cachefile, data=self.data, expire=self.expiration
         )
 
-        # pylint: disable-next=consider-using-f-string
-        assert os.path.exists("{}.json".format(self.cachefile))
+        assert os.path.exists(f"{self.cachefile}.json")
 
         out, expiration = spacecmd.utils.load_cache(self.cachefile)
 
@@ -131,8 +128,7 @@ class TestSCUtilsCacheIntegration:
         assert out == {}
         # pylint: disable-next=bad-chained-comparison
         assert expiration != self.expiration is not None
-        # pylint: disable-next=consider-using-f-string
-        assert not os.path.exists("{}.json".format(self.cachefile))
+        assert not os.path.exists(f"{self.cachefile}.json")
 
 
 class TestSCUtils:


### PR DESCRIPTION
## What does this PR change?

The spacecmd codebase had pylint's `consider-using-f-string` warnings suppressed
on a per-line basis instead of actually fixing them. This PR does the conversion
for real — all `.format()` and `%`-style formatting that was flagged gets converted
to f-strings, and the suppression comments are removed.

Covers both source files in `spacecmd/src/spacecmd/` and test files in `spacecmd/tests/`.

No logic changes, just string formatting cleanup.

## GUI diff

N/A — spacecmd is a CLI tool, no GUI involved.

- [x] **DONE**

## Documentation

No documentation needed.

- [x] **DONE**

## Test coverage

All existing `spacecmd_unittests` pass. No new tests needed since this is a
formatting-only refactor.

- [x] **DONE**

## Links

No related issue — this is a code quality cleanup.

- [x] **DONE**

## Changelogs

- [x] No changelog needed