### PR TITLE
SonarCloud error reduction fix, miscellaneous 14 rules

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/common/util/CryptHelper.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/util/CryptHelper.java
@@ -31,6 +31,7 @@ public class CryptHelper {
         "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
     private static String md5prefix = "$1$";
     private static String sha256prefix = "$5$";
+    private static Random secureRandom = new SecureRandom();
 
     /**
      * CryptHelper
@@ -104,10 +105,9 @@ public class CryptHelper {
      */
     static String generateRandomSalt(Integer saltLength) {
         StringBuilder salt = new StringBuilder();
-        Random r = new SecureRandom();
 
         for (int i = 0; i < saltLength; i++) {
-            int rand = r.nextInt(b64t.length());
+            int rand = secureRandom.nextInt(b64t.length());
             salt.append(b64t.charAt(rand));
         }
 

--- a/java/core/src/main/java/com/redhat/rhn/domain/contentmgmt/validation/ContentPropertiesValidator.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/contentmgmt/validation/ContentPropertiesValidator.java
@@ -49,21 +49,23 @@ public class ContentPropertiesValidator {
         if (StringUtils.isEmpty(label)) {
             result.addFieldError("label", "contentmanagement.label_required");
         }
-
-        if (!isLabelValid(label)) {
-            result.addFieldError("label", "contentmanagement.label_invalid");
+        else {
+            if (label.length() > 24) {
+                result.addFieldError("label", "contentmanagement.project_label_too_long");
+            }
         }
 
-        if (label.length() > 24) {
-            result.addFieldError("label", "contentmanagement.project_label_too_long");
+        if ((null != label) && (!isLabelValid(label))) {
+            result.addFieldError("label", "contentmanagement.label_invalid");
         }
 
         if (StringUtils.isEmpty(name)) {
             result.addFieldError("name", "contentmanagement.name_required");
         }
-
-        if (name.length() > 128) {
-            result.addFieldError("name", "contentmanagement.project_name_too_long");
+        else {
+            if (name.length() > 128) {
+                result.addFieldError("name", "contentmanagement.project_name_too_long");
+            }
         }
 
         ContentManager.lookupProjectByNameAndOrg(name, user).ifPresent(cp -> {
@@ -90,21 +92,23 @@ public class ContentPropertiesValidator {
         if (StringUtils.isEmpty(label)) {
             result.addFieldError("label", "contentmanagement.label_required");
         }
+        else {
+            if (label.length() > 16) {
+                result.addFieldError("label", "contentmanagement.environment_lbl_too_long");
+            }
+        }
 
         if (StringUtils.isEmpty(name)) {
             result.addFieldError("name", "contentmanagement.name_required");
         }
+        else {
+            if (name.length() > 128) {
+                result.addFieldError("name", "contentmanagement.environment_name_too_long");
+            }
+        }
 
-        if (!isLabelValid(label)) {
+        if ((null != label) && (!isLabelValid(label))) {
             result.addFieldError("label", "contentmanagement.label_invalid");
-        }
-
-        if (label.length() > 16) {
-            result.addFieldError("label", "contentmanagement.environment_lbl_too_long");
-        }
-
-        if (name.length() > 128) {
-            result.addFieldError("name", "contentmanagement.environment_name_too_long");
         }
 
         if (result.hasErrors()) {
@@ -125,7 +129,7 @@ public class ContentPropertiesValidator {
             result.addFieldError("filter_name", "contentmanagement.name_required");
         }
 
-        if (name.length() > 128) {
+        if ((null != name) && (name.length() > 128)) {
             result.addFieldError("filter_name", "contentmanagement.filter_name_too_long");
         }
 

--- a/java/core/src/main/java/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -264,8 +264,8 @@ public class ErrataFactory extends HibernateFactory {
                 packagesToPush.add(pack);
             }
 
-            Errata e = addErrataPackagesToChannel(errata, chan, user, packagesToPush);
-            toReturn.add(e);
+            addErrataPackagesToChannel(errata, chan, user, packagesToPush);
+            toReturn.add(errata);
         }
         if (performPostActions) {
             ChannelManager.refreshWithNewestPackages(chan, "java::addErrataPackagesToChannel");
@@ -281,20 +281,18 @@ public class ErrataFactory extends HibernateFactory {
      * @param chan channel to add it to
      * @param user the user doing the adding
      * @param packages the packages to add
-     * @return the added errata
      */
-    public static Errata addToChannel(Errata errata, Channel chan, User user,
+    public static void addToChannel(Errata errata, Channel chan, User user,
                                       Set<Package> packages) {
         errata.addChannel(chan);
-        errata = addErrataPackagesToChannel(errata, chan, user, packages);
+        addErrataPackagesToChannel(errata, chan, user, packages);
         ChannelManager.refreshWithNewestPackages(chan, "java::addErrataPackagesToChannel");
-        return errata;
     }
 
     /**
      * Private helper method that pushes errata packages to a channel
      */
-    private static Errata addErrataPackagesToChannel(Errata errata,
+    private static void addErrataPackagesToChannel(Errata errata,
                                                      Channel chan, User user, Set<Package> packages) {
         // Much quicker to push all packages at once
         List<Long> pids = new ArrayList<>();
@@ -319,8 +317,6 @@ public class ErrataFactory extends HibernateFactory {
         ChannelFactory.save(chan);
 
         ErrataCacheManager.insertCacheForChannelErrataAsync(List.of(chan.getId()), errata);
-
-        return errata;
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/domain/errata/Severity.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/errata/Severity.java
@@ -172,7 +172,7 @@ public class Severity implements Serializable {
         }
 
         Severity newSeverity = new Severity();
-        newSeverity.setId(Integer.valueOf(id).longValue());
+        newSeverity.setId(id.longValue());
         newSeverity.setLabel(SEVERITY_MAP.get(id));
         newSeverity.setRank(id);
         return newSeverity;

--- a/java/core/src/main/java/com/redhat/rhn/domain/notification/UserNotificationFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/notification/UserNotificationFactory.java
@@ -157,8 +157,11 @@ public class UserNotificationFactory extends HibernateFactory {
         if (!isNotificationTypeDisabled(notificationMessage)) {
             String[] receipients = users.stream()
                                         .filter(user -> !user.isDisabled())
-                                        .peek(user -> UserNotificationFactory.store(
-                                                new UserNotification(user, notificationMessage)))
+                                        .map(user -> {
+                                            UserNotificationFactory.store(
+                                                new UserNotification(user, notificationMessage));
+                                            return user;
+                                        })
                                         .filter(user -> user.getEmailNotify() == 1)
                                         .map(User::getEmail)
                                         .toArray(String[]::new);

--- a/java/core/src/main/java/com/redhat/rhn/domain/user/UserFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/user/UserFactory.java
@@ -44,7 +44,6 @@ import org.hibernate.type.StandardBasicTypes;
 
 import java.sql.Types;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -67,12 +66,10 @@ public class UserFactory extends HibernateFactory {
 
     private static List<RhnTimeZone> timeZoneList;
 
-    private static final Role[] IMPLIEDROLESARRAY = { RoleFactory.CHANNEL_ADMIN,
-            RoleFactory.CONFIG_ADMIN, RoleFactory.SYSTEM_GROUP_ADMIN,
-            RoleFactory.ACTIVATION_KEY_ADMIN, RoleFactory.IMAGE_ADMIN };
-
     /** List of Role objects that are applied if you are an Org_admin */
-    public static final List<Role> IMPLIEDROLES = Arrays.asList(IMPLIEDROLESARRAY);
+    public static final List<Role> IMPLIEDROLES = List.of(RoleFactory.CHANNEL_ADMIN,
+            RoleFactory.CONFIG_ADMIN, RoleFactory.SYSTEM_GROUP_ADMIN,
+            RoleFactory.ACTIVATION_KEY_ADMIN, RoleFactory.IMAGE_ADMIN);
 
     public static final State ENABLED = loadState("enabled");
     public static final State DISABLED = loadState("disabled");

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/errata/ErrataConfirmAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/errata/ErrataConfirmAction.java
@@ -124,11 +124,7 @@ public class ErrataConfirmAction extends RhnListDispatchAction {
 
         if (actionChain == null) {
             Action update = ActionManager.createErrataAction(user, user.getOrg(), currentErrata);
-            for (Object systemIn : systems) {
-                ActionFactory.addServerToAction(
-                        ((SystemOverview) systemIn).getId(),
-                        update);
-            }
+            systems.forEach(systemIn -> ActionFactory.addServerToAction(systemIn.getId(), update));
 
             update.setEarliestAction(getStrutsDelegate().readScheduleDate(form, "date",
                     DatePicker.YEAR_RANGE_POSITIVE));
@@ -155,11 +151,11 @@ public class ErrataConfirmAction extends RhnListDispatchAction {
         }
         else {
             int sortOrder = ActionChainFactory.getNextSortOrderValue(actionChain);
-            for (Object systemIn : systems) {
+            for (SystemOverview systemIn : systems) {
                 Action update = ActionManager.createErrataAction(user, user.getOrg(), currentErrata);
                 ActionFactory.save(update);
                 ActionChainFactory.queueActionChainEntry(update, actionChain,
-                        ((SystemOverview) systemIn).getId(), sortOrder);
+                        systemIn.getId(), sortOrder);
             }
 
             messageKey = "message.addedtoactionchain";

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/kickstart/KickstartTreeUpdateType.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/kickstart/KickstartTreeUpdateType.java
@@ -21,7 +21,7 @@ package com.redhat.rhn.frontend.action.kickstart;
  */
 public enum KickstartTreeUpdateType {
     ALL("all"), RED_HAT("red_hat"), NONE("none");
-    private String type;
+    private final String type;
 
     /**
      * Create a new KickstartTreeUpdateType
@@ -37,14 +37,6 @@ public enum KickstartTreeUpdateType {
      */
     public String getType() {
         return type;
-    }
-
-    /**
-     * Set the type
-     * @param updateType the update type to set
-     */
-    public void setType(String updateType) {
-        type = updateType;
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/AdminMonitoringHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/AdminMonitoringHandler.java
@@ -24,7 +24,6 @@ import com.suse.manager.webui.services.impl.MonitoringService;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -36,13 +35,11 @@ import java.util.stream.Collectors;
  */
 public class AdminMonitoringHandler extends BaseHandler {
 
-    private static Map<String, String> messageMap;
-    {
-        messageMap = new HashMap<>();
-        messageMap.put("enable", "enable_again_to_sync_config");
-        messageMap.put("disable", "disable_again_to_sync_config");
-        messageMap.put("restart", "restart_needed");
-    }
+    private static Map<String, String> messageMap = Map.of(
+            "enable", "enable_again_to_sync_config",
+            "disable", "disable_again_to_sync_config",
+            "restart", "restart_needed"
+    );
 
     private static String toString(boolean enabled, String msg) {
         String str = enabled ? "enabled" : "disabled";

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/ProfileHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/ProfileHandler.java
@@ -1003,12 +1003,7 @@ public class ProfileHandler extends BaseHandler {
                custom.setModified(new Date());
                customSet.add(custom);
            }
-           if (cmd.getKickstartData().getCustomOptions() == null) {
-               cmd.getKickstartData().setCustomOptions(customSet);
-           }
-           else {
-               cmd.getKickstartData().setCustomOptions(customSet);
-           }
+           cmd.getKickstartData().setCustomOptions(customSet);
            cmd.store();
        }
        return 1;

--- a/java/core/src/main/java/com/redhat/rhn/manager/configuration/file/SymlinkData.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/configuration/file/SymlinkData.java
@@ -114,6 +114,6 @@ public class SymlinkData extends DirectoryData {
        if (!super.matchesRevision(cRevision)) {
            return Boolean.FALSE;
        }
-       return getTargetPath().equals(cRevision.getConfigInfo().getTargetFileName());
+       return getTargetPath().equals(cRevision.getConfigInfo().getTargetFileName().getPath());
    }
 }

--- a/java/core/src/main/java/com/redhat/rhn/manager/kickstart/tree/TreeEditOperation.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/kickstart/tree/TreeEditOperation.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.manager.kickstart.tree;
 
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.kickstart.KickstartFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerCommand;
@@ -45,7 +46,7 @@ public class TreeEditOperation extends BaseTreeEditOperation {
         this.tree = KickstartFactory.lookupKickstartTreeByIdAndOrg(treeId, userIn.getOrg());
 
         // Detach this instance to ensure changes are not auto-flushed until we merge it
-        KickstartFactory.getSession().detach(this.tree);
+        HibernateFactory.getSession().detach(this.tree);
     }
 
 

--- a/java/core/src/main/java/com/suse/manager/attestation/AttestationManager.java
+++ b/java/core/src/main/java/com/suse/manager/attestation/AttestationManager.java
@@ -57,6 +57,7 @@ public class AttestationManager {
     private static final Logger LOG = LogManager.getLogger(AttestationManager.class);
     private final AttestationFactory factory;
     private final TaskomaticApi taskomaticApi;
+    private SecureRandom secureRandom = new SecureRandom();
 
     /**
      * Constructor
@@ -186,9 +187,8 @@ public class AttestationManager {
         ServerCoCoAttestationReport initReport = factory.createReportForServer(minion);
         initReport.setAction(action);
         if (initReport.getEnvironmentType().isNonceRequired()) {
-            SecureRandom rand = new SecureRandom();
             byte[] bytes = new byte[64];
-            rand.nextBytes(bytes);
+            secureRandom.nextBytes(bytes);
             initReport.setInData(Map.of("nonce", Base64.getEncoder().encodeToString(bytes)));
         }
 

--- a/java/core/src/test/java/com/redhat/rhn/common/hibernate/TestFactoryWrapperTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/hibernate/TestFactoryWrapperTest.java
@@ -93,13 +93,13 @@ public class TestFactoryWrapperTest extends HibernateBaseTest {
         assertNull(TestFactory.lookupByFoobar(testInsert));
 
         // insert
-        TestInterface record = TestFactory.createTest();
-        record.setFoobar(testInsert);
-        TestFactory.save(record);
+        TestInterface testRecord = TestFactory.createTest();
+        testRecord.setFoobar(testInsert);
+        TestFactory.save(testRecord);
 
         // verify
-        assertTrue(record.getId() != 0L);
-        assertTrue(HibernateFactory.getSession().contains(record));
+        assertTrue(testRecord.getId() != 0L);
+        assertTrue(HibernateFactory.getSession().contains(testRecord));
     }
 
     /**
@@ -111,21 +111,21 @@ public class TestFactoryWrapperTest extends HibernateBaseTest {
         assertNull(TestFactory.lookupByFoobar(testReload));
 
         // insert the record
-        TestInterface record = TestFactory.createTest();
-        record.setFoobar(testReload);
-        TestFactory.save(record);
-        Long id = record.getId();
+        TestInterface testRecord = TestFactory.createTest();
+        testRecord.setFoobar(testReload);
+        TestFactory.save(testRecord);
+        Long id = testRecord.getId();
 
         // evict and confirm record is detached
-        TestUtils.flushAndEvict(record);
-        assertFalse(HibernateFactory.getSession().contains(record));
+        TestUtils.flushAndEvict(testRecord);
+        assertFalse(HibernateFactory.getSession().contains(testRecord));
         assertNotNull(id);
 
         // verify reload retrieves the same record but on a different instance
-        TestInterface recordReloaded = TestUtils.reload(record);
+        TestInterface recordReloaded = TestUtils.reload(testRecord);
         assertTrue(HibernateFactory.getSession().contains(recordReloaded));
         assertEquals(id, recordReloaded.getId());
-        assertTrue(record != recordReloaded);
+        assertTrue(testRecord != recordReloaded);
     }
 
     /**

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerProvisioningTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerProvisioningTest.java
@@ -123,8 +123,10 @@ public class SystemHandlerProvisioningTest extends BaseHandlerTestCase {
                 KickstartScheduleCommand.setTaskomaticApi(testApi);
         }
 
+        @Override
         @AfterEach
         public void tearDown() throws Exception {
+                super.tearDown();
                 KickstartScheduleCommand.setTaskomaticApi(new TaskomaticApi());
         }
 


### PR DESCRIPTION
## What does this PR change?
SonarCloud error reduction fix, rules:

SonarCloud fix: java:S2159 Comparisons between unrelated types always return false
SonarCloud fix: java:S1171 Only static class initializers should be used
SonarCloud fix: java:S2386 Mutable fields should not be public static
SonarCloud fix: java:S3923 All branches should not have the same implementation
SonarCloud fix: java:S3252 Static base class members should not be accessed via derived types
SonarCloud fix: java:S3066 Enum fields should not be publicly mutable
SonarCloud fix: java:S3864 implementation is free to skip calls to peek() for optimization purposes
SonarCloud fix: java:S1161 Override should be used on overriding and implementing methods
SonarCloud fix: java:S2153 Unnecessary boxing and unboxing should be avoided
SonarCloud fix: java:S6213 Restricted Identifiers should not be used as identifiers
SonarCloud fix: java:S4165 Assignments should not be redundant
SonarCloud fix: java:S4838 Change Object to the type handled by the collection
SonarCloud fix: java:S2119 Random objects should be reused
SonarCloud fix: javabugs:S2259 Fix access on a value that can be null

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s): 
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
