### PR TITLE
Fix SSm scenarios to re-select sle_minion in SSM for package operations

### DIFF
--- a/testsuite/features/secondary/allcli_system_group.feature
+++ b/testsuite/features/secondary/allcli_system_group.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 SUSE LLC
+# Copyright (c) 2017-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_ssm
@@ -102,6 +102,13 @@ Feature: Manage a group of systems and the Systems Set Manager
     And I wait until event "Patch Update: andromeda-dummy-6789 - Test update for andromeda-dummy scheduled by admin" is completed
 
 @skip_if_github_validation
+  Scenario: Pre-requisite: re-select sle_minion in SSM for package operations
+    When I follow the left menu "Systems > System Groups"
+    And I click on "Use in SSM" in row "new-systems-group"
+    Then I should see a "Selected Systems List" text
+    And I should see "sle_minion" as link
+
+@skip_if_github_validation
   Scenario: Delete a package from systems in the SSM
     When I follow the left menu "Systems > System Set Manager > Overview"
     And I follow "Packages"
@@ -113,6 +120,13 @@ Feature: Manage a group of systems and the Systems Set Manager
     And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "Package removals are being scheduled, it may take several minutes for this to complete." text
+
+@skip_if_github_validation
+  Scenario: Pre-requisite: re-select sle_minion in SSM for package install
+    When I follow the left menu "Systems > System Groups"
+    And I click on "Use in SSM" in row "new-systems-group"
+    Then I should see a "Selected Systems List" text
+    And I should see "sle_minion" as link
 
 @skip_if_github_validation
   Scenario: Install a package to systems in the SSM


### PR DESCRIPTION
## What does this PR change?

**Root cause**: Uyuni clears the SSM after applying a patch action via Confirm. The "Apply a patch to systems in the SSM" scenario (line 88-102) ends by clicking Confirm and the SSM is  then empty. When the Delete and Install scenarios run next, they see 0 systems selected →"No packages" / "No channels found" → the filter input never renders.

**Fix**: Added two pre-requisite scenarios, one before Delete and one before Install and that navigate to System Groups and click "Use in SSM" to re-populate the SSM with sle_minion before each package operation.

The step I click on "Use in SSM" in row "new-systems-group" is already used at line 160 in the same file, so we're following the established pattern. Both pre-req scenarios are tagged @skip_if_github_validation to match their dependent  scenarios.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): 
 - https://github.com/SUSE/spacewalk/issues/26550
 - https://github.com/SUSE/spacewalk/issues/26549
 - https://github.com/SUSE/spacewalk/issues/27650
Port(s): 
  - 5.1: https://github.com/SUSE/spacewalk/pull/30239
  - 5.0: https://github.com/SUSE/spacewalk/pull/30256


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
