### PR TITLE
Avoid injection in rhn.conf of http proxy settings inputs (bsc#1245107)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/manager/setup/ProxySettingsManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/setup/ProxySettingsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014--2025 SUSE LLC
+ * Copyright (c) 2014--2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -19,6 +19,9 @@ import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.satellite.ProxySettingsConfigureSatelliteCommand;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -49,6 +52,9 @@ public final class ProxySettingsManager {
      */
     public static ValidatorError[] storeProxySettings(ProxySettingsDto settings,
             User userIn, HttpServletRequest request) {
+
+        sanitizeInput(settings);
+
         ProxySettingsConfigureSatelliteCommand configCommand = new ProxySettingsConfigureSatelliteCommand(userIn);
         configCommand.updateString(ConfigDefaults.HTTP_PROXY, settings.getHostname());
         configCommand.updateString(ConfigDefaults.HTTP_PROXY_USERNAME, settings.getUsername());
@@ -60,5 +66,28 @@ public final class ProxySettingsManager {
             SetupWizardSessionCache.clearAllSubscriptions(request);
         }
         return ret;
+    }
+
+    /**
+     * Sanitizes any input string
+     *
+     * @param stringIn the input string to sanitize
+     * @return the safe string
+     */
+    public static String sanitizeInput(String stringIn) {
+        Pattern pattern = Pattern.compile("\\p{C}"); //any control character
+        Matcher matcher = pattern.matcher(stringIn);
+        return matcher.replaceAll("");
+    }
+
+    /**
+     * Sanitizes any input settings
+     *
+     * @param settings the input settings to sanitize
+     */
+    public static void sanitizeInput(ProxySettingsDto settings) {
+        settings.setHostname(sanitizeInput(settings.getHostname()));
+        settings.setUsername(sanitizeInput(settings.getUsername()));
+        settings.setPassword(sanitizeInput(settings.getPassword()));
     }
 }

--- a/java/core/src/test/java/com/redhat/rhn/manager/setup/test/ProxySettingsManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/setup/test/ProxySettingsManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014--2025 SUSE LLC
+ * Copyright (c) 2014--2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -221,5 +221,48 @@ public class ProxySettingsManagerTest extends RhnBaseTestCase {
         assertEquals("/dev/null", cmdArgs[7]);
 
         assertEquals("UYUNICFG_PWD_PLACEHOLDER=", configCommand.getFirstEnvironmentVar());
+    }
+
+    @Test
+    public void testSanitizeInput() {
+        // chars " and \ are accepted
+        assertEquals("\"\\", ProxySettingsManager.sanitizeInput("\"\\"));
+
+        // set of accepted printable chars
+        assertEquals("!#$%&’()*+,-./:;<=>?@[]^_`{|}~",
+                ProxySettingsManager.sanitizeInput("!#$%&’()*+,-./:;<=>?@[]^_`{|}~"));
+
+        // standard ascii chars
+        assertEquals("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+                ProxySettingsManager.sanitizeInput("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"));
+
+        // remove tab and newline
+        assertEquals("", ProxySettingsManager.sanitizeInput("\r\n\t"));
+
+        //remove control chars
+        StringBuilder builder = new StringBuilder();
+        for (char ch = 0; ch < 32; ch++) {
+            builder.append(ch);
+        }
+        builder.append((char) 127);
+        assertEquals("", ProxySettingsManager.sanitizeInput(builder.toString()));
+
+        assertEquals("Kind of string!",
+                ProxySettingsManager.sanitizeInput("\n\nKind \n\n\n\tof string!\n\t"));
+    }
+
+    @Test
+    public void testSanitizeSettingsInput() {
+
+        ProxySettingsDto settings = new ProxySettingsDto();
+        settings.setHostname("one\ntwo\nthree");
+        settings.setUsername("@my+user^name%$\tone\ntwo");
+        settings.setPassword("!#$%&’()pass\"word\\");
+
+        ProxySettingsManager.sanitizeInput(settings);
+
+        assertEquals("onetwothree", settings.getHostname());
+        assertEquals("@my+user^name%$onetwo", settings.getUsername());
+        assertEquals("!#$%&’()pass\"word\\", settings.getPassword());
     }
 }

--- a/java/spacewalk-java.changes.carlo.uyuni-http-proxy-data-injection
+++ b/java/spacewalk-java.changes.carlo.uyuni-http-proxy-data-injection
@@ -1,0 +1,2 @@
+- Sanitize inputs to avoid injection in rhn_conf
+  of http proxy settings inputs (bsc#1245107)


### PR DESCRIPTION

## What does this PR change?

Sanitize inputs to avoid injection in rhn.conf  of http proxy settings inputs (bsc#1245107)

Tested like this:
- Go to Admin > Setup Wizard > HTTP Proxy
- Add wrong values in the form
- Example: Hostname (http-proxy.mgr.suse.de:3128), User (suma2), Password(Test)
- Notice a red banner "Proxy settings are not valid"
- Go inside the server:
    - mgrctl term
    - cat /etc/rhn/rhn.conf
    - notice that the wrong values have been added.
- get the HTTP request through an inspector (I did it with firefox inspect) getting `JSESSIONID` and  `pxt-session-cookie` from the cookies
- substitite `JSESSIONID` and  `pxt-session-cookie` in the snippet below and run it
```
curl 'https://server1/rhn/ajax/save-proxy-settings' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en,en-GB;q=0.9,es;q=0.8,ca;q=0.7' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json; charset=UTF-8' \
  -b '_ga=GA1.2.1210866300.1725281440; JSESSIONID=27F7098662AC261CB052593294ADDF54; pxt-session-cookie=213x4bafa606ed9b1735967ec6d2fe9cc52765b3d32f43ab10ce03e96799bcb366fa' \
  -H 'DNT: 1' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'X-Requested-With: XMLHttpRequest' \
  -H 'sec-ch-ua: "Google Chrome";v="137", "Chromium";v="137", "Not/A)Brand";v="24"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  --data-raw '{"hostname":"my.server.test:1234","username":"my.username\nintruderLine","password":"my.pass\nintruderLine"}' \
  --insecure ;
```
- Go inside the server:
    - cat /etc/rhn/rhn.conf
    - verify that the added values have no intruder line on a new line


## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/27589
Port(s): 
5.1: https://github.com/SUSE/spacewalk/pull/30155
5.0: https://github.com/SUSE/spacewalk/pull/30156
4.3: not backported
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
