### PR TITLE
Remove sanity checks for enabled services

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -9,21 +9,13 @@ Feature: Sanity checks
     Then "server" should have a FQDN
     And reverse resolution should work for "server"
     And the clock from "server" should be exact
-    And service "apache2" is enabled on "server"
     And service "apache2" is active on "server"
-    And service "cobblerd" is enabled on "server"
     And service "cobblerd" is active on "server"
-    And service "rhn-search" is enabled on "server"
     And service "rhn-search" is active on "server"
-    And service "salt-api" is enabled on "server"
     And service "salt-api" is active on "server"
-    And service "salt-master" is enabled on "server"
     And service "salt-master" is active on "server"
-    And service "taskomatic" is enabled on "server"
     And service "taskomatic" is active on "server"
-    And socket "tftp" is enabled on "server"
     And socket "tftp" is active on "server"
-    And service "tomcat" is enabled on "server"
     And service "tomcat" is active on "server"
 
 @proxy


### PR DESCRIPTION
## What does this PR change?

Remove sanity checks for enabled services because these are started by the containers themselves and there is no need to check the systemd status. We have an apache service that is now disabled but the service is running and that should be enough of a check. This will fix head and uyuni failing in core. 

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were removed

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30210
Port(s): 
5.1: https://github.com/SUSE/spacewalk/pull/30211
5.0: https://github.com/SUSE/spacewalk/pull/30212
4.3: not done because it's not containerised server

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
