### PR TITLE
Fix CPU reporting for ppc64le clients

### DIFF
--- a/susemanager-utils/susemanager-sls/src/grains/cpuinfo.py
+++ b/susemanager-utils/susemanager-sls/src/grains/cpuinfo.py
@@ -135,11 +135,29 @@ def cpusockets():
 
 
 def total_num_cpus():
-    """returns the total number of CPU in system.
-    /proc/cpuinfo shows the number of active CPUs
-    On s390x this can be different from the number of present CPUs in a system
-    See IBM redbook: "Using z/VM for Test and Development Environments: A Roundup" chapter 3.5
+    """Returns the total number of CPUs in the system.
+
+    The definition of "CPU" varies by architecture to provide the most accurate
+    representation. Note that /proc/cpuinfo shows the number of active CPUs, which
+    can differ from the number of present CPUs.
+
+    Architectural differences:
+    - On x86_64 it returns the logical processor
+      count (Cores x SMT threads) by counting entries in /sys/devices/system/cpu/.
+    - On ppc64/ppc64le, it returns the Virtual Processor (VP) count from
+      /proc/ppc64/lparcfg, ignoring SMT threads to avoid inflated counts.
+    - On s390x, it returns the number of present CPUs, which may differ from
+      active CPUs shown in /proc/cpuinfo (see IBM Redbook: "Using z/VM for Test
+      and Development Environments: A Roundup" chapter 3.5).
     """
+    arch = _get_architecture()
+    if arch in ["ppc64", "ppc64le"]:
+        lparcfg = _read_file("/proc/ppc64/lparcfg")
+        match = re.search(r"partition_active_processors\s*=\s*(\d+)", lparcfg)
+        if match:
+            return {"total_num_cpus": int(match.group(1))}
+        log.warning("Failed to parse partition_active_processors")
+
     re_cpu = re.compile(r"^cpu[0-9]+$")
     sysdev = "/sys/devices/system/cpu/"
     return {
@@ -246,6 +264,15 @@ def _add_ppc64_extras(specs):
         match = re.search(r"shared_processor_mode\s*=\s*(\d+)", lparcfg_content)
         if match:
             specs["lpar_mode"] = "shared" if match.group(1) == "1" else "dedicated"
+        match = re.search(r"partition_active_processors\s*=\s*(\d+)", lparcfg_content)
+        if match:
+            specs["total_virtual_processors"] = int(match.group(1))
+        match = re.search(r"partition_entitled_capacity\s*=\s*(\d+)", lparcfg_content)
+        if match:
+            specs["entitled_capacity"] = int(match.group(1))
+        match = re.search(r"capped\s*=\s*(\d+)", lparcfg_content)
+        if match:
+            specs["capping_mode"] = "capped" if match.group(1) == "1" else "uncapped"
 
 
 def _add_arm64_extras(specs):

--- a/susemanager-utils/susemanager-sls/src/tests/test_grains_cpuinfo.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_grains_cpuinfo.py
@@ -13,39 +13,24 @@ mockery.setup_environment()
 from ..grains import cpuinfo
 
 
-def test_total_num_cpus():
+@pytest.mark.parametrize(
+    "arch, lparcfg_content, expected_count",
+    [("ppc64le", "partition_active_processors=8\n", 8), ("x86_64", None, 4)],
+)
+def test_total_num_cpus(arch, lparcfg_content, expected_count):
     """
-    Test total_num_cpus function.
-
-    :return:
+    Test that total_num_cpus returns the correct count based on architecture.
     """
-    os_listdir = [
-        "cpu0",
-        "cpu1",
-        "cpu2",
-        "cpu3",
-        "cpufreq",
-        "cpuidle",
-        "power",
-        "modalias",
-        "kernel_max",
-        "possible",
-        "online",
-        "offline",
-        "isolated",
-        "uevent",
-        "intel_pstate",
-        "microcode",
-        "present",
-    ]
+    os_listdir = ["cpu0", "cpu1", "cpu2", "cpu3"]
 
-    with patch("os.path.exists", MagicMock(return_value=True)):
-        with patch("os.listdir", MagicMock(return_value=os_listdir)):
-            cpus = cpuinfo.total_num_cpus()
-            # pylint: disable-next=unidiomatic-typecheck
-            assert type(cpus) == dict
-            assert "total_num_cpus" in cpus
-            assert cpus["total_num_cpus"] == 4
+    with patch("os.path.exists", return_value=True), patch(
+        "os.listdir", return_value=os_listdir
+    ), patch("src.grains.cpuinfo._get_architecture", return_value=arch), patch(
+        "src.grains.cpuinfo._read_file", return_value=lparcfg_content
+    ):
+
+        cpus = cpuinfo.total_num_cpus()
+        assert cpus["total_num_cpus"] == expected_count
 
 
 def test_cpusockets_dmidecode_count_sockets():
@@ -167,19 +152,29 @@ def test_arch_specs_unknown():
 
 
 def test_arch_specs_ppc64():
+    """
+    Test that arch_specs extracts all relevant PPC64 LPAR and device tree fields.
+    """
     # pylint: disable-next=protected-access
     cpuinfo._get_architecture = MagicMock(return_value="ppc64")
     # pylint: disable-next=protected-access
     cpuinfo._read_file = MagicMock(
         side_effect=lambda path: (
-            "shared_processor_mode = 1"
+            "shared_processor_mode = 1\n"
+            "partition_active_processors = 4\n"
+            "partition_entitled_capacity = 2\n"
+            "capped = 0\n"
             if path == "/proc/ppc64/lparcfg"
             else "device tree content"
         )
     )
     specs = cpuinfo.arch_specs()
-    assert specs == {
-        "cpu_arch_specs": {"lpar_mode": "shared", "device_tree": "device tree content"}
+    assert specs["cpu_arch_specs"] == {
+        "lpar_mode": "shared",
+        "total_virtual_processors": 4,
+        "entitled_capacity": 2,
+        "capping_mode": "uncapped",
+        "device_tree": "device tree content",
     }
 
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.ygutierrez.fix-ppc64le-ncpus-report
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.ygutierrez.fix-ppc64le-ncpus-report
@@ -1,0 +1,1 @@
+- Fix CPU reporting for ppc64le clients (bsc#1259521)


### PR DESCRIPTION
## What does this PR change?

On ppc64le clients, /proc/cpuinfo reports logical threads (SMT) as individual processors. This leads to inflated "CPU" counts in the UI. This change aligns CPU reporting for ppc64le clients with the actual virtualized hardware allocation by leveraging LPAR-specific configuration.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.



- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [X] **DONE**

## Test coverage

- Unit tests were added


- [X] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/29992


- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
