### PR TITLE
fix(ssm): ensure consistent SSM button behavior across tabs

### DIFF
--- a/java/core/src/main/resources/com/suse/manager/webui/templates/minion/minion-header.jade
+++ b/java/core/src/main/resources/com/suse/manager/webui/templates/minion/minion-header.jade
@@ -1,10 +1,5 @@
-.spacewalk-toolbar-h1
-  .spacewalk-toolbar
-    a.btn.btn-danger(href="/rhn/systems/details/DeleteConfirm.do?sid=#{server.id}")
-        i.fa.fa-trash-o(title='Delete System')
-        | #{l.t("Delete System")}
-
-        
+include ../system-common.jade
+     
   h1
     if server.bootstrap
         i.fa.spacewalk-icon-bare-metal

--- a/java/core/src/main/resources/com/suse/manager/webui/templates/minion/minion-header.jade
+++ b/java/core/src/main/resources/com/suse/manager/webui/templates/minion/minion-header.jade
@@ -3,14 +3,8 @@
     a.btn.btn-danger(href="/rhn/systems/details/DeleteConfirm.do?sid=#{server.id}")
         i.fa.fa-trash-o(title='Delete System')
         | #{l.t("Delete System")}
-    if inSSM
-      a.btn.btn-default(href="/rhn/systems/details/RemoveFromSSM.do?sid=#{server.id}")
-        i.fa.fa-minus-circle(title='Remove from SSM')
-        | #{l.t("Remove from SSM")}
-    else
-      a.btn.btn-default(href="/rhn/systems/details/AddToSSM.do?sid=#{server.id}")
-        i.fa.fa-plus-circle(title='Add to SSM')
-        | #{l.t("Add to SSM")}
+
+        
   h1
     if server.bootstrap
         i.fa.spacewalk-icon-bare-metal

--- a/java/spacewalk-java.changes.pratik.ssm-button-fix
+++ b/java/spacewalk-java.changes.pratik.ssm-button-fix
@@ -1,0 +1,4 @@
+- Fix inconsistent "Add to SSM" / "Remove from SSM"
+  button behavior across system detail tabs
+- Remove duplicated SSM button logic from
+  minion-header.jade to ensure consistent UI behavior

--- a/java/spacewalk-java.changes.pratik.ssm-button-fix
+++ b/java/spacewalk-java.changes.pratik.ssm-button-fix
@@ -1,4 +1,2 @@
-- Fix inconsistent "Add to SSM" / "Remove from SSM"
-  button behavior across system detail tabs
-- Remove duplicated SSM button logic from
-  minion-header.jade to ensure consistent UI behavior
+- Fix inconsistent "Add to SSM" / "Remove from SSM" button behavior across system detail pages
+- Centralize SSM button rendering using system-common.jade to ensure consistent UI behavior


### PR DESCRIPTION
## What does this PR change?

Fixes inconsistent behavior of **"Add to SSM" / "Remove from SSM"** buttons across system detail tabs.

Previously, the SSM button logic was duplicated in `minion-header.jade`, which caused inconsistent UI behavior depending on the page. This PR removes the duplicated logic and ensures that the buttons are rendered consistently via the shared `system-common.jade` template.

---

## GUI diff

No difference in layout, but behavior is now consistent across all tabs.

Before:
- Inconsistent SSM button behavior depending on the page

After:
- Consistent "Add to SSM" / "Remove from SSM" behavior across all system detail tabs

- [x] **DONE**

---

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

---

## Test coverage

- No tests: already covered (UI template change, no new functionality)

- [x] **DONE**

---

## Links

Issue(s): #9169 

- [x] **DONE**

---

## Changelogs

- Changelog entry added for `spacewalk-java` package

---

## Re-run a test

(no action needed)