### PR TITLE
Try to fix the db issue

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -125,6 +125,14 @@ class Responder:
             conn_string = "dbname='{dbname}' user='{user}' host='{host}' password='{password}'".format(
                 **db_config
             )
+        # Enable TCP keepalives so the OS detects and tears down stale SSL connections
+        # before PostgreSQL silently closes them on the server side.
+        # keepalives_idle=30:    send the first keepalive probe after 30 s of inactivity
+        # keepalives_interval=10: retry probe every 10 s if no reply
+        # keepalives_count=3:    drop the connection after 3 consecutive missed probes
+        conn_string += (
+            " keepalives=1 keepalives_idle=30 keepalives_interval=10 keepalives_count=3"
+        )
         log.debug("connecting to database")
         while True:
             try:
@@ -249,8 +257,16 @@ class Responder:
             log.warning("Unable to unpack the event data: %s", e)
 
     def db_keepalive(self):
-        if self.connection.closed:
-            log.error("Diconnected from database. Trying to reconnect...")
+        # psycopg2's connection.closed flag is only set when the connection is
+        # explicitly closed from our side.  A PostgreSQL-initiated SSL teardown
+        # (e.g. idle_session_timeout, SSL renegotiation, network drop) leaves
+        # connection.closed == 0 until the next I/O call raises an exception.
+        # Use an active probe query so we detect and recover from silent drops
+        # *before* an event INSERT fails and risks losing the event.
+        try:
+            self.cursor.execute("SELECT 1")
+        except Exception:  # pylint: disable=broad-exception-caught
+            log.error("Disconnected from database. Trying to reconnect...")
             self._connect_to_database()
 
     def queue_thread(self):

--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -125,11 +125,13 @@ class Responder:
             conn_string = "dbname='{dbname}' user='{user}' host='{host}' password='{password}'".format(
                 **db_config
             )
-        # Enable TCP keepalives so the OS detects and tears down stale SSL connections
-        # before PostgreSQL silently closes them on the server side.
-        # keepalives_idle=30:    send the first keepalive probe after 30 s of inactivity
+        # Enable TCP keepalives so the OS can detect and tear down stale or half-open
+        # network connections (for example after NAT/firewall timeouts or broken links).
+        # These probes do not prevent PostgreSQL from closing idle sessions on the server
+        # side; they mainly help detect dead peers when the network path disappears.
+        # keepalives_idle=30:     send the first keepalive probe after 30 s of inactivity
         # keepalives_interval=10: retry probe every 10 s if no reply
-        # keepalives_count=3:    drop the connection after 3 consecutive missed probes
+        # keepalives_count=3:     consider the connection dead after 3 missed probes
         conn_string += (
             " keepalives=1 keepalives_idle=30 keepalives_interval=10 keepalives_count=3"
         )
@@ -265,8 +267,21 @@ class Responder:
         # *before* an event INSERT fails and risks losing the event.
         try:
             self.cursor.execute("SELECT 1")
+            if self.counter == 0:
+                # The keepalive probe starts a transaction when autocommit is
+                # disabled. Roll it back if there are no pending inserts so the
+                # session does not remain idle in transaction.
+                self.connection.rollback()
         except Exception:  # pylint: disable=broad-exception-caught
             log.error("Disconnected from database. Trying to reconnect...")
+            try:
+                self.cursor.close()
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+            try:
+                self.connection.close()
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
             self._connect_to_database()
 
     def queue_thread(self):

--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -125,13 +125,6 @@ class Responder:
             conn_string = "dbname='{dbname}' user='{user}' host='{host}' password='{password}'".format(
                 **db_config
             )
-        # Enable TCP keepalives so the OS can detect and tear down stale or half-open
-        # network connections (for example after NAT/firewall timeouts or broken links).
-        # These probes do not prevent PostgreSQL from closing idle sessions on the server
-        # side; they mainly help detect dead peers when the network path disappears.
-        # keepalives_idle=30:     send the first keepalive probe after 30 s of inactivity
-        # keepalives_interval=10: retry probe every 10 s if no reply
-        # keepalives_count=3:     consider the connection dead after 3 missed probes
         conn_string += (
             " keepalives=1 keepalives_idle=30 keepalives_interval=10 keepalives_count=3"
         )
@@ -259,18 +252,9 @@ class Responder:
             log.warning("Unable to unpack the event data: %s", e)
 
     def db_keepalive(self):
-        # psycopg2's connection.closed flag is only set when the connection is
-        # explicitly closed from our side.  A PostgreSQL-initiated SSL teardown
-        # (e.g. idle_session_timeout, SSL renegotiation, network drop) leaves
-        # connection.closed == 0 until the next I/O call raises an exception.
-        # Use an active probe query so we detect and recover from silent drops
-        # *before* an event INSERT fails and risks losing the event.
         try:
             self.cursor.execute("SELECT 1")
             if self.counter == 0:
