### PR TITLE
Fix the hostNetwork typo in charts readmes

### DIFF
--- a/containers/proxy-helm/README.md
+++ b/containers/proxy-helm/README.md
@@ -91,7 +91,7 @@ Here is a list of the ports to map:
 
 
 Exposing the `tftp` service has to be done differently due to the way TFTP protocol is working.
-Either use the host network using the `tftp.hostnetwork` value or configure a load balancer for the `tftp` service.
+Either use the host network using the `tftp.hostNetwork` value or configure a load balancer for the `tftp` service.
 Note that not all load balancers will work: `serviceLB` implementation is not compatible with TFTP protocol, while MetalLB works.
 
 ## Usage

--- a/containers/server-helm/README.md
+++ b/containers/server-helm/README.md
@@ -122,7 +122,7 @@ Here is a list of the ports to map:
 
 
 Exposing the `tftp` service has to be done differently due to the way TFTP protocol is working.
-Either use the host network using the `tftp.hostnetwork` value or configure a load balancer for the `tftp` service.
+Either use the host network using the `tftp.hostNetwork` value or configure a load balancer for the `tftp` service.
 Note that not all load balancers will work: `serviceLB` implementation is not compatible with TFTP protocol, while MetalLB works.
 
 ### Ingress vs Gateway API


### PR DESCRIPTION
## What does this PR change?

`hostnetwork` is not a property.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: readme fix

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
