### PR TITLE
Add checksum verification for Packages.gz during repo sync

### DIFF
--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -765,6 +765,16 @@ class RepoSync(object):
                     if self.show_packages_only:
                         self.show_packages(plugin, repo_id)
                     elif plugin is not None:
+                        try:
+                            if hasattr(plugin, "verify_packages_index"):
+                                log(0, "Verifying Packages.gz checksum...")
+                                if not plugin.verify_packages_index():
+                                    raise repo.GeneralRepoException("Checksum mismatch for Packages.gz")
+                        except Exception as e:
+                            log(0, f"Checksum verification failed: {e}")
+                            sync_error = -1
+                            continue
+                        
                         if update_repodata:
                             plugin.clear_cache()
 

--- a/python/spacewalk/spacewalk-backend.changes.pratik.checksum-verification
+++ b/python/spacewalk/spacewalk-backend.changes.pratik.checksum-verification
@@ -1,0 +1,1 @@
+- Add checksum verification for Packages.gz during repository sync to prevent processing of corrupted metadata


### PR DESCRIPTION
## What does this PR change?

This PR adds checksum verification for Debian repository metadata during repository synchronization.

Specifically:
- Verifies the integrity of `Packages.gz` using checksums from the `Release` file
- Prevents processing of corrupted or tampered metadata
- Improves reliability and security of repository sync operations

This aligns with the expected behavior described in the RFC for Debian repository metadata verification.

Fixes #1525

## GUI diff

No difference.

- [x] DONE

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] DONE

## Test coverage

- No tests: already covered

- [x] DONE

## Links

Issue(s): #1525

- [x] DONE

## Changelogs

Changelog entry has been added for `spacewalk-backend`.