### PR TITLE
Fix hub SCC forwarding registration credential filter (bsc#1260031)

### DIFF
--- a/java/core/src/main/java/com/suse/scc/SCCTaskManager.java
+++ b/java/core/src/main/java/com/suse/scc/SCCTaskManager.java
@@ -107,7 +107,10 @@ public class SCCTaskManager {
     protected Optional<SCCCredentials> getSCCCredentialsPeripheralCase(IssHub hub) {
         List<SCCCredentials> credentials = CredentialsFactory.listSCCCredentials();
         Optional<SCCCredentials> optHubCredential = credentials.stream()
-                .filter(c -> hub.getFqdn().equals(c.getUrl()))
+                .filter(c -> hub.getFqdn().equals(c.getUrl()
+                        .replace("http://", "")
+                        .replace("https://", "")
+                ))
                 .findFirst();
 
         if (optHubCredential.isEmpty()) {

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/test/ForwardRegistrationTaskTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/test/ForwardRegistrationTaskTest.java
@@ -83,6 +83,9 @@ import org.apache.http.message.BasicStatusLine;
 import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.net.URI;
@@ -95,6 +98,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.servlet.http.HttpServletResponse;
 import spark.route.HttpMethod;
@@ -232,6 +236,10 @@ public class ForwardRegistrationTaskTest extends BaseTestCaseWithUser {
         @Override
         public Optional<SCCCredentials> getSCCCredentials() {
             return super.getSCCCredentials();
+        }
+        @Override
+        public Optional<SCCCredentials> getSCCCredentialsPeripheralCase(IssHub hub) {
+            return super.getSCCCredentialsPeripheralCase(hub);
         }
     }
 
@@ -670,6 +678,42 @@ public class ForwardRegistrationTaskTest extends BaseTestCaseWithUser {
                     testSystems.stream().filter(i -> i.getOptCredentials().isPresent()).count(),
                     "no new systems should have credentials");
             return this;
+        }
+    }
+
+    private static Stream<Arguments> provideHubUrls() {
+        return Stream.of(
+                Arguments.of("hub1.fqdn.addr", "https://hub1.fqdn.addr", true),
+                Arguments.of("hub2.fqdn.addr", "http://hub2.fqdn.addr", true),
+                Arguments.of("hub3.fqdn.addr", "hub3.fqdn.addr", true),
+                Arguments.of("hub4.fqdn.addr", "ftp://hub4.fqdn.addr", false),
+                Arguments.of("hub5.fqdn.addr", "wronghub5.fqdn.addr", false)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideHubUrls")
+    public void matchHubSccCredentials(String hubFqdn, String hubUrl, boolean matchSucceed) {
+        MockCredentialsSCCTaskManager mockSccTaskManager = new MockCredentialsSCCTaskManager();
+        //
+        SCCCredentials sccCredentialsHubHttps =
+                CredentialsFactory.createSCCCredentials(PERIPHERAL_USERNAME, PERIPHERAL_PASSWD);
+        sccCredentialsHubHttps.setUrl(hubUrl);
+        CredentialsFactory.storeCredentials(sccCredentialsHubHttps);
+        //
+        IssHub hub = new IssHub(hubFqdn, "");
+        //
+
+        Optional<SCCCredentials> sccCredentialsMatch = mockSccTaskManager.getSCCCredentialsPeripheralCase(hub);
+
+        if (matchSucceed) {
+            assertTrue(sccCredentialsMatch.isPresent());
+            assertEquals(hubUrl, sccCredentialsMatch.get().getUrl());
+            assertEquals(PERIPHERAL_USERNAME, sccCredentialsMatch.get().getUsername());
+            assertEquals(PERIPHERAL_PASSWD, sccCredentialsMatch.get().getPassword());
+        }
+        else {
+            assertTrue(sccCredentialsMatch.isEmpty());
         }
     }
 

--- a/java/spacewalk-java.changes.carlo.uyuni-1260031_hub_forwarding_registration
+++ b/java/spacewalk-java.changes.carlo.uyuni-1260031_hub_forwarding_registration
@@ -1,0 +1,2 @@
+- Fix hub SCC forwarding registration credential filter
+  (bsc#1260031)


### PR DESCRIPTION
## What does this PR change?

Fix hub SCC forwarding registration credential filter (bsc#1260031)

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/30094
Port(s): 
5.1: https://github.com/SUSE/spacewalk/pull/30178
5.0, 4.3: not backported (no hub/peripheral)
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

