### PR TITLE
Generate credentials for reporting service user

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -32,6 +32,8 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import com.suse.manager.saltboot.SaltbootException;
 import com.suse.manager.saltboot.SaltbootUtils;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
+import com.suse.manager.webui.services.pillar.MinionReportDBPillarGenerator;
 import com.suse.utils.Maps;
 import com.suse.utils.Opt;
 
@@ -65,6 +67,7 @@ public class FormulaFactory {
 
     /** This formula is coupled with the monitoring system type */
     public static final String PROMETHEUS_EXPORTERS = "prometheus-exporters";
+    public static final String GRAFANA = "grafana";
     public static final String PREFIX = "formula-";
 
     /** Saltboot group deployment formula */
@@ -244,6 +247,17 @@ public class FormulaFactory {
                     systemEntitlementManager.addEntitlementToServer(s, EntitlementManager.MONITORING);
                 }
             });
+        }
+
+        if (GRAFANA.equals(formulaName)) {
+            Optional<Pillar> reportDBPillar = minion.getPillarByCategory("reportDB");
+            if (reportDBPillar.isEmpty() && hasReportingEnabled(formData)) {
+                MinionPillarManager.INSTANCE.generatePillar(minion, false,
+                    MinionPillarManager.PillarSubset.REPORT_DB);
+            }
+            else if (reportDBPillar.isPresent() && !hasReportingEnabled(formData)) {
+                MinionReportDBPillarGenerator.INSTANCE.removePillar(minion);
+            }
         }
     }
 
@@ -722,6 +736,25 @@ public class FormulaFactory {
         else {
             return false;
         }
+    }
+
+    /**
+     * Check wether Grafana formula has reporting datasource enabled.
+     * @param formData data of the Grafana formula
+     * @return true if datasource is enabled, otherwise false
+     */
+    public static boolean hasReportingEnabled(Map<String, Object> formData) {
+        boolean grafanaEnabled = Maps.getValueByPath(formData, "grafana:enabled")
+                .filter(Boolean.class::isInstance)
+                .map(Boolean.class::cast)
+                .orElse(false);
+
+        boolean reportDbEnabled = Maps.getValueByPath(formData, "grafana:datasources:reportdb:enabled")
+                .filter(Boolean.class::isInstance)
+                .map(Boolean.class::cast)
+                .orElse(false);
+
+        return grafanaEnabled && reportDbEnabled;
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionPillarManager.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionPillarManager.java
@@ -34,7 +34,8 @@ public class MinionPillarManager {
         GENERAL,
         GROUP_MEMBERSHIP,
         VIRTUALIZATION,
-        CUSTOM_INFO
+        CUSTOM_INFO,
+        REPORT_DB
     }
 
     /** Logger */
@@ -44,12 +45,14 @@ public class MinionPillarManager {
                     MinionGeneralPillarGenerator.INSTANCE,
                     MinionGroupMembershipPillarGenerator.INSTANCE,
                     MinionVirtualizationPillarGenerator.INSTANCE,
-                    MinionCustomInfoPillarGenerator.INSTANCE);
+                    MinionCustomInfoPillarGenerator.INSTANCE,
+                    MinionReportDBPillarGenerator.INSTANCE);
 
     private MinionPillarGenerator generalPillarGenerator;
     private MinionPillarGenerator groupMembershipPillarGenerator;
     private MinionPillarGenerator virtualizationPillarGenerator;
     private MinionPillarGenerator customInfoPillarGenerator;
