### PR TITLE
Add unit tests for UserManager.loginUser() method

### DIFF
--- a/java/core/src/test/java/com/redhat/rhn/manager/user/test/UserManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/user/test/UserManagerTest.java
@@ -76,6 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.security.auth.login.LoginException;
 
 /** JUnit test case for the User
  *  class.
@@ -652,4 +653,76 @@ public class UserManagerTest extends RhnBaseTestCase {
        SystemSearchResult sr = dr.get(0);
        assertNotNull(sr.getDescription());
    }
+    /**
+     * Tests that a valid user can log in successfully with correct credentials.
+     */
+    @Test
+    public void testLoginUserSuccess() throws Exception {
+        User user = UserTestUtils.createUser(this);
+        User result = UserManager.loginUser(user.getLogin(), "password");
+        assertNotNull(result);
+        assertEquals(user.getLogin(), result.getLogin());
+    }
+
+    /**
+     * Tests that passing a null username throws a LoginException.
+     */
+    @Test
+    public void testLoginUserNullUsername() {
+        try {
+            UserManager.loginUser(null, "password");
+            fail("Expected LoginException for null username");
+        }
+        catch (LoginException e) {
+            assertEquals("error.invalid_login", e.getMessage());
+        }
+    }
+
+    /**
+     * Tests that an incorrect password throws a LoginException.
+     */
+    @Test
+    public void testLoginUserWrongPassword() {
+        try {
+            User user = UserTestUtils.createUser(this);
+            UserManager.loginUser(user.getLogin(), "wrongpassword");
+            fail("Expected LoginException for wrong password");
+        }
+        catch (LoginException e) {
+            assertEquals("error.invalid_login", e.getMessage());
+        }
+    }
+
+    /**
+     * Tests that attempting to log in as a disabled user throws a LoginException.
+     */
+    @Test
+    public void testLoginUserDisabled() {
+        try {
+            User admin = UserTestUtils.createUser("adminUser", "testOrg");
+            admin.addPermanentRole(RoleFactory.ORG_ADMIN);
+            UserManager.storeUser(admin);
+            User user = UserTestUtils.createUser("disabledUser", admin.getOrg().getId());
+            UserManager.disableUser(admin, user);
+            UserManager.loginUser(user.getLogin(), "password");
+            fail("Expected LoginException for disabled user");
+        }
+        catch (LoginException e) {
+            assertEquals("account.disabled", e.getMessage());
+        }
+    }
+
+    /**
+     * Tests that logging in with a non-existent username throws a LoginException.
+     */
+    @Test
+    public void testLoginUserNotFound() {
+        try {
+            UserManager.loginUser("nonexistentuser123", "password");
+            fail("Expected LoginException for non-existent user");
+        }
+        catch (LoginException e) {
+            assertEquals("error.invalid_login", e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## What does this PR change?
Added unit tests covering success, null username, wrong password, disabled user, and non-existent user cases for UserManager.loginUser().

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- [x] No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- [x] Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
