### PR TITLE
QE: fix and refactor checks on volumes' SELinux labels

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -751,11 +751,22 @@ end
 
 Then(/^files on container volumes should all have the proper SELinux label$/) do
   node = get_target('server')
-  cmd = '[ "$(sestatus 2>/dev/null | head -n 1 | grep enabled)" != "" ] && ' \
-        '(find /var/lib/containers/storage/volumes/*/_data -exec ls -Zd {} \; | grep -v ":object_r:container_file_t:s0 ")'
-  output, _code = node.run_local(cmd, check_errors: false)
-  log output if output != ''
-  raise ScriptError, 'Wrong SELinux labels' if output != ''
+  # Check SELinux is enabled
+  sestatus, = node.run_local('sestatus | head -n 1', check_errors: false)
+  raise ScriptError, "SELinux is NOT enabled on the server host." unless sestatus.include?('enabled')
+
+  volume_path = '/var/lib/containers/storage/volumes/*/_data'
+  expected_context = ':object_r:container_file_t:s0'
+  # Get containers' labels
+  output, = node.run_local("find #{volume_path} -exec ls -Zd {} +", check_errors: false)
+  # Filter out files with the expected label
+  invalid_files = output.split("\n").reject { |line| line.include?(expected_context) }
+  # If any file with an unexpected label remains, log it and fail
+  if invalid_files.any?
+    log "Found files with incorrect SELinux labels:"
+    invalid_files.each { |f| log "  #{f}" }
+    raise ScriptError, "SELinux Label Validation Failed: #{invalid_files.size} files incorrectly labeled."
+  end
 end
 
 When(/^I run "([^"]*)" on "([^"]*)"$/) do |cmd, host|


### PR DESCRIPTION
## What does this PR change?

The test is failing in CI because of the trailing space in the last grep, which ends up making the test not take into account the specific categories assigned to a file.

e..g. the c390 and c722 in this line

system_u:object_r:container_file_t:s0:c390,c722 /var/lib/containers/storage/volumes/etc-tomcat/_data/server.xml

Beside fixing the test itself, the PR also attempts to refactor and make more readable and debuggable the scenario implementation.


## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): 
https://github.com/SUSE/spacewalk/issues/30186
Port(s): -

- [x] **DONE**

## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
