### PR TITLE
Properly cleanup before bootstrapping

### DIFF
--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 SUSE LLC
+# Copyright (c) 2021-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation
@@ -75,7 +75,8 @@ Feature: Bootstrapping with reactivation key
     Then "sle_minion" should not be registered
 
   Scenario: Cleanup: bootstrap a SLES minion after reactivation tests
-    When I follow the left menu "Systems > Bootstrapping"
+    When I perform a full salt minion cleanup on "sle_minion"
+    And I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle_minion" as "hostname"
     And I enter "22" as "port"

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2024 SUSE LLC.
+# Copyright (c) 2015-2026 SUSE LLC.
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
@@ -95,7 +95,8 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     Then "sle_minion" should not be registered
 
   Scenario: Cleanup: bootstrap again the minion after mgrcompat tests
-    When I follow the left menu "Systems > Bootstrapping"
+    When I perform a full salt minion cleanup on "sle_minion"
+    And I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle_minion" as "hostname"
     And I enter "22" as "port"

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2024 SUSE LLC
+# Copyright (c) 2015-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
@@ -77,7 +77,8 @@ Feature: Management of minion keys
     Then "sle_minion" should not be registered
 
   Scenario: Cleanup: bootstrap again the minion
-    When I follow the left menu "Systems > Bootstrapping"
+    When I perform a full salt minion cleanup on "sle_minion"
+    And I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle_minion" as "hostname"
     And I enter "22" as "port"


### PR DESCRIPTION
## What does this PR change?

When a minion's system profile is deleted and re-bootstrapped in the secondary phase, the old venv-salt-minion service keeps running on the physical machine with its original key files.
The bootstrap generates a new key on the master, so when the running service tries to reconnect, the master rejects it. Systemd restarts the service every ~10 minutes, each time presenting the wrong key — causing a cascade of salt key rejections that can last several hours and pollute the salt master log.

The fix adds I perform a full salt minion cleanup on "sle_minion" before the re-bootstrap in the three cleanup scenarios (min_salt_minions_page, min_bootstrap_reactivation, min_salt_mgrcompat_state). This removes the stale key files and stops the running service before the new bootstrap runs, so the master and minion start from a consistent state — matching what the build validation init_clients already does.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): #
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/30336
 - 5.0: https://github.com/SUSE/spacewalk/pull/30335

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
