### PR TITLE
Fix mixed up tomcat and tasko JMX metrics ports

### DIFF
--- a/containers/server-helm/templates/ingress.yaml
+++ b/containers/server-helm/templates/ingress.yaml
@@ -339,14 +339,14 @@ spec:
           service:
             name: taskomatic
             port:
-              number: 5556
+              number: 5557
         pathType: Prefix
       - path: /tomcat-jmx
         backend:
           service:
             name: tomcat
             port:
-              number: 5557
+              number: 5556
         pathType: Prefix
   {{- end }}
   {{- if .Values.saline.enable }}

--- a/containers/server-helm/templates/routes.yaml
+++ b/containers/server-helm/templates/routes.yaml
@@ -132,7 +132,7 @@ spec:
             path: { type: ReplacePrefixMatch, replacePrefixMatch: / }
       backendRefs:
         - name: tomcat
-          port: 5557
+          port: 5556
     
     # Taskomatic Monitoring Exporter
     - matches:
@@ -154,7 +154,7 @@ spec:
             path: { type: ReplacePrefixMatch, replacePrefixMatch: / }
       backendRefs:
         - name: taskomatic
-          port: 5556
+          port: 5557
     {{- end }}
     {{- if .Values.saline.enable }}
     - matches:

--- a/containers/server-helm/templates/services.yaml
+++ b/containers/server-helm/templates/services.yaml
@@ -138,9 +138,9 @@ spec:
   ports:
 {{- if ne .Values.enableMonitoring false }}
     - name: jmx
-      port: 5556
+      port: 5557
       protocol: TCP
-      targetPort: 5556
+      targetPort: 5557
     - name: mtrx
       port: 9800
       protocol: TCP
@@ -208,9 +208,9 @@ spec:
       targetPort: 9100
 {{- if ne .Values.enableMonitoring false }}
     - name: jmx
-      port: 5557
+      port: 5556
       protocol: TCP
-      targetPort: 5557
+      targetPort: 5556
     - name: pgsql-exporter
       port: 9187
       protocol: TCP

--- a/containers/server-helm/tests/gateway_test.yaml
+++ b/containers/server-helm/tests/gateway_test.yaml
@@ -262,7 +262,7 @@ tests:
                     replacePrefixMatch: /
             backendRefs:
               - name: tomcat
-                port: 5557
+                port: 5556
           any: true
         template: routes.yaml
         documentSelector:
@@ -284,7 +284,7 @@ tests:
                     replacePrefixMatch: /
             backendRefs:
               - name: taskomatic
-                port: 5556
+                port: 5557
           any: true
         template: routes.yaml
         documentSelector:

--- a/containers/server-helm/tests/ingress_test.yaml
+++ b/containers/server-helm/tests/ingress_test.yaml
@@ -235,7 +235,7 @@ tests:
               service:
                 name: taskomatic
                 port:
-                  number: 5556
+                  number: 5557
         documentSelector:
           path: metadata.name
           value: "uyuni-ingress-nossl"
@@ -248,7 +248,7 @@ tests:
               service:
                 name: tomcat
                 port:
-                  number: 5557
+                  number: 5556
         documentSelector:
           path: metadata.name
           value: "uyuni-ingress-nossl"

--- a/containers/server-helm/tests/ports_test.yaml
+++ b/containers/server-helm/tests/ports_test.yaml
@@ -20,9 +20,9 @@ tests:
           path: spec.ports
           content:
             name: jmx
-            port: 5556
+            port: 5557
             protocol: TCP
-            targetPort: 5556
+            targetPort: 5557
         template: services.yaml
         documentSelector:
           path: metadata.name
@@ -93,9 +93,9 @@ tests:
           path: spec.ports
           content:
             name: jmx
-            port: 5556
+            port: 5557
             protocol: TCP
-            targetPort: 5556
+            targetPort: 5557
         template: services.yaml
         documentSelector:
           path: metadata.name

--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -150,14 +150,14 @@ ProxyPassReverse "/tasko-exporter" "http://localhost:9800"
   ErrorDocument 502 "Taskomatic exporter is not available"
 </Location>
 
-ProxyPass "/tasko-jmx" "http://localhost:5556"
-ProxyPassReverse "/tasko-jmx" "http://localhost:5556"
+ProxyPass "/tasko-jmx" "http://localhost:5557"
+ProxyPassReverse "/tasko-jmx" "http://localhost:5557"
 <Location /tasko-jmx>
   ErrorDocument 502 "Taskomatic JMX exporter is not available"
 </Location>
 
-ProxyPass "/tomcat-jmx" "http://localhost:5557"
-ProxyPassReverse "/tomcat-jmx" "http://localhost:5557"
+ProxyPass "/tomcat-jmx" "http://localhost:5556"
+ProxyPassReverse "/tomcat-jmx" "http://localhost:5556"
 <Location /tomcat-jmx>
   ErrorDocument 502 "Tomcat JMX exporter is not available"
 </Location>


### PR DESCRIPTION
## What does this PR change?

The tomcat and taskomatic JMX metrics port have been exchanged: route them correctly again in the helm chart and the apache config.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: nothing using the different data yet in our dashboards

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
