### PR TITLE
Fix ServerFactory.lookupProxiesByOrg query (bsc#1259991)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/server/ServerFactory.java
@@ -1142,6 +1142,7 @@ public class ServerFactory extends HibernateFactory {
                                 FROM UserServerPermission usp
                                 WHERE usp.user.id = :userId
                                         AND usp.server.org.id = :orgId
+                                        AND usp.server.proxyInfo IS NOT NULL
                                 """, Server.class)
                 .setParameter("userId", user.getId())
                 .setParameter("orgId", user.getOrg().getId())

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/ServerFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/ServerFactoryTest.java
@@ -88,6 +88,7 @@ import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.salt.netapi.calls.LocalCall;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -1611,6 +1612,34 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         assertTrue(ServerFactory.isPtfUninstallationSupported(ptfFullSupport));
     }
 
+    @Test
+    @DisplayName("ServerFactory.lookupProxiesByOrg detects a proxy")
+    public void testLookupProxiesByOrgWithProxy() {
+        Server proxyServer = createTestServer(user, true,
+                ServerConstants.getServerGroupTypeSaltEntitled(), TYPE_SERVER_PROXY);
+        proxyServer.setHostname(HOSTNAME);
+        TestUtils.flushAndClearSession();
+
+        assertEquals(proxyServer, ServerFactory.lookupProxyServer(HOSTNAME).orElseThrow());
+
+        List<Server> proxyList = ServerFactory.lookupProxiesByOrg(user);
+        assertEquals(1, proxyList.size());
+        assertEquals(proxyServer, proxyList.get(0));
+    }
+
+    @Test
+    @DisplayName("ServerFactory.lookupProxiesByOrg avoid to detect normal minions")
+    public void testLookupProxiesByOrgWithMinion() {
+        Server normalMinion = createTestServer(user, true,
+                ServerConstants.getServerGroupTypeSaltEntitled(), TYPE_SERVER_MINION);
+        normalMinion.setHostname("my.minion.com");
+        TestUtils.flushAndClearSession();
+
+        assertTrue(ServerFactory.lookupProxyServer("my.minion.com").isEmpty());
+
+        List<Server> proxyList = ServerFactory.lookupProxiesByOrg(user);
+        assertEquals(0, proxyList.size());
+    }
 
 
     @Test

--- a/java/spacewalk-java.changes.carlo.uyuni-1259991-bootstrap-wrong-proxy-list
+++ b/java/spacewalk-java.changes.carlo.uyuni-1259991-bootstrap-wrong-proxy-list
@@ -1,0 +1,1 @@
+- Fix ServerFactory lookupProxiesByOrg query (bsc#1259991)


### PR DESCRIPTION
## What does this PR change?

The combo box showing the available proxy list on the bootstrap page, incorrectly shows all the possible minions.
This is a leftover of a missing criteria while translating the ServerFactory.lookupProxiesByOrg query, during the  jakarta migration (see [here](https://github.com/mackdk/uyuni/commit/4c9c78279716d88b20f4e545d0bbdaf5b91960de))

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links

Issue(s):  https://github.com/SUSE/spacewalk/issues/30096
Port(s): 5.1, 5.0, 4.3 not backported (not needed, master only)
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
