### PR TITLE
Keep synced errata in custom channels

### DIFF
--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -1256,7 +1256,10 @@ class RepoSync(object):
                 existing_errata, notice["version"], updated_date, e["packages"]
             )
         ):
-            # We have it already. Save the name for later use
+            # We already have this erratum and it does not need an update.
+            # Track its advisory name in self.all_errata so that later strict-mode
+            # cleanup logic does not delete errata that were present in the channel
+            # before the current sync run.
             self.all_errata.add(patch_name)
             return None
 


### PR DESCRIPTION
## What does this PR change?

In `strict` mode, we remove all errata from custom channels which should not be part of the channel.
When the errata already exist in the channel before, we do not save the name and we remove it by accident.
This patch take care that the names of existing errata are saved and we keep them.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/30092

Broke with https://github.com/uyuni-project/uyuni/pull/11580

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
