### PR TITLE
Use an authenticated request to determine PR author association in external PR labeler action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -46,6 +46,7 @@ jobs:
       id: association
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd #v8.0.0
       with:
+        github-token: ${{ github.token }}
         script: |
           const prNumber = Number('${{ steps.pr.outputs.number }}');
           const { data: pullRequest } = await github.rest.pulls.get({


### PR DESCRIPTION
When the GH api (`/repos/${owner}/${repo}/pulls/${prNumber}`) is called without authentication, it reports everyone as "CONTRIBUTOR":

```json
  "pr": {
    ...
    "user": "cbbayburt",
    "author_association": "CONTRIBUTOR",
    "base_repo": "uyuni-project/uyuni",
  },
```
When called **with** authentication:
```json
  "pr": {
    ...
    "user": "cbbayburt",
    "author_association": "MEMBER",
    "base_repo": "uyuni-project/uyuni",
  },
```

To properly classify authors as internal/external, this API must be called with a GITHUB_TOKEN.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
