### PR TITLE
Fix intermittent failure in Ansible "Display inventories" scenario

### DIFF
--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -56,7 +56,7 @@ Feature: Operate an Ansible control node in a normal minion
     When I follow "Ansible" in the content area
     And I follow "Inventories" in the content area
     And I wait until I see "/srv/playbooks/orion_dummy/hosts" text
-    And I click on "/srv/playbooks/orion_dummy/hosts"
+    And I click on the inventory accordion for "/srv/playbooks/orion_dummy/hosts"
     Then I wait until I see "myself" text, refreshing the page
 
   Scenario: Discover playbooks and display them

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2025 SUSE LLC
+# Copyright (c) 2021-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_ansible
@@ -57,7 +57,7 @@ Feature: Operate an Ansible control node in SSH minion
     When I follow "Ansible" in the content area
     And I follow "Inventories" in the content area
     And I wait until I see "/srv/playbooks/orion_dummy/hosts" text
-    And I click on "/srv/playbooks/orion_dummy/hosts"
+    And I click on the inventory accordion for "/srv/playbooks/orion_dummy/hosts"
     Then I wait until I see "myself" text
 
   Scenario: Discover playbooks and display them

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -316,6 +316,18 @@ When(/^I click on "([^"]*)"$/) do |text|
 end
 
 #
+# Click on an accordion panel-heading button containing the given text.
+# Waits for the full button structure (including the chevron icon) to be present,
+# which confirms the React component is fully mounted with its onClick handler bound.
+#
+When(/^I click on the inventory accordion for "([^"]*)"$/) do |text|
+  xpath = "//button[contains(@class, 'panel-heading') " \
+          "and .//i[contains(@class, 'fa-chevron-right')] " \
+          "and contains(., '#{text}')]"
+  find(:xpath, xpath, wait: DEFAULT_TIMEOUT).click
+end
+
+#
 # Click on a button which appears inside of <div> with
 # the given "id"
 When(/^I click on "([^"]*)" in element "([^"]*)"$/) do |text, element_id|


### PR DESCRIPTION
## What does this PR change?

The test was clicking the inventory accordion immediately after detecting the path text in the DOM, but has_text? only confirms text presence and not that the React AccordionPathContent component has finished mounting. This caused the click to occasionally land before the onClick handler was ready, leaving the accordion closed.

The wait until I see ... text step is kept as a first guard, then replaced click on ... with a dedicated step that additionally waits for the fa-chevron-right icon inside the <button class="panel-heading">. The icon's presence confirms the component has completed its initial  render and onToggle is bound. The click is then dispatched directly to the resolved DOM node via find(:xpath, ...).click, avoiding the ambiguity of click_button's text search.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29691
Port(s):
 - 5.1: https://github.com/SUSE/spacewalk/pull/30257

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
