### PR TITLE
Allow read-only users to call logout (bsc#1259471)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/auth/AuthHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/auth/AuthHandler.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.manager.user.UserManager;
 
 import com.suse.manager.api.ApiIgnore;
 import com.suse.manager.api.ApiType;
+import com.suse.manager.api.ReadOnly;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -59,6 +60,9 @@ public class AuthHandler extends BaseHandler {
      * @apidoc.returntype #return_int_success()
      */
     @ApiIgnore(ApiType.HTTP)
+    // logout() actually removes the session, so it changes the state, but we need to annotate it anyway, otherwise
+    // a read-only user won't be able to terminate their session
+    @ReadOnly
     public int logout(String sessionKey) {
         SessionManager.killSession(sessionKey);
         return 1;

--- a/java/spacewalk-java.changes.mackdk.allow-readonly-logout
+++ b/java/spacewalk-java.changes.mackdk.allow-readonly-logout
@@ -1,0 +1,1 @@
+- Allow read-only users to call logout (bsc#1259471)


### PR DESCRIPTION
## What does this PR change?

This PR add the annotation `@ReadOnly` to `AuthHandler#logout()` to prevent the call from failing for read-only users. Although this method is technically state changing (as it invalidates the session), this is needed after the change intruduced by https://github.com/SUSE/spacewalk/commit/ea8def24c571bba389b282773d4a57377168dd11, which correctly set the user for all `AuthHandler` operations.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [X] **DONE**

## Links

Port(s): [5.1](https://github.com/SUSE/spacewalk/pull/30030)

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
