### PR TITLE
helm: add a link to the k8s doc to create registry secret

### DIFF
--- a/containers/proxy-helm/values.yaml
+++ b/containers/proxy-helm/values.yaml
@@ -2,12 +2,15 @@
 repository: registry.opensuse.org/uyuni
 tag: latest
 
-## Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
-##
+# Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+#
 pullPolicy: "Always"
 
-## registrySecret defines the name of secret to use to pull the images from the
-## registry with authentication. Leave empty for no authentication.
+# registrySecret defines the name of secret to use to pull the images from the
+# registry with authentication. Leave empty for no authentication.
+#
+# To create the secret, see:
+# https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 registrySecret: ""
 
 global:
@@ -30,87 +33,87 @@ global:
   ssh:
 
 ingress:
-  ## ingress.type defines the ingress that is used in the cluster.
-  ## It can be either "nginx", "traefik" or any other value.
-  ##
+  # ingress.type defines the ingress that is used in the cluster.
+  # It can be either "nginx", "traefik" or any other value.
+  #
   type: "traefik"
   
-  ## Specify the ingress class name to use. Empty, means that the default one will be used.
-  ## If using the traefik end points and TCP routers, this value needs to match Traefik's
-  ## --providers.kubernetescrd.ingressclass parameter's value.
-  ## On rke2 this is likely to be "traefik". On K3S it is likely to be ""
-  ##
+  # Specify the ingress class name to use. Empty, means that the default one will be used.
+  # If using the traefik end points and TCP routers, this value needs to match Traefik's
+  # --providers.kubernetescrd.ingressclass parameter's value.
+  # On rke2 this is likely to be "traefik". On K3S it is likely to be ""
+  #
   class: ""
   
-  ## annotations can be used to set custom annotations on the created ingress rules.
-  ## This can be used to configure another ingress than the ones already wired with the ingress.type.
+  # annotations can be used to set custom annotations on the created ingress rules.
+  # This can be used to configure another ingress than the ones already wired with the ingress.type.
   annotations:
     ssl:
 
 # Gateway configures the Gateway API.
 gateway:
-  ## If enabled, Gateway API 1.4 resources will be deployed instead of the ingress ones.
-  ## Note that TCPRoute is used and is still in alpha2 stage.
+  # If enabled, Gateway API 1.4 resources will be deployed instead of the ingress ones.
+  # Note that TCPRoute is used and is still in alpha2 stage.
   enable: false
 
-  ## Name of the gateway class to use. For rke2 with traefik, it is likely to be "traefik".
+  # Name of the gateway class to use. For rke2 with traefik, it is likely to be "traefik".
   class: ""
 
-  ## Name of the gateway to use. An empty string value means that a gateway will be deployed and named uyuni-gateway.
+  # Name of the gateway to use. An empty string value means that a gateway will be deployed and named uyuni-gateway.
   name: ""
 
   listeners:
     http:
-      ## Name to set for the gateway http listener. The default is adjusted for traefik on rke2
+      # Name to set for the gateway http listener. The default is adjusted for traefik on rke2
       name: "web"
-      ## Port to set for the gateway http listener. The default is adjusted for traefik on rke2
+      # Port to set for the gateway http listener. The default is adjusted for traefik on rke2
       port: 8000
     https:
-      ## Name to set for the gateway https listener. The default is adjusted for traefik on rke2
+      # Name to set for the gateway https listener. The default is adjusted for traefik on rke2
       name: "websecure"
-      ## Port to set for the gateway https listener. The default is adjusted for traefik on rke2
+      # Port to set for the gateway https listener. The default is adjusted for traefik on rke2
       port: 8443
 
 volumes:
   # squid is the volume for the proxy's cache.
   # The size of the squid cache is set when creating the configuration file on the server side.
   squid:
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default storage class.
+    # If defined, storageClassName: <storageClass>
+    # If set to "-", storageClassName: "", which disables dynamic provisioning
+    # If undefined (the default) or set to null, no storageClassName spec is
+    #   set, choosing the default storage class.
     storageClass:
 
-    ## extraLabels adds custom labels to the PVC metadata
+    # extraLabels adds custom labels to the PVC metadata
     extraLabels:
 
