### PR TITLE
Reduce chrome logging for performance

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -102,6 +102,7 @@ def capybara_register_driver
         --js-flags=--max-old-space-size=2048
         --no-sandbox
         --disable-notifications
+        --log-level=3
       ]
     )
     chrome_options.args << '--headless=new' unless $debug_mode


### PR DESCRIPTION
## What does this PR change?

Reduce chrome logging for performance. Main purpose is to reduce number of I/O in BV, in parallel stages, not to gain space on disk.

From 5.1 CI at some point:
```
mlm-ci-51-controller:~ # ls -lh /tmp/org.chromium.Chromium.scoped_dir.jomuZz/chrome_debug.log
-rw-r--r-- 1 root root 766K Apr 14 09:44 /tmp/org.chromium.Chromium.scoped_dir.jomuZz/chrome_debug.log
```

The content is not completely uninteresting, but it essentially confirms what we already know the test suite is doing:
```
(...)
[19425:19425:0414/055953.534804:INFO:CONSOLE:2] "Leaving `https://mlm-ci-51-server.mgr.suse.de/rhn/channels/manage/Manage.do`", source: https://mlm-ci-51-server.mgr.suse.de/javascript/manager/main.js?cb=20260409090747 (2)
[19425:19425:0414/055953.655132:INFO:CONSOLE:2] "Loading `https://mlm-ci-51-server.mgr.suse.de/rhn/YourRhn.do`", source: https://mlm-ci-51-server.mgr.suse.de/javascript/manager/main.js?cb=20260409090747 (2)
[19425:19425:0414/055953.732688:INFO:CONSOLE:2] "Websocket error: {"isTrusted":true}", source: https://mlm-ci-51-server.mgr.suse.de/javascript/manager/main.js?cb=20260409090747 (2)
[19425:19425:0414/055953.927846:INFO:CONSOLE:2] "The POST request to the url '/rhn/manager/frontend-log' completed with status 401 and the response cannot be parsed.", source: https://mlm-ci-51-server.mgr.suse.de/javascript/manager/main.js?cb=20260409090747 (2)
[19425:19425:0414/055953.982848:INFO:CONSOLE:2] "Leaving `https://mlm-ci-51-server.mgr.suse.de/rhn/YourRhn.do`", source: https://mlm-ci-51-server.mgr.suse.de/javascript/manager/main.js?cb=20260409090747 (2)
[19425:19425:0414/055954.113201:INFO:CONSOLE:2] "Loading `https://mlm-ci-51-server.mgr.suse.de/rhn/Login2.do`", source: https://mlm-ci-51-server.mgr.suse.de/javascript/manager/main.js?cb=20260409090747 (2)
[19425:19425:0414/055954.515667:INFO:CONSOLE:2] "Leaving `https://mlm-ci-51-server.mgr.suse.de/rhn/Login2.do`", source: https://mlm-ci-51-server.mgr.suse.de/javascript/manager/main.js?cb=20260409090747 (2)
[19425:19425:0414/055954.641187:INFO:CONSOLE:2] "Loading `https://mlm-ci-51-server.mgr.suse.de/rhn/YourRhn.do`", source: https://mlm-ci-51-server.mgr.suse.de/javascript/manager/main.js?cb=20260409090747 (2)
[19425:19425:0414/055954.916976:INFO:CONSOLE:2] "The POST request to the url '/rhn/manager/frontend-log' completed with status 401 and the response cannot be parsed.", source: https://mlm-ci-51-server.mgr.suse.de/javascript/manager/main.js?cb=20260409090747 (2)
[19425:19425:0414/055955.145283:INFO:CONSOLE:0] "Autofocus processing was blocked because a document already has a focused element.", source: https://mlm-ci-51-server.mgr.suse.de/rhn/channels/manage/Manage.do (0)
[19425:19425:0414/055955.153592:INFO:CONSOLE:2] "Loading `https://mlm-ci-51-server.mgr.suse.de/rhn/channels/manage/Manage.do`", source: https://mlm-ci-51-server.mgr.suse.de/javascript/manager/main.js?cb=20260409090747 (2)
(...)
```


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes.

- [x] **DONE**


## Test coverage

Cucumber tests were refined.

- [x] **DONE**


## Links

Port(s):
 * 5.1: https://github.com/SUSE/spacewalk/pull/30312
 * 5.0: https://github.com/SUSE/spacewalk/pull/30313

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
