### PR TITLE
Fix schema migration for RBAC mappings

### DIFF
--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.4-to-susemanager-schema-5.2.5/200-rbac-ui-mappings.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.4-to-susemanager-schema-5.2.5/200-rbac-ui-mappings.sql
@@ -1,14 +1,33 @@
 -- Set POST instead of GET
-UPDATE access.endpoint SET http_method = 'POST' WHERE endpoint = '/manager/api/oidcLogin';
+DELETE FROM access.endpoint WHERE endpoint = '/manager/api/oidcLogin' AND http_method = 'GET'
+    AND EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/api/oidcLogin' AND http_method = 'POST');
+UPDATE access.endpoint SET http_method = 'POST' WHERE endpoint = '/manager/api/oidcLogin' AND http_method = 'GET';
 
 -- Rename 'create' to 'create-access-group'
-UPDATE access.endpoint SET endpoint = '/manager/admin/access-control/create-access-group' WHERE endpoint = '/manager/admin/access-control/create';
+DELETE FROM access.endpoint WHERE endpoint = '/manager/admin/access-control/create'
+    AND EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/admin/access-control/create-access-group');
+UPDATE access.endpoint SET endpoint = '/manager/admin/access-control/create-access-group'
+    WHERE endpoint = '/manager/admin/access-control/create';
 
 -- Remove leading '/rhn' from endpoints
+DELETE FROM access.endpoint WHERE endpoint = '/rhn/manager/systems/ssm/appstreams'
+    AND EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/systems/ssm/appstreams');
 UPDATE access.endpoint SET endpoint = '/manager/systems/ssm/appstreams' WHERE endpoint = '/rhn/manager/systems/ssm/appstreams';
+
+DELETE FROM access.endpoint WHERE endpoint = '/rhn/manager/systems/ssm/appstreams/configure/:channelId'
+    AND EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/systems/ssm/appstreams/configure/:channelId');
 UPDATE access.endpoint SET endpoint = '/manager/systems/ssm/appstreams/configure/:channelId' WHERE endpoint = '/rhn/manager/systems/ssm/appstreams/configure/:channelId';
+
+DELETE FROM access.endpoint WHERE endpoint = '/rhn/manager/api/ssm/appstreams/save'
+    AND EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/api/ssm/appstreams/save');
 UPDATE access.endpoint SET endpoint = '/manager/api/ssm/appstreams/save' WHERE endpoint = '/rhn/manager/api/ssm/appstreams/save';
+
+DELETE FROM access.endpoint WHERE endpoint = '/rhn/manager/api/system/appstreams/ssmEnable'
+    AND EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/api/system/appstreams/ssmEnable');
 UPDATE access.endpoint SET endpoint = '/manager/api/system/appstreams/ssmEnable' WHERE endpoint = '/rhn/manager/api/system/appstreams/ssmEnable';
+
+DELETE FROM access.endpoint WHERE endpoint = '/rhn/manager/api/system/appstreams/ssmDisable'
+    AND EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/api/system/appstreams/ssmDisable');
 UPDATE access.endpoint SET endpoint = '/manager/api/system/appstreams/ssmDisable' WHERE endpoint = '/rhn/manager/api/system/appstreams/ssmDisable';
 
 -- Add namespaces for API endpoints


### PR DESCRIPTION
Fixes migration idempotency issues on the latest RBAC mappings.

Follow up to: https://github.com/uyuni-project/uyuni/pull/11473
Partial port of: https://github.com/SUSE/spacewalk/pull/30055

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
