### PR TITLE
Fix buildhost activation key entitlement not being set

### DIFF
--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -353,8 +353,11 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
 
   is_ssh_minion = client.include? 'ssh_minion'
   $api_test.activationkey.details_set?(key, description, base_channel_label, 100, is_ssh_minion ? 'ssh-push' : 'default')
-  entitlements = client.include?('buildhost') ? ['osimage_build_host'] : ''
-  $api_test.activationkey.set_entitlement(key, entitlements) unless entitlements.empty?
+  is_buildhost = client.include?('buildhost')
+  entitlements = is_buildhost ? ['osimage_build_host'] : []
+  unless entitlements.empty?
+    result = $api_test.activationkey.set_entitlement(key, entitlements)
+  end
 
   # Get the list of child channels for this base channel
   child_channels = $api_test.channel.software.list_child_channels(base_channel_label)


### PR DESCRIPTION

## What does this PR change?

Separate the include? call from the ternary operator to avoid Ruby parser ambiguity that caused the entitlement to evaluate to an empty string instead of ['osimage_build_host'].

BV 5.0.7: Even if activation key has buildhost in the keyname, entitlement was not set:

Debug log:

```
  Scenario: Prepare activation key for SLES 15 SP7 build host                                  # features/build_validation/retail/test.feature:11
      This scenario ran at: 2026-03-17 13:18:40 +0100
Activation key 1-sle15sp7_buildhost_key created
Client 'sle15sp7_buildhost' includes 'buildhost': true, entitlements: ""
Child_channels for 1-sle15sp7_buildhost_key: <["custom_channel_monitoring_server", "custom_channel_sle15sp7_minion", "sle-manager-tools15-pool-x86_64-sp7", "sle-manager-tools15-updates-x86_64-sp7", "sle-module-basesystem15-sp7-pool-x86_64", "sle-module-basesystem15-sp7-updates-x86_64", "sle-module-containers15-sp7-pool-x86_64", "sle-module-containers15-sp7-updates-x86_64", "sle-module-desktop-applications15-sp7-pool-x86_64", "sle-module-desktop-applications15-sp7-updates-x86_64", "sle-module-devtools15-sp7-pool-x86_64", "sle-module-devtools15-sp7-updates-x86_64", "sle-module-python3-15-sp7-pool-x86_64", "sle-module-python3-15-sp7-updates-x86_64", "sle-module-server-applications15-sp7-pool-x86_64", "sle-module-server-applications15-sp7-updates-x86_64", "sle-module-systems-management-15-sp7-pool-x86_64", "sle-module-systems-management-15-sp7-updates-x86_64", "sle-product-sles15-sp7-updates-x86_64", "sle15-sp7-installer-updates-x86_64"]>
    When I create an activation key including custom channels for "sle15sp7_buildhost" via API # features/step_definitions/api_common.rb:320
      This scenario took: 4 seconds

```

With this changes it correctly assigns it:

```
  Scenario: Prepare activation key for SLES 15 SP7 build host                                  # features/build_validation/retail/test.feature:11
      This scenario ran at: 2026-03-17 13:28:29 +0100
Activation key 1-sle15sp7_buildhost_key created
Client 'sle15sp7_buildhost' includes 'buildhost': true, entitlements: ["osimage_build_host"]
set_entitlement(1-sle15sp7_buildhost_key, ["osimage_build_host"]) returned: 1
Child_channels for 1-sle15sp7_buildhost_key: <["custom_channel_monitoring_server", "custom_channel_sle15sp7_minion", "sle-manager-tools15-pool-x86_64-sp7", "sle-manager-tools15-updates-x86_64-sp7", "sle-module-basesystem15-sp7-pool-x86_64", "sle-module-basesystem15-sp7-updates-x86_64", "sle-module-containers15-sp7-pool-x86_64", "sle-module-containers15-sp7-updates-x86_64", "sle-module-desktop-applications15-sp7-pool-x86_64", "sle-module-desktop-applications15-sp7-updates-x86_64", "sle-module-devtools15-sp7-pool-x86_64", "sle-module-devtools15-sp7-updates-x86_64", "sle-module-python3-15-sp7-pool-x86_64", "sle-module-python3-15-sp7-updates-x86_64", "sle-module-server-applications15-sp7-pool-x86_64", "sle-module-server-applications15-sp7-updates-x86_64", "sle-module-systems-management-15-sp7-pool-x86_64", "sle-module-systems-management-15-sp7-updates-x86_64", "sle-product-sles15-sp7-updates-x86_64", "sle15-sp7-installer-updates-x86_64"]>
    When I create an activation key including custom channels for "sle15sp7_buildhost" via API # features/step_definitions/api_common.rb:320
      This scenario took: 4 seconds
```

Visible also from the Web UI (before it wasn't selected):

<img width="714" height="888" alt="Screenshot From 2026-03-17 13-32-39" src="https://github.com/user-attachments/assets/f3d85fdf-20cc-45ab-891c-f45f02674c15" />

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29748
Port(s): DOING

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
