### PR TITLE
GHA permissions CodeQL

### DIFF
--- a/.github/workflows/acceptance_tests_scheduler.yml
+++ b/.github/workflows/acceptance_tests_scheduler.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 */12 * * *'  # Every 12 hours
   workflow_dispatch: # Allow manual triggering
 
+permissions:
+  contents: read
+
 jobs:
   scheduled-acceptance-tests:
     name: Acceptance

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -12,6 +12,9 @@ on:
       - 'web/html/src/**'
       - '.github/workflows/frontend-build.yml'
 
+permissions:
+  contents: read
+
 jobs:
   frontend_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-dependency-audit.yml
+++ b/.github/workflows/frontend-dependency-audit.yml
@@ -9,6 +9,9 @@ on:
       - 'web/html/src/package.json'
       - '.github/workflows/frontend-dependency-audit.yml'
 
+permissions:
+  contents: read
+
 jobs:
   frontend_dependency_audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-lint-fix-pr.yml
+++ b/.github/workflows/frontend-lint-fix-pr.yml
@@ -8,6 +8,10 @@ on:
       - 'web/html/src/**'
       - '.github/workflows/frontend-lint-fix-pr.yml'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   frontend_lint_fix_pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -12,6 +12,9 @@ on:
       - 'web/html/src/**'
       - '.github/workflows/frontend-lint.yml'
 
+permissions:
+  contents: read
+
 jobs:
   frontend_lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-typescript-compilation.yml
+++ b/.github/workflows/frontend-typescript-compilation.yml
@@ -12,6 +12,9 @@ on:
       - 'web/html/src/**'
       - '.github/workflows/frontend-typescript-compilation.yml'
 
+permissions:
+  contents: read
+
 jobs:
   frontend_typescript_compilation:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -12,6 +12,9 @@ on:
       - 'web/html/src/**'
       - '.github/workflows/frontend-unit-tests.yml'
 
+permissions:
+  contents: read
+
 jobs:
   frontend_unit_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/git-checks.yml
+++ b/.github/workflows/git-checks.yml
@@ -2,6 +2,9 @@ name: Git Checks
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   block-fixup:
     runs-on: ubuntu-latest

--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -22,6 +22,9 @@ on:
       - 'java/**.xml'
       - '.github/workflows/java-checkstyle.yml'
 
+permissions:
+  contents: read
+
 jobs:
   checkstyle:
     runs-on: ubuntu-latest

--- a/.github/workflows/java-microservices-mvn-build.yml
+++ b/.github/workflows/java-microservices-mvn-build.yml
@@ -16,6 +16,8 @@ on:
       - 'microservices/**'
       - '.github/workflows/java-microservices-mvn-build.yml'
 
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/proxy-helm-chart.yml
+++ b/.github/workflows/proxy-helm-chart.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'containers/proxy-helm/**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,6 +10,9 @@ on:
       - 'testsuite/Gemfile'
       - 'testsuite/Rakefile'
 
+permissions:
+  contents: read
+
 jobs:
   rubocop:
 

--- a/.github/workflows/schema-migration-reportdb-test-pgsql.yml
+++ b/.github/workflows/schema-migration-reportdb-test-pgsql.yml
@@ -6,6 +6,10 @@ on:
       - 'schema/reportdb/**/*'
       - 'schema/spacewalk/spacewalk-schema-upgrade'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   schema_migration_reportdb_test_pgsql:
     runs-on: ubuntu-latest

--- a/.github/workflows/search-server-compile.yml
+++ b/.github/workflows/search-server-compile.yml
@@ -18,6 +18,9 @@ on:
       - 'search-server/spacewalk-search/**.xml'
       - '.github/workflows/search-server-compile.yml'
 
+permissions:
+  contents: read
+
 jobs:
   compile:
     runs-on: ubuntu-latest

--- a/.github/workflows/server-helm-chart.yml
+++ b/.github/workflows/server-helm-chart.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'containers/server-helm/**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/susemanager-sls-unit-tests.yml
+++ b/.github/workflows/susemanager-sls-unit-tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths: 'susemanager-utils/susemanager-sls/**/*'
 
+permissions:
+  contents: read
+
 jobs:
   susemanager_sls_unit_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_translations.yml
+++ b/.github/workflows/update_translations.yml
@@ -27,6 +27,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
  run:
    name: Update translation files

--- a/.github/workflows/verify-done-checkboxes.yml
+++ b/.github/workflows/verify-done-checkboxes.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   check-done-checkboxes:
     runs-on: ubuntu-latest

--- a/.github/workflows/yard-doc-test-framework.yml
+++ b/.github/workflows/yard-doc-test-framework.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   generate_documentation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this PR change?

Adds explicit top-level `permissions:` blocks to 19 GitHub Actions workflow files that previously relied on the default `GITHUB_TOKEN` permissions.

Closes CodeQL `actions/missing-workflow-permissions` alerts:

- https://github.com/uyuni-project/uyuni/security/code-scanning/1255
- https://github.com/uyuni-project/uyuni/security/code-scanning/1257
- https://github.com/uyuni-project/uyuni/security/code-scanning/1266
- https://github.com/uyuni-project/uyuni/security/code-scanning/1267
- https://github.com/uyuni-project/uyuni/security/code-scanning/1268
- https://github.com/uyuni-project/uyuni/security/code-scanning/1269
- https://github.com/uyuni-project/uyuni/security/code-scanning/1270
- https://github.com/uyuni-project/uyuni/security/code-scanning/1271
- https://github.com/uyuni-project/uyuni/security/code-scanning/1272
- https://github.com/uyuni-project/uyuni/security/code-scanning/1273
- https://github.com/uyuni-project/uyuni/security/code-scanning/1276
- https://github.com/uyuni-project/uyuni/security/code-scanning/1278
- https://github.com/uyuni-project/uyuni/security/code-scanning/1279
- https://github.com/uyuni-project/uyuni/security/code-scanning/1280
- https://github.com/uyuni-project/uyuni/security/code-scanning/1281
- https://github.com/uyuni-project/uyuni/security/code-scanning/1282
- https://github.com/uyuni-project/uyuni/security/code-scanning/1284
- https://github.com/uyuni-project/uyuni/security/code-scanning/1285
- https://github.com/uyuni-project/uyuni/security/code-scanning/1378
- https://github.com/uyuni-project/uyuni/security/code-scanning/1386
- https://github.com/uyuni-project/uyuni/security/code-scanning/1387

## GUI diff

No difference. CI-only configuration change; no runtime or UI impact.

- [x] **DONE**

## Documentation
- No documentation needed: internal CI hardening, no user-visible surface.

- [x] **DONE**

## Test coverage
- No tests: configuration-only change. Correctness is verified by the existing workflows still running (and by CodeQL closing the listed alerts on the next scan).

- [x] **DONE**

## Links

Issue(s): n/a (driven by CodeQL code-scanning alerts listed above)
Port(s): n/a

- [x] **DONE**

## Changelogs

- [x] No changelog needed

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
