### PR TITLE
Remove now unneeded ports from server chart readme

### DIFF
--- a/containers/server-helm/README.md
+++ b/containers/server-helm/README.md
@@ -112,9 +112,6 @@ Here is a list of the ports to map:
 | TCP      | 5432  | reportdb     | 5432         |                                                  |
 | TCP      | 4505  | salt         | 4505         |                                                  |
 | TCP      | 4506  | salt         | 4506         |                                                  |
-| TCP      | 25151 | cobbler      | 25151        |                                                  |
-| TCP      | 9100  | tomcat       | 9100         |                                                  |
-| TCP      | 9187  | db           | 9187         | Not if installed with `enableMonitoring = false` |
 | TCP      | 8001  | taskomatic   | 8001         | Only if installed with `exposeJavaDebug = true`  |
 | TCP      | 8002  | search       | 8002         | Only if installed with `exposeJavaDebug = true`  |
 | TCP      | 8003  | tomcat       | 8003         | Only if installed with `exposeJavaDebug = true`  |


### PR DESCRIPTION
## What does this PR change?

Cobbler API port is only to be used from localhost. The 9100 and 9187 ports are exporters and now routed using ingress rules. Those ports need to be removed from the server helm README list of ports to expose.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: documentation change
- [x] **DONE**

## Test coverage
- No tests: doc change

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