-    ## annotations sets annotations to the PVC.
-    ## This may be useful to configure some storage backends
+    # annotations sets annotations to the PVC.
+    # This may be useful to configure some storage backends
     annotations:
 
-    ## volumeName sets the volumeName to bind to if defined.
+    # volumeName sets the volumeName to bind to if defined.
     #volumeName:
 
-    ## selector is rendered with toYAML and can be used to bind to a specific PV.
+    # selector is rendered with toYAML and can be used to bind to a specific PV.
     selector:
 
 services:
-    ## Select service type
-    ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/
+    # Select service type
+    # Ref: https://kubernetes.io/docs/concepts/services-networking/service/
     type: ClusterIP
 
-    ## Annotations sets annotations to all services.
+    # Annotations sets annotations to all services.
     annotations:
 
 httpd:
-  ## image overrides the default image computed using the repository property
-  ## Leave undefined to use the default
+  # image overrides the default image computed using the repository property
+  # Leave undefined to use the default
   image:
-  ## tag overrides the default tag in the tag property
-  ## Leave undefined to use the default
+  # tag overrides the default tag in the tag property
+  # Leave undefined to use the default
   tag:
 
-  ## Apache configuration tuning to use
+  # Apache configuration tuning to use
   tuning: ""
   
   # Service ports to use if the type is NodePort
@@ -119,25 +122,25 @@ httpd:
     https: 30443
 
 squid:
-  ## image overrides the default image computed using the repository property
-  ## Leave undefined to use the default
+  # image overrides the default image computed using the repository property
+  # Leave undefined to use the default
   image:
-  ## tag overrides the default tag in the tag property
-  ## Leave undefined to use the default
+  # tag overrides the default tag in the tag property
+  # Leave undefined to use the default
   tag:
 
-  ## Squid configuration tuning to use
+  # Squid configuration tuning to use
   tuning: ""
 
 ssh:
-  ## image overrides the default image computed using the repository property
-  ## Leave undefined to use the default
+  # image overrides the default image computed using the repository property
+  # Leave undefined to use the default
   image:
-  ## tag overrides the default tag in the tag property
-  ## Leave undefined to use the default
+  # tag overrides the default tag in the tag property
+  # Leave undefined to use the default
   tag:
 
-  ## SSHD configuration tuning to use
+  # SSHD configuration tuning to use
   tuning: ""
   
   # Service ports to use if the type is NodePort
@@ -145,24 +148,24 @@ ssh:
     ssh: 38022
 
 tftp:
-  ## image overrides the default image computed using the repository property
-  ## Leave undefined to use the default
+  # image overrides the default image computed using the repository property
+  # Leave undefined to use the default
   image:
-  ## tag overrides the default tag in the tag property
-  ## Leave undefined to use the default
+  # tag overrides the default tag in the tag property
+  # Leave undefined to use the default
   tag:
 
-  ## Use the host network to bypass the Kubernetes network layers.
-  ## This may be needed if not using a LoadBalancer for the TFTP server.
-  ## Note that this may be more complex to manage on multi-node clusters.
+  # Use the host network to bypass the Kubernetes network layers.
+  # This may be needed if not using a LoadBalancer for the TFTP server.
+  # Note that this may be more complex to manage on multi-node clusters.
   hostNetwork: false
 
 salt:
-  ## image overrides the default image computed using the repository property
-  ## Leave undefined to use the default
+  # image overrides the default image computed using the repository property
+  # Leave undefined to use the default
   image:
-  ## tag overrides the default tag in the tag property
-  ## Leave undefined to use the default
+  # tag overrides the default tag in the tag property
+  # Leave undefined to use the default
   tag:
   
   # Service ports to use if the type is NodePort

--- a/containers/server-helm/values.yaml
+++ b/containers/server-helm/values.yaml
@@ -8,6 +8,9 @@ pullPolicy: "IfNotPresent"
 
 # registrySecret defines the name of secret to use to pull the images from the
 # registry with authentication. Leave empty for no authentication.
+#
+# To create the secret, see:
+# https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 registrySecret: ""
 
 # The time zone to set in the containers


### PR DESCRIPTION
## What does this PR change?

Add a link to the doc telling how to create registry secret.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: doc change

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
