### PR TITLE
Improve CPU and LPAR reporting for ppc64le architectures

### DIFF
--- a/susemanager-utils/susemanager-sls/src/grains/cpuinfo.py
+++ b/susemanager-utils/susemanager-sls/src/grains/cpuinfo.py
@@ -135,11 +135,28 @@ def cpusockets():
 
 
 def total_num_cpus():
-    """returns the total number of CPU in system.
-    /proc/cpuinfo shows the number of active CPUs
-    On s390x this can be different from the number of present CPUs in a system
-    See IBM redbook: "Using z/VM for Test and Development Environments: A Roundup" chapter 3.5
+    """Returns the total number of CPUs in the system.
+
+    The definition of "CPU" varies by architecture to provide the most accurate
+    representation for licensing and UI display. Note that /proc/cpuinfo shows the
+    number of active CPUs, which can differ from the number of present CPUs.
+
+    Architectural differences:
+    - On x86_64 and other general architectures, it returns the logical processor
+      count (Cores x SMT threads) by counting entries in /sys/devices/system/cpu/.
+    - On ppc64/ppc64le, it returns the Virtual Processor (VP) count from
+      /proc/ppc64/lparcfg, ignoring SMT threads to avoid inflated counts.
+    - On s390x, it returns the number of present CPUs, which may differ from
+      active CPUs shown in /proc/cpuinfo (see IBM Redbook: "Using z/VM for Test
+      and Development Environments: A Roundup" chapter 3.5).
     """
+    arch = _get_architecture()
+    if arch in ["ppc64", "ppc64le"]:
+        lparcfg = _read_file("/proc/ppc64/lparcfg")
+        match = re.search(r"partition_active_processors\s*=\s*(\d+)", lparcfg)
+        if match:
+            return {"total_num_cpus": int(match.group(1))}
+
     re_cpu = re.compile(r"^cpu[0-9]+$")
     sysdev = "/sys/devices/system/cpu/"
     return {
@@ -246,7 +263,15 @@ def _add_ppc64_extras(specs):
         match = re.search(r"shared_processor_mode\s*=\s*(\d+)", lparcfg_content)
         if match:
             specs["lpar_mode"] = "shared" if match.group(1) == "1" else "dedicated"
-
+        match = re.search(r"partition_active_processors\s*=\s*(\d+)", lparcfg_content)
+        if match:
+            specs["total_virtual_processors"] = int(match.group(1))
+        match = re.search(r"partition_entitled_capacity\s*=\s*(\d+)", lparcfg_content)
+        if match:
+            specs["entitled_capacity"] = int(match.group(1))
+        match = re.search(r"capped\s*=\s*(\d+)", lparcfg_content)
+        if match:
+            specs["capping_mode"] = "capped" if match.group(1) == "1" else "uncapped"
 
 def _add_arm64_extras(specs):
     """


### PR DESCRIPTION
## What does this PR change?

On ppc64le clients, /proc/cpuinfo reports logical threads (SMT) as individual processors. This leads to inflated "CPU" counts in the UI. This change aligns CPU reporting for ppc64le clients with the actual virtualized hardware allocation by leveraging LPAR-specific configuration.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.



- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/29992


- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
