### PR TITLE
QE: pick IPv6 interface for PXE boot from node attributes

### DIFF
--- a/testsuite/features/support/retail.rb
+++ b/testsuite/features/support/retail.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 SUSE LLC
+# Copyright (c) 2023-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # This function returns the net prefix, caching it
@@ -99,11 +99,12 @@ def execute_expect_command_proxy(host, exp_file, context)
   mac = mac.tr(':', '')
   eui64_base = "#{mac[0..5]}fffe#{mac[6..11]}"
   hex = (eui64_base.to_i(16) ^ 0x0200000000000000).to_s(16)
-  interface = product == 'Uyuni' ? 'ens4' : 'eth1'
-  ipv6 = "fe80::#{hex[0..3]}:#{hex[4..7]}:#{hex[8..11]}:#{hex[12..15]}%#{interface}"
+
+  proxy = get_target('proxy')
+  ipv6 = "fe80::#{hex[0..3]}:#{hex[4..7]}:#{hex[8..11]}:#{hex[12..15]}%#{proxy.private_interface}"
   source = "#{File.dirname(__FILE__)}/../upload_files/#{exp_file}"
   dest = "/tmp/#{exp_file}"
-  success = file_inject(get_target('proxy'), source, dest)
+  success = file_inject(proxy, source, dest)
   raise ScriptError, 'File injection failed' unless success
 
   get_target('proxy').run("expect -f /tmp/#{exp_file} #{ipv6} #{context}")


### PR DESCRIPTION
## What does this PR change?

It seems we can no longer rely on the assumption that we will have a network interface named **ens4** on the Uyuni proxy and **eth1** on all SUSE Manager proxies.
E.G. The newly added SL Micro 6.2 OS uses **ens4** as well.

However, we already pick up what the private network interface of the proxy is when initializing the corresponding node https://github.com/NamelessOne91/uyuni/blob/master/testsuite/features/support/remote_node.rb#L57
So it should just be enough to read it here.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): #
Port(s):  

- 5.1 https://github.com/SUSE/spacewalk/pull/30085
- 5.0 https://github.com/SUSE/spacewalk/pull/30086
- 4.3 https://github.com/SUSE/spacewalk/pull/30087

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"