### PR TITLE
Add formula metadata for managing custom GPG keys

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.pratik.gpg-keys
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.pratik.gpg-keys
@@ -1,0 +1,3 @@
+- Add formula metadata for managing custom GPG keys
+  * Expose custom_gpgkeys pillar in formula UI
+  * Improve usability for managing GPG keys via Uyuni

--- a/susemanager-utils/susemanager-sls/test/data/formulas/metadata/gpg-keys/form.yml
+++ b/susemanager-utils/susemanager-sls/test/data/formulas/metadata/gpg-keys/form.yml
@@ -1,0 +1,7 @@
+gpg_keys:
+  $type: group
+
+  custom_gpgkeys:
+    $type: array
+    $name: Custom GPG Keys
+    $help: List of GPG key filenames located in salt://gpg/

--- a/susemanager-utils/susemanager-sls/test/data/formulas/metadata/gpg-keys/metadata.yml
+++ b/susemanager-utils/susemanager-sls/test/data/formulas/metadata/gpg-keys/metadata.yml
@@ -1,0 +1,5 @@
+description:
+  Manage custom GPG keys deployed to clients
+group: software_management
+after:
+  - channels


### PR DESCRIPTION
Summary
-------
This PR introduces formula metadata for managing custom GPG keys.

The formula exposes the existing `custom_gpgkeys` pillar variable used in
`susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls`.

This allows administrators to configure custom GPG keys through the
formula UI instead of manually editing pillar data.

Details
-------
- Added metadata definition for the `gpg-keys` formula
- Added form configuration exposing `custom_gpgkeys`
- Integrates with existing Salt state logic

Related Issue
-------------
Fixes #7966 

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"