### PR TITLE
Use primary FQDN to contact Build Host (bsc#1247004)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/action/HardwareRefreshAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/HardwareRefreshAction.java
@@ -36,6 +36,7 @@ import com.suse.manager.reactor.hardware.HardwareMapper;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.utils.gson.ProxyConfigUpdateJson;
 import com.suse.manager.webui.utils.salt.custom.HwProfileUpdateSlsResult;
 import com.suse.proxy.ProxyConfigUtils;
@@ -187,6 +188,9 @@ public class HardwareRefreshAction extends Action {
                     hwMapper.getErrors().stream().collect(Collectors.joining("\n")));
             serverAction.setResultCode(-1L);
         }
+
+        MinionPillarManager.INSTANCE.generatePillar(server, false,
+                MinionPillarManager.PillarSubset.GENERAL);
 
         if (LOG.isDebugEnabled()) {
             long duration = Duration.between(start, Instant.now()).getSeconds();

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/sdc/SystemHardwareAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/sdc/SystemHardwareAction.java
@@ -34,6 +34,8 @@ import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -89,6 +91,8 @@ public class SystemHardwareAction extends RhnAction {
             if (ctx.hasParam("update_networking_properties")) {
                 server.setPrimaryInterfaceWithName(form.get("primaryInterface").toString());
                 server.setPrimaryFQDNWithName(form.get("primaryFQDN").toString());
+                server.asMinionServer().ifPresent(m -> MinionPillarManager.INSTANCE.generatePillar(m,
+                                                  false, MinionPillarManager.PillarSubset.GENERAL));
                 createSuccessMessage(request, "message.interfaceSet", null);
             }
             else {

--- a/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.domain.channel.AccessToken;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Pillar;
+import com.redhat.rhn.domain.server.ServerFQDN;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.AnsibleManager;
 
@@ -81,6 +82,8 @@ public class MinionGeneralPillarGenerator extends MinionPillarGeneratorBase {
 
         pillar.add("mgr_origin_server", ConfigDefaults.get().getJavaHostname());
         pillar.add("mgr_server_is_uyuni", ConfigDefaults.get().isUyuni());
+        pillar.add("primary_fqdn", Optional.ofNullable(minion.findPrimaryFqdn())
+                .map(ServerFQDN::getName).orElse(minion.getHostname()));
         pillar.add("machine_password", MachinePasswordUtils.machinePassword(minion));
 
         Map<String, Object> chanPillar = new HashMap<>();

--- a/java/core/src/test/java/com/suse/manager/webui/services/pillar/MinionPillarManagerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/pillar/MinionPillarManagerTest.java
@@ -84,6 +84,8 @@ public class MinionPillarManagerTest extends BaseTestCaseWithUser {
         assertEquals(ConfigDefaults.get().getJavaHostname(), map.get("mgr_origin_server"));
         assertTrue(map.containsKey("mgr_server_is_uyuni"));
         assertEquals(ConfigDefaults.get().isUyuni(), map.get("mgr_server_is_uyuni"));
+        assertTrue(map.containsKey("primary_fqdn"));
+        assertEquals(minion.getHostname(), map.get("primary_fqdn"));
 
         assertTrue(map.containsKey("channels"));
         Map<String, Object> channels = (Map<String, Object>) map.get("channels");
@@ -215,6 +217,8 @@ public class MinionPillarManagerTest extends BaseTestCaseWithUser {
         assertEquals(ConfigDefaults.get().getJavaHostname(), map.get("mgr_origin_server"));
         assertTrue(map.containsKey("mgr_server_is_uyuni"));
         assertEquals(ConfigDefaults.get().isUyuni(), map.get("mgr_server_is_uyuni"));
+        assertTrue(map.containsKey("primary_fqdn"));
+        assertEquals(minion.getHostname(), map.get("primary_fqdn"));
 
         Map<String, Object> channels = (Map<String, Object>) map.get("channels");
         assertEquals(1, channels.size());

--- a/java/spacewalk-java.changes.nadvornik.primary_fqdn
+++ b/java/spacewalk-java.changes.nadvornik.primary_fqdn
@@ -1,0 +1,1 @@
+- Add primary FQDN to pillar (bsc#1247004)

--- a/susemanager-utils/susemanager-sls/modules/runners/kiwi-image-collect.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/kiwi-image-collect.py
@@ -14,7 +14,10 @@ log = logging.getLogger(__name__)
 
 def upload_file_from_minion(minion, minion_ip, filetoupload, targetdir):
     # pylint: disable-next=undefined-variable
-    fqdn = __salt__["cache.grains"](tgt=minion).get(minion, {}).get("fqdn")
+    fqdn = __salt__["cache.pillar"](tgt=minion).get(minion, {}).get("primary_fqdn")
+    if not fqdn:
+        # pylint: disable-next=undefined-variable
+        fqdn = __salt__["cache.grains"](tgt=minion).get(minion, {}).get("fqdn")
     # pylint: disable-next=undefined-variable
     ssh_port = __salt__["cache.grains"](tgt=minion).get(minion, {}).get("ssh_port", 22)
     log.info(

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.nadvornik.primary_fqdn
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.nadvornik.primary_fqdn
@@ -1,0 +1,1 @@
+- Use primary FQDN to contact Build Host (bsc#1247004)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/30183
This PR adds the primary FQDN to pillars and use it to contact the Build Host.
This makes the FQDN detection more robust.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: fix

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27936
https://bugzilla.suse.com/show_bug.cgi?id=1247004
Port(s): https://github.com/SUSE/spacewalk/pull/30183

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
