### PR TITLE
Change migration target from SL micro 6.1 to SL micro 6.2

### DIFF
--- a/testsuite/features/build_validation/migration/migration_sle15sp6_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_sle15sp6_minion.feature
@@ -1,7 +1,8 @@
-# Copyright (c) 2024-2025 SUSE LLC
+# Copyright (c) 2024-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle15sp6_minion
+@sle15sp7_minion
 Feature: Migrate a SLES 15 SP6 Salt minion to 15 SP7
 
   Scenario: Log in as admin user

--- a/testsuite/features/build_validation/migration/migration_sle15sp6_ssh_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_sle15sp6_ssh_minion.feature
@@ -1,7 +1,8 @@
-# Copyright (c) 2025 SUSE LLC
+# Copyright (c) 2025-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle15sp6_ssh_minion
+@sle15sp7_minion
 Feature: Migrate a SLES 15 SP6 Salt SSH minion to 15 SP7
 
   Scenario: Log in as admin user

--- a/testsuite/features/build_validation/migration/migration_slemicro54_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_slemicro54_minion.feature
@@ -1,7 +1,8 @@
-# Copyright (c) 2022-2025 SUSE LLC
+# Copyright (c) 2022-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @slemicro54_minion
+@slemicro55_minion
 Feature: Migrate a SLE Micro 5.4 Salt minion to SLE Micro 5.5
 
   Scenario: Log in as admin user

--- a/testsuite/features/build_validation/migration/migration_slemicro55_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_slemicro55_minion.feature
@@ -2,6 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 @slemicro55_minion
+# SL Micro 6.2 is reposynched even if there is no SL Micro 6.2 minion deployed
 Feature: Migrate a SLE Micro 5.5 Salt minion to SL Micro 6.2
 
   Scenario: Log in as admin user


### PR DESCRIPTION
## What does this PR change?

Fixup of #11407

This PR changes migration target from SL micro 6.1 to SL micro 6.2.

Reason is that, if SL micro 6.1 minion is not deployed, then 6.1 product won't be reposynched,
while 6.2 product is almost always reposynched, because of the proxy.

Piggyback: for all OS migrations, skip migration test if destination custom channel does not exist.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes.

- [x] **DONE**


## Test coverage

Cucumber tests were fixed

- [x] **DONE**


## Links

Issue(s): SUSE/spacewalk#30089

No ports, Head only.

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
