### PR TITLE
Add all vendor repo channels to hub access token(bsc#1259230)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -2326,19 +2326,29 @@ public class ChannelFactory extends HibernateFactory {
         String hostname = ConfigDefaults.get().getJavaHostname();
         String channelLabel = channel.getLabel();
 
-        Optional<String> tokenString = SCCEndpoints.buildHubRepositoryToken(channel);
-        if (tokenString.isPresent()) {
-            SCCRepositoryJson repositoryInfo;
-            if (channel.getOrg() != null) {
-                repositoryInfo = SCCEndpoints.buildCustomRepoJson(channelLabel, hostname, tokenString.get());
-            }
-            else {
-                repositoryInfo = SUSEProductFactory.lookupByChannelLabelFirst(channelLabel)
-                        .map(ct -> SCCEndpoints.buildVendorRepoJson(ct, hostname, tokenString.get()))
-                        .orElse(SCCEndpoints.buildCustomRepoJson(channelLabel, hostname, tokenString.get()));
-            }
-            channelInfo.setRepositoryInfo(repositoryInfo);
+        Long oid = Optional.ofNullable(channel.getOrg()).map(Org::getId).orElse(0L);
+        SCCRepositoryJson repositoryInfo;
+        if (channel.getOrg() != null) {
+            String tokenString = SCCEndpoints.buildHubRepositoryToken(Set.of(channel.getLabel()), oid)
+                    .orElse("");
+            repositoryInfo = SCCEndpoints.buildCustomRepoJson(channelLabel, hostname, tokenString);
         }
+        else {
+            repositoryInfo = SUSEProductFactory.lookupByChannelLabelFirst(channelLabel)
+                    .map(ct -> {
+                        Set<String> vendorChannelLabels = new HashSet<>(ct.getRepository().getChannelTemplates()
+                                .stream().map(ChannelTemplate::getChannelLabel).toList());
+                        String tokenString = SCCEndpoints.buildHubRepositoryToken(vendorChannelLabels, 0L)
+                                .orElse("");
+                        return SCCEndpoints.buildVendorRepoJson(ct, hostname, tokenString);
+                    })
+                    .orElseGet(() -> {
+                        String tokenString = SCCEndpoints.buildHubRepositoryToken(Set.of(channel.getLabel()), oid)
+                                .orElse("");
+                        return SCCEndpoints.buildCustomRepoJson(channelLabel, hostname, tokenString);
+                    });
+        }
+        channelInfo.setRepositoryInfo(repositoryInfo);
 
         return channelInfo;
     }

--- a/java/core/src/main/java/com/suse/scc/SCCEndpoints.java
+++ b/java/core/src/main/java/com/suse/scc/SCCEndpoints.java
@@ -60,6 +60,7 @@ import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.util.Base64;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -207,22 +208,21 @@ public class SCCEndpoints {
 
     /**
      * Build and return a short living token for a Hub repository sync
-     * @param channel the channel to the create the token for
+     * @param channelLabels the channel Labels to the create the token for
+     * @param orgId the orgId of the channels. 0 if is a vendor channel
      * @return the token
      */
-    public static Optional<String> buildHubRepositoryToken(Channel channel) {
-        String channelLabel = channel.getLabel();
+    public static Optional<String> buildHubRepositoryToken(Set<String> channelLabels, Long orgId) {
         try {
-            Long oid = Optional.ofNullable(channel.getOrg()).map(Org::getId).orElse(0L);
-            DownloadTokenBuilder builder = new DownloadTokenBuilder(oid)
+            DownloadTokenBuilder builder = new DownloadTokenBuilder(orgId)
                     .usingServerSecret()
                     // Short lived 2 day + 4 hours tokens refreshed on ever sync
                     .expiringAfterMinutes(2L * (24 + 2) * 60)
-                    .allowingOnlyChannels(Set.of(channelLabel));
+                    .allowingOnlyChannels(channelLabels);
             return Optional.of(builder.build().getSerializedForm());
         }
         catch (TokenBuildingException e) {
-            LOG.error("Error creating token for channel: {}", channelLabel, e);
+            LOG.error("Error creating token for channel: {}", channelLabels, e);
             return Optional.empty();
         }
     }
@@ -266,10 +266,19 @@ public class SCCEndpoints {
         var jsonRepos = channels.stream().map(c -> {
             Channel channel = c.getChannel();
             String label = channel.getLabel();
-            String tokenString = buildHubRepositoryToken(channel).orElse("");
+
             return SUSEProductFactory.lookupByChannelLabelFirst(label)
-                    .map(channelTemplate -> buildVendorRepoJson(channelTemplate, hostname, tokenString))
-                    .orElseGet(() -> buildCustomRepoJson(label, hostname, tokenString));
+                    .map(channelTemplate -> {
+                        Set<String> channelLabels = new HashSet<>(channelTemplate.getRepository().getChannelTemplates()
+                                .stream().map(ChannelTemplate::getChannelLabel).toList());
+                        String tokenString = buildHubRepositoryToken(channelLabels, 0L).orElse("");
+                        return buildVendorRepoJson(channelTemplate, hostname, tokenString);
+                    })
+                    .orElseGet(() -> {
+                        Long oid = Optional.ofNullable(channel.getOrg()).map(Org::getId).orElse(0L);
+                        String tokenString = buildHubRepositoryToken(Set.of(channel.getLabel()), oid).orElse("");
+                        return buildCustomRepoJson(label, hostname, tokenString);
+                    });
         }).toList();
         return gson.toJson(jsonRepos);
     }

--- a/java/spacewalk-java.changes.rmateus.Manager-5.1-MU-5.1.1
+++ b/java/spacewalk-java.changes.rmateus.Manager-5.1-MU-5.1.1
@@ -1,0 +1,1 @@
+- Add all vendor repo channels to hub access token(bsc#1259230)


### PR DESCRIPTION
## What does this PR change?

Port of: https://github.com/SUSE/spacewalk/pull/29982

When we look for the channel access, we run the following query (using a channel as example):
```
SELECT r.scc_id, c.*, cl.original_id,
CASE WHEN cl.original_id IS NULL THEN 0 ELSE 1 END AS clazz_
FROM suseSCCRepository r
JOIN suseChannelTemplate ct ON r.id = ct.repo_id
JOIN rhnChannel c on c.label = ct.channel_label
LEFT JOIN rhnChannelCloned cl ON c.id = cl.id
WHERE r.scc_id = 5710
ORDER BY c.label
```

If we run a subset of that query to see the products assigned to those channels, we can get:
```
select * from suseChannelTemplate ct
JOIN suseSCCRepository r ON r.id = ct.repo_id
WHERE r.scc_id = 5710;
```

This returns 5 rows with:

```
                channel_label                 
----------------------------------------------
 scc_id |                channel_label                 
--------+----------------------------------------------
   5710 | sle-module-basesystem15-sp5-pool-x86_64
   5710 | sle-module-basesystem15-sp5-pool-x86_64-sap
   5710 | sle-module-basesystem15-sp5-pool-x86_64-sled
   5710 | sle-module-basesystem15-sp5-pool-x86_64-hpc
   5710 | sle-module-basesystem15-sp5-pool-x86_64-rt

```

The token gives access to a specific channel. The URL is using the SCC ID, which is the same for those 5 channels. When processing the access token, we get the first one, which is `sle-module-basesystem15-sp5-pool-x86_64`, that causes failure in all the other 4 channels when a peripheral tries to synchronize it.

This solution gives access to all channel labels the scc repo can be linked to.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: internal chanes only

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ x] **DONE**

## Links

Issue(s): https://bugzilla.suse.com/show_bug.cgi?id=1259230
Port(s): https://github.com/SUSE/spacewalk/pull/29982

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
