### PR TITLE
Add support for AppArmor profiles in server chart

### DIFF
--- a/containers/server-helm/README.md
+++ b/containers/server-helm/README.md
@@ -96,6 +96,118 @@ The other values in the `gateway` structure may need to be set depending on the 
 
 **Note that on RKE2 1.35 on top of enabling Traefik with Gateway API, the `TLSRoute` and `TCPRoute` CRDs need to be manually added and the Traefik helm chart has to be deployed with the `providers.kubernetesGateway.experimentalChannel`.**
 
+### AppArmor
+
+If the node where the server pod is running has AppArmor, the containerd profile won't let it mount the cgroup2 file system.
+This can be addressed in two different ways.
+The easiest, but unsafe way is to set `server.superPrivileged=true` value so the server containers run unconfined.
+Otherwise set the `server.apparmorProfile` to the name of a profile containing a definition like the following.
+If using exactly this content, the name of the profile to use will be `k8s-systemd-uyuni`.
+
+To deploy the AppArmor profile, copy this content to `/etc/apparmor.d/k8s-systemd-uyuni` and run `apparmor_parser -r /etc/apparmor.d/k8s-systemd-uyuni` to load it.
+
+```
+#include <tunables/global>
+
+profile k8s-systemd-uyuni flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+
+  # Standard container permissions
+  file,
+  network,
+  capability,
+  ptrace,
+  unix,
+
+  # Deny writes to critical kernel interfaces that systemd doesn't need to change
+  deny /sys/firmware/** rwklx,
+  deny /sys/kernel/debug/** rwklx,
+
+  # Broadly allow the specific flag combinations used for systemd hardening
+  # This covers /dev/pts/, /dev/mqueue/, and the previous /etc/ errors.
+  mount options=(ro, nosuid, noexec, nodev, remount, bind) -> **,
+  mount options=(ro, nosuid, noexec, remount, bind) -> **,
+  mount options=(ro, nosuid, nodev, remount, bind) -> **,
+  mount options=(ro, nosuid, remount, bind) -> **,
+  mount options=(ro, remount, bind) -> **,
+
+  # Allow mount propagation (Required for systemd to function at all)
+  mount options=(rw, rslave) -> **,
+  mount options=(rw, slave) -> **,
+  mount options=(rw, shared) -> **,
+
+  # Specific filesystem types for systemd's API mounts
+  mount fstype=tmpfs options=(rw, nosuid, nodev, noexec) -> /tmp/,
+  mount fstype=tmpfs options=(rw, nosuid, nodev) -> /tmp/,
+  mount fstype=tmpfs -> /run/**,
+  mount fstype=cgroup2 -> /sys/fs/cgroup/,
+  mount fstype=mqueue -> /dev/mqueue/,
+  mount fstype=fusectl -> /sys/fs/fuse/connections/,
+  mount fstype=devpts -> /dev/pts/,
+
+  # Generic remounts (for general compatibility)
+  mount options=(rw, remount) -> **,
+  mount options=(ro, remount) -> **, 
+  
+  # Required for the uyuni server container specifically
+  /sys/fs/cgroup/** rw,
+  /run/** rw,
+  /var/** rw,
+  # Allow reading the various config volumes mapped in the chart
+  /etc/** r,
+}
+```
+
+### SELinux
+
+If the node where the server pod is running has SELinux and RKE2 is configured to use it, the container won't be able to mount the cgroup2 file system.
+This can be addressed in two different ways.
+The easiest, but unsafe way is to set `server.superPrivileged=true` value so the server containers run with the `spc_t` label.
+Otherwise apply the following custom policy:
+
+* Create a `/root/systemdcontainerpolicy.te` file with this content:
+
+```sepolicy
+module systemdcontainerpolicy 1.0;
+
+require {
+    type container_t;
+    type cgroup_t;
+    type tmpfs_t;
+    type proc_t;
+    
+    class dir { search write add_name create remove_name rmdir setattr getattr mounton search };
+    class file { create open write append read unlink setattr getattr watch };
+    class filesystem { mount getattr relabelfrom relabelto };
+}
+
+#============= container_t ==============
+allow container_t cgroup_t:dir { add_name create remove_name rmdir setattr write search getattr };
+allow container_t cgroup_t:file { create open write append read setattr getattr unlink watch };
+allow container_t cgroup_t:filesystem { mount getattr relabelfrom relabelto };
+
+# Allow systemd's credential helper (sd-mkdcreds) to use /dev/shm as a mount point for service credentials.
+allow container_t tmpfs_t:dir mounton;
+
+# Standard lookups and attributes for the mount point
+allow container_t tmpfs_t:dir { getattr search };
+
+# Allow systemd to mount/remount the proc filesystem for namespacing
+allow container_t proc_t:filesystem { mount remount unmount };
+
+# Required to use directories as mount points
+allow container_t proc_t:dir mounton;
+```
+
+* Apply it:
+
+```sh
+checkmodule -M -m -o /root/systemdcontainerpolicy.mod /root/systemdcontainerpolicy.te
+semodule_package -o /root/systemdcontainerpolicy.pp -m /root/systemdcontainerpolicy.mod
+semodule -i /root/systemdcontainerpolicy.pp
+```
+
 ## Usage
 
 Once installed, the web interface can be accessed directly on the configured FQDN.

