### PR TITLE
Cleanup cobbler system entries after successful kickstart session completion

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/kickstart/KickstartSession.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/kickstart/KickstartSession.java
@@ -515,22 +515,31 @@ public class KickstartSession extends BaseDomainHelper {
      */
     public void markComplete(String messageIn) {
     this.setState(KickstartFactory.SESSION_STATE_COMPLETE);
+
     this.setAction(null);
     this.addHistory(this.getState(), messageIn);
+
     SystemManager.updateSystemOverview(this.currentServer());
 
     // Cleanup Cobbler system entry created during kickstart provisioning
     if (shouldCleanupCobbler()) {
+
         Server server = this.currentServer();
-        if (server != null) {
+        User user = this.getUser();
+
+        if (server != null && user != null) {
+
             CobblerSystemRemoveCommand cmd =
-                new CobblerSystemRemoveCommand(UserFactory.getSystemUser(), server);
+                new CobblerSystemRemoveCommand(user, server);
+
             cmd.store();
+
         }
     }
 }
 
 private boolean shouldCleanupCobbler() {
+
     return this.currentServer() != null &&
            this.getState() == KickstartFactory.SESSION_STATE_COMPLETE;
 }

--- a/java/core/src/main/java/com/redhat/rhn/domain/kickstart/KickstartSession.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/kickstart/KickstartSession.java
@@ -26,6 +26,8 @@ import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.legacy.UserImpl;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.kickstart.cobbler.CobblerSystemRemoveCommand;
+import com.redhat.rhn.domain.user.UserFactory;
 
 import org.hibernate.type.YesNoConverter;
 
@@ -512,11 +514,26 @@ public class KickstartSession extends BaseDomainHelper {
      * @param messageIn to fill into into the History field
      */
     public void markComplete(String messageIn) {
-        this.setState(KickstartFactory.SESSION_STATE_COMPLETE);
-        this.setAction(null);
-        this.addHistory(this.getState(), messageIn);
-        SystemManager.updateSystemOverview(this.currentServer());
+    this.setState(KickstartFactory.SESSION_STATE_COMPLETE);
+    this.setAction(null);
+    this.addHistory(this.getState(), messageIn);
+    SystemManager.updateSystemOverview(this.currentServer());
+
+    // Cleanup Cobbler system entry created during kickstart provisioning
+    if (shouldCleanupCobbler()) {
+        Server server = this.currentServer();
+        if (server != null) {
+            CobblerSystemRemoveCommand cmd =
+                new CobblerSystemRemoveCommand(UserFactory.getSystemUser(), server);
+            cmd.store();
+        }
     }
+}
+
+private boolean shouldCleanupCobbler() {
+    return this.currentServer() != null
+        && this.getState() == KickstartFactory.SESSION_STATE_COMPLETE;
+}
 
     /**
      * Add a History entry

--- a/java/core/src/main/java/com/redhat/rhn/domain/kickstart/KickstartSession.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/kickstart/KickstartSession.java
@@ -24,10 +24,10 @@ import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.rhnpackage.profile.Profile;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.domain.user.legacy.UserImpl;
-import com.redhat.rhn.manager.system.SystemManager;
-import com.redhat.rhn.manager.kickstart.cobbler.CobblerSystemRemoveCommand;
 import com.redhat.rhn.domain.user.UserFactory;
+import com.redhat.rhn.domain.user.legacy.UserImpl;
+import com.redhat.rhn.manager.kickstart.cobbler.CobblerSystemRemoveCommand;
+import com.redhat.rhn.manager.system.SystemManager;
 
 import org.hibernate.type.YesNoConverter;
 
@@ -531,8 +531,8 @@ public class KickstartSession extends BaseDomainHelper {
 }
 
 private boolean shouldCleanupCobbler() {
-    return this.currentServer() != null
-        && this.getState() == KickstartFactory.SESSION_STATE_COMPLETE;
+    return this.currentServer() != null &&
+           this.getState() == KickstartFactory.SESSION_STATE_COMPLETE;
 }
 
     /**

--- a/java/spacewalk-java.changes.pratik.cobbler-cleanup
+++ b/java/spacewalk-java.changes.pratik.cobbler-cleanup
@@ -1,3 +1,4 @@
 - Clean up temporary Cobbler system entries after successful
   kickstart provisioning to avoid stale entries remaining
   in the system.
+  

--- a/java/spacewalk-java.changes.pratik.cobbler-cleanup
+++ b/java/spacewalk-java.changes.pratik.cobbler-cleanup
@@ -1,0 +1,3 @@
+- Clean up temporary Cobbler system entries after successful
+  kickstart provisioning to avoid stale entries remaining
+  in the system.


### PR DESCRIPTION
## What does this PR change?

This PR ensures that temporary Cobbler system entries created during kickstart provisioning are cleaned up after successful completion of a KickstartSession.

Currently, cleanup is triggered when a session is cancelled, but not when it completes successfully. This can leave stale Cobbler entries in the system.

The change triggers cleanup in `KickstartSession.markComplete()` by invoking `CobblerSystemRemoveCommand` for the associated server.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #11660

## Changelogs

- [x] Added changelog entry