+    private MinionPillarGenerator reportDBPillarGenerator;
 
     /**
      * Constructor for MinionPillarManager
@@ -57,15 +60,18 @@ public class MinionPillarManager {
      * @param groupMembershipPillarGeneratorIn group membership pillar generator
      * @param virtualizationPillarGeneratorIn virtualization pillar generator
      * @param customInfoPillarGeneratorIn custom info pillar generator
+     * @param reportDBPillarGeneratorIn reportDB pillar generator
      */
     public MinionPillarManager(MinionPillarGenerator generalPillarGeneratorIn,
                                MinionPillarGenerator groupMembershipPillarGeneratorIn,
                                MinionPillarGenerator virtualizationPillarGeneratorIn,
-                               MinionPillarGenerator customInfoPillarGeneratorIn) {
+                               MinionPillarGenerator customInfoPillarGeneratorIn,
+                               MinionPillarGenerator reportDBPillarGeneratorIn) {
         this.generalPillarGenerator = generalPillarGeneratorIn;
         this.groupMembershipPillarGenerator = groupMembershipPillarGeneratorIn;
         this.virtualizationPillarGenerator = virtualizationPillarGeneratorIn;
         this.customInfoPillarGenerator = customInfoPillarGeneratorIn;
+        this.reportDBPillarGenerator = reportDBPillarGeneratorIn;
     }
 
     /**
@@ -101,6 +107,9 @@ public class MinionPillarManager {
                 case CUSTOM_INFO:
                     customInfoPillarGenerator.generatePillarData(minion);
                     break;
+                case REPORT_DB:
+                    reportDBPillarGenerator.generatePillarData(minion);
+                    break;
                 default:
                     throw new RuntimeException("unreachable");
             }
@@ -124,6 +133,7 @@ public class MinionPillarManager {
         groupMembershipPillarGenerator.generatePillarData(minion);
         virtualizationPillarGenerator.generatePillarData(minion);
         customInfoPillarGenerator.generatePillarData(minion);
+        reportDBPillarGenerator.generatePillarData(minion);
     }
 
     /**
@@ -135,5 +145,6 @@ public class MinionPillarManager {
         groupMembershipPillarGenerator.removePillar(minion);
         virtualizationPillarGenerator.removePillar(minion);
         customInfoPillarGenerator.removePillar(minion);
+        reportDBPillarGenerator.removePillar(minion);
     }
 }

--- a/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionPillarManager.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionPillarManager.java
@@ -133,7 +133,6 @@ public class MinionPillarManager {
         groupMembershipPillarGenerator.generatePillarData(minion);
         virtualizationPillarGenerator.generatePillarData(minion);
         customInfoPillarGenerator.generatePillarData(minion);
-        reportDBPillarGenerator.generatePillarData(minion);
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionReportDBPillarGenerator.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionReportDBPillarGenerator.java
@@ -51,8 +51,8 @@ public class MinionReportDBPillarGenerator extends MinionPillarGeneratorBase {
         String reportDBUser = "grafana_" + minion.getId();
         String reportDBPass = RandomStringUtils.secure().nextAlphanumeric(12);
         ConnectionManager localRcm = ConnectionManagerFactory.localReportingConnectionManager();
+        ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
         try {
-            ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
             ReportDBHelper dbHelper = ReportDBHelper.INSTANCE;
 
             pillar.add("reportdb_name", reportDBName);
@@ -64,13 +64,17 @@ public class MinionReportDBPillarGenerator extends MinionPillarGeneratorBase {
             else {
                 dbHelper.createDBUser(localRh.getSession(), reportDBName, reportDBUser, reportDBPass);
             }
-            localRcm.commitTransaction();
+            localRh.commitTransaction();
         }
         catch (Exception e) {
             LOG.error("Setting user/password failed", e);
             pillar.getPillar().clear();
             minion.getPillars().remove(pillar);
-            localRcm.rollbackTransaction();
+            localRh.rollbackTransaction();
+        }
+        finally {
+            localRh.closeSession();
+            localRh.closeSessionFactory();
         }
 
         return Optional.of(pillar);
@@ -80,14 +84,14 @@ public class MinionReportDBPillarGenerator extends MinionPillarGeneratorBase {
     public void removePillar(MinionServer minion) {
         minion.getPillarByCategory(CATEGORY).ifPresent(pillar -> {
             ConnectionManager localRcm = ConnectionManagerFactory.localReportingConnectionManager();
+            ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
             try {
-                ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
                 ReportDBHelper dbHelper = ReportDBHelper.INSTANCE;
                 try {
                     String username = (String)pillar.getPillarValue("reportdb_user");
                     if (dbHelper.hasDBUser(localRh.getSession(), username)) {
                         dbHelper.dropDBUser(localRh.getSession(), username);
-                        localRcm.commitTransaction();
+                        localRh.commitTransaction();
                     }
                     else {
                         LOG.warn("DB User '{}' does not exist", username);
@@ -101,7 +105,11 @@ public class MinionReportDBPillarGenerator extends MinionPillarGeneratorBase {
             }
             catch (Exception e) {
                 LOG.error("Removing user failed", e);
-                localRcm.rollbackTransaction();
+                localRh.rollbackTransaction();
+            }
+            finally {
+                localRh.closeSession();
+                localRh.closeSessionFactory();
             }
         });
     }

--- a/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionReportDBPillarGenerator.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionReportDBPillarGenerator.java
@@ -49,7 +49,7 @@ public class MinionReportDBPillarGenerator extends MinionPillarGeneratorBase {
         pillar.getPillar().clear();
         String reportDBName = Config.get().getString(ConfigDefaults.REPORT_DB_NAME, "reportdb");
         String reportDBUser = "grafana_" + minion.getId();
-        String reportDBPass = RandomStringUtils.secure().nextAlphanumeric(12);
+        String reportDBPass = RandomStringUtils.secure().nextAlphanumeric(20);
         ConnectionManager localRcm = ConnectionManagerFactory.localReportingConnectionManager();
         ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
         try {

--- a/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionReportDBPillarGenerator.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionReportDBPillarGenerator.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.services.pillar;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.hibernate.ConnectionManager;
+import com.redhat.rhn.common.hibernate.ConnectionManagerFactory;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.hibernate.LookupException;
+import com.redhat.rhn.common.hibernate.ReportDbHibernateFactory;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.Pillar;
+import com.redhat.rhn.taskomatic.task.ReportDBHelper;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+public class MinionReportDBPillarGenerator extends MinionPillarGeneratorBase {
+
+    private static final Logger LOG = LogManager.getLogger(MinionReportDBPillarGenerator.class);
+    public static final MinionReportDBPillarGenerator INSTANCE = new MinionReportDBPillarGenerator();
+    public static final String CATEGORY = "reportDB";
+
+    @Override
+    public Optional<Pillar> generatePillarData(MinionServer minion) {
+        Pillar pillar = minion.getPillarByCategory(CATEGORY).orElseGet(() -> {
+            Pillar newPillar = new Pillar(CATEGORY, new HashMap<>(), minion);
+            minion.getPillars().add(newPillar);
+            return newPillar;
+        });
+        pillar.getPillar().clear();
+        String reportDBName = Config.get().getString(ConfigDefaults.REPORT_DB_NAME, "reportdb");
+        String reportDBUser = "grafana_" + minion.getId();
+        String reportDBPass = RandomStringUtils.secure().nextAlphanumeric(12);
+        ConnectionManager localRcm = ConnectionManagerFactory.localReportingConnectionManager();
+        try {
+            ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
+            ReportDBHelper dbHelper = ReportDBHelper.INSTANCE;
+
+            pillar.add("reportdb_name", reportDBName);
+            pillar.add("reportdb_user", reportDBUser);
+            pillar.add("reportdb_pass", reportDBPass);
+            if (dbHelper.hasDBUser(localRh.getSession(), reportDBUser)) {
+                dbHelper.changeDBPassword(localRh.getSession(), reportDBUser, reportDBPass);
+            }
+            else {
+                dbHelper.createDBUser(localRh.getSession(), reportDBName, reportDBUser, reportDBPass);
+            }
+            localRcm.commitTransaction();
+        }
+        catch (Exception e) {
+            LOG.error("Setting user/password failed", e);
+            pillar.getPillar().clear();
+            minion.getPillars().remove(pillar);
+            localRcm.rollbackTransaction();
+        }
+
+        return Optional.of(pillar);
+    }
+
+    @Override
+    public void removePillar(MinionServer minion) {
+        minion.getPillarByCategory(CATEGORY).ifPresent(pillar -> {
+            ConnectionManager localRcm = ConnectionManagerFactory.localReportingConnectionManager();
+            try {
+                ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
+                ReportDBHelper dbHelper = ReportDBHelper.INSTANCE;
+                try {
+                    String username = (String)pillar.getPillarValue("reportdb_user");
+                    if (dbHelper.hasDBUser(localRh.getSession(), username)) {
+                        dbHelper.dropDBUser(localRh.getSession(), username);
+                        localRcm.commitTransaction();
+                    }
+                    else {
+                        LOG.warn("DB User '{}' does not exist", username);
+                    }
+                }
+                catch (LookupException le) {
+                    LOG.warn("Pillar does not contain reportdb_user key.");
+                }
+                minion.getPillars().remove(pillar);
+                HibernateFactory.getSession().remove(pillar);
+            }
+            catch (Exception e) {
+                LOG.error("Removing user failed", e);
+                localRcm.rollbackTransaction();
+            }
+        });
+    }
+
+    @Override
+    public String getCategory() {
+        return CATEGORY;
+    }
+}

--- a/java/spacewalk-java.changes.witek.reporting
+++ b/java/spacewalk-java.changes.witek.reporting
@@ -1,0 +1,1 @@
+- Generate service user for Grafana reporting datasource


### PR DESCRIPTION
## What does this PR change?

If reporting datasource is enabled in Grafana formula a dedicated service user is created and credentials saved in the pillar.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/30174

- [x] **DONE**

## Test coverage
- No tests:

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28572

- [x] **DONE**

## Changelogs

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