--- a/containers/server-helm/server-helm.changes.cbosdo.server-chart-confinment
+++ b/containers/server-helm/server-helm.changes.cbosdo.server-chart-confinment
@@ -1,0 +1,1 @@
+- Server chart: handle apparmor nodes

--- a/containers/server-helm/templates/server.yaml
+++ b/containers/server-helm/templates/server.yaml
@@ -64,8 +64,14 @@ spec:
             add:
             - SYS_ADMIN
   {{- if .Values.server.superPrivileged }}
+          appArmorProfile:
+            type: Unconfined
           seLinuxOptions:
             type: "spc_t"
+  {{- else if .Values.server.apparmorProfile }}
+          appArmorProfile:
+            type: Localhost
+            localhostProfile: {{ .Values.server.apparmorProfile }}
   {{- end }}
         ports:
         - containerPort: 80

--- a/containers/server-helm/tests/deployment_test.yaml
+++ b/containers/server-helm/tests/deployment_test.yaml
@@ -12,7 +12,7 @@ tests:
           path: metadata.name
           value: uyuni
       - equal:
-          path: spec.template.spec.containers[0].image
+          path: spec.template.spec.containers[?(@.name=="uyuni")].image
           value: registry.opensuse.org/uyuni/server:latest
 
   - it: should override image when values.images is provided
@@ -23,5 +23,5 @@ tests:
         tag: 5.0.0
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].image
+          path: spec.template.spec.containers[?(@.name=="uyuni")].image
           value: my-custom-registry/uyuni-server:5.0.0

--- a/containers/server-helm/tests/security_test.yaml
+++ b/containers/server-helm/tests/security_test.yaml
@@ -1,0 +1,59 @@
+suite: test server security options
+templates:
+  - server.yaml
+tests:
+  - it: should render the minimal security options by default
+    set:
+      global.fqdn: uyuni.example.com
+    asserts:
+      - isSubset:
+          path: spec.template.spec.containers[?(@.name=="uyuni")].securityContext
+          content:
+            capabilities:
+              add:
+              - SYS_ADMIN
+      - isNotSubset:
+          path: spec.template.spec.containers[?(@.name=="uyuni")].securityContext
+          content:
+            appArmorProfile:
+              type: Unconfined
+            seLinuxOptions:
+              type: "spc_t"
+
+  - it: should render the super privileged options
+    set:
+      global.fqdn: uyuni.example.com
+      server:
+        superPrivileged: true
+    asserts:
+      - isSubset:
+          path: spec.template.spec.containers[?(@.name=="uyuni")].securityContext
+          content:
+            capabilities:
+              add:
+              - SYS_ADMIN
+            appArmorProfile:
+              type: Unconfined
+            seLinuxOptions:
+              type: "spc_t"
+
+  - it: should render the AppArmor profile
+    set:
+      global.fqdn: uyuni.example.com
+      server:
+        apparmorProfile: test-prof
+    asserts:
+      - isSubset:
+          path: spec.template.spec.containers[?(@.name=="uyuni")].securityContext
+          content:
+            capabilities:
+              add:
+              - SYS_ADMIN
+            appArmorProfile:
+              type: Localhost
+              localhostProfile: test-prof
+      - isNotSubset:
+          path: spec.template.spec.containers[?(@.name=="uyuni")].securityContext
+          content:
+            seLinuxOptions:
+              type: "spc_t"

--- a/containers/server-helm/values.schema.json
+++ b/containers/server-helm/values.schema.json
@@ -57,8 +57,12 @@
         },
         "superPrivileged": {
           "type": "boolean",
-          "description": "Run the server container with super privileges, bypassing a lot of selinux checks. This is dangerous!",
+          "description": "Run the server container with super privileges, bypassing a lot of selinux or AppArmor checks. This is dangerous!",
           "default": false
+        },
+        "apparmorProfile": {
+          "type": "string",
+          "description": "appArmor profile is the name of an AppArmor profile to use for the server pod."
         },
         "systemdLogLevel": {
           "type": "string",

--- a/containers/server-helm/values.yaml
+++ b/containers/server-helm/values.yaml
@@ -39,7 +39,7 @@ server:
   #  claimName: mirror
   #  hostPath: /srv/mirror
 
-  ## superPrivileged may need to be set to true to run on a cluster with selinux enforced.
+  ## superPrivileged may need to be set to true to run on a cluster with selinux or AppArmor enforced.
   ## This is only for the server pod, since it runs systemd.
   ## Setting this to true opens a big security can of worms.
   superPrivileged: false
@@ -48,6 +48,10 @@ server:
   ## Note, that this will add a tty to the container.
   ## The possible values are debug, info, notice, warning, err, crit, alert, emerg or "" to keep the default.
   systemdLogLevel: ""
+
+  ## appArmor profile is the name of an AppArmor profile to use for the server pod.
+  ## The profile need to be showing up in the aa-status command output.
+  apparmorProfile: ""
 
 
 global:


### PR DESCRIPTION
## What does this PR change?

AppArmor has a different way to set super privileges. Add support for it in the server helm chart. Also document how to configure the node for SELinux policy and AppArmor profiles.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed:  to be handled with the Kubernetes install doc. Chart README updated

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
