### PR TITLE
Move Salt > Remote Commands to RBAC namespace 'salt.remote_commands' (bsc#1261305)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/manager/user/UserManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/user/UserManager.java
@@ -168,7 +168,8 @@ public class UserManager extends BaseManager {
      * @param mode the access mode (view/modify)
      * @throws PermissionException if the user is not permitted to access the specified namespace
      */
-    public static void ensureRoleBasedAccess(User user, String namespace, Namespace.AccessMode mode) {
+    public static void ensureRoleBasedAccess(User user, String namespace, Namespace.AccessMode mode)
+            throws PermissionException {
         if (!verifyRoleBasedAccess(user, namespace, mode)) {
             if (user == null) {
                 log.debug("Access restricted for unauthenticated user to namespace '{}' [{}]", namespace, mode);

--- a/java/core/src/main/java/com/suse/manager/webui/websocket/RemoteMinionCommands.java
+++ b/java/core/src/main/java/com/suse/manager/webui/websocket/RemoteMinionCommands.java
@@ -14,9 +14,13 @@
  */
 package com.suse.manager.webui.websocket;
 
+import static com.redhat.rhn.manager.user.UserManager.ensureRoleBasedAccess;
+
 import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.common.util.StringUtil;
+import com.redhat.rhn.domain.access.Namespace;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.session.WebSession;
@@ -106,7 +110,14 @@ public class RemoteMinionCommands {
             }
         }
         else {
-            HEARTBEAT_SERVICE.register(session);
+            try {
+                if (validateWebSession(session, getWebSession())) {
+                    HEARTBEAT_SERVICE.register(session);
+                }
+            }
+            finally {
+                HibernateFactory.closeSession();
+            }
         }
     }
 
@@ -134,9 +145,8 @@ public class RemoteMinionCommands {
         ExecuteMinionActionDto msg = Json.GSON.fromJson(
                 messageBody, ExecuteMinionActionDto.class);
         try {
-            WebSession webSession = WebSessionFactory.lookupById(sessionId);
-
-            if (invalidWebSession(session, webSession)) {
+            WebSession webSession = getWebSession();
+            if (!validateWebSession(session, webSession)) {
                 return;
             }
 
@@ -347,20 +357,38 @@ public class RemoteMinionCommands {
         );
     }
 
-    private boolean invalidWebSession(Session session, WebSession webSession) {
+    private boolean validateWebSession(Session session, WebSession webSession) {
+        boolean valid = true;
         if (webSession == null || webSession.getUser() == null) {
-            LOG.debug("Invalid web sessionId. Closing the web socket.");
-            sendMessage(session, new ActionErrorEventDto(null,
-                    "INVALID_SESSION", "Invalid user session."));
+            valid = false;
+            LOG.debug("Invalid web sessionId.");
+            sendMessage(session, new ActionErrorEventDto(null, "INVALID_SESSION", "Invalid user session."));
+        }
+        else {
             try {
-                session.close();
-                return true;
+                ensureRoleBasedAccess(webSession.getUser(), "salt.remote_commands", Namespace.AccessMode.W);
             }
-            catch (IOException e) {
-                LOG.debug("Error closing web socket session", e);
+            catch (PermissionException ePerm) {
+                valid = false;
+                LOG.debug("Session unauthorized.", ePerm);
+                sendMessage(session, new ActionErrorEventDto(null, "UNAUTHORIZED", "User is unauthorized."));
             }
         }
-        return false;
+
+        if (!valid) {
+            try {
+                LOG.debug("Closing websocket session.");
+                session.close();
+            }
+            catch (IOException e) {
+                LOG.debug("Error closing websocket session.", e);
+            }
+        }
+        return valid;
+    }
+
+    private WebSession getWebSession() {
+        return WebSessionFactory.lookupById(this.sessionId);
     }
 
     /**

--- a/java/spacewalk-java.changes.cbbayburt.Manager-5.1-bsc1261305
+++ b/java/spacewalk-java.changes.cbbayburt.Manager-5.1-bsc1261305
@@ -1,0 +1,2 @@
+- Move Salt > Remote Commands to its own RBAC namespace
+  (bsc#1261305)

--- a/schema/spacewalk/common/data/endpointNamespace.sql
+++ b/schema/spacewalk/common/data/endpointNamespace.sql
@@ -1638,7 +1638,7 @@ INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
-    WHERE ns.namespace = 'salt.keys' AND ns.access_mode = 'W'
+    WHERE ns.namespace = 'salt.remote_commands' AND ns.access_mode = 'W'
     AND ep.endpoint = '/manager/systems/cmd' AND ep.http_method = 'GET'
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)

--- a/schema/spacewalk/common/data/namespace.sql
+++ b/schema/spacewalk/common/data/namespace.sql
@@ -252,6 +252,9 @@ INSERT INTO access.namespace (namespace, access_mode, description)
     VALUES ('salt.keys', 'W', NULL)
     ON CONFLICT (namespace, access_mode) DO NOTHING;
 INSERT INTO access.namespace (namespace, access_mode, description)
+    VALUES ('salt.remote_commands', 'W', 'Execute remote commands on systems')
+    ON CONFLICT (namespace, access_mode) DO NOTHING;
+INSERT INTO access.namespace (namespace, access_mode, description)
     VALUES ('salt.formulas', 'R', NULL)
     ON CONFLICT (namespace, access_mode) DO NOTHING;
 INSERT INTO access.namespace (namespace, access_mode, description)

--- a/schema/spacewalk/susemanager-schema.changes.cbbayburt.Manager-5.1-bsc1261305
+++ b/schema/spacewalk/susemanager-schema.changes.cbbayburt.Manager-5.1-bsc1261305
@@ -1,0 +1,2 @@
+- Move Salt > Remote Commands to its own RBAC namespace
+  (bsc#1261305)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.7-to-susemanager-schema-5.2.8/200-rbac-remote-cmds.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.7-to-susemanager-schema-5.2.8/200-rbac-remote-cmds.sql
@@ -1,0 +1,33 @@
+--
+-- Copyright (c) 2026 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+INSERT INTO access.namespace (namespace, access_mode, description)
+    SELECT 'salt.remote_commands', 'W', 'Execute remote commands on systems'
+    WHERE NOT EXISTS (SELECT 1 FROM access.namespace WHERE namespace = 'salt.remote_commands' AND access_mode = 'W');
+
+DELETE FROM access.endpointNamespace
+WHERE
+    namespace_id = (SELECT id FROM access.namespace WHERE namespace = 'salt.keys' AND access_mode = 'W') AND
+    endpoint_id = (SELECT id FROM access.endpoint WHERE endpoint = '/manager/systems/cmd' AND http_method = 'GET');
+
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'salt.remote_commands' AND ns.access_mode = 'W'
+    AND ep.endpoint = '/manager/systems/cmd' AND ep.http_method = 'GET'
+    ON CONFLICT DO NOTHING;
+
+-- Permit to all access groups
+INSERT INTO access.accessGroupNamespace
+    SELECT ag.id, ns.id
+    FROM access.accessGroup ag, access.namespace ns
+    WHERE ns.namespace = 'salt.remote_commands'
+    AND ns.access_mode = 'W'
+    ON CONFLICT DO NOTHING;


### PR DESCRIPTION
Previously, Salt > Remote Commands was mapped to RBAC namespace 'salt.keys'. This PR moves it to a new namespace called 'salt.remote_commands'. It also enforces the access control on the Websocket backend.

Port of: https://github.com/SUSE/spacewalk/pull/30255

## Links

Fixes https://github.com/SUSE/spacewalk/issues/30205

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
