### PR TITLE
Fix labeler workflows for PRs accross forks

### DIFF
--- a/.github/workflows/acceptance_tests_feedback_comment.yml
+++ b/.github/workflows/acceptance_tests_feedback_comment.yml
@@ -16,20 +16,23 @@ jobs:
           github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pull-requests: write
     steps:
-      - name: Read PR number
-        id: pr
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd #v8.0.0
+      - name: Download PR metadata artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
         with:
-          script: |
-            const pullRequests = context.payload.workflow_run.pull_requests || [];
-            if (pullRequests.length !== 1 || !pullRequests[0].number) {
-              core.setFailed('Expected exactly one pull request in workflow_run payload.');
-              return;
-            }
-            core.setOutput('number', pullRequests[0].number.toString());
+          name: pr-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: .
+
+      - name: Read PR number from artifact
+        id: pr
+        run: |
+          pr_number="$(cat pr-number)"
+          echo "number=${pr_number}" >> "$GITHUB_OUTPUT"
 
       - uses: actions-cool/maintain-one-comment@4b2dbf086015f892dcb5e8c1106f5fccd6c1476b # v3.2.0
         with:

--- a/.github/workflows/acceptance_tests_feedback_trigger.yml
+++ b/.github/workflows/acceptance_tests_feedback_trigger.yml
@@ -27,4 +27,13 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     steps:
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > pr-number
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 #v5.0.0
+        with:
+          name: pr-metadata
+          path: pr-number
+
       - run: echo "Acceptance tests feedback trigger workflow completed"

--- a/.github/workflows/check_translations.yml
+++ b/.github/workflows/check_translations.yml
@@ -94,7 +94,10 @@ jobs:
             needs_translation=false
           fi
 
-          echo "needs_translation=${needs_translation}" > translation-result
+          {
+            echo "pr_number=${{ github.event.pull_request.number }}"
+            echo "needs_translation=${needs_translation}"
+          } > translation-result
 
       - name: Upload translation result
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 #v5.0.0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -21,31 +21,39 @@ jobs:
           github.event.workflow_run.name == 'PR event trigger' }}
     outputs:
       pr-number: ${{ steps.pr.outputs.number }}
-      is-external: ${{ steps.pr.outputs.is_external }}
+      is-external: ${{ steps.association.outputs.is_external }}
     permissions:
+      actions: read
       contents: read
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
-    - name: Read PR number
+    - name: Download PR metadata artifact
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
+      with:
+        name: pr-metadata
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ github.token }}
+        path: .
+
+    - name: Read PR number from artifact
       id: pr
+      run: |
+        pr_number="$(cat pr-number)"
+        echo "number=${pr_number}" >> "$GITHUB_OUTPUT"
+
+    - name: Read PR association
+      id: association
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd #v8.0.0
       with:
         script: |
-          const pullRequests = context.payload.workflow_run.pull_requests || [];
-          if (pullRequests.length !== 1 || !pullRequests[0].number) {
-            core.setFailed('Expected exactly one pull request in workflow_run payload.');
-            return;
-          }
-
-          const prNumber = pullRequests[0].number;
+          const prNumber = Number('${{ steps.pr.outputs.number }}');
           const { data: pullRequest } = await github.rest.pulls.get({
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: prNumber,
           });
 
-          core.setOutput('number', prNumber.toString());
           const internalAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
           const isExternal = !internalAssociations.has(pullRequest.author_association);
           core.setOutput('is_external', isExternal ? 'true' : 'false');
@@ -88,7 +96,8 @@ jobs:
             labels: ['community'],
           });
 
-  # Applies or removes needs-translation based on translation producer result artifact.
+  # Applies or removes needs-translation based on translation producer
+  # (check_translations.yml) result artifact.
   translation-labeler:
     # Security invariant: keep this workflow_run job metadata-only.
     # Do not checkout or execute content from PR branches in this privileged context.
@@ -102,18 +111,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Read PR number
-        id: pr
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd #v8.0.0
-        with:
-          script: |
-            const pullRequests = context.payload.workflow_run.pull_requests || [];
-            if (pullRequests.length !== 1 || !pullRequests[0].number) {
-              core.setFailed('Expected exactly one pull request in workflow_run payload.');
-              return;
-            }
-            core.setOutput('number', pullRequests[0].number.toString());
-
       - name: Download translation result artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
         with:
@@ -125,12 +122,10 @@ jobs:
       - name: Read translation result
         id: translation
         run: |
-          line="$(grep -E '^needs_translation=(true|false)$' translation-result || true)"
-          if [ -z "$line" ]; then
-            echo "Invalid translation-result content; expected 'needs_translation=true' or 'needs_translation=false'." >&2
-            exit 1
-          fi
-          needs_translation="${line#needs_translation=}"
+          pr_number="$(grep -E '^pr_number=' translation-result | cut -d= -f2)"
+          needs_translation="$(grep -E '^needs_translation=' translation-result | cut -d= -f2)"
+
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
           echo "needs_translation=${needs_translation}" >> "$GITHUB_OUTPUT"
 
       - name: Add needs-translation label
@@ -141,7 +136,7 @@ jobs:
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: Number('${{ steps.pr.outputs.number }}'),
+              issue_number: Number('${{ steps.translation.outputs.pr_number }}'),
               labels: ['needs-translation'],
             });
 
@@ -154,7 +149,7 @@ jobs:
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: Number('${{ steps.pr.outputs.number }}'),
+                issue_number: Number('${{ steps.translation.outputs.pr_number }}'),
                 name: 'needs-translation',
               });
             } catch (error) {

--- a/.github/workflows/pr-event-trigger.yml
+++ b/.github/workflows/pr-event-trigger.yml
@@ -19,4 +19,13 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     steps:
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > pr-number
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 #v5.0.0
+        with:
+          name: pr-metadata
+          path: pr-number
+
       - run: echo "PR event trigger workflow completed"


### PR DESCRIPTION
PR numbers are not included in the workflow payloads when the PR is from a fork. This patch saves the PR number in an artifact instead for consumer workflows to access.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
