### PR TITLE
testsuite: ansible_param_tester.sh fix correcting the simple math arguments

### DIFF
--- a/testsuite/features/upload_files/ansible/playbooks/host_files/ansible_param_tester.sh
+++ b/testsuite/features/upload_files/ansible/playbooks/host_files/ansible_param_tester.sh
@@ -10,12 +10,15 @@ ALL_PARAMS=('Hello world,' "y'all :)" "I'm singing \"I'm singing in the rain\"" 
 DEBUG_MSG=""
 for ((i = 0 ; i < ${#ALL_PARAMS[@]} ; i++ )); do
     PARAM="${ALL_PARAMS[@]:${i}:1}"
-    if [[ "${PARAM}" =~ [0-9*/+-]+ ]]; then
+    DEBUG_MSG="${DEBUG_MSG}  $((${i} + 1)):"
+    if [[ "${PARAM}" =~ ^[\ ()0-9*/+-]+$ ]]; then
         echo "${PARAM} = $((${PARAM}))"
+        DEBUG_MSG="${DEBUG_MSG}  [NUM]"
     else
         echo "${PARAM}"
+        DEBUG_MSG="${DEBUG_MSG}  [STR]"
     fi
-    DEBUG_MSG="${DEBUG_MSG}  $((${i} + 1)):  ${PARAM}\n"
+    DEBUG_MSG="${DEBUG_MSG}  ${PARAM}\n"
 done
 printf "\n\n### Shell script debug ###\nParameters:\n${DEBUG_MSG}"
 IFS=${_IFS}


### PR DESCRIPTION
The fix corrects handling of string parameters falling into math operations and adding more debug information.
The script is used for checking the values, not appearing in ansible playbooks, and the correct execution of ansible playbooks.
Example of the script execution:
```
$ ./ansible_param_tester.sh "1" "1e" "abc" "(1 +1)" "13 * ( -13) " "25" "xyz" "-1 +2 * (-3)"
1 = 1
1e
abc
(1 +1) = 2
13 * ( -13)  = -169
25 = 25
xyz
-1 +2 * (-3) = -7


### Shell script debug ###
Parameters:
  1:  [NUM]  1
  2:  [STR]  1e
  3:  [STR]  abc
  4:  [NUM]  (1 +1)
  5:  [NUM]  13 * ( -13) 
  6:  [NUM]  25
  7:  [STR]  xyz
  8:  [NUM]  -1 +2 * (-3)
```