-                # The keepalive probe starts a transaction when autocommit is
-                # disabled. Roll it back if there are no pending inserts so the
-                # session does not remain idle in transaction.
                 self.connection.rollback()
         except Exception:  # pylint: disable=broad-exception-caught
             log.error("Disconnected from database. Trying to reconnect...")

--- a/susemanager-utils/susemanager-sls/test/test_engine.py
+++ b/susemanager-utils/susemanager-sls/test/test_engine.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock, patch, call
 from sqlalchemy import create_engine
 from sqlalchemy_utils import database_exists, create_database, drop_database
 
-
 ch = logging.StreamHandler()
 ch.setLevel(logging.DEBUG)
 log = logging.getLogger("mgr_events")

--- a/susemanager-utils/susemanager-sls/test/test_engine.py
+++ b/susemanager-utils/susemanager-sls/test/test_engine.py
@@ -248,9 +248,6 @@ def test_commit_avoidance_without_tokens(responder):
 
 # pylint: disable-next=redefined-outer-name
 def test_postgres_connect(db_connection, responder):
-    disposable_connection = new_connection()
-    disposable_connection.close()
-    responder.connection = disposable_connection
     with patch("mgr_events.time") as mock_time:
         with patch("mgr_events.psycopg2") as mock_psycopg2:
             mock_psycopg2.connect.side_effect = [
@@ -258,7 +255,13 @@ def test_postgres_connect(db_connection, responder):
                 db_connection,
             ]
             mock_psycopg2.OperationalError = psycopg2.OperationalError
-            responder.db_keepalive()
+            # Simulate the cursor detecting a dead connection (e.g. SSL teardown)
+            with patch.object(
+                responder.cursor,
+                "execute",
+                side_effect=Exception("SSL connection has been closed unexpectedly"),
+            ):
+                responder.db_keepalive()
             assert mock_psycopg2.connect.call_count == 2
     mock_time.sleep.assert_called_once_with(5)
 
@@ -271,4 +274,5 @@ def test_postgres_connect_with_port(responder):
         responder._connect_to_database()
         mock_psycopg2.connect.assert_called_once_with(
             "dbname='tests' user='postgres' host='localhost' port='1234' password=''"
+            " keepalives=1 keepalives_idle=30 keepalives_interval=10 keepalives_count=3"
         )

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2025 SUSE LLC
+# Copyright (c) 2019-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:


### PR DESCRIPTION
## What does this PR change?

Fix intermittent PostgreSQL SSL disconnects in mgr_events engine

### Problem

The mgr_events Salt engine writes salt events to PostgreSQL and notifies the Java SaltReactor via LISTEN/NOTIFY. In CI, we observed intermittent SSL connection drops during proxy
bootstrap:
```
ERROR Error while inserting data to the table: SSL connection has been closed unexpectedly
ERROR Error commiting: connection already closed
ERROR Diconnected from database. Trying to reconnect...
```

The drop happens at exactly the moment the proxy minion's salt/minion/.../start event should be processed. Because the event INSERT fails during reconnection, the Java SaltReactor may not
 receive the NOTIFY, leaving the proxy system partially registered as [Foreign][Proxy] instead of [Salt][Proxy]. As a result the proxy never appears in the managed systems list within the
 test timeout.

### Root causes

1. db_keepalive() was blind to server-side SSL teardowns. psycopg2's connection.closed flag is only set when we close the connection explicitly. A PostgreSQL-initiated SSL teardown (network drop, NAT timeout, SSL renegotiation) leaves connection.closed == 0 until the next I/O call raises an exception — which is too late if that I/O call is an event INSERT.
2. No TCP keepalives on the connection. Without OS-level keepalive probes, a half-open TCP connection after a network interruption is only detected on the next I/O attempt.

### Changes

**mgr_events.py**

- Active connection probe in db_keepalive() — replaces the connection.closed flag check with cursor.execute("SELECT 1"). This detects dead connections before the INSERT loop, avoiding
event loss.
- Rollback probe transaction when idle — SELECT 1 in psycopg2's default non-autocommit mode opens a transaction. If there are no pending inserts (counter == 0), we immediately rollback()
to prevent the session from sitting in idle in transaction and potentially hitting idle_in_transaction_session_timeout.
- Clean up handles before reconnecting — explicitly closes cursor and connection (both in try/except) before calling _connect_to_database() to avoid leaking file descriptors.
- TCP keepalive parameters — adds keepalives=1 keepalives_idle=30 keepalives_interval=10 keepalives_count=3 to the libpq connection string. These OS-level probes detect dead network peers
 (NAT/firewall timeouts, broken links) faster, so the next I/O failure and reconnect happen sooner. Note: these do not prevent PostgreSQL from closing idle sessions server-side.
- Typo fix — Diconnected → Disconnected.

**test_engine.py**

- test_postgres_connect — updated to patch cursor.execute to raise an SSL exception, matching the real failure mode (the old approach of setting responder.connection to a closed
connection would not trigger the new probe path since responder.cursor still pointed at the live connection).
- test_postgres_connect_with_port — updated expected connection string to include keepalive parameters.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
