### PR TITLE
Fix billing-data-service crashing on concurrent requests  (bsc#1252927)

### DIFF
--- a/python/billingdataservice/billing-data-service.changes.kwalter.bsc1252927
+++ b/python/billingdataservice/billing-data-service.changes.kwalter.bsc1252927
@@ -1,0 +1,1 @@
+- Fix billing-data-service crashing (bsc#1252927)

--- a/python/billingdataservice/billingdataservice.py
+++ b/python/billingdataservice/billingdataservice.py
@@ -11,6 +11,7 @@
 
 import os
 import json
+import threading
 from flask import Flask, abort
 from spacewalk.server import rhnSQL
 from spacewalk.common.rhnConfig import initCFG
@@ -23,6 +24,7 @@ from spacewalk.common.rhnConfig import initCFG
 # cli.show_server_banner = lambda *_: None
 
 app = Flask(__name__)
+db_lock = threading.Lock()
 
 if os.environ.get("TESTING", "0") != "1":
     initCFG("server.susemanager")
@@ -31,16 +33,16 @@ if os.environ.get("TESTING", "0") != "1":
 
 @app.route("/")
 def index():
-    result = rhnSQL.fetchone_dict(
-        rhnSQL.Statement("select '1' || '2' || '3' as testing from dual")
-    )
+    with db_lock:
+        result = rhnSQL.fetchone_dict(
+            rhnSQL.Statement("select '1' || '2' || '3' as testing from dual")
+        )
     if result:
         return "online"
     abort(503)  # Service Unavailable
 
 
-_query_metering_data = rhnSQL.Statement(
-    """
+_query_metering_data = rhnSQL.Statement("""
     SELECT r.dimension usage_metric, r.count
       FROM susePaygDimensionResult r
      WHERE r.computation_id = (SELECT c.id
@@ -48,13 +50,13 @@ _query_metering_data = rhnSQL.Statement(
                                 WHERE c.success = true
                              ORDER BY c.timestamp DESC
                                 LIMIT 1)
-"""
-)
+""")
 
 
 @app.route("/metering")
 def metering():
-    h = rhnSQL.prepare(_query_metering_data)
-    h.execute()
-    result = h.fetchall_dict() or []
+    with db_lock:
+        h = rhnSQL.prepare(_query_metering_data)
+        h.execute()
+        result = h.fetchall_dict() or []
     return json.dumps({"usage_metrics": result})


### PR DESCRIPTION
## What does this PR change?

This PR fixes a crash caused by concurrent requests using the same database connection. A lock has been added to prevent this.


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests:

- [x] **DONE**

Issue: https://github.com/SUSE/spacewalk/issues/29128

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
