### PR TITLE
python/spacewalk/server/rhnSQL/dbi.py: remove unnecessary try-except-raise

### DIFF
--- a/python/spacewalk/server/rhnSQL/dbi.py
+++ b/python/spacewalk/server/rhnSQL/dbi.py
@@ -34,15 +34,9 @@ def get_database_module(backend=None):
 
     driver_dir = "spacewalk.server.rhnSQL"
     driver_mod = "driver_" + driver
-    try:
-        module = __import__(driver_dir, globals(), locals(), [driver_mod])
-        module = getattr(module, driver_mod)
-    # pylint: disable-next=try-except-raise
-    except ImportError:
-        raise
-
+    module = __import__(driver_dir, globals(), locals(), [driver_mod])
+    module = getattr(module, driver_mod)
     return module
-
 
 def get_database_class(backend=None):
     """Returns the database class"""


### PR DESCRIPTION
## What does this PR change?

Removes a redundant `try-except-raise` block in `get_database_module()`.

The existing code catches `ImportError` and immediately re-raises it,
which is equivalent to not having the try/except at all. Removing it
resolves the `pylint: disable-next=try-except-raise` suppression comment.

## GUI diff

N/A — backend Python module, no GUI involved.

- [x] **DONE**

## Documentation

No documentation needed.

- [x] **DONE**

## Test coverage

No logic change — the exception propagation behavior is identical
with or without the bare re-raise.

- [x] **DONE**

## Links

Follow-up to feedback from @m-czernek on #11592, focusing on
resolvable pylint disable comments in the `python/` directory.

- [x] **DONE**

## Changelogs

- [x] No changelog needed