### PR TITLE
Restructuring CoCo attestation to support attestation on more platforms

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
@@ -16,7 +16,7 @@ import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.server.MinionSummary;
 
 import com.suse.manager.attestation.AttestationManager;
-import com.suse.manager.model.attestation.CoCoAttestationStatus;
+import com.suse.manager.model.attestation.CoCoReportStatus;
 import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltParameters;
@@ -64,7 +64,7 @@ public class CoCoAttestationAction extends Action {
                 if (rep.getResults().isEmpty()) {
                     // results are not initialized yet. So we need to set the report status
                     // directly to failed.
-                    rep.setStatus(CoCoAttestationStatus.FAILED);
+                    rep.setStatus(CoCoReportStatus.FAILED);
                 }
             });
         }
@@ -131,7 +131,7 @@ public class CoCoAttestationAction extends Action {
             if (report.getResults().isEmpty()) {
                 // results are not initialized yet. So we need to set the report status
                 // directly to failed.
-                report.setStatus(CoCoAttestationStatus.FAILED);
+                report.setStatus(CoCoReportStatus.FAILED);
             }
         }
         else {

--- a/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
@@ -16,14 +16,13 @@ import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.server.MinionSummary;
 
 import com.suse.manager.attestation.AttestationManager;
-import com.suse.manager.model.attestation.CoCoReportStatus;
+import com.suse.manager.model.attestation.CoCoResultStatus;
 import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltParameters;
-import com.suse.manager.webui.utils.salt.custom.CoCoAttestationRequestData;
+import com.suse.manager.webui.utils.salt.custom.coco.CoCoAttestationResponseDataParser;
 import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.calls.modules.State;
-import com.suse.utils.Json;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
@@ -133,53 +132,57 @@ public class CoCoAttestationAction extends Action {
      */
     @Override
     public void handleUpdateServerAction(ServerAction serverAction, JsonElement jsonResult, UpdateAuxArgs auxArgs) {
-        AttestationManager mgr = new AttestationManager();
-
+        AttestationManager attestationManager = GlobalInstanceHolder.ATTESTATION_MANAGER;
         Optional<ServerCoCoAttestationReport> optReport =
-                mgr.lookupReportByServerAndAction(serverAction.getServer(), this);
+                attestationManager.lookupReportByServerAndAction(serverAction.getServer(), this);
         if (optReport.isEmpty()) {
-            serverAction.setStatusFailed();
-            serverAction.setResultMsg("Failed to find a report entry");
+            LOG.debug("Failed to find a report entry while parsing salt state apply result");
+            serverAction.fail("Failed to find a report entry");
             return;
         }
         ServerCoCoAttestationReport report = optReport.get();
 
         if (jsonResult == null) {
-            serverAction.setStatusFailed();
-            if (StringUtils.isBlank(serverAction.getResultMsg())) {
-                serverAction.setResultMsg("Error while request attestation data from target system:\n" +
-                        "Got no result from system");
+            String msg = serverAction.getResultMsg();
+            if (StringUtils.isBlank(msg)) {
+                msg = "Error while request attestation data from target system:\nGot no result from system";
             }
+            setFailure(msg, serverAction, report);
             return;
         }
 
         try {
-            CoCoAttestationRequestData requestData = Json.GSON.fromJson(jsonResult, CoCoAttestationRequestData.class);
-            report.setOutData(requestData.asMap());
-            mgr.initializeResults(report);
+            CoCoAttestationResponseDataParser responseDataParser = new CoCoAttestationResponseDataParser();
+            responseDataParser.parse(jsonResult);
+
+            report.setOutData(responseDataParser.asMap());
+            report.setPendingResults();
+            attestationManager.saveReport(report);
         }
         catch (JsonSyntaxException e) {
             String msg = "Failed to parse the attestation result:\n";
             msg += Optional.of(jsonResult)
                     .map(JsonElement::toString)
                     .orElse("Got no result");
-            LOG.error(msg);
-            serverAction.setStatusFailed();
-            serverAction.setResultMsg(msg);
+
+            setFailure(msg, serverAction, report);
             return;
         }
         if (serverAction.isStatusFailed()) {
             String msg = "Error while request attestation data from target system:\n";
             msg += SaltUtils.getJsonResultWithPrettyPrint(jsonResult);
             serverAction.setResultMsg(msg);
-            if (report.getResults().isEmpty()) {
-                // results are not initialized yet. So we need to set the report status
-                // directly to failed.
-                report.setStatus(CoCoReportStatus.FAILED);
-            }
         }
         else {
             serverAction.setResultMsg("Successfully collected attestation data");
         }
     }
+
+    private void setFailure(String message, ServerAction serverAction, ServerCoCoAttestationReport report) {
+        LOG.error(message);
+        serverAction.fail(message);
+        report.setFailed();
+        report.getResults().forEach(result -> result.setStatus(CoCoResultStatus.FAILED));
+    }
+
 }

--- a/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
@@ -29,7 +29,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -68,24 +67,8 @@ public class CoCoAttestationAction extends Action {
 
     @Override
     public void onFailAction(ServerAction serverActionIn) {
-        AttestationManager attestationManager = GlobalInstanceHolder.ATTESTATION_MANAGER;
         if (!Objects.equals(serverActionIn.getParentAction(), this)) {
             LOG.error("This is not the action which belongs to the passed server action");
-            return;
-        }
-        try {
-            Optional<ServerCoCoAttestationReport> report = attestationManager.lookupReportByServerAndAction(
-                    serverActionIn.getServer(), this);
-            report.ifPresent(rep -> {
-                if (rep.getResults().isEmpty()) {
-                    // results are not initialized yet. So we need to set the report status
-                    // directly to failed.
-                    rep.setStatus(CoCoReportStatus.FAILED);
-                }
-            });
-        }
-        catch (Exception e) {
-            LOG.log(Level.ERROR, e);
         }
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
@@ -62,7 +62,7 @@ public class CoCoAttestationAction extends Action {
             return false;
         }
 
-        return actionReportList.stream().allMatch(ServerCoCoAttestationReport::hasAllInputDataFromResults);
+        return actionReportList.stream().allMatch(attestationManager::hasAllInputDataFromResults);
     }
 
     @Override
@@ -81,7 +81,7 @@ public class CoCoAttestationAction extends Action {
         List<ServerCoCoAttestationReport> actionReportList =
                 attestationManager.listCoCoAttestationReportsForAction(this);
         if (actionReportList.isEmpty()) {
-            LOG.debug("Failed to find any report entry while creating the pillar data");
+            LOG.warn("Failed to find any report entry while creating the pillar data");
             return Map.of();
         }
 
@@ -96,7 +96,7 @@ public class CoCoAttestationAction extends Action {
             Optional<Map<String, Object>> pillarData = Optional.empty();
             if (optReport.isPresent()) {
                 ServerCoCoAttestationReport report = optReport.get();
-                report.mergeInputDataFromResults();
+                attestationManager.mergeInputDataFromResults(report);
 
                 //pillar data sent to minion during coco attestation is cryptographically safe by design!
                 pillarData = createPillarData(report);
@@ -136,7 +136,7 @@ public class CoCoAttestationAction extends Action {
         Optional<ServerCoCoAttestationReport> optReport =
                 attestationManager.lookupReportByServerAndAction(serverAction.getServer(), this);
         if (optReport.isEmpty()) {
-            LOG.debug("Failed to find a report entry while parsing salt state apply result");
+            LOG.warn("Failed to find a report entry while parsing salt state apply result");
             serverAction.fail("Failed to find a report entry");
             return;
         }
@@ -147,7 +147,7 @@ public class CoCoAttestationAction extends Action {
             if (StringUtils.isBlank(msg)) {
                 msg = "Error while request attestation data from target system:\nGot no result from system";
             }
-            setFailure(msg, serverAction, report);
+            setFailure(msg, serverAction, attestationManager, report);
             return;
         }
 
@@ -156,7 +156,7 @@ public class CoCoAttestationAction extends Action {
             responseDataParser.parse(jsonResult);
 
             report.setOutData(responseDataParser.asMap());
-            report.setPendingResults();
+            attestationManager.setPendingResults(report);
             attestationManager.saveReport(report);
         }
         catch (JsonSyntaxException e) {
@@ -165,7 +165,7 @@ public class CoCoAttestationAction extends Action {
                     .map(JsonElement::toString)
                     .orElse("Got no result");
 
-            setFailure(msg, serverAction, report);
+            setFailure(msg, serverAction, attestationManager, report);
             return;
         }
         if (serverAction.isStatusFailed()) {
@@ -178,10 +178,11 @@ public class CoCoAttestationAction extends Action {
         }
     }
 
-    private void setFailure(String message, ServerAction serverAction, ServerCoCoAttestationReport report) {
+    private void setFailure(String message, ServerAction serverAction,
+                            AttestationManager attestationManager, ServerCoCoAttestationReport report) {
         LOG.error(message);
         serverAction.fail(message);
-        report.setFailed();
+        attestationManager.setFailed(report);
         report.getResults().forEach(result -> result.setStatus(CoCoResultStatus.FAILED));
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -77,10 +78,29 @@ public class CoCoAttestationAction extends Action {
      */
     @Override
     public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
-        return Map.of(
-                State.apply(Collections.singletonList(SaltParameters.COCOATTEST_REQUESTDATA), Optional.empty()),
-                minionSummaries
-        );
+        AttestationManager attestationManager = GlobalInstanceHolder.ATTESTATION_MANAGER;
+        Optional<ServerCoCoAttestationReport> optReport = attestationManager.lookupReportByAction(this);
+        if (optReport.isEmpty()) {
+            LOG.debug("Failed to find a report entry while creating the pillar data");
+            return Map.of();
+        }
+        ServerCoCoAttestationReport report = optReport.get();
+
+        report.mergeInputDataFromResults();
+
+        //pillar data sent to minion during coco attestation is cryptographically safe by design!
+        return Map.of(State.apply(Collections.singletonList(SaltParameters.COCOATTEST_REQUESTDATA),
+                        createPillarData(report)), minionSummaries);
+    }
+
+    private Optional<Map<String, Object>> createPillarData(ServerCoCoAttestationReport report) {
+        Map<String, Object> attestationPillar = new HashMap<>(report.getInData());
+        attestationPillar.put("environment_type", report.getEnvironmentType().name());
+
+        Map<String, Object> pillarData = new HashMap<>();
+        pillarData.put("attestation_data", attestationPillar);
+
+        return Optional.of(pillarData);
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
@@ -16,14 +16,12 @@ import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.server.MinionSummary;
 
 import com.suse.manager.attestation.AttestationManager;
-import com.suse.manager.model.attestation.CoCoReportStatus;
 import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltParameters;
-import com.suse.manager.webui.utils.salt.custom.CoCoAttestationRequestData;
+import com.suse.manager.webui.utils.salt.custom.coco.CoCoAttestationResponseDataParser;
 import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.calls.modules.State;
-import com.suse.utils.Json;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
@@ -108,11 +106,11 @@ public class CoCoAttestationAction extends Action {
      */
     @Override
     public void handleUpdateServerAction(ServerAction serverAction, JsonElement jsonResult, UpdateAuxArgs auxArgs) {
-        AttestationManager mgr = new AttestationManager();
-
+        AttestationManager attestationManager = GlobalInstanceHolder.ATTESTATION_MANAGER;
         Optional<ServerCoCoAttestationReport> optReport =
-                mgr.lookupReportByServerAndAction(serverAction.getServer(), this);
+                attestationManager.lookupReportByServerAndAction(serverAction.getServer(), this);
         if (optReport.isEmpty()) {
+            LOG.debug("Failed to find a report entry while parsing salt state apply result");
             serverAction.setStatusFailed();
             serverAction.setResultMsg("Failed to find a report entry");
             return;
@@ -120,41 +118,46 @@ public class CoCoAttestationAction extends Action {
         ServerCoCoAttestationReport report = optReport.get();
 
         if (jsonResult == null) {
-            serverAction.setStatusFailed();
-            if (StringUtils.isBlank(serverAction.getResultMsg())) {
-                serverAction.setResultMsg("Error while request attestation data from target system:\n" +
-                        "Got no result from system");
+            String msg = serverAction.getResultMsg();
+            if (StringUtils.isBlank(msg)) {
+                msg = "Error while request attestation data from target system:\nGot no result from system";
             }
+            setFailure(msg, serverAction, report);
             return;
         }
 
         try {
-            CoCoAttestationRequestData requestData = Json.GSON.fromJson(jsonResult, CoCoAttestationRequestData.class);
-            report.setOutData(requestData.asMap());
-            mgr.initializeResults(report);
+            CoCoAttestationResponseDataParser responseDataParser = new CoCoAttestationResponseDataParser();
+            responseDataParser.parse(jsonResult);
+
+            report.setOutData(responseDataParser.asMap());
+            report.setPendingResults();
+            attestationManager.saveReport(report);
         }
         catch (JsonSyntaxException e) {
             String msg = "Failed to parse the attestation result:\n";
             msg += Optional.of(jsonResult)
                     .map(JsonElement::toString)
                     .orElse("Got no result");
-            LOG.error(msg);
-            serverAction.setStatusFailed();
-            serverAction.setResultMsg(msg);
+
+            setFailure(msg, serverAction, report);
             return;
         }
         if (serverAction.isStatusFailed()) {
             String msg = "Error while request attestation data from target system:\n";
             msg += SaltUtils.getJsonResultWithPrettyPrint(jsonResult);
             serverAction.setResultMsg(msg);
-            if (report.getResults().isEmpty()) {
-                // results are not initialized yet. So we need to set the report status
-                // directly to failed.
-                report.setStatus(CoCoReportStatus.FAILED);
-            }
         }
         else {
             serverAction.setResultMsg("Successfully collected attestation data");
         }
     }
+
+    private void setFailure(String message, ServerAction serverAction, ServerCoCoAttestationReport report) {
+        LOG.error(message);
+        serverAction.setStatusFailed();
+        serverAction.setResultMsg(message);
+        report.setFailed();
+    }
+
 }

--- a/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -77,10 +78,54 @@ public class CoCoAttestationAction extends Action {
      */
     @Override
     public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
-        return Map.of(
-                State.apply(Collections.singletonList(SaltParameters.COCOATTEST_REQUESTDATA), Optional.empty()),
-                minionSummaries
-        );
+        AttestationManager attestationManager = GlobalInstanceHolder.ATTESTATION_MANAGER;
+        List<ServerCoCoAttestationReport> actionReportList =
+                attestationManager.listCoCoAttestationReportsForAction(this);
+        if (actionReportList.isEmpty()) {
+            LOG.debug("Failed to find any report entry while creating the pillar data");
+            return Map.of();
+        }
+
+        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
+
+        minionSummaries.forEach(minionSummary -> {
+
+            Optional<ServerCoCoAttestationReport> optReport = actionReportList.stream()
+                    .filter(r -> r.getServer().getId().equals(minionSummary.getServerId()))
+                    .findAny();
+
+            Optional<Map<String, Object>> pillarData = Optional.empty();
+            if (optReport.isPresent()) {
+                ServerCoCoAttestationReport report = optReport.get();
+                report.mergeInputDataFromResults();
+
+                //pillar data sent to minion during coco attestation is cryptographically safe by design!
+                pillarData = createPillarData(report);
+            }
+            else {
+                LOG.debug("Failed to find a report entry while creating the pillar data for minion {}",
+                        minionSummary);
+            }
+
+            ret.put(State.apply(Collections.singletonList(SaltParameters.COCOATTEST_REQUESTDATA), pillarData),
+                    List.of(minionSummary));
+        });
+
+        return ret;
+    }
+
+    private Optional<Map<String, Object>> createPillarData(ServerCoCoAttestationReport report) {
+        Map<String, Object> attestationPillar = new HashMap<>(report.getInData());
+        attestationPillar.put("environment_type", report.getEnvironmentType().name());
+
+        List<String> resultTypes = report.getEnvironmentType().getSupportedResultTypes().stream()
+                .map(Enum::name).toList();
+        attestationPillar.put("result_types", resultTypes);
+
+        Map<String, Object> pillarData = new HashMap<>();
+        pillarData.put("attestation_data", attestationPillar);
+
+        return Optional.of(pillarData);
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
@@ -50,6 +50,22 @@ import jakarta.persistence.Entity;
 public class CoCoAttestationAction extends Action {
     private static final Logger LOG = LogManager.getLogger(CoCoAttestationAction.class);
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isReadyToRun() {
+        AttestationManager attestationManager = GlobalInstanceHolder.ATTESTATION_MANAGER;
+        List<ServerCoCoAttestationReport> actionReportList =
+                attestationManager.listCoCoAttestationReportsForAction(this);
+        if (actionReportList.isEmpty()) {
+            LOG.debug("Failed to find a report entry while checking for input data");
+            return false;
+        }
+
+        return actionReportList.stream().allMatch(ServerCoCoAttestationReport::hasAllInputDataFromResults);
+    }
+
     @Override
     public void onFailAction(ServerAction serverActionIn) {
         AttestationManager attestationManager = GlobalInstanceHolder.ATTESTATION_MANAGER;

--- a/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/CoCoAttestationAction.java
@@ -50,6 +50,22 @@ import jakarta.persistence.Entity;
 public class CoCoAttestationAction extends Action {
     private static final Logger LOG = LogManager.getLogger(CoCoAttestationAction.class);
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isReadyToRun() {
+        AttestationManager attestationManager = GlobalInstanceHolder.ATTESTATION_MANAGER;
+        Optional<ServerCoCoAttestationReport> optReport = attestationManager.lookupReportByAction(this);
+        if (optReport.isEmpty()) {
+            LOG.debug("Failed to find a report entry while checking for input data");
+            return false;
+        }
+        ServerCoCoAttestationReport report = optReport.get();
+
+        return report.hasAllInputDataFromResults();
+    }
+
     @Override
     public void onFailAction(ServerAction serverActionIn) {
         AttestationManager attestationManager = GlobalInstanceHolder.ATTESTATION_MANAGER;

--- a/java/core/src/main/java/com/suse/manager/attestation/AttestationManager.java
+++ b/java/core/src/main/java/com/suse/manager/attestation/AttestationManager.java
@@ -387,6 +387,14 @@ public class AttestationManager {
         return factory.listCoCoAttestationReportsForAction(actionIn);
     }
 
+    /**
+     * @param reportIn the report to be saved
+     * @return returns the saved report
+     */
+    public ServerCoCoAttestationReport saveReport(ServerCoCoAttestationReport reportIn) {
+        return factory.save(reportIn);
+    }
+
     private void ensureSystemAccessible(User userIn, Server serverIn) {
         if (serverIn == null) {
             LOG.error("Server not found");

--- a/java/core/src/main/java/com/suse/manager/attestation/AttestationManager.java
+++ b/java/core/src/main/java/com/suse/manager/attestation/AttestationManager.java
@@ -379,6 +379,14 @@ public class AttestationManager {
         return factory.listCoCoAttestationReportsForUser(userIn, offset, limit);
     }
 
+    /**
+     * @param actionIn the action
+     * @return returns the attestation report for this server and action if available
+     */
+    public Optional<ServerCoCoAttestationReport> lookupReportByAction(Action actionIn) {
+        return factory.lookupReportByAction(actionIn);
+    }
+
     private void ensureSystemAccessible(User userIn, Server serverIn) {
         if (serverIn == null) {
             LOG.error("Server not found");

--- a/java/core/src/main/java/com/suse/manager/attestation/AttestationManager.java
+++ b/java/core/src/main/java/com/suse/manager/attestation/AttestationManager.java
@@ -387,6 +387,14 @@ public class AttestationManager {
         return factory.lookupReportByAction(actionIn);
     }
 
+    /**
+     * @param reportIn the report to be saved
+     * @return returns the saved report
+     */
+    public ServerCoCoAttestationReport saveReport(ServerCoCoAttestationReport reportIn) {
+        return factory.save(reportIn);
+    }
+
     private void ensureSystemAccessible(User userIn, Server serverIn) {
         if (serverIn == null) {
             LOG.error("Server not found");

--- a/java/core/src/main/java/com/suse/manager/attestation/AttestationManager.java
+++ b/java/core/src/main/java/com/suse/manager/attestation/AttestationManager.java
@@ -35,17 +35,13 @@ import com.suse.manager.model.attestation.CoCoAttestationResult;
 import com.suse.manager.model.attestation.CoCoEnvironmentType;
 import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
 import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
-import com.suse.manager.webui.services.pillar.MinionPillarManager;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -57,7 +53,6 @@ public class AttestationManager {
     private static final Logger LOG = LogManager.getLogger(AttestationManager.class);
     private final AttestationFactory factory;
     private final TaskomaticApi taskomaticApi;
-    private SecureRandom secureRandom = new SecureRandom();
 
     /**
      * Constructor
@@ -145,7 +140,7 @@ public class AttestationManager {
                                                                   Set<MinionServer> minionsSet, Date earliest)
         throws TaskomaticApiException {
         CoCoAttestationAction action = createAttestationAction(userIn.orElse(null), orgIn, earliest);
-        minionsSet.forEach(minionServer -> initializeReport(action, minionServer));
+        minionsSet.forEach(minionServer -> initializeAttestation(action, minionServer));
 
         Set<Long> minionIds = minionsSet.stream().map(Server::getId).collect(Collectors.toSet());
         ActionFactory.scheduleForExecution(action, minionIds);
@@ -164,7 +159,7 @@ public class AttestationManager {
         List<CoCoAttestationAction> actionsList = new ArrayList<>();
         for (MinionServer server : minionsSet) {
             CoCoAttestationAction action = createAttestationAction(userIn.orElse(null), orgIn, earliest);
-            initializeReport(action, server);
+            initializeAttestation(action, server);
 
             ActionChainFactory.queueActionChainEntry(action, actionChain, server.getId(), nextSortOrder);
             actionsList.add(action);
@@ -183,16 +178,10 @@ public class AttestationManager {
         return action;
     }
 
-    private void initializeReport(CoCoAttestationAction action, MinionServer minion) {
+    private void initializeAttestation(CoCoAttestationAction action, MinionServer minion) {
         ServerCoCoAttestationReport initReport = factory.createReportForServer(minion);
         initReport.setAction(action);
-        if (initReport.getEnvironmentType().isNonceRequired()) {
-            byte[] bytes = new byte[64];
-            secureRandom.nextBytes(bytes);
-            initReport.setInData(Map.of("nonce", Base64.getEncoder().encodeToString(bytes)));
-        }
-
-        MinionPillarManager.INSTANCE.generatePillar(minion, false, MinionPillarManager.PillarSubset.GENERAL);
+        factory.initResultsForReport(initReport);
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/attestation/AttestationManager.java
+++ b/java/core/src/main/java/com/suse/manager/attestation/AttestationManager.java
@@ -33,6 +33,8 @@ import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.suse.manager.model.attestation.AttestationFactory;
 import com.suse.manager.model.attestation.CoCoAttestationResult;
 import com.suse.manager.model.attestation.CoCoEnvironmentType;
+import com.suse.manager.model.attestation.CoCoReportStatus;
+import com.suse.manager.model.attestation.CoCoResultStatus;
 import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
 import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
 
@@ -42,6 +44,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -421,6 +424,59 @@ public class AttestationManager {
             LOG.error("Attestation disabled");
             throw new AttestationDisabledException();
         }
+    }
+
+    /**
+     * Checks if all results have their input data already computed
+     * @param report the report
+     * @return true if all results have their input data already computed
+     */
+    public boolean hasAllInputDataFromResults(ServerCoCoAttestationReport report) {
+        return report.getResults().stream()
+                .allMatch(result -> result.getStatus().hasInputData());
+    }
+
+    /**
+     * Sets failure in report and inputs not yet computed
+     * @param report the report
+     */
+    public void setFailed(ServerCoCoAttestationReport report) {
+        report.setStatus(CoCoReportStatus.FAILED);
+
+        report.getResults().stream()
+                .filter(result -> !result.getStatus().hasInputData())
+                .forEach(result -> {
+                    result.setStatus(CoCoResultStatus.FAILED);
+                    result.setDetails("No input data");
+                });
+    }
+
+    /**
+     * Collects and merges input data from results, stores it in report input data member
+     * @param report the report
+     */
+    public void mergeInputDataFromResults(ServerCoCoAttestationReport report) {
+        Map<String, Object> mergedInputData = report.getResults().stream()
+                .map(CoCoAttestationResult::getInData)
+                .flatMap(map -> map.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        report.setInData(mergedInputData);
+        report.getResults().forEach(result -> result.setStatus(CoCoResultStatus.SUBMITTED));
+    }
+
+    /**
+     * Sets pending status in report and in all results
+     * @param report the report
+     */
+    public void setPendingResults(ServerCoCoAttestationReport report) {
+        report.setStatus(CoCoReportStatus.PENDING);
+
+        report.getResults().stream()
+                .filter(result -> result.getStatus().hasInputData())
+                .forEach(result -> {
+                    result.setStatus(CoCoResultStatus.PENDING);
+                });
     }
 
 }

--- a/java/core/src/main/java/com/suse/manager/attestation/AttestationManager.java
+++ b/java/core/src/main/java/com/suse/manager/attestation/AttestationManager.java
@@ -379,6 +379,14 @@ public class AttestationManager {
         return factory.listCoCoAttestationReportsForUser(userIn, offset, limit);
     }
 
+    /**
+     * @param actionIn the action
+     * @return returns the attestation report for this server and action if available
+     */
+    public List<ServerCoCoAttestationReport> listCoCoAttestationReportsForAction(Action actionIn) {
+        return factory.listCoCoAttestationReportsForAction(actionIn);
+    }
+
     private void ensureSystemAccessible(User userIn, Server serverIn) {
         if (serverIn == null) {
             LOG.error("Server not found");

--- a/java/core/src/main/java/com/suse/manager/model/attestation/AttestationFactory.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/AttestationFactory.java
@@ -190,7 +190,7 @@ public class AttestationFactory extends HibernateFactory {
             result.setEnvironmentType(envType);
             result.setResultType(t);
             result.setReport(report);
-            result.setStatus(CoCoResultStatus.PENDING);
+            result.setStatus(CoCoResultStatus.REQUESTED);
             result.setDescription(t.getTypeDescription());
             save(result);
             report.addResults(result);

--- a/java/core/src/main/java/com/suse/manager/model/attestation/AttestationFactory.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/AttestationFactory.java
@@ -187,6 +187,7 @@ public class AttestationFactory extends HibernateFactory {
         CoCoEnvironmentType envType = report.getEnvironmentType();
         for (CoCoResultType t : envType.getSupportedResultTypes()) {
             CoCoAttestationResult result = new CoCoAttestationResult();
+            result.setEnvironmentType(envType);
             result.setResultType(t);
             result.setReport(report);
             result.setStatus(CoCoResultStatus.PENDING);

--- a/java/core/src/main/java/com/suse/manager/model/attestation/AttestationFactory.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/AttestationFactory.java
@@ -169,7 +169,7 @@ public class AttestationFactory extends HibernateFactory {
             ServerCoCoAttestationReport rpt = new ServerCoCoAttestationReport();
             rpt.setServer(serverIn);
             rpt.setEnvironmentType(cnf.get().getEnvironmentType());
-            rpt.setStatus(CoCoAttestationStatus.PENDING);
+            rpt.setStatus(CoCoReportStatus.PENDING);
             save(rpt);
             serverIn.addCocoAttestationReports(rpt);
             return rpt;
@@ -189,7 +189,7 @@ public class AttestationFactory extends HibernateFactory {
             CoCoAttestationResult result = new CoCoAttestationResult();
             result.setResultType(t);
             result.setReport(report);
-            result.setStatus(CoCoAttestationStatus.PENDING);
+            result.setStatus(CoCoResultStatus.PENDING);
             result.setDescription(t.getTypeDescription());
             save(result);
             report.addResults(result);

--- a/java/core/src/main/java/com/suse/manager/model/attestation/AttestationFactory.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/AttestationFactory.java
@@ -291,4 +291,16 @@ public class AttestationFactory extends HibernateFactory {
             .setFirstResult(offsetIn)
             .list();
     }
+
+    /**
+     * @param actionIn the action
+     * @return returns the attestation report for this action if available
+     */
+    public Optional<ServerCoCoAttestationReport> lookupReportByAction(Action actionIn) {
+        return getSession()
+                .createQuery("FROM ServerCoCoAttestationReport WHERE action = :action",
+                        ServerCoCoAttestationReport.class)
+                .setParameter("action", actionIn)
+                .uniqueResultOptional();
+    }
 }

--- a/java/core/src/main/java/com/suse/manager/model/attestation/AttestationFactory.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/AttestationFactory.java
@@ -170,6 +170,7 @@ public class AttestationFactory extends HibernateFactory {
             rpt.setServer(serverIn);
             rpt.setEnvironmentType(cnf.get().getEnvironmentType());
             rpt.setStatus(CoCoReportStatus.PENDING);
+            rpt.setConfigData(cnf.get().getInData());
             save(rpt);
             serverIn.addCocoAttestationReports(rpt);
             return rpt;

--- a/java/core/src/main/java/com/suse/manager/model/attestation/AttestationFactory.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/AttestationFactory.java
@@ -291,4 +291,16 @@ public class AttestationFactory extends HibernateFactory {
             .setFirstResult(offsetIn)
             .list();
     }
+
+    /**
+     * @param actionIn the action
+     * @return returns the attestation report for this action if available
+     */
+    public List<ServerCoCoAttestationReport> listCoCoAttestationReportsForAction(Action actionIn) {
+        return getSession()
+                .createQuery("FROM ServerCoCoAttestationReport WHERE action = :action",
+                        ServerCoCoAttestationReport.class)
+                .setParameter("action", actionIn)
+                .list();
+    }
 }

--- a/java/core/src/main/java/com/suse/manager/model/attestation/CoCoAttestationResult.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/CoCoAttestationResult.java
@@ -41,7 +41,7 @@ public class CoCoAttestationResult implements Serializable {
     private Long id;
     private ServerCoCoAttestationReport report;
     private CoCoResultType resultType;
-    private CoCoAttestationStatus status;
+    private CoCoResultStatus status;
     private String description;
     private String details;
     private String processOutput;
@@ -80,7 +80,7 @@ public class CoCoAttestationResult implements Serializable {
      */
     @Column(name = "status")
     @Enumerated(EnumType.STRING)
-    public CoCoAttestationStatus getStatus() {
+    public CoCoResultStatus getStatus() {
         return status;
     }
 
@@ -156,7 +156,7 @@ public class CoCoAttestationResult implements Serializable {
     /**
      * @param statusIn the status to set
      */
-    public void setStatus(CoCoAttestationStatus statusIn) {
+    public void setStatus(CoCoResultStatus statusIn) {
         status = statusIn;
     }
 

--- a/java/core/src/main/java/com/suse/manager/model/attestation/CoCoAttestationResult.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/CoCoAttestationResult.java
@@ -12,11 +12,15 @@ package com.suse.manager.model.attestation;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -41,6 +45,8 @@ public class CoCoAttestationResult implements Serializable {
     private Long id;
     private ServerCoCoAttestationReport report;
     private CoCoResultType resultType;
+    private CoCoEnvironmentType environmentType;
+    private Map<String, Object> inData = new TreeMap<>();
     private CoCoResultStatus status;
     private String description;
     private String details;
@@ -67,12 +73,30 @@ public class CoCoAttestationResult implements Serializable {
     }
 
     /**
-     * @return return the selected environment type
+     * @return return the selected result type
      */
     @Column(name = "result_type")
     @Convert(converter = CoCoResultTypeConverter.class)
     public CoCoResultType getResultType() {
         return resultType;
+    }
+
+    /**
+     * @return return the selected environment type
+     */
+    @Column(name = "env_type")
+    @Convert(converter = CoCoEnvironmentTypeConverter.class)
+    public CoCoEnvironmentType getEnvironmentType() {
+        return environmentType;
+    }
+
+    /**
+     * @return returns the input data
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", name = "in_data")
+    public Map<String, Object> getInData() {
+        return inData;
     }
 
     /**
@@ -151,6 +175,20 @@ public class CoCoAttestationResult implements Serializable {
      */
     public void setResultType(CoCoResultType resultTypeIn) {
         resultType = resultTypeIn;
+    }
+
+    /**
+     * @param environmentTypeIn set the environment type
+     */
+    public void setEnvironmentType(CoCoEnvironmentType environmentTypeIn) {
+        environmentType = environmentTypeIn;
+    }
+
+    /**
+     * @param inDataIn the input data to set
+     */
+    public void setInData(Map<String, Object> inDataIn) {
+        inData = inDataIn;
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/model/attestation/CoCoEnvironmentType.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/CoCoEnvironmentType.java
@@ -53,6 +53,10 @@ public enum CoCoEnvironmentType {
         return LocalizationService.getInstance().getMessage(descriptionKey);
     }
 
+    public static CoCoEnvironmentType getDefault() {
+        return KVM_AMD_EPYC_MILAN;
+    }
+
     /**
      * @return returns the list of supported {@link CoCoResultType} for this environment
      */

--- a/java/core/src/main/java/com/suse/manager/model/attestation/CoCoEnvironmentType.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/CoCoEnvironmentType.java
@@ -82,11 +82,4 @@ public enum CoCoEnvironmentType {
     public static List<CoCoEnvironmentType> validValues() {
         return Stream.of(CoCoEnvironmentType.values()).filter(e -> e != NONE).toList();
     }
-
-    /**
-     * @return returns if a nonce value is required
-     */
-    public boolean isNonceRequired() {
-        return (NONE != this);
-    }
 }

--- a/java/core/src/main/java/com/suse/manager/model/attestation/CoCoReportStatus.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/CoCoReportStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SUSE LLC
+ * Copyright (c) 2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -16,14 +16,14 @@ package com.suse.manager.model.attestation;
 
 import com.redhat.rhn.common.localization.LocalizationService;
 
-public enum CoCoAttestationStatus {
+public enum CoCoReportStatus {
     PENDING,
     SUCCEEDED,
     FAILED;
 
     private final String descriptionKey;
 
-    CoCoAttestationStatus() {
+    CoCoReportStatus() {
         this.descriptionKey = "coco.status." + name().toLowerCase() + ".description";
     }
 

--- a/java/core/src/main/java/com/suse/manager/model/attestation/CoCoReportStatus.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/CoCoReportStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 SUSE LLC
+ * Copyright (c) 2024--2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/java/core/src/main/java/com/suse/manager/model/attestation/CoCoResultStatus.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/CoCoResultStatus.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.model.attestation;
+
+import com.redhat.rhn.common.localization.LocalizationService;
+
+public enum CoCoResultStatus {
+    PENDING,
+    SUCCEEDED,
+    FAILED;
+
+    private final String descriptionKey;
+
+    CoCoResultStatus() {
+        this.descriptionKey = "coco.status." + name().toLowerCase() + ".description";
+    }
+
+    public String getDescription() {
+        return LocalizationService.getInstance().getMessage(descriptionKey);
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/model/attestation/CoCoResultStatus.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/CoCoResultStatus.java
@@ -19,7 +19,10 @@ import com.redhat.rhn.common.localization.LocalizationService;
 public enum CoCoResultStatus {
     PENDING,
     SUCCEEDED,
-    FAILED;
+    FAILED,
+    REQUESTED,
+    QUEUED,
+    SUBMITTED;
 
     private final String descriptionKey;
 

--- a/java/core/src/main/java/com/suse/manager/model/attestation/CoCoResultStatus.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/CoCoResultStatus.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 package com.suse.manager.model.attestation;
 

--- a/java/core/src/main/java/com/suse/manager/model/attestation/CoCoResultStatus.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/CoCoResultStatus.java
@@ -33,4 +33,12 @@ public enum CoCoResultStatus {
     public String getDescription() {
         return LocalizationService.getInstance().getMessage(descriptionKey);
     }
+
+    /**
+     * checks if status has input data present
+     * @return true if status has input data present
+     */
+    public boolean hasInputData() {
+        return (this != REQUESTED);
+    }
 }

--- a/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationConfig.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationConfig.java
@@ -51,7 +51,7 @@ public class ServerCoCoAttestationConfig implements Serializable  {
     public ServerCoCoAttestationConfig(boolean enabledIn, Server serverIn) {
         enabled = enabledIn;
         server = serverIn;
-        environmentType = CoCoEnvironmentType.NONE;
+        environmentType = CoCoEnvironmentType.getDefault();
         attestOnBoot = false;
     }
 

--- a/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationConfig.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationConfig.java
@@ -14,8 +14,12 @@ import com.redhat.rhn.domain.server.Server;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.io.Serializable;
+import java.util.Map;
+import java.util.TreeMap;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -35,6 +39,7 @@ public class ServerCoCoAttestationConfig implements Serializable  {
     private Server server;
     private boolean enabled;
     private CoCoEnvironmentType environmentType;
+    private Map<String, Object> inData = new TreeMap<>();
     private boolean attestOnBoot;
 
     // Default empty constructor for hibernate
@@ -94,6 +99,18 @@ public class ServerCoCoAttestationConfig implements Serializable  {
         return environmentType;
     }
 
+    /**
+     * @return returns the input data
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", name = "in_data")
+    public Map<String, Object> getInData() {
+        return inData;
+    }
+
+    /**
+     * @return returns true attest on boot flag is set
+     */
     @Column(name = "attest_on_boot")
     public boolean isAttestOnBoot() {
         return attestOnBoot;
@@ -128,6 +145,16 @@ public class ServerCoCoAttestationConfig implements Serializable  {
         environmentType = environmentTypeIn;
     }
 
+    /**
+     * @param inDataIn the input data to set
+     */
+    public void setInData(Map<String, Object> inDataIn) {
+        inData = inDataIn;
+    }
+
+    /**
+     * @param attestOnBootIn the value of attest on boot flag
+     */
     public void setAttestOnBoot(boolean attestOnBootIn) {
         this.attestOnBoot = attestOnBootIn;
     }

--- a/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
@@ -48,7 +48,7 @@ public class ServerCoCoAttestationReport extends BaseDomainHelper implements Ser
     private Server server;
     private Action action;
     private CoCoEnvironmentType environmentType;
-    private CoCoAttestationStatus status;
+    private CoCoReportStatus status;
     private Map<String, Object> inData = new TreeMap<>();
     private Map<String, Object> outData = new TreeMap<>();
     private List<CoCoAttestationResult> results = new ArrayList<>();
@@ -91,7 +91,7 @@ public class ServerCoCoAttestationReport extends BaseDomainHelper implements Ser
 
     @Column(name = "status")
     @Enumerated(EnumType.STRING)
-    public CoCoAttestationStatus getStatus() {
+    public CoCoReportStatus getStatus() {
         return status;
     }
 
@@ -144,7 +144,7 @@ public class ServerCoCoAttestationReport extends BaseDomainHelper implements Ser
     /**
      * @param statusIn the status to set
      */
-    public void setStatus(CoCoAttestationStatus statusIn) {
+    public void setStatus(CoCoReportStatus statusIn) {
         status = statusIn;
     }
 

--- a/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
@@ -49,6 +49,7 @@ public class ServerCoCoAttestationReport extends BaseDomainHelper implements Ser
     private Action action;
     private CoCoEnvironmentType environmentType;
     private CoCoReportStatus status;
+    private Map<String, Object> configData = new TreeMap<>();
     private Map<String, Object> inData = new TreeMap<>();
     private Map<String, Object> outData = new TreeMap<>();
     private List<CoCoAttestationResult> results = new ArrayList<>();
@@ -93,6 +94,12 @@ public class ServerCoCoAttestationReport extends BaseDomainHelper implements Ser
     @Enumerated(EnumType.STRING)
     public CoCoReportStatus getStatus() {
         return status;
+    }
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", name = "config_data")
+    public Map<String, Object> getConfigData() {
+        return configData;
     }
 
     @JdbcTypeCode(SqlTypes.JSON)
@@ -146,6 +153,13 @@ public class ServerCoCoAttestationReport extends BaseDomainHelper implements Ser
      */
     public void setStatus(CoCoReportStatus statusIn) {
         status = statusIn;
+    }
+
+    /**
+     * @param configDataIn the config data to set
+     */
+    public void setConfigData(Map<String, Object> configDataIn) {
+        configData = configDataIn;
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
@@ -199,6 +199,20 @@ public class ServerCoCoAttestationReport extends BaseDomainHelper implements Ser
                 .allMatch(result -> result.getStatus().hasInputData());
     }
 
+    /**
+     * Sets failure in report and inputs not yet computed
+     */
+    public void setFailed() {
+        setStatus(CoCoReportStatus.FAILED);
+
+        getResults().stream()
+                .filter(result -> !result.getStatus().hasInputData())
+                .forEach(result -> {
+                    result.setStatus(CoCoResultStatus.FAILED);
+                    result.setDetails("No input data");
+                });
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -211,6 +212,19 @@ public class ServerCoCoAttestationReport extends BaseDomainHelper implements Ser
                     result.setStatus(CoCoResultStatus.FAILED);
                     result.setDetails("No input data");
                 });
+    }
+
+    /**
+     * Collects and merges input data from results, stores it in report input data member
+     */
+    public void mergeInputDataFromResults() {
+        Map<String, Object> mergedInputData = getResults().stream()
+                .map(CoCoAttestationResult::getInData)
+                .flatMap(map -> map.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        setInData(mergedInputData);
+        getResults().forEach(result -> result.setStatus(CoCoResultStatus.SUBMITTED));
     }
 
     @Override

--- a/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
@@ -190,6 +190,15 @@ public class ServerCoCoAttestationReport extends BaseDomainHelper implements Ser
         results.add(resultIn);
     }
 
+    /**
+     * Checks if all results have their input data already computed
+     * @return true if all results have their input data already computed
+     */
+    public boolean hasAllInputDataFromResults() {
+        return getResults().stream()
+                .allMatch(result -> result.getStatus().hasInputData());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
@@ -227,6 +227,19 @@ public class ServerCoCoAttestationReport extends BaseDomainHelper implements Ser
         getResults().forEach(result -> result.setStatus(CoCoResultStatus.SUBMITTED));
     }
 
+    /**
+     * Sets pending status in report and in all results
+     */
+    public void setPendingResults() {
+        setStatus(CoCoReportStatus.PENDING);
+
+        getResults().stream()
+                .filter(result -> result.getStatus().hasInputData())
+                .forEach(result -> {
+                    result.setStatus(CoCoResultStatus.PENDING);
+                });
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
+++ b/java/core/src/main/java/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -189,55 +188,6 @@ public class ServerCoCoAttestationReport extends BaseDomainHelper implements Ser
      */
     public void addResults(CoCoAttestationResult resultIn) {
         results.add(resultIn);
-    }
-
-    /**
-     * Checks if all results have their input data already computed
-     * @return true if all results have their input data already computed
-     */
-    public boolean hasAllInputDataFromResults() {
-        return getResults().stream()
-                .allMatch(result -> result.getStatus().hasInputData());
-    }
-
-    /**
-     * Sets failure in report and inputs not yet computed
-     */
-    public void setFailed() {
-        setStatus(CoCoReportStatus.FAILED);
-
-        getResults().stream()
-                .filter(result -> !result.getStatus().hasInputData())
-                .forEach(result -> {
-                    result.setStatus(CoCoResultStatus.FAILED);
-                    result.setDetails("No input data");
-                });
-    }
-
-    /**
-     * Collects and merges input data from results, stores it in report input data member
-     */
-    public void mergeInputDataFromResults() {
-        Map<String, Object> mergedInputData = getResults().stream()
-                .map(CoCoAttestationResult::getInData)
-                .flatMap(map -> map.entrySet().stream())
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-        setInData(mergedInputData);
-        getResults().forEach(result -> result.setStatus(CoCoResultStatus.SUBMITTED));
-    }
-
-    /**
-     * Sets pending status in report and in all results
-     */
-    public void setPendingResults() {
-        setStatus(CoCoReportStatus.PENDING);
-
-        getResults().stream()
-                .filter(result -> result.getStatus().hasInputData())
-                .forEach(result -> {
-                    result.setStatus(CoCoResultStatus.PENDING);
-                });
     }
 
     @Override

--- a/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -26,7 +26,7 @@ import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.AnsibleManager;
 
 import com.suse.manager.model.attestation.AttestationFactory;
-import com.suse.manager.model.attestation.CoCoAttestationStatus;
+import com.suse.manager.model.attestation.CoCoReportStatus;
 import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
 import com.suse.manager.utils.MachinePasswordUtils;
 
@@ -121,7 +121,7 @@ public class MinionGeneralPillarGenerator extends MinionPillarGeneratorBase {
         cocoCnf.filter(ServerCoCoAttestationConfig::isEnabled).ifPresent(cnf -> {
             AttestationFactory attfct = new AttestationFactory();
             Map<String, Object> attestationPillar = attfct.lookupLatestReportByServer(minion)
-                    .filter(r -> r.getStatus().equals(CoCoAttestationStatus.PENDING))
+                    .filter(r -> r.getStatus().equals(CoCoReportStatus.PENDING))
                     .map(r -> new HashMap<>(r.getInData()))
                     .orElse(new HashMap<>());
             attestationPillar.put("environment_type", cnf.getEnvironmentType().name());

--- a/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -25,9 +25,6 @@ import com.redhat.rhn.domain.server.ServerFQDN;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.AnsibleManager;
 
-import com.suse.manager.model.attestation.AttestationFactory;
-import com.suse.manager.model.attestation.CoCoReportStatus;
-import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
 import com.suse.manager.utils.MachinePasswordUtils;
 
 import org.apache.logging.log4j.LogManager;
@@ -117,16 +114,6 @@ public class MinionGeneralPillarGenerator extends MinionPillarGeneratorBase {
             pillar.add("beacons", beaconConfig);
         }
 
-        Optional<ServerCoCoAttestationConfig> cocoCnf = minion.getOptCocoAttestationConfig();
-        cocoCnf.filter(ServerCoCoAttestationConfig::isEnabled).ifPresent(cnf -> {
-            AttestationFactory attfct = new AttestationFactory();
-            Map<String, Object> attestationPillar = attfct.lookupLatestReportByServer(minion)
-                    .filter(r -> r.getStatus().equals(CoCoReportStatus.PENDING))
-                    .map(r -> new HashMap<>(r.getInData()))
-                    .orElse(new HashMap<>());
-            attestationPillar.put("environment_type", cnf.getEnvironmentType().name());
-            pillar.add("attestation_data", attestationPillar);
-        });
         return Optional.of(pillar);
     }
 

--- a/java/core/src/main/java/com/suse/manager/webui/utils/gson/CoCoAttestationReportJson.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/gson/CoCoAttestationReportJson.java
@@ -21,7 +21,7 @@ import com.redhat.rhn.domain.action.ActionType;
 import com.redhat.rhn.domain.user.User;
 
 import com.suse.manager.model.attestation.CoCoAttestationResult;
-import com.suse.manager.model.attestation.CoCoAttestationStatus;
+import com.suse.manager.model.attestation.CoCoResultStatus;
 import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
 
 import java.util.Date;
@@ -178,7 +178,7 @@ public class CoCoAttestationReportJson {
     }
 
     private static Date getAttestationTime(List<CoCoAttestationResult> results) {
-        if (results.stream().anyMatch(r -> r.getStatus() != CoCoAttestationStatus.SUCCEEDED)) {
+        if (results.stream().anyMatch(r -> r.getStatus() != CoCoResultStatus.SUCCEEDED)) {
             return null;
         }
 

--- a/java/core/src/main/java/com/suse/manager/webui/utils/gson/CoCoSettingsJson.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/gson/CoCoSettingsJson.java
@@ -44,7 +44,7 @@ public class CoCoSettingsJson {
      * @param supportedIn if confidential computing is supported
      */
     public CoCoSettingsJson(boolean supportedIn) {
-        this(supportedIn, false, CoCoEnvironmentType.NONE, false);
+        this(supportedIn, false, CoCoEnvironmentType.getDefault(), false);
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAbstractAttestationResponseData.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAbstractAttestationResponseData.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.webui.utils.salt.custom.coco;
+
+import com.suse.salt.netapi.results.CmdResult;
+import com.suse.salt.netapi.results.StateApplyResult;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class CoCoAbstractAttestationResponseData {
+
+    /**
+     * @return a map of tags to response items
+     */
+    public abstract Map<String, Optional<StateApplyResult<CmdResult>>> getResults();
+
+    /**
+     * @return a map of tags to data items
+     */
+    public Map<String, Object> asMap() {
+        Map<String, Object> outMap = new HashMap<>();
+
+        getResults().entrySet().stream()
+                .filter(e -> e.getValue().isPresent())
+                .forEach(e -> insertItemInMap(e.getKey(), e.getValue().get(), outMap));
+
+        return outMap;
+    }
+
+    protected boolean hasBase64Stdout(StateApplyResult<CmdResult> responseItem) {
+        return responseItem.getName()
+                .map(x -> x.fold(Arrays::asList, List::of))
+                .orElseGet(ArrayList::new)
+                .stream()
+                .anyMatch(s -> s.contains("/usr/bin/base64"));
+    }
+
+    protected void insertItemInMap(String tagKey, StateApplyResult<CmdResult> responseItem,
+                                   Map<String, Object> outMap) {
+        if (null == responseItem) {
+            return;
+        }
+
+        Optional.ofNullable(responseItem.getChanges())
+                .ifPresent(cmdResult -> {
+                    if (StringUtils.isNotEmpty(cmdResult.getStdout())) {
+                        if (hasBase64Stdout(responseItem)) {
+                            outMap.put(tagKey, cmdResult.getStdout().replace("\n", ""));
+                        }
+                        else {
+                            outMap.put(tagKey, cmdResult.getStdout());
+                        }
+                    }
+                    else if (StringUtils.isNotEmpty(cmdResult.getStderr())) {
+                        outMap.put(tagKey, cmdResult.getStderr());
+                    }
+                    else if (StringUtils.isNotEmpty(responseItem.getComment())) {
+                        outMap.put(tagKey, responseItem.getComment());
+                    }
+                });
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAbstractAttestationResponseData.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAbstractAttestationResponseData.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.webui.utils.salt.custom.coco;
+
+import com.suse.salt.netapi.results.CmdResult;
+import com.suse.salt.netapi.results.StateApplyResult;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class CoCoAbstractAttestationResponseData {
+
+    /**
+     * @return a map of tags to response items
+     */
+    public abstract Map<String, Optional<StateApplyResult<CmdResult>>> getResults();
+
+    /**
+     * @return a map of tags to data items
+     */
+    public Map<String, Object> asMap() {
+        Map<String, Object> outMap = new HashMap<>();
+
+        getResults().entrySet().stream()
+                .filter(e -> e.getValue().isPresent())
+                .forEach(e -> insertItemInMap(e.getKey(), e.getValue().get(), outMap));
+
+        return outMap;
+    }
+
+    protected boolean hasBase64Stdout(StateApplyResult<CmdResult> responseItem) {
+        return responseItem.getName()
+                .map(x -> x.fold(Arrays::asList, List::of))
+                .orElseGet(ArrayList::new)
+                .stream()
+                .anyMatch(s -> s.contains("/usr/bin/base64"));
+    }
+
+    protected void insertItemInMap(String tagKey, StateApplyResult<CmdResult> responseItem,
+                                   Map<String, Object> outMap) {
+        if (null == responseItem) {
+            return;
+        }
+
+        Optional.ofNullable(responseItem.getChanges())
+                .ifPresent(cmdResult -> {
+                    if (hasBase64Stdout(responseItem)) {
+                        if (StringUtils.isNotEmpty(cmdResult.getStdout())) {
+                            outMap.put(tagKey, cmdResult.getStdout().replace("\n", ""));
+                        }
+                        else {
+                            outMap.put(tagKey, "");
+                        }
+                    }
+                    else if (StringUtils.isNotEmpty(cmdResult.getStdout())) {
+                        outMap.put(tagKey, cmdResult.getStdout());
+                    }
+                    else if (StringUtils.isNotEmpty(cmdResult.getStderr())) {
+                        outMap.put(tagKey, cmdResult.getStderr());
+                    }
+                    else if (StringUtils.isNotEmpty(responseItem.getComment())) {
+                        outMap.put(tagKey, responseItem.getComment());
+                    }
+                });
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAbstractAttestationResponseData.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAbstractAttestationResponseData.java
@@ -53,29 +53,27 @@ public abstract class CoCoAbstractAttestationResponseData {
 
     protected void insertItemInMap(String tagKey, StateApplyResult<CmdResult> responseItem,
                                    Map<String, Object> outMap) {
-        if (null == responseItem) {
+        if (responseItem == null || (responseItem.getChanges() == null)) {
             return;
         }
 
-        Optional.ofNullable(responseItem.getChanges())
-                .ifPresent(cmdResult -> {
-                    if (hasBase64Stdout(responseItem)) {
-                        if (StringUtils.isNotEmpty(cmdResult.getStdout())) {
-                            outMap.put(tagKey, cmdResult.getStdout().replace("\n", ""));
-                        }
-                        else {
-                            outMap.put(tagKey, "");
-                        }
-                    }
-                    else if (StringUtils.isNotEmpty(cmdResult.getStdout())) {
-                        outMap.put(tagKey, cmdResult.getStdout());
-                    }
-                    else if (StringUtils.isNotEmpty(cmdResult.getStderr())) {
-                        outMap.put(tagKey, cmdResult.getStderr());
-                    }
-                    else if (StringUtils.isNotEmpty(responseItem.getComment())) {
-                        outMap.put(tagKey, responseItem.getComment());
-                    }
-                });
+        CmdResult cmdResult = responseItem.getChanges();
+        if (hasBase64Stdout(responseItem)) {
+            if (StringUtils.isNotEmpty(cmdResult.getStdout())) {
+                outMap.put(tagKey, cmdResult.getStdout().replace("\n", ""));
+            }
+            else {
+                outMap.put(tagKey, "");
+            }
+        }
+        else if (StringUtils.isNotEmpty(cmdResult.getStdout())) {
+            outMap.put(tagKey, cmdResult.getStdout());
+        }
+        else if (StringUtils.isNotEmpty(cmdResult.getStderr())) {
+            outMap.put(tagKey, cmdResult.getStderr());
+        }
+        else if (StringUtils.isNotEmpty(responseItem.getComment())) {
+            outMap.put(tagKey, responseItem.getComment());
+        }
     }
 }

--- a/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAmdEpycAttestationResponseData.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAmdEpycAttestationResponseData.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.webui.utils.salt.custom.coco;
+
+import com.suse.salt.netapi.results.CmdResult;
+import com.suse.salt.netapi.results.StateApplyResult;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class CoCoAmdEpycAttestationResponseData extends CoCoAbstractAttestationResponseData {
+
+    @SerializedName("cmd_|-mgr_snpguest_response_|-/usr/bin/cat /tmp/cocoattest/response.bin | /usr/bin/base64_|-run")
+    private StateApplyResult<CmdResult> snpguestResponse;
+
+    @SerializedName("cmd_|-mgr_vlek_certificate_|-/usr/bin/cat /tmp/cocoattest/vlek.pem_|-run")
+    private StateApplyResult<CmdResult> vlekCertificate;
+
+    public static final String SNP_GUEST_RESPONSE_TAG = "mgr_snpguest_response";
+    public static final String VLEK_CERTIFICATE_TAG = "mgr_vlek_certificate";
+
+    @Override
+    public Map<String, Optional<StateApplyResult<CmdResult>>> getResults() {
+        Map<String, Optional<StateApplyResult<CmdResult>>> out = new HashMap<>();
+        out.put(SNP_GUEST_RESPONSE_TAG, Optional.ofNullable(snpguestResponse));
+        out.put(VLEK_CERTIFICATE_TAG, Optional.ofNullable(vlekCertificate));
+        return out;
+    }
+
+    /**
+     * @return snpguest result response item
+     */
+    public Optional<StateApplyResult<CmdResult>> getSnpguestResponse() {
+        return Optional.ofNullable(snpguestResponse);
+    }
+
+    /**
+     * @return vlek certificate response item
+     */
+    public Optional<StateApplyResult<CmdResult>> getVlekCertificate() {
+        return Optional.ofNullable(vlekCertificate);
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAmdEpycAttestationResponseData.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAmdEpycAttestationResponseData.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.webui.utils.salt.custom.coco;
+
+import com.suse.salt.netapi.results.CmdResult;
+import com.suse.salt.netapi.results.StateApplyResult;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class CoCoAmdEpycAttestationResponseData extends CoCoAbstractAttestationResponseData {
+
+    @SuppressWarnings("checkstyle:lineLength")
+    @SerializedName("cmd_|-mgr_sevsnp_snpguest_response_|-/usr/bin/cat /tmp/cocoattest_sevsnp/response.bin | /usr/bin/base64_|-run")
+    private StateApplyResult<CmdResult> snpguestResponse;
+
+    @SerializedName("cmd_|-mgr_sevsnp_vlek_certificate_|-/usr/bin/cat /tmp/cocoattest_sevsnp/vlek.pem_|-run")
+    private StateApplyResult<CmdResult> vlekCertificate;
+
+    public static final String SNP_GUEST_RESPONSE_TAG = "mgr_snpguest_response";
+    public static final String VLEK_CERTIFICATE_TAG = "mgr_vlek_certificate";
+
+    @Override
+    public Map<String, Optional<StateApplyResult<CmdResult>>> getResults() {
+        Map<String, Optional<StateApplyResult<CmdResult>>> out = new HashMap<>();
+        out.put(SNP_GUEST_RESPONSE_TAG, Optional.ofNullable(snpguestResponse));
+        out.put(VLEK_CERTIFICATE_TAG, Optional.ofNullable(vlekCertificate));
+        return out;
+    }
+
+    /**
+     * @return snpguest result response item
+     */
+    public Optional<StateApplyResult<CmdResult>> getSnpguestResponse() {
+        return Optional.ofNullable(snpguestResponse);
+    }
+
+    /**
+     * @return vlek certificate response item
+     */
+    public Optional<StateApplyResult<CmdResult>> getVlekCertificate() {
+        return Optional.ofNullable(vlekCertificate);
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAttestationResponseDataParser.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAttestationResponseDataParser.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.webui.utils.salt.custom.coco;
+
+import com.suse.salt.netapi.results.CmdResult;
+import com.suse.salt.netapi.results.StateApplyResult;
+import com.suse.utils.Json;
+
+import com.google.gson.JsonElement;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class CoCoAttestationResponseDataParser {
+
+    protected final List<CoCoAbstractAttestationResponseData> chunks = new ArrayList<>();
+
+    /**
+     * Constructor
+     */
+    public CoCoAttestationResponseDataParser() {
+        //empty constructor
+    }
+
+    /**
+     * @param jsonResult dummy
+     */
+    public void parse(JsonElement jsonResult) {
+        chunks.clear();
+        chunks.add(Json.GSON.fromJson(jsonResult, CoCoAmdEpycAttestationResponseData.class));
+        chunks.add(Json.GSON.fromJson(jsonResult, CoCoSecureBootAttestationResponseData.class));
+        //add here further children of CoCoAbstractAttestationResponseData
+    }
+
+    /**
+     * @return a map of tags to data items
+     */
+    public Map<String, Object> asMap() {
+        Map<String, Object> out = new HashMap<>();
+        chunks.forEach(c -> out.putAll(c.asMap()));
+        return out;
+    }
+
+    /**
+     * @param tagKey a tag representing a piece of response data
+     * @return a response item associated to that tagKey
+     */
+    public Optional<StateApplyResult<CmdResult>> getResult(String tagKey) {
+
+        return chunks.stream()
+                .map(CoCoAbstractAttestationResponseData::getResults)
+                .filter(r -> r.containsKey(tagKey))
+                .findFirst()
+                .flatMap(item -> item.get(tagKey));
+    }
+
+    /**
+     * @param clazz a clazz
+     * @return an CoCoAbstractAttestationResponseData object if any
+     */
+    public Optional<CoCoAbstractAttestationResponseData> getChunk(final Class<?> clazz) {
+        return chunks.stream().filter(c -> c.getClass().equals(clazz)).findAny();
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAttestationResponseDataParser.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAttestationResponseDataParser.java
@@ -22,26 +22,26 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.ServiceLoader;
 
 public class CoCoAttestationResponseDataParser {
 
+    private final ServiceLoader<CoCoAbstractAttestationResponseData> loader;
     protected final List<CoCoAbstractAttestationResponseData> chunks = new ArrayList<>();
 
     /**
      * Constructor
      */
     public CoCoAttestationResponseDataParser() {
-        //empty constructor
+        loader = ServiceLoader.load(CoCoAbstractAttestationResponseData.class);
     }
 
     /**
      * @param jsonResult dummy
      */
     public void parse(JsonElement jsonResult) {
-        chunks.clear();
-        chunks.add(Json.GSON.fromJson(jsonResult, CoCoAmdEpycAttestationResponseData.class));
-        chunks.add(Json.GSON.fromJson(jsonResult, CoCoSecureBootAttestationResponseData.class));
-        //add here further children of CoCoAbstractAttestationResponseData
+        loader.forEach(responseData ->
+            chunks.add(Json.GSON.fromJson(jsonResult, responseData.getClass())));
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoSecureBootAttestationResponseData.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoSecureBootAttestationResponseData.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.webui.utils.salt.custom.coco;
+
+import com.suse.salt.netapi.results.CmdResult;
+import com.suse.salt.netapi.results.StateApplyResult;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class CoCoSecureBootAttestationResponseData extends CoCoAbstractAttestationResponseData {
+
+    @SerializedName("cmd_|-mgr_secureboot_enabled_|-/usr/bin/mokutil --sb-state_|-run")
+    private StateApplyResult<CmdResult> securebootResult;
+
+    public static final String SECURE_BOOT_ENABLED_TAG = "mgr_secureboot_enabled";
+
+    @Override
+    public Map<String, Optional<StateApplyResult<CmdResult>>> getResults() {
+        Map<String, Optional<StateApplyResult<CmdResult>>> out = new HashMap<>();
+        out.put(SECURE_BOOT_ENABLED_TAG, Optional.ofNullable(securebootResult));
+        return out;
+    }
+
+    /**
+     * @return secure boot enabled response item
+     */
+    public Optional<StateApplyResult<CmdResult>> getSecureBoot() {
+        return Optional.ofNullable(securebootResult);
+    }
+
+}

--- a/java/core/src/main/resources/META-INF/services/com.suse.manager.webui.utils.salt.custom.coco.CoCoAbstractAttestationResponseData
+++ b/java/core/src/main/resources/META-INF/services/com.suse.manager.webui.utils.salt.custom.coco.CoCoAbstractAttestationResponseData
@@ -1,0 +1,2 @@
+com.suse.manager.webui.utils.salt.custom.coco.CoCoAmdEpycAttestationResponseData
+com.suse.manager.webui.utils.salt.custom.coco.CoCoSecureBootAttestationResponseData

--- a/java/core/src/main/resources/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -10034,6 +10034,15 @@ For a detailed analysis, please refer to the log files.
       <trans-unit id="coco.status.failed.description">
         <source>Failed</source>
       </trans-unit>
+      <trans-unit id="coco.status.requested.description">
+        <source>Requested</source>
+      </trans-unit>
+      <trans-unit id="coco.status.queued.description">
+        <source>Queued</source>
+      </trans-unit>
+      <trans-unit id="coco.status.submitted.description">
+        <source>Submitted</source>
+      </trans-unit>
       <trans-unit id="system.audit.coco.unsupported">
         <source>This system does not have any Confidential Computing capability.</source>
       </trans-unit>

--- a/java/core/src/test/java/com/suse/manager/attestation/AttestationManagerTest.java
+++ b/java/core/src/test/java/com/suse/manager/attestation/AttestationManagerTest.java
@@ -39,8 +39,9 @@ import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.model.attestation.AttestationFactory;
 import com.suse.manager.model.attestation.CoCoAttestationResult;
-import com.suse.manager.model.attestation.CoCoAttestationStatus;
 import com.suse.manager.model.attestation.CoCoEnvironmentType;
+import com.suse.manager.model.attestation.CoCoReportStatus;
+import com.suse.manager.model.attestation.CoCoResultStatus;
 import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
 import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
 import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
@@ -174,7 +175,7 @@ public class AttestationManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals(2, reports.size());
 
         ServerCoCoAttestationReport latestReport = mgr.lookupLatestCoCoAttestationReport(user, server);
-        assertEquals(CoCoAttestationStatus.SUCCEEDED, latestReport.getStatus());
+        assertEquals(CoCoReportStatus.SUCCEEDED, latestReport.getStatus());
         assertEquals("Some details", latestReport.getResults().get(0).getDetailsOpt().orElse(""));
     }
 
@@ -274,7 +275,7 @@ public class AttestationManagerTest extends JMockBaseTestCaseWithUser {
     }
     private void fakeSuccessfullAttestation(ServerCoCoAttestationReport reportIn) {
         reportIn.getResults().forEach(res -> {
-            res.setStatus(CoCoAttestationStatus.SUCCEEDED);
+            res.setStatus(CoCoResultStatus.SUCCEEDED);
             res.setDetails("Some details");
             res.setAttested(new Date());
         });

--- a/java/core/src/test/java/com/suse/manager/attestation/AttestationManagerTest.java
+++ b/java/core/src/test/java/com/suse/manager/attestation/AttestationManagerTest.java
@@ -17,6 +17,7 @@ package com.suse.manager.attestation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -53,7 +54,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -118,7 +118,9 @@ public class AttestationManagerTest extends JMockBaseTestCaseWithUser {
     @Test
     public void testCreateAttestationAction() throws TaskomaticApiException {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
-        mgr.createConfig(user, minion, CoCoEnvironmentType.KVM_AMD_EPYC_GENOA, true);
+        var config = mgr.createConfig(user, minion, CoCoEnvironmentType.KVM_AMD_EPYC_GENOA, true);
+        config.setInData(Map.of("dummyConfigKey1", "dummyConfigVal1", "dummyConfigKey2", "dummyConfigVal2"));
+
         Date now = new Date();
         CoCoAttestationAction action = mgr.scheduleAttestationAction(user, minion, now);
         assertNotNull(action);
@@ -127,14 +129,18 @@ public class AttestationManagerTest extends JMockBaseTestCaseWithUser {
         Optional<ServerCoCoAttestationReport> latestReport = f.lookupLatestReportByServer(minion);
         Map<String, Object> inData = latestReport.orElse(new ServerCoCoAttestationReport()).getInData();
         assertNotNull(inData);
-        String nonceReport = (String) inData.getOrDefault("nonce", "not in report");
+        //no more data at initial stage
+        assertEquals(0, inData.size());
+
+        Map<String, Object> configData = latestReport.orElse(new ServerCoCoAttestationReport()).getConfigData();
+        assertNotNull(configData);
+        assertEquals(2, configData.size());
+        assertTrue(configData.containsKey("dummyConfigKey1"));
+        assertTrue(configData.containsKey("dummyConfigKey2"));
+
         Pillar pillar = minion.getPillarByCategory(MinionGeneralPillarGenerator.CATEGORY).orElse(new Pillar());
-        Map<String, Object> attestationData = (Map<String, Object>) pillar.getPillar()
-                .getOrDefault("attestation_data", new HashMap<>());
-        String noncePillar = (String) attestationData.getOrDefault("nonce", "not in pillar");
-        assertEquals(nonceReport, noncePillar);
-        assertEquals("KVM_AMD_EPYC_GENOA",
-                attestationData.getOrDefault("environment_type", "environment_type not found"));
+        //no more pillars at initial stage
+        assertNull(pillar.getPillar());
     }
 
     @Test

--- a/java/core/src/test/java/com/suse/manager/model/attestation/AttestationFactoryTest.java
+++ b/java/core/src/test/java/com/suse/manager/model/attestation/AttestationFactoryTest.java
@@ -143,7 +143,7 @@ public class AttestationFactoryTest extends BaseTestCaseWithUser {
         ServerCoCoAttestationReport report = attestationFactory.createReportForServer(server);
         TestUtils.flushSession();
         assertNotNull(report);
-        assertEquals(CoCoAttestationStatus.PENDING, report.getStatus());
+        assertEquals(CoCoReportStatus.PENDING, report.getStatus());
         assertEquals(cnf.getEnvironmentType(), report.getEnvironmentType());
         assertNull(report.getAction());
 

--- a/java/core/src/test/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAttestationResponseDataParserTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAttestationResponseDataParserTest.java
@@ -1,0 +1,513 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.utils.salt.custom.coco;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+
+import com.suse.salt.netapi.results.CmdResult;
+import com.suse.salt.netapi.results.StateApplyResult;
+import com.suse.utils.Json;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.annotations.SerializedName;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class CoCoAttestationResponseDataParserTest extends JMockBaseTestCaseWithUser {
+
+    //suppress checkstyle warnings in order to keep it as it appears in the file
+    @SuppressWarnings("checkstyle:lineLength")
+    private static final String AMD_SALT_STATE_JSON_INPUT_STRING = """
+                {
+                   "saltutil_|-sync_states_|-sync_states_|-sync_states":{
+                      "name":"sync_states",
+                      "changes":{
+                      },
+                      "result":true,
+                      "comment":"No updates to sync",
+                      "__sls__":"util.syncstates",
+                      "__run_num__":0,
+                      "start_time":"09:51:03.373782",
+                      "duration":104.521,
+                      "__id__":"sync_states"
+                   },
+                   "pkg_|-mgr_absent_ca_package_|-rhn-org-trusted-ssl-cert_|-removed":{
+                      "name":"rhn-org-trusted-ssl-cert",
+                      "changes":{
+                      },
+                      "result":true,
+                      "comment":"All specified packages are already absent",
+                      "__sls__":"certs",
+                      "__run_num__":1,
+                      "start_time":"09:51:03.992424",
+                      "duration":3.079,
+                      "__id__":"mgr_absent_ca_package"
+                   },
+                   "file_|-mgr_ca_cert_|-/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT_|-managed":{
+                      "changes":{
+                      },
+                      "comment":"File /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT is in the correct state",
+                      "name":"/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT",
+                      "result":true,
+                      "__sls__":"certs",
+                      "__run_num__":2,
+                      "start_time":"09:51:03.996701",
+                      "duration":14.323,
+                      "__id__":"mgr_ca_cert"
+                   },
+                   "cmd_|-update-ca-certificates_|-/usr/sbin/update-ca-certificates_|-run":{
+                      "changes":{
+                      },
+                      "result":true,
+                      "duration":0.002,
+                      "start_time":"09:51:04.011737",
+                      "comment":"State was not run because none of the onchanges reqs changed",
+                      "__state_ran__":false,
+                      "__run_num__":3,
+                      "__sls__":"certs",
+                      "__id__":"update-ca-certificates",
+                      "name":"/usr/sbin/update-ca-certificates"
+                   },
+                   "file_|-mgr_proxy_ca_cert_symlink_|-/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT_|-symlink":{
+                      "result":true,
+                      "name":"/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT",
+                      "changes":{
+                      },
+                      "comment":"onlyif condition is false",
+                      "__sls__":"certs",
+                      "__id__":"mgr_proxy_ca_cert_symlink",
+                      "skip_watch":true,
+                      "__run_num__":4,
+                      "start_time":"09:51:04.011780",
+                      "duration":240.799
+                   },
+                   "file_|-mgr_deploy_tools_uyuni_key_|-/etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d12345w.key_|-managed":{
+                      "changes":{
+                      },
+                      "comment":"File /etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d12345w.key is in the correct state",
+                      "name":"/etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d12345w.key",
+                      "result":true,
+                      "__sls__":"channels.gpg-keys",
+                      "__run_num__":5,
+                      "start_time":"09:51:04.252657",
+                      "duration":14.5,
+                      "__id__":"mgr_deploy_tools_uyuni_key"
+                   },
+                   "file_|-mgr_deploy_suse_addon_key_|-/etc/pki/rpm-gpg/suse-addon-12a345bc6def7ghi.key_|-managed":{
+                      "changes":{
+                      },
+                      "comment":"File /etc/pki/rpm-gpg/suse-addon-12a345bc6def7ghi.key is in the correct state",
+                      "name":"/etc/pki/rpm-gpg/suse-addon-12a345bc6def7ghi.key",
+                      "result":true,
+                      "__sls__":"channels.gpg-keys",
+                      "__run_num__":6,
+                      "start_time":"09:51:04.267225",
+                      "duration":13.196,
+                      "__id__":"mgr_deploy_suse_addon_key"
+                   },
+                   "file_|-mgr_deploy_suse16_gpg_key_|-/etc/pki/rpm-gpg/suse16-gpg-pubkey-98a7bc65.key_|-managed":{
+                      "changes":{
+                      },
+                      "comment":"File /etc/pki/rpm-gpg/suse16-gpg-pubkey-98a7bc65.key is in the correct state",
+                      "name":"/etc/pki/rpm-gpg/suse16-gpg-pubkey-98a7bc65.key",
+                      "result":true,
+                      "__sls__":"channels.gpg-keys",
+                      "__run_num__":7,
+                      "start_time":"09:51:04.280505",
+                      "duration":13.293,
+                      "__id__":"mgr_deploy_suse16_gpg_key"
+                   },
+                   "file_|-mgrchannels_repo_|-/etc/zypp/repos.d/susemanager:channels.repo_|-managed":{
+                      "changes":{
+                      },
+                      "comment":"File /etc/zypp/repos.d/susemanager:channels.repo is in the correct state",
+                      "name":"/etc/zypp/repos.d/susemanager:channels.repo",
+                      "result":true,
+                      "__sls__":"channels",
+                      "__run_num__":8,
+                      "start_time":"09:51:04.293915",
+                      "duration":43.894,
+                      "__id__":"mgrchannels_repo"
+                   },
+                   "product_|-mgrchannels_install_products_|-mgrchannels_install_products_|-all_installed":{
+                      "name":"mgrchannels_install_products",
+                      "changes":{
+                      },
+                      "result":true,
+                      "comment":"All subscribed products are already installed",
+                      "__sls__":"channels",
+                      "__run_num__":9,
+                      "start_time":"09:51:04.338216",
+                      "duration":431.093,
+                      "__id__":"mgrchannels_install_products"
+                   },
+                   "pkg_|-mgrchannels_inst_suse_build_key_|-suse-build-key_|-installed":{
+                      "name":"suse-build-key",
+                      "changes":{
+                      },
+                      "result":true,
+                      "comment":"All specified packages are already installed",
+                      "__sls__":"channels",
+                      "__run_num__":10,
+                      "start_time":"09:51:04.769675",
+                      "duration":1965.43,
+                      "__id__":"mgrchannels_inst_suse_build_key"
+                   },
+                   "file_|-mgr_create_attestdir_|-/tmp/cocoattest_|-directory":{
+                      "name":"/tmp/cocoattest",
+                      "changes":{
+                      },
+                      "result":true,
+                      "comment":"The directory /tmp/cocoattest is in the correct state",
+                      "__sls__":"manager_org_1.test",
+                      "__run_num__":11,
+                      "start_time":"09:51:06.735206",
+                      "duration":0.589,
+                      "__id__":"mgr_create_attestdir"
+                   },
+                   "pkg_|-mgr_inst_snpguest_|-mgr_inst_snpguest_|-latest":{
+                      "name":"mgr_inst_snpguest",
+                      "changes":{
+                      },
+                      "result":true,
+                      "comment":"All packages are up-to-date (mokutil, snpguest).",
+                      "__sls__":"manager_org_1.test",
+                      "__run_num__":12,
+                      "start_time":"09:51:06.735880",
+                      "duration":378.838,
+                      "__id__":"mgr_inst_snpguest"
+                   },
+                   "cmd_|-mgr_write_request_data_|-ls -l_|-run":{
+                      "name":"ls -l",
+                      "changes":{
+                         "pid":2742,
+                         "retcode":0,
+                         "stdout":"total 4\\ndrwxr-xr-x  2 root root    6 Mar 15  2022 bin\\ndrwxr-xr-x 21 root root 4096 Feb 24 18:29 salt",
+                         "stderr":""
+                      },
+                      "result":true,
+                      "comment":"Command \\"ls -l\\" run",
+                      "__sls__":"manager_org_1.test",
+                      "__run_num__":13,
+                      "start_time":"09:51:07.114915",
+                      "duration":6.539,
+                      "__id__":"mgr_write_request_data"
+                   },
+                   "cmd_|-mgr_create_snpguest_result_|-ls -l_|-run":{
+                      "name":"ls -l",
+                      "changes":{
+                         "pid":2743,
+                         "retcode":0,
+                         "stdout":"total 4\\ndrwxr-xr-x  2 root root    6 Mar 15  2022 bin\\ndrwxr-xr-x 21 root root 4096 Feb 24 18:29 salt",
+                         "stderr":""
+                      },
+                      "result":true,
+                      "comment":"Command \\"ls -l\\" run",
+                      "__sls__":"manager_org_1.test",
+                      "__run_num__":14,
+                      "start_time":"09:51:07.121630",
+                      "duration":2.207,
+                      "__id__":"mgr_create_snpguest_result"
+                   },
+                   "cmd_|-mgr_snpguest_response_|-/usr/bin/cat /tmp/cocoattest/response.bin | /usr/bin/base64_|-run":{
+                      "name":"/usr/bin/cat /tmp/cocoattest/result.bin | /usr/bin/base64",
+                      "changes":{
+                         "pid":2744,
+                         "retcode":0,
+                         "stdout":"BQAAAAAAAAAAAAMCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAEAAAAE\\nAAAAAAAd3icAAAAAAAAABAAAAAAAAACvUTwurA60JuLr4saoUcqnlRByTSye2RoG7cm7aV3GFDM8\\nhBVP1bRVv+xZ+xgMnSxeXtRHKWQWIJeOKWzdHrjKUH6C0n6luVHddlo+sxul9YJnOzAdaYPe1ILT\\n/rBmy2iXnx8R/t6XaHN006JQAqFfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC0BzK9Zd/WojFnYDcZSyMuFyK38wdR\\nFG1y0mG8SdJ85///////////////////////////////////////////BAAAAAAAHd4ZAQEAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAHd4BOgEAAToBAAQAAAAAAB3eDwAAAAAAAAAP\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAl5RQN5FIiFMGs4Ud\\nFRQ/It0+g1ccaH0sbEgIVvRsxZMs5UwjpgqEwwqXKJ+vWUP3AAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAJFiRN+f4t0/lz6CxHmVe4DEl+YWRZ/U/jacsJCUt7XqpIHqeJUr0u4F4s3NIMTZGAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                         "stderr":""
+                      },
+                      "result":true,
+                      "comment":"Command \\"/usr/bin/cat /tmp/cocoattest/result.bin | /usr/bin/base64\\" run",
+                      "__sls__":"manager_org_1.test",
+                      "__run_num__":15,
+                      "start_time":"09:51:07.123989",
+                      "duration":1.806,
+                      "__id__":"mgr_snpguest_response"
+                   },
+                   "cmd_|-mgr_create_vlek_certificate_|-ls -l_|-run":{
+                      "name":"ls -l",
+                      "changes":{
+                         "pid":2747,
+                         "retcode":0,
+                         "stdout":"total 4\\ndrwxr-xr-x  2 root root    6 Mar 15  2022 bin\\ndrwxr-xr-x 21 root root 4096 Feb 24 18:29 salt",
+                         "stderr":""
+                      },
+                      "result":true,
+                      "comment":"Command \\"ls -l\\" run",
+                      "__sls__":"manager_org_1.test",
+                      "__run_num__":16,
+                      "start_time":"09:51:07.125867",
+                      "duration":1.497,
+                      "__id__":"mgr_create_vlek_certificate"
+                   },
+                   "cmd_|-mgr_vlek_certificate_|-/usr/bin/cat /tmp/cocoattest/vlek.pem_|-run":{
+                      "name":"/usr/bin/cat /tmp/cocoattest/vlek.pem",
+                      "changes":{
+                         "pid":2748,
+                         "retcode":0,
+                         "stdout":"-----BEGIN CERTIFICATE-----\\nMIIFIzCCAtegAwIBAgIBADBBBgkqhkiG9w0BAQowNKAPMA0GCWCGSAFlAwQCAgUA\\noRwwGgYJKoZIhvcNAQEIMA0GCWCGSAFlAwQCAgUAogMCATAwgYAxFDASBgNVBAsM\\nC0VuZ2luZWVyaW5nMQswCQYDVQQGEwJVUzEUMBIGA1UEBwwLU2FudGEgQ2xhcmEx\\nCzAJBgNVBAgMAkNBMR8wHQYDVQQKDBZBZHZhbmNlZCBNaWNybyBEZXZpY2VzMRcw\\nFQYDVQQDDA5TRVYtVkxFSy1NaWxhbjAeFw0yNjAzMDkxOTMwMDVaFw0yNzAzMDkx\\nOTMwMDVaMHoxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQswCQYDVQQGEwJVUzEUMBIG\\nA1UEBwwLU2FudGEgQ2xhcmExCzAJBgNVBAgMAkNBMR8wHQYDVQQKDBZBZHZhbmNl\\nZCBNaWNybyBEZXZpY2VzMREwDwYDVQQDDAhTRVYtVkxFSzB2MBAGByqGSM49AgEG\\nBSuBBAAiA2IABE/rO0PxEkKVu5SAX9Fv+h1pF0r+wWNmNO+DLcMENz2IOaqYiS6s\\nwJjXThFjsjIx5mdy42ozh33DIC+b02LmGScVQrREUL0h5KR4Qd5+BTiO+UDBb8Xd\\n/p8rzpTQn+foEKOB8jCB7zAQBgkrBgEEAZx4AQEEAwIBADAUBgkrBgEEAZx4AQIE\\nBxYFTWlsYW4wEQYKKwYBBAGceAEDAQQDAgEEMBEGCisGAQQBnHgBAwIEAwIBADAR\\nBgorBgEEAZx4AQMEBAMCAQAwEQYKKwYBBAGceAEDBQQDAgEAMBEGCisGAQQBnHgB\\nAwYEAwIBADARBgorBgEEAZx4AQMHBAMCAQAwEQYKKwYBBAGceAEDAwQDAgEdMBIG\\nCisGAQQBnHgBAwgEBAICAN4wLAYJKwYBBAGceAEFBB8WHUNOPWNjLXVzLWVhc3Qt\\nMi5hbWF6b25hd3MuY29tMEEGCSqGSIb3DQEBCjA0oA8wDQYJYIZIAWUDBAICBQCh\\nHDAaBgkqhkiG9w0BAQgwDQYJYIZIAWUDBAICBQCiAwIBMAOCAgEAezLRKlKoxDhJ\\n9gGLDoIhruKSWJcwMHPn6E/aJzJvpDaYfb12ACKHyiMsm5htk6+lL9Kse544pmhh\\nUm/hxlpUNXiF+61obfKcaxp11Q2hzC/hTyLYpse6IXskLq6OH+DXzrcw0X30t3YI\\niUqzCGszbeTBy4uUOULxz3XbSUYFsKwsk9oMuo7isOUM3INiMiOTq91THlp6ZSVJ\\nDLIpW8v17DSL7yfJsvyLKsvtL7YjohFsOJe/qr/ttVSLC9WJmnxMxaxtgLSVGwCN\\nTHsx6646R7SAPRVXpdOd4f+Gfj4Dk1eiELs1L85Qm0tChDLrLLO31X9cwPxg6fjd\\nZ3sgqZrOv9Up2EiiX3uzH9pjuek9KZw8BvbNmkABURnj2QVKkANKWeVwJ2OI9xmb\\nKnLDQp+t3Q6gTcdPdcjSsAkT0JijpzamEmIPLdBobgVHAcxCxRhBILmJWQcU8V8R\\ng2+n/Zs8gpuGaCj0j8s8YDq7+sgy0/5CsDgAhU7+4HqzBTPbhOCNAI9uptU6v0xo\\nDLzldXmVJQaGWp6zQ+WB29ZnFrF4UE85+os3uIwc6uEPBjh3bjmhTwa3I7LWRWld\\nRyoJUuLnBIdTJYVIkgrYJ47LfI3akZxUM0D+FpqawemnHOTT1z8ee1wj7wnE6nS2\\nX0R7cJNthweU48At2ZfRIuPYvu9av2Y=\\n-----END CERTIFICATE-----",
+                         "stderr":""
+                      },
+                      "result":true,
+                      "comment":"Command \\"/usr/bin/cat /tmp/cocoattest/vlek.pem\\" run",
+                      "__sls__":"manager_org_1.test",
+                      "__run_num__":17,
+                      "start_time":"09:51:07.127515",
+                      "duration":1.291,
+                      "__id__":"mgr_vlek_certificate"
+                   },
+                   "cmd_|-mgr_secureboot_enabled_|-/usr/bin/mokutil --sb-state_|-run":{
+                      "name":"/usr/bin/mokutil --sb-state",
+                      "changes":{
+                         "pid":2749,
+                         "retcode":1,
+                         "stdout":"",
+                         "stderr":"EFI variables are not supported on this system"
+                      },
+                      "result":false,
+                      "comment":"Command \\"/usr/bin/mokutil --sb-state\\" run",
+                      "__sls__":"manager_org_1.test",
+                      "__run_num__":18,
+                      "start_time":"09:51:07.128844",
+                      "duration":2.288,
+                      "__id__":"mgr_secureboot_enabled"
+                   }
+                }
+                """;
+
+    private static final String AMD_EXPECTED_BASE_64_REPORT_DATA = """
+                BQAAAAAAAAAAAAMCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAEAAAAE
+                AAAAAAAd3icAAAAAAAAABAAAAAAAAACvUTwurA60JuLr4saoUcqnlRByTSye2RoG7cm7aV3GFDM8
+                hBVP1bRVv+xZ+xgMnSxeXtRHKWQWIJeOKWzdHrjKUH6C0n6luVHddlo+sxul9YJnOzAdaYPe1ILT
+                /rBmy2iXnx8R/t6XaHN006JQAqFfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC0BzK9Zd/WojFnYDcZSyMuFyK38wdR
+                FG1y0mG8SdJ85///////////////////////////////////////////BAAAAAAAHd4ZAQEAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAHd4BOgEAAToBAAQAAAAAAB3eDwAAAAAAAAAP
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAl5RQN5FIiFMGs4Ud
+                FRQ/It0+g1ccaH0sbEgIVvRsxZMs5UwjpgqEwwqXKJ+vWUP3AAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAJFiRN+f4t0/lz6CxHmVe4DEl+YWRZ/U/jacsJCUt7XqpIHqeJUr0u4F4s3NIMTZGAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=""";
+
+    private static final String AMD_EXPECTED_VLEK_CERTIFICATE = """
+                -----BEGIN CERTIFICATE-----
+                MIIFIzCCAtegAwIBAgIBADBBBgkqhkiG9w0BAQowNKAPMA0GCWCGSAFlAwQCAgUA
+                oRwwGgYJKoZIhvcNAQEIMA0GCWCGSAFlAwQCAgUAogMCATAwgYAxFDASBgNVBAsM
+                C0VuZ2luZWVyaW5nMQswCQYDVQQGEwJVUzEUMBIGA1UEBwwLU2FudGEgQ2xhcmEx
+                CzAJBgNVBAgMAkNBMR8wHQYDVQQKDBZBZHZhbmNlZCBNaWNybyBEZXZpY2VzMRcw
+                FQYDVQQDDA5TRVYtVkxFSy1NaWxhbjAeFw0yNjAzMDkxOTMwMDVaFw0yNzAzMDkx
+                OTMwMDVaMHoxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQswCQYDVQQGEwJVUzEUMBIG
+                A1UEBwwLU2FudGEgQ2xhcmExCzAJBgNVBAgMAkNBMR8wHQYDVQQKDBZBZHZhbmNl
+                ZCBNaWNybyBEZXZpY2VzMREwDwYDVQQDDAhTRVYtVkxFSzB2MBAGByqGSM49AgEG
+                BSuBBAAiA2IABE/rO0PxEkKVu5SAX9Fv+h1pF0r+wWNmNO+DLcMENz2IOaqYiS6s
+                wJjXThFjsjIx5mdy42ozh33DIC+b02LmGScVQrREUL0h5KR4Qd5+BTiO+UDBb8Xd
+                /p8rzpTQn+foEKOB8jCB7zAQBgkrBgEEAZx4AQEEAwIBADAUBgkrBgEEAZx4AQIE
+                BxYFTWlsYW4wEQYKKwYBBAGceAEDAQQDAgEEMBEGCisGAQQBnHgBAwIEAwIBADAR
+                BgorBgEEAZx4AQMEBAMCAQAwEQYKKwYBBAGceAEDBQQDAgEAMBEGCisGAQQBnHgB
+                AwYEAwIBADARBgorBgEEAZx4AQMHBAMCAQAwEQYKKwYBBAGceAEDAwQDAgEdMBIG
+                CisGAQQBnHgBAwgEBAICAN4wLAYJKwYBBAGceAEFBB8WHUNOPWNjLXVzLWVhc3Qt
+                Mi5hbWF6b25hd3MuY29tMEEGCSqGSIb3DQEBCjA0oA8wDQYJYIZIAWUDBAICBQCh
+                HDAaBgkqhkiG9w0BAQgwDQYJYIZIAWUDBAICBQCiAwIBMAOCAgEAezLRKlKoxDhJ
+                9gGLDoIhruKSWJcwMHPn6E/aJzJvpDaYfb12ACKHyiMsm5htk6+lL9Kse544pmhh
+                Um/hxlpUNXiF+61obfKcaxp11Q2hzC/hTyLYpse6IXskLq6OH+DXzrcw0X30t3YI
+                iUqzCGszbeTBy4uUOULxz3XbSUYFsKwsk9oMuo7isOUM3INiMiOTq91THlp6ZSVJ
+                DLIpW8v17DSL7yfJsvyLKsvtL7YjohFsOJe/qr/ttVSLC9WJmnxMxaxtgLSVGwCN
+                THsx6646R7SAPRVXpdOd4f+Gfj4Dk1eiELs1L85Qm0tChDLrLLO31X9cwPxg6fjd
+                Z3sgqZrOv9Up2EiiX3uzH9pjuek9KZw8BvbNmkABURnj2QVKkANKWeVwJ2OI9xmb
+                KnLDQp+t3Q6gTcdPdcjSsAkT0JijpzamEmIPLdBobgVHAcxCxRhBILmJWQcU8V8R
+                g2+n/Zs8gpuGaCj0j8s8YDq7+sgy0/5CsDgAhU7+4HqzBTPbhOCNAI9uptU6v0xo
+                DLzldXmVJQaGWp6zQ+WB29ZnFrF4UE85+os3uIwc6uEPBjh3bjmhTwa3I7LWRWld
+                RyoJUuLnBIdTJYVIkgrYJ47LfI3akZxUM0D+FpqawemnHOTT1z8ee1wj7wnE6nS2
+                X0R7cJNthweU48At2ZfRIuPYvu9av2Y=
+                -----END CERTIFICATE-----""";
+
+    private static final String AMD_EXPECTED_SECURE_BOOT_RESULT = "EFI variables are not supported on this system";
+
+
+    private CoCoAttestationResponseDataParser responseDataParser;
+    private Optional<CoCoAbstractAttestationResponseData> optAmdChunk;
+    private Optional<CoCoAbstractAttestationResponseData> optBootChunk;
+
+    private void setUpAmdTest() {
+        JsonElement jsonResult = JsonParser.parseString(AMD_SALT_STATE_JSON_INPUT_STRING);
+        responseDataParser = new CoCoAttestationResponseDataParser();
+        responseDataParser.parse(jsonResult);
+        optAmdChunk = responseDataParser.getChunk(CoCoAmdEpycAttestationResponseData.class);
+        optBootChunk = responseDataParser.getChunk(CoCoSecureBootAttestationResponseData.class);
+    }
+
+    @Test
+    @DisplayName("check that parse() method is giving the expected results with AMD json result")
+    public void testAmdTestParsing() {
+        setUpAmdTest();
+
+        assertTrue(optAmdChunk.isPresent());
+        CoCoAmdEpycAttestationResponseData amdChunk = (CoCoAmdEpycAttestationResponseData)optAmdChunk.get();
+        assertTrue(optBootChunk.isPresent());
+        CoCoSecureBootAttestationResponseData bootChunk = (CoCoSecureBootAttestationResponseData)optBootChunk.get();
+
+        Optional<StateApplyResult<CmdResult>> optResult;
+
+        optResult = responseDataParser.getResult(CoCoAmdEpycAttestationResponseData.SNP_GUEST_RESPONSE_TAG);
+        assertTrue(optResult.isPresent());
+        assertEquals(AMD_EXPECTED_BASE_64_REPORT_DATA, optResult.get().getChanges().getStdout());
+        assertTrue(amdChunk.getSnpguestResponse().isPresent());
+        assertEquals(AMD_EXPECTED_BASE_64_REPORT_DATA, amdChunk.getSnpguestResponse().get().getChanges().getStdout());
+
+        optResult = responseDataParser.getResult(CoCoAmdEpycAttestationResponseData.VLEK_CERTIFICATE_TAG);
+        assertTrue(optResult.isPresent());
+        assertEquals(AMD_EXPECTED_VLEK_CERTIFICATE, optResult.get().getChanges().getStdout());
+        assertTrue(amdChunk.getVlekCertificate().isPresent());
+        assertEquals(AMD_EXPECTED_VLEK_CERTIFICATE, amdChunk.getVlekCertificate().get().getChanges().getStdout());
+
+        optResult = responseDataParser.getResult(CoCoSecureBootAttestationResponseData.SECURE_BOOT_ENABLED_TAG);
+        assertTrue(optResult.isPresent());
+        assertEquals(AMD_EXPECTED_SECURE_BOOT_RESULT, optResult.get().getChanges().getStderr());
+        assertTrue(bootChunk.getSecureBoot().isPresent());
+        assertEquals(AMD_EXPECTED_SECURE_BOOT_RESULT, bootChunk.getSecureBoot().get().getChanges().getStderr());
+    }
+
+    @Test
+    @DisplayName("check that asMap() method is giving the expected results with AMD json result")
+    public void testAmdAsMap() {
+        setUpAmdTest();
+
+        assertTrue(optAmdChunk.isPresent());
+        CoCoAmdEpycAttestationResponseData amdChunk = (CoCoAmdEpycAttestationResponseData)optAmdChunk.get();
+        assertTrue(optBootChunk.isPresent());
+        CoCoSecureBootAttestationResponseData bootChunk = (CoCoSecureBootAttestationResponseData)optBootChunk.get();
+
+        Map<String, Object> requestDataMap = responseDataParser.asMap();
+        assertEquals(3, requestDataMap.size());
+        assertEquals(AMD_EXPECTED_BASE_64_REPORT_DATA.replace("\n", ""),
+                requestDataMap.get(CoCoAmdEpycAttestationResponseData.SNP_GUEST_RESPONSE_TAG));
+        assertEquals(AMD_EXPECTED_VLEK_CERTIFICATE,
+                requestDataMap.get(CoCoAmdEpycAttestationResponseData.VLEK_CERTIFICATE_TAG));
+        assertEquals(AMD_EXPECTED_SECURE_BOOT_RESULT,
+                requestDataMap.get(CoCoSecureBootAttestationResponseData.SECURE_BOOT_ENABLED_TAG));
+
+        assertEquals(2, amdChunk.asMap().size());
+        assertEquals(AMD_EXPECTED_BASE_64_REPORT_DATA.replace("\n", ""),
+                amdChunk.asMap().get(CoCoAmdEpycAttestationResponseData.SNP_GUEST_RESPONSE_TAG));
+        assertEquals(AMD_EXPECTED_VLEK_CERTIFICATE,
+                amdChunk.asMap().get(CoCoAmdEpycAttestationResponseData.VLEK_CERTIFICATE_TAG));
+
+        assertEquals(1, bootChunk.asMap().size());
+        assertEquals(AMD_EXPECTED_SECURE_BOOT_RESULT,
+                bootChunk.asMap().get(CoCoSecureBootAttestationResponseData.SECURE_BOOT_ENABLED_TAG));
+    }
+
+
+    private static class TestResponseData extends CoCoAbstractAttestationResponseData {
+
+        @SerializedName("cmd_|-test_command_|-/usr/bin/cat binary_file.bin | /usr/bin/base64_|-run")
+        private StateApplyResult<CmdResult> base64Binary;
+
+        @Override
+        public Map<String, Optional<StateApplyResult<CmdResult>>> getResults() {
+            Map<String, Optional<StateApplyResult<CmdResult>>> out = new HashMap<>();
+            out.put("base64BinaryTag", Optional.ofNullable(base64Binary));
+            return out;
+        }
+    }
+
+
+    private static class TestDataParser extends CoCoAttestationResponseDataParser {
+        @Override
+        public void parse(JsonElement jsonResult) {
+            chunks.clear();
+            chunks.add(Json.GSON.fromJson(jsonResult, TestResponseData.class));
+        }
+    }
+
+    //suppress checkstyle warnings in order to keep it as it appears in the file
+    //original binary file represented in stdout: 864 bytes
+    //original base64 string in stdout: 15 rows x 76 chars + 12 chars = 1152 chars + 15 crlf = 1167
+    @SuppressWarnings("checkstyle:lineLength")
+    private static final String BASE64_BIN_FILE_EXAMPLE = """
+            {
+            "cmd_|-test_command_|-/usr/bin/cat binary_file.bin | /usr/bin/base64_|-run":{
+                  "name":"/usr/bin/cat binary_file.bin | /usr/bin/base64",
+                  "changes":{
+                     "pid":20446,
+                     "retcode":0,
+                     "stdout":"cHZhdHRlc3QAAAEAAAADYAAAAAAAAAAAAAABkAAAAEAAAABAAAAB0AAAAEAAAAIQAAABAAAAAlAA\\nAAAQAAADUAAAAAAAAAAAAAABAAAAAZBBLTgZS4052sfgucEAAAAAAAAAAAAAAAEAAAAAAAAAUHAA\\nAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAACKt+uyUssDiTYXy+KNpqaUhsfNO0U2wrl82kDQ\\nHFhlf6SRoRiqfY4PTqmU1ufYx/HL6UI6nWDszrnV1Yr6fHhdAwAAAAAAAAAAAAAAAAAAAWuCp/Xk\\nqA/YiEtOaWsT3jD4BNJM6e+DWJfEKKUPEMpyW69KU9tvrXRqGcKUzpxCiK/VzHIWt4Vb5qjGCjl2\\nH0AT0fco79meHaZQ51hRJiGmX53Y132NNLHbu1aQTrNzuDzL84FaRMxHnRGKNBKKRofcMv+hXDIE\\nOdM5sXOEn7EkuH2TAQP+j0FnxBvPQCOjVNBbgPmqXa9AGYcsU/PNZROEbQhxPYGO+3LBg8iQEfev\\nE2tL2Rot4Ete/DsmUZed/0lGI/79Ke7BMNB26nhGNNJ2X1NHWsHpux2wuRT+Cn2TMRCDWVfLXdLv\\n/3YI59qYvihf/FYwkFbPucBeg/tfRxnPkh7OAZy7bK/vilksUrxWFmthKsyw5z4KSBGeWmoW2+wc\\n6Og6acBXWyO+rTPUVXOv0fco79meHaZQ51hRJiGmX53Y132NNLHbu1aQTrNzuDzR9yjv2Z4dplDn\\nWFEmIaZfndjXfY00sdu7VpBOs3O4PGF2570RMsTUC2HOjn7iX1pwO5LHBJfR4JmiR2NZbx+15bo4\\nUI/av+oKuznJEqY/zgRuxofzfdU/WlgpN/AFR75RPqeNWfrpV3Ep4mjEaCW3H4+rM1Y3cGlB7yxe\\nnYQT6M+qpWk6NH6rakoJN9gelv/JXCgF5gMR8t8Bq2ZiK6SKwkJVEuxv6m74RiYIONIKprrPz5SR\\nOBFGWdUfRCHGA5LvGcxJL3mrt0lwcRuNeatFIRYjdxn8OLg9lFehhvx+KMXmy4oarU5rhR4SVjSf\\nW7w+0c4Ihinkd8CwLdIDvmAjMBwRyRRtPe/0o+X2206E3JodtS6V5OJ5nXk+ApLpVXau7LVvIc1f\\n6BDXLViQLYAJ",
+                     "stderr":""
+                  },
+                  "result":true,
+                  "comment":"Command \\"/usr/bin/cat binary_file.bin | /usr/bin/base64\\" run",
+                  "__sls__":"cocoattest.test_file",
+                  "__run_num__":16,
+                  "start_time":"11:48:13.072596",
+                  "duration":2.811,
+                  "__id__":"test_command"
+               }
+            }
+            """;
+
+    @Test
+    @DisplayName("check that asMap() method correctly gets binary files in base64 format")
+    public void testBase64Encoding() {
+        JsonElement jsonResult = JsonParser.parseString(BASE64_BIN_FILE_EXAMPLE);
+        responseDataParser = new TestDataParser();
+        responseDataParser.parse(jsonResult);
+
+        Optional<StateApplyResult<CmdResult>> optResult = responseDataParser.getResult("base64BinaryTag");
+        assertTrue(optResult.isPresent());
+
+        //original binary file represented in stdout: 864 bytes
+        //original base64 string in stdout: 15 rows x 76 chars + 12 chars = 1152 chars + 15 crlf = 1167
+        StateApplyResult<CmdResult> res = optResult.get();
+        String parsedBase64BinaryFromStdout = res.getChanges().getStdout();
+
+        assertEquals(1167, parsedBase64BinaryFromStdout.length());
+        assertEquals(15, StringUtils.countMatches(parsedBase64BinaryFromStdout, "\n"));
+        assertEquals(1152, parsedBase64BinaryFromStdout.replace("\n", "").length());
+        byte[] decoded = Base64.getDecoder().decode(parsedBase64BinaryFromStdout.replace("\n", ""));
+        assertEquals(864, decoded.length);
+
+        //asMap() has no cr/lf
+        Map<String, Object> requestDataMap = responseDataParser.asMap();
+        assertTrue(requestDataMap.containsKey("base64BinaryTag"));
+        String parsedBase64BinaryFromAsMap = (String)requestDataMap.get("base64BinaryTag");
+
+        assertEquals(1152, parsedBase64BinaryFromAsMap.length());
+        assertEquals(0, StringUtils.countMatches(parsedBase64BinaryFromAsMap, "\n"));
+        byte[] decodedAsMap = Base64.getDecoder().decode(parsedBase64BinaryFromAsMap);
+        assertEquals(864, decodedAsMap.length);
+    }
+
+}

--- a/java/core/src/test/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAttestationResponseDataParserTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/utils/salt/custom/coco/CoCoAttestationResponseDataParserTest.java
@@ -1,0 +1,525 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.utils.salt.custom.coco;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+
+import com.suse.salt.netapi.results.CmdResult;
+import com.suse.salt.netapi.results.StateApplyResult;
+import com.suse.utils.Json;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.annotations.SerializedName;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class CoCoAttestationResponseDataParserTest extends JMockBaseTestCaseWithUser {
+
+    //suppress checkstyle warnings in order to keep it as it appears in the file
+    @SuppressWarnings("checkstyle:lineLength")
+    private static final String AMD_SALT_STATE_JSON_INPUT_STRING = """
+                {
+                   "saltutil_|-sync_states_|-sync_states_|-sync_states":{
+                      "name":"sync_states",
+                      "changes":{
+                      },
+                      "result":true,
+                      "comment":"No updates to sync",
+                      "__sls__":"util.syncstates",
+                      "__run_num__":0,
+                      "start_time":"09:51:03.373782",
+                      "duration":104.521,
+                      "__id__":"sync_states"
+                   },
+                   "pkg_|-mgr_absent_ca_package_|-rhn-org-trusted-ssl-cert_|-removed":{
+                      "name":"rhn-org-trusted-ssl-cert",
+                      "changes":{
+                      },
+                      "result":true,
+                      "comment":"All specified packages are already absent",
+                      "__sls__":"certs",
+                      "__run_num__":1,
+                      "start_time":"09:51:03.992424",
+                      "duration":3.079,
+                      "__id__":"mgr_absent_ca_package"
+                   },
+                   "file_|-mgr_ca_cert_|-/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT_|-managed":{
+                      "changes":{
+                      },
+                      "comment":"File /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT is in the correct state",
+                      "name":"/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT",
+                      "result":true,
+                      "__sls__":"certs",
+                      "__run_num__":2,
+                      "start_time":"09:51:03.996701",
+                      "duration":14.323,
+                      "__id__":"mgr_ca_cert"
+                   },
+                   "cmd_|-update-ca-certificates_|-/usr/sbin/update-ca-certificates_|-run":{
+                      "changes":{
+                      },
+                      "result":true,
+                      "duration":0.002,
+                      "start_time":"09:51:04.011737",
+                      "comment":"State was not run because none of the onchanges reqs changed",
+                      "__state_ran__":false,
+                      "__run_num__":3,
+                      "__sls__":"certs",
+                      "__id__":"update-ca-certificates",
+                      "name":"/usr/sbin/update-ca-certificates"
+                   },
+                   "file_|-mgr_proxy_ca_cert_symlink_|-/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT_|-symlink":{
+                      "result":true,
+                      "name":"/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT",
+                      "changes":{
+                      },
+                      "comment":"onlyif condition is false",
+                      "__sls__":"certs",
+                      "__id__":"mgr_proxy_ca_cert_symlink",
+                      "skip_watch":true,
+                      "__run_num__":4,
+                      "start_time":"09:51:04.011780",
+                      "duration":240.799
+                   },
+                   "file_|-mgr_deploy_tools_uyuni_key_|-/etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d12345w.key_|-managed":{
+                      "changes":{
+                      },
+                      "comment":"File /etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d12345w.key is in the correct state",
+                      "name":"/etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d12345w.key",
+                      "result":true,
+                      "__sls__":"channels.gpg-keys",
+                      "__run_num__":5,
+                      "start_time":"09:51:04.252657",
+                      "duration":14.5,
+                      "__id__":"mgr_deploy_tools_uyuni_key"
+                   },
+                   "file_|-mgr_deploy_suse_addon_key_|-/etc/pki/rpm-gpg/suse-addon-12a345bc6def7ghi.key_|-managed":{
+                      "changes":{
+                      },
+                      "comment":"File /etc/pki/rpm-gpg/suse-addon-12a345bc6def7ghi.key is in the correct state",
+                      "name":"/etc/pki/rpm-gpg/suse-addon-12a345bc6def7ghi.key",
+                      "result":true,
+                      "__sls__":"channels.gpg-keys",
+                      "__run_num__":6,
+                      "start_time":"09:51:04.267225",
+                      "duration":13.196,
+                      "__id__":"mgr_deploy_suse_addon_key"
+                   },
+                   "file_|-mgr_deploy_suse16_gpg_key_|-/etc/pki/rpm-gpg/suse16-gpg-pubkey-98a7bc65.key_|-managed":{
+                      "changes":{
+                      },
+                      "comment":"File /etc/pki/rpm-gpg/suse16-gpg-pubkey-98a7bc65.key is in the correct state",
+                      "name":"/etc/pki/rpm-gpg/suse16-gpg-pubkey-98a7bc65.key",
+                      "result":true,
+                      "__sls__":"channels.gpg-keys",
+                      "__run_num__":7,
+                      "start_time":"09:51:04.280505",
+                      "duration":13.293,
+                      "__id__":"mgr_deploy_suse16_gpg_key"
+                   },
+                   "file_|-mgrchannels_repo_|-/etc/zypp/repos.d/susemanager:channels.repo_|-managed":{
+                      "changes":{
+                      },
+                      "comment":"File /etc/zypp/repos.d/susemanager:channels.repo is in the correct state",
+                      "name":"/etc/zypp/repos.d/susemanager:channels.repo",
+                      "result":true,
+                      "__sls__":"channels",
+                      "__run_num__":8,
+                      "start_time":"09:51:04.293915",
+                      "duration":43.894,
+                      "__id__":"mgrchannels_repo"
+                   },
+                   "product_|-mgrchannels_install_products_|-mgrchannels_install_products_|-all_installed":{
+                      "name":"mgrchannels_install_products",
+                      "changes":{
+                      },
+                      "result":true,
+                      "comment":"All subscribed products are already installed",
+                      "__sls__":"channels",
+                      "__run_num__":9,
+                      "start_time":"09:51:04.338216",
+                      "duration":431.093,
+                      "__id__":"mgrchannels_install_products"
+                   },
+                   "pkg_|-mgrchannels_inst_suse_build_key_|-suse-build-key_|-installed":{
+                      "name":"suse-build-key",
+                      "changes":{
+                      },
+                      "result":true,
+                      "comment":"All specified packages are already installed",
+                      "__sls__":"channels",
+                      "__run_num__":10,
+                      "start_time":"09:51:04.769675",
+                      "duration":1965.43,
+                      "__id__":"mgrchannels_inst_suse_build_key"
+                   },
+                   "file_|-mgr_sevsnp_create_attestdir_|-/tmp/cocoattest_sevsnp_|-directory":{
+                       "name":"/tmp/cocoattest_sevsnp",
+                       "changes":{
+                       },
+                       "result":true,
+                       "comment":"The directory /tmp/cocoattest_sevsnp is in the correct state",
+                       "__sls__":"cocoattest.coco_sev_snp",
+                       "__run_num__":11,
+                       "start_time":"11:55:16.601550",
+                       "duration":0.573,
+                       "__id__":"mgr_sevsnp_create_attestdir"
+                    },
+                   "pkg_|-mgr_sevsnp_inst_snpguest_|-mgr_sevsnp_inst_snpguest_|-latest":{
+                       "name":"mgr_sevsnp_inst_snpguest",
+                       "changes":{
+                       },
+                       "result":true,
+                       "comment":"Package snpguest is already up-to-date",
+                       "__sls__":"cocoattest.coco_sev_snp",
+                       "__run_num__":12,
+                       "start_time":"11:55:16.602215",
+                       "duration":479.856,
+                       "__id__":"mgr_sevsnp_inst_snpguest"
+                    },
+                   "cmd_|-mgr_sevsnp_write_request_data_|-/usr/bin/echo \\"l/BVaYeYPhEhf75K9pxDspw2DYAFdg7Op81zn8a+ql6tlHAG/e8S3cu7oeSSbViaWJv6xUNSEPsr2xBYJSc43g==\\" | /usr/bin/base64 -d > /tmp/cocoattest_sevsnp/random_user_nonce.bin_|-run":{
+                       "name":"/usr/bin/echo \\"l/BVaYeYPhEhf75K9pxDspw2DYAFdg7Op81zn8a+ql6tlHAG/e8S3cu7oeSSbViaWJv6xUNSEPsr2xBYJSc43g==\\" | /usr/bin/base64 -d > /tmp/cocoattest_sevsnp/random_user_nonce.bin",
+                       "changes":{
+                          "pid":10947,
+                          "retcode":0,
+                          "stdout":"",
+                          "stderr":""
+                       },
+                       "result":true,
+                       "comment":"Command \\"/usr/bin/echo \\"l/BVaYeYPhEhf75K9pxDspw2DYAFdg7Op81zn8a+ql6tlHAG/e8S3cu7oeSSbViaWJv6xUNSEPsr2xBYJSc43g==\\" | /usr/bin/base64 -d > /tmp/cocoattest_sevsnp/random_user_nonce.bin\\" run",
+                       "__sls__":"cocoattest.coco_sev_snp",
+                       "__run_num__":13,
+                       "start_time":"11:55:17.082297",
+                       "duration":7.369,
+                       "__id__":"mgr_sevsnp_write_request_data"
+                    },
+                   "cmd_|-mgr_sevsnp_create_snpguest_response_|-/usr/bin/snpguest report /tmp/cocoattest_sevsnp/response.bin /tmp/cocoattest_sevsnp/random_user_nonce.bin_|-run":{
+                       "name":"/usr/bin/snpguest report /tmp/cocoattest_sevsnp/response.bin /tmp/cocoattest_sevsnp/random_user_nonce.bin",
+                       "changes":{
+                          "pid":10950,
+                          "retcode":0,
+                          "stdout":"",
+                          "stderr":""
+                       },
+                       "result":true,
+                       "comment":"Command \\"/usr/bin/snpguest report /tmp/cocoattest_sevsnp/response.bin /tmp/cocoattest_sevsnp/random_user_nonce.bin\\" run",
+                       "__sls__":"cocoattest.coco_sev_snp",
+                       "__run_num__":14,
+                       "start_time":"11:55:17.089899",
+                       "duration":3.37,
+                       "__id__":"mgr_sevsnp_create_snpguest_response"
+                    },
+                   "cmd_|-mgr_sevsnp_snpguest_response_|-/usr/bin/cat /tmp/cocoattest_sevsnp/response.bin | /usr/bin/base64_|-run":{
+                      "name":"/usr/bin/cat /tmp/cocoattest_sevsnp/response.bin | /usr/bin/base64",
+                      "changes":{
+                         "pid":2744,
+                         "retcode":0,
+                         "stdout":"BQAAAAAAAAAAAAMCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAEAAAAE\\nAAAAAAAd3icAAAAAAAAABAAAAAAAAACvUTwurA60JuLr4saoUcqnlRByTSye2RoG7cm7aV3GFDM8\\nhBVP1bRVv+xZ+xgMnSxeXtRHKWQWIJeOKWzdHrjKUH6C0n6luVHddlo+sxul9YJnOzAdaYPe1ILT\\n/rBmy2iXnx8R/t6XaHN006JQAqFfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC0BzK9Zd/WojFnYDcZSyMuFyK38wdR\\nFG1y0mG8SdJ85///////////////////////////////////////////BAAAAAAAHd4ZAQEAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAHd4BOgEAAToBAAQAAAAAAB3eDwAAAAAAAAAP\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAl5RQN5FIiFMGs4Ud\\nFRQ/It0+g1ccaH0sbEgIVvRsxZMs5UwjpgqEwwqXKJ+vWUP3AAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAJFiRN+f4t0/lz6CxHmVe4DEl+YWRZ/U/jacsJCUt7XqpIHqeJUr0u4F4s3NIMTZGAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                         "stderr":""
+                      },
+                      "result":true,
+                      "comment":"Command \\"/usr/bin/cat /tmp/cocoattest_sevsnp/response.bin | /usr/bin/base64\\" run",
+                      "__sls__":"cocoattest.coco_sev_snp",
+                      "__run_num__":15,
+                      "start_time":"09:51:07.123989",
+                      "duration":1.806,
+                      "__id__":"mgr_sevsnp_snpguest_response"
+                   },
+                   "cmd_|-mgr_sevsnp_create_vlek_certificate_|-/usr/bin/snpguest certificates PEM /tmp/cocoattest_sevsnp_|-run":{
+                      "name":"/usr/bin/snpguest certificates PEM /tmp/cocoattest_sevsnp",
+                      "changes":{
+                         "pid":2747,
+                         "retcode":0,
+                         "stdout":"total 4\\ndrwxr-xr-x  2 root root    6 Mar 15  2022 bin\\ndrwxr-xr-x 21 root root 4096 Feb 24 18:29 salt",
+                         "stderr":""
+                      },
+                      "result":true,
+                      "comment":"Command \\"/usr/bin/snpguest certificates PEM /tmp/cocoattest_sevsnp\\" run",
+                      "__sls__":"cocoattest.coco_sev_snp",
+                      "__run_num__":16,
+                      "start_time":"09:51:07.125867",
+                      "duration":1.497,
+                      "__id__":"mgr_sevsnp_create_vlek_certificate"
+                   },
+                   "cmd_|-mgr_sevsnp_vlek_certificate_|-/usr/bin/cat /tmp/cocoattest_sevsnp/vlek.pem_|-run":{
+                      "name":"/usr/bin/cat /tmp/cocoattest_sevsnp/vlek.pem",
+                      "changes":{
+                         "pid":2748,
+                         "retcode":0,
+                         "stdout":"-----BEGIN CERTIFICATE-----\\nMIIFIzCCAtegAwIBAgIBADBBBgkqhkiG9w0BAQowNKAPMA0GCWCGSAFlAwQCAgUA\\noRwwGgYJKoZIhvcNAQEIMA0GCWCGSAFlAwQCAgUAogMCATAwgYAxFDASBgNVBAsM\\nC0VuZ2luZWVyaW5nMQswCQYDVQQGEwJVUzEUMBIGA1UEBwwLU2FudGEgQ2xhcmEx\\nCzAJBgNVBAgMAkNBMR8wHQYDVQQKDBZBZHZhbmNlZCBNaWNybyBEZXZpY2VzMRcw\\nFQYDVQQDDA5TRVYtVkxFSy1NaWxhbjAeFw0yNjAzMDkxOTMwMDVaFw0yNzAzMDkx\\nOTMwMDVaMHoxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQswCQYDVQQGEwJVUzEUMBIG\\nA1UEBwwLU2FudGEgQ2xhcmExCzAJBgNVBAgMAkNBMR8wHQYDVQQKDBZBZHZhbmNl\\nZCBNaWNybyBEZXZpY2VzMREwDwYDVQQDDAhTRVYtVkxFSzB2MBAGByqGSM49AgEG\\nBSuBBAAiA2IABE/rO0PxEkKVu5SAX9Fv+h1pF0r+wWNmNO+DLcMENz2IOaqYiS6s\\nwJjXThFjsjIx5mdy42ozh33DIC+b02LmGScVQrREUL0h5KR4Qd5+BTiO+UDBb8Xd\\n/p8rzpTQn+foEKOB8jCB7zAQBgkrBgEEAZx4AQEEAwIBADAUBgkrBgEEAZx4AQIE\\nBxYFTWlsYW4wEQYKKwYBBAGceAEDAQQDAgEEMBEGCisGAQQBnHgBAwIEAwIBADAR\\nBgorBgEEAZx4AQMEBAMCAQAwEQYKKwYBBAGceAEDBQQDAgEAMBEGCisGAQQBnHgB\\nAwYEAwIBADARBgorBgEEAZx4AQMHBAMCAQAwEQYKKwYBBAGceAEDAwQDAgEdMBIG\\nCisGAQQBnHgBAwgEBAICAN4wLAYJKwYBBAGceAEFBB8WHUNOPWNjLXVzLWVhc3Qt\\nMi5hbWF6b25hd3MuY29tMEEGCSqGSIb3DQEBCjA0oA8wDQYJYIZIAWUDBAICBQCh\\nHDAaBgkqhkiG9w0BAQgwDQYJYIZIAWUDBAICBQCiAwIBMAOCAgEAezLRKlKoxDhJ\\n9gGLDoIhruKSWJcwMHPn6E/aJzJvpDaYfb12ACKHyiMsm5htk6+lL9Kse544pmhh\\nUm/hxlpUNXiF+61obfKcaxp11Q2hzC/hTyLYpse6IXskLq6OH+DXzrcw0X30t3YI\\niUqzCGszbeTBy4uUOULxz3XbSUYFsKwsk9oMuo7isOUM3INiMiOTq91THlp6ZSVJ\\nDLIpW8v17DSL7yfJsvyLKsvtL7YjohFsOJe/qr/ttVSLC9WJmnxMxaxtgLSVGwCN\\nTHsx6646R7SAPRVXpdOd4f+Gfj4Dk1eiELs1L85Qm0tChDLrLLO31X9cwPxg6fjd\\nZ3sgqZrOv9Up2EiiX3uzH9pjuek9KZw8BvbNmkABURnj2QVKkANKWeVwJ2OI9xmb\\nKnLDQp+t3Q6gTcdPdcjSsAkT0JijpzamEmIPLdBobgVHAcxCxRhBILmJWQcU8V8R\\ng2+n/Zs8gpuGaCj0j8s8YDq7+sgy0/5CsDgAhU7+4HqzBTPbhOCNAI9uptU6v0xo\\nDLzldXmVJQaGWp6zQ+WB29ZnFrF4UE85+os3uIwc6uEPBjh3bjmhTwa3I7LWRWld\\nRyoJUuLnBIdTJYVIkgrYJ47LfI3akZxUM0D+FpqawemnHOTT1z8ee1wj7wnE6nS2\\nX0R7cJNthweU48At2ZfRIuPYvu9av2Y=\\n-----END CERTIFICATE-----",
+                         "stderr":""
+                      },
+                      "result":true,
+                      "comment":"Command \\"/usr/bin/cat /tmp/cocoattest_sevsnp/vlek.pem\\" run",
+                      "__sls__":"cocoattest.coco_sev_snp",
+                      "__run_num__":17,
+                      "start_time":"09:51:07.127515",
+                      "duration":1.291,
+                      "__id__":"mgr_sevsnp_vlek_certificate"
+                   },
+                   "pkg_|-mgr_secureboot_inst_mokutil_|-mgr_secureboot_inst_mokutil_|-latest":{
+                     "name":"mgr_secureboot_inst_mokutil",
+                     "changes":{
+                     },
+                     "result":true,
+                     "comment":"Package mokutil is already up-to-date",
+                     "__sls__":"cocoattest.coco_secure_boot",
+                     "__run_num__":18,
+                     "start_time":"11:55:17.096480",
+                     "duration":474.938,
+                     "__id__":"mgr_secureboot_inst_mokutil"
+                  },
+                   "cmd_|-mgr_secureboot_enabled_|-/usr/bin/mokutil --sb-state_|-run":{
+                      "name":"/usr/bin/mokutil --sb-state",
+                      "changes":{
+                         "pid":10978,
+                         "retcode":1,
+                         "stdout":"",
+                         "stderr":"EFI variables are not supported on this system"
+                      },
+                      "result":false,
+                      "comment":"Command \\"/usr/bin/mokutil --sb-state\\" run",
+                      "__sls__":"cocoattest.coco_secure_boot",
+                      "__run_num__":19,
+                      "start_time":"11:55:17.571515",
+                      "duration":3.706,
+                      "__id__":"mgr_secureboot_enabled"
+                   }
+                }
+                """;
+
+    private static final String AMD_EXPECTED_BASE_64_REPORT_DATA = """
+                BQAAAAAAAAAAAAMCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAEAAAAE
+                AAAAAAAd3icAAAAAAAAABAAAAAAAAACvUTwurA60JuLr4saoUcqnlRByTSye2RoG7cm7aV3GFDM8
+                hBVP1bRVv+xZ+xgMnSxeXtRHKWQWIJeOKWzdHrjKUH6C0n6luVHddlo+sxul9YJnOzAdaYPe1ILT
+                /rBmy2iXnx8R/t6XaHN006JQAqFfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC0BzK9Zd/WojFnYDcZSyMuFyK38wdR
+                FG1y0mG8SdJ85///////////////////////////////////////////BAAAAAAAHd4ZAQEAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAHd4BOgEAAToBAAQAAAAAAB3eDwAAAAAAAAAP
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAl5RQN5FIiFMGs4Ud
+                FRQ/It0+g1ccaH0sbEgIVvRsxZMs5UwjpgqEwwqXKJ+vWUP3AAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAJFiRN+f4t0/lz6CxHmVe4DEl+YWRZ/U/jacsJCUt7XqpIHqeJUr0u4F4s3NIMTZGAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=""";
+
+    private static final String AMD_EXPECTED_VLEK_CERTIFICATE = """
+                -----BEGIN CERTIFICATE-----
+                MIIFIzCCAtegAwIBAgIBADBBBgkqhkiG9w0BAQowNKAPMA0GCWCGSAFlAwQCAgUA
+                oRwwGgYJKoZIhvcNAQEIMA0GCWCGSAFlAwQCAgUAogMCATAwgYAxFDASBgNVBAsM
+                C0VuZ2luZWVyaW5nMQswCQYDVQQGEwJVUzEUMBIGA1UEBwwLU2FudGEgQ2xhcmEx
+                CzAJBgNVBAgMAkNBMR8wHQYDVQQKDBZBZHZhbmNlZCBNaWNybyBEZXZpY2VzMRcw
+                FQYDVQQDDA5TRVYtVkxFSy1NaWxhbjAeFw0yNjAzMDkxOTMwMDVaFw0yNzAzMDkx
+                OTMwMDVaMHoxFDASBgNVBAsMC0VuZ2luZWVyaW5nMQswCQYDVQQGEwJVUzEUMBIG
+                A1UEBwwLU2FudGEgQ2xhcmExCzAJBgNVBAgMAkNBMR8wHQYDVQQKDBZBZHZhbmNl
+                ZCBNaWNybyBEZXZpY2VzMREwDwYDVQQDDAhTRVYtVkxFSzB2MBAGByqGSM49AgEG
+                BSuBBAAiA2IABE/rO0PxEkKVu5SAX9Fv+h1pF0r+wWNmNO+DLcMENz2IOaqYiS6s
+                wJjXThFjsjIx5mdy42ozh33DIC+b02LmGScVQrREUL0h5KR4Qd5+BTiO+UDBb8Xd
+                /p8rzpTQn+foEKOB8jCB7zAQBgkrBgEEAZx4AQEEAwIBADAUBgkrBgEEAZx4AQIE
+                BxYFTWlsYW4wEQYKKwYBBAGceAEDAQQDAgEEMBEGCisGAQQBnHgBAwIEAwIBADAR
+                BgorBgEEAZx4AQMEBAMCAQAwEQYKKwYBBAGceAEDBQQDAgEAMBEGCisGAQQBnHgB
+                AwYEAwIBADARBgorBgEEAZx4AQMHBAMCAQAwEQYKKwYBBAGceAEDAwQDAgEdMBIG
+                CisGAQQBnHgBAwgEBAICAN4wLAYJKwYBBAGceAEFBB8WHUNOPWNjLXVzLWVhc3Qt
+                Mi5hbWF6b25hd3MuY29tMEEGCSqGSIb3DQEBCjA0oA8wDQYJYIZIAWUDBAICBQCh
+                HDAaBgkqhkiG9w0BAQgwDQYJYIZIAWUDBAICBQCiAwIBMAOCAgEAezLRKlKoxDhJ
+                9gGLDoIhruKSWJcwMHPn6E/aJzJvpDaYfb12ACKHyiMsm5htk6+lL9Kse544pmhh
+                Um/hxlpUNXiF+61obfKcaxp11Q2hzC/hTyLYpse6IXskLq6OH+DXzrcw0X30t3YI
+                iUqzCGszbeTBy4uUOULxz3XbSUYFsKwsk9oMuo7isOUM3INiMiOTq91THlp6ZSVJ
+                DLIpW8v17DSL7yfJsvyLKsvtL7YjohFsOJe/qr/ttVSLC9WJmnxMxaxtgLSVGwCN
+                THsx6646R7SAPRVXpdOd4f+Gfj4Dk1eiELs1L85Qm0tChDLrLLO31X9cwPxg6fjd
+                Z3sgqZrOv9Up2EiiX3uzH9pjuek9KZw8BvbNmkABURnj2QVKkANKWeVwJ2OI9xmb
+                KnLDQp+t3Q6gTcdPdcjSsAkT0JijpzamEmIPLdBobgVHAcxCxRhBILmJWQcU8V8R
+                g2+n/Zs8gpuGaCj0j8s8YDq7+sgy0/5CsDgAhU7+4HqzBTPbhOCNAI9uptU6v0xo
+                DLzldXmVJQaGWp6zQ+WB29ZnFrF4UE85+os3uIwc6uEPBjh3bjmhTwa3I7LWRWld
+                RyoJUuLnBIdTJYVIkgrYJ47LfI3akZxUM0D+FpqawemnHOTT1z8ee1wj7wnE6nS2
+                X0R7cJNthweU48At2ZfRIuPYvu9av2Y=
+                -----END CERTIFICATE-----""";
+
+    private static final String AMD_EXPECTED_SECURE_BOOT_RESULT = "EFI variables are not supported on this system";
+
+
+    private CoCoAttestationResponseDataParser responseDataParser;
+    private Optional<CoCoAbstractAttestationResponseData> optAmdChunk;
+    private Optional<CoCoAbstractAttestationResponseData> optBootChunk;
+
+    private void setUpAmdTest() {
+        JsonElement jsonResult = JsonParser.parseString(AMD_SALT_STATE_JSON_INPUT_STRING);
+        responseDataParser = new CoCoAttestationResponseDataParser();
+        responseDataParser.parse(jsonResult);
+        optAmdChunk = responseDataParser.getChunk(CoCoAmdEpycAttestationResponseData.class);
+        optBootChunk = responseDataParser.getChunk(CoCoSecureBootAttestationResponseData.class);
+    }
+
+    @Test
+    @DisplayName("check that parse() method is giving the expected results with AMD json result")
+    public void testAmdTestParsing() {
+        setUpAmdTest();
+
+        assertTrue(optAmdChunk.isPresent());
+        CoCoAmdEpycAttestationResponseData amdChunk = (CoCoAmdEpycAttestationResponseData)optAmdChunk.get();
+        assertTrue(optBootChunk.isPresent());
+        CoCoSecureBootAttestationResponseData bootChunk = (CoCoSecureBootAttestationResponseData)optBootChunk.get();
+
+        Optional<StateApplyResult<CmdResult>> optResult;
+
+        optResult = responseDataParser.getResult(CoCoAmdEpycAttestationResponseData.SNP_GUEST_RESPONSE_TAG);
+        assertTrue(optResult.isPresent());
+        assertEquals(AMD_EXPECTED_BASE_64_REPORT_DATA, optResult.get().getChanges().getStdout());
+        assertTrue(amdChunk.getSnpguestResponse().isPresent());
+        assertEquals(AMD_EXPECTED_BASE_64_REPORT_DATA, amdChunk.getSnpguestResponse().get().getChanges().getStdout());
+
+        optResult = responseDataParser.getResult(CoCoAmdEpycAttestationResponseData.VLEK_CERTIFICATE_TAG);
+        assertTrue(optResult.isPresent());
+        assertEquals(AMD_EXPECTED_VLEK_CERTIFICATE, optResult.get().getChanges().getStdout());
+        assertTrue(amdChunk.getVlekCertificate().isPresent());
+        assertEquals(AMD_EXPECTED_VLEK_CERTIFICATE, amdChunk.getVlekCertificate().get().getChanges().getStdout());
+
+        optResult = responseDataParser.getResult(CoCoSecureBootAttestationResponseData.SECURE_BOOT_ENABLED_TAG);
+        assertTrue(optResult.isPresent());
+        assertEquals(AMD_EXPECTED_SECURE_BOOT_RESULT, optResult.get().getChanges().getStderr());
+        assertTrue(bootChunk.getSecureBoot().isPresent());
+        assertEquals(AMD_EXPECTED_SECURE_BOOT_RESULT, bootChunk.getSecureBoot().get().getChanges().getStderr());
+    }
+
+    @Test
+    @DisplayName("check that asMap() method is giving the expected results with AMD json result")
+    public void testAmdAsMap() {
+        setUpAmdTest();
+
+        assertTrue(optAmdChunk.isPresent());
+        CoCoAmdEpycAttestationResponseData amdChunk = (CoCoAmdEpycAttestationResponseData)optAmdChunk.get();
+        assertTrue(optBootChunk.isPresent());
+        CoCoSecureBootAttestationResponseData bootChunk = (CoCoSecureBootAttestationResponseData)optBootChunk.get();
+
+        Map<String, Object> requestDataMap = responseDataParser.asMap();
+        assertEquals(3, requestDataMap.size());
+        assertEquals(AMD_EXPECTED_BASE_64_REPORT_DATA.replace("\n", ""),
+                requestDataMap.get(CoCoAmdEpycAttestationResponseData.SNP_GUEST_RESPONSE_TAG));
+        assertEquals(AMD_EXPECTED_VLEK_CERTIFICATE,
+                requestDataMap.get(CoCoAmdEpycAttestationResponseData.VLEK_CERTIFICATE_TAG));
+        assertEquals(AMD_EXPECTED_SECURE_BOOT_RESULT,
+                requestDataMap.get(CoCoSecureBootAttestationResponseData.SECURE_BOOT_ENABLED_TAG));
+
+        assertEquals(2, amdChunk.asMap().size());
+        assertEquals(AMD_EXPECTED_BASE_64_REPORT_DATA.replace("\n", ""),
+                amdChunk.asMap().get(CoCoAmdEpycAttestationResponseData.SNP_GUEST_RESPONSE_TAG));
+        assertEquals(AMD_EXPECTED_VLEK_CERTIFICATE,
+                amdChunk.asMap().get(CoCoAmdEpycAttestationResponseData.VLEK_CERTIFICATE_TAG));
+
+        assertEquals(1, bootChunk.asMap().size());
+        assertEquals(AMD_EXPECTED_SECURE_BOOT_RESULT,
+                bootChunk.asMap().get(CoCoSecureBootAttestationResponseData.SECURE_BOOT_ENABLED_TAG));
+    }
+
+
+    private static class TestResponseData extends CoCoAbstractAttestationResponseData {
+
+        @SerializedName("cmd_|-test_command_|-/usr/bin/cat binary_file.bin | /usr/bin/base64_|-run")
+        private StateApplyResult<CmdResult> base64Binary;
+
+        @Override
+        public Map<String, Optional<StateApplyResult<CmdResult>>> getResults() {
+            Map<String, Optional<StateApplyResult<CmdResult>>> out = new HashMap<>();
+            out.put("base64BinaryTag", Optional.ofNullable(base64Binary));
+            return out;
+        }
+    }
+
+
+    private static class TestDataParser extends CoCoAttestationResponseDataParser {
+        @Override
+        public void parse(JsonElement jsonResult) {
+            chunks.clear();
+            chunks.add(Json.GSON.fromJson(jsonResult, TestResponseData.class));
+        }
+    }
+
+    //suppress checkstyle warnings in order to keep it as it appears in the file
+    //original binary file represented in stdout: 864 bytes
+    //original base64 string in stdout: 15 rows x 76 chars + 12 chars = 1152 chars + 15 crlf = 1167
+    @SuppressWarnings("checkstyle:lineLength")
+    private static final String BASE64_BIN_FILE_EXAMPLE = """
+            {
+            "cmd_|-test_command_|-/usr/bin/cat binary_file.bin | /usr/bin/base64_|-run":{
+                  "name":"/usr/bin/cat binary_file.bin | /usr/bin/base64",
+                  "changes":{
+                     "pid":20446,
+                     "retcode":0,
+                     "stdout":"cHZhdHRlc3QAAAEAAAADYAAAAAAAAAAAAAABkAAAAEAAAABAAAAB0AAAAEAAAAIQAAABAAAAAlAA\\nAAAQAAADUAAAAAAAAAAAAAABAAAAAZBBLTgZS4052sfgucEAAAAAAAAAAAAAAAEAAAAAAAAAUHAA\\nAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAACKt+uyUssDiTYXy+KNpqaUhsfNO0U2wrl82kDQ\\nHFhlf6SRoRiqfY4PTqmU1ufYx/HL6UI6nWDszrnV1Yr6fHhdAwAAAAAAAAAAAAAAAAAAAWuCp/Xk\\nqA/YiEtOaWsT3jD4BNJM6e+DWJfEKKUPEMpyW69KU9tvrXRqGcKUzpxCiK/VzHIWt4Vb5qjGCjl2\\nH0AT0fco79meHaZQ51hRJiGmX53Y132NNLHbu1aQTrNzuDzL84FaRMxHnRGKNBKKRofcMv+hXDIE\\nOdM5sXOEn7EkuH2TAQP+j0FnxBvPQCOjVNBbgPmqXa9AGYcsU/PNZROEbQhxPYGO+3LBg8iQEfev\\nE2tL2Rot4Ete/DsmUZed/0lGI/79Ke7BMNB26nhGNNJ2X1NHWsHpux2wuRT+Cn2TMRCDWVfLXdLv\\n/3YI59qYvihf/FYwkFbPucBeg/tfRxnPkh7OAZy7bK/vilksUrxWFmthKsyw5z4KSBGeWmoW2+wc\\n6Og6acBXWyO+rTPUVXOv0fco79meHaZQ51hRJiGmX53Y132NNLHbu1aQTrNzuDzR9yjv2Z4dplDn\\nWFEmIaZfndjXfY00sdu7VpBOs3O4PGF2570RMsTUC2HOjn7iX1pwO5LHBJfR4JmiR2NZbx+15bo4\\nUI/av+oKuznJEqY/zgRuxofzfdU/WlgpN/AFR75RPqeNWfrpV3Ep4mjEaCW3H4+rM1Y3cGlB7yxe\\nnYQT6M+qpWk6NH6rakoJN9gelv/JXCgF5gMR8t8Bq2ZiK6SKwkJVEuxv6m74RiYIONIKprrPz5SR\\nOBFGWdUfRCHGA5LvGcxJL3mrt0lwcRuNeatFIRYjdxn8OLg9lFehhvx+KMXmy4oarU5rhR4SVjSf\\nW7w+0c4Ihinkd8CwLdIDvmAjMBwRyRRtPe/0o+X2206E3JodtS6V5OJ5nXk+ApLpVXau7LVvIc1f\\n6BDXLViQLYAJ",
+                     "stderr":""
+                  },
+                  "result":true,
+                  "comment":"Command \\"/usr/bin/cat binary_file.bin | /usr/bin/base64\\" run",
+                  "__sls__":"cocoattest.test_file",
+                  "__run_num__":16,
+                  "start_time":"11:48:13.072596",
+                  "duration":2.811,
+                  "__id__":"test_command"
+               }
+            }
+            """;
+
+    @Test
+    @DisplayName("check that asMap() method correctly gets binary files in base64 format")
+    public void testBase64Encoding() {
+        JsonElement jsonResult = JsonParser.parseString(BASE64_BIN_FILE_EXAMPLE);
+        responseDataParser = new TestDataParser();
+        responseDataParser.parse(jsonResult);
+
+        Optional<StateApplyResult<CmdResult>> optResult = responseDataParser.getResult("base64BinaryTag");
+        assertTrue(optResult.isPresent());
+
+        //original binary file represented in stdout: 864 bytes
+        //original base64 string in stdout: 15 rows x 76 chars + 12 chars = 1152 chars + 15 crlf = 1167
+        StateApplyResult<CmdResult> res = optResult.get();
+        String parsedBase64BinaryFromStdout = res.getChanges().getStdout();
+
+        assertEquals(1167, parsedBase64BinaryFromStdout.length());
+        assertEquals(15, StringUtils.countMatches(parsedBase64BinaryFromStdout, "\n"));
+        assertEquals(1152, parsedBase64BinaryFromStdout.replace("\n", "").length());
+        byte[] decoded = Base64.getDecoder().decode(parsedBase64BinaryFromStdout.replace("\n", ""));
+        assertEquals(864, decoded.length);
+
+        //asMap() has no cr/lf
+        Map<String, Object> requestDataMap = responseDataParser.asMap();
+        assertTrue(requestDataMap.containsKey("base64BinaryTag"));
+        String parsedBase64BinaryFromAsMap = (String)requestDataMap.get("base64BinaryTag");
+
+        assertEquals(1152, parsedBase64BinaryFromAsMap.length());
+        assertEquals(0, StringUtils.countMatches(parsedBase64BinaryFromAsMap, "\n"));
+        byte[] decodedAsMap = Base64.getDecoder().decode(parsedBase64BinaryFromAsMap);
+        assertEquals(864, decodedAsMap.length);
+    }
+
+}

--- a/schema/spacewalk/common/tables/suseCoCoAttestationResult.sql
+++ b/schema/spacewalk/common/tables/suseCoCoAttestationResult.sql
@@ -18,9 +18,11 @@ CREATE TABLE suseCoCoAttestationResult
                             REFERENCES suseServerCoCoAttestationReport (id)
                             ON DELETE CASCADE,
         result_type     NUMERIC     NOT NULL,
+        env_type        NUMERIC NOT NULL default 0,
         status          VARCHAR(32) NOT NULL
                           CONSTRAINT suse_cocoatt_res_st_ck
-                            CHECK(status IN ('PENDING', 'SUCCEEDED', 'FAILED')),
+                            CHECK(status IN ('PENDING', 'SUCCEEDED', 'FAILED', 'REQUESTED', 'QUEUED', 'SUBMITTED')),
+        in_data         JSONB NOT NULL default '{}',
         description     VARCHAR(256) NOT NULL,
         details         TEXT NULL,
         process_output  TEXT NULL,

--- a/schema/spacewalk/common/tables/suseServerCoCoAttestationConfig.sql
+++ b/schema/spacewalk/common/tables/suseServerCoCoAttestationConfig.sql
@@ -18,6 +18,7 @@ CREATE TABLE suseServerCoCoAttestationConfig
                                 REFERENCES rhnServer (id) ON DELETE CASCADE,
     enabled             BOOLEAN NOT NULL DEFAULT FALSE,
     env_type            NUMERIC NULL,
+    in_data             JSONB NOT NULL default '{}',
     attest_on_boot      BOOLEAN NOT NULL DEFAULT FALSE
 );
 

--- a/schema/spacewalk/common/tables/suseServerCoCoAttestationReport.sql
+++ b/schema/spacewalk/common/tables/suseServerCoCoAttestationReport.sql
@@ -23,6 +23,7 @@ CREATE TABLE suseServerCoCoAttestationReport
 	status      VARCHAR(32) NOT NULL
 	              CONSTRAINT suse_srvcocoatt_rep_st_ck
                         CHECK(status IN ('PENDING', 'SUCCEEDED', 'FAILED')),
+        config_data JSONB NOT NULL default '{}', -- copy of the configuration data
         in_data     JSONB NOT NULL, -- input data for the state.apply
         out_data    JSONB NOT NULL, -- output data from the state.apply
 	created     TIMESTAMPTZ DEFAULT (current_timestamp) NOT NULL,

--- a/schema/spacewalk/postgres/triggers/suseCoCoAttestationResult.sql
+++ b/schema/spacewalk/postgres/triggers/suseCoCoAttestationResult.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION suse_cocoatt_res_up_trig_fun() RETURNS TRIGGER AS
 $$
 BEGIN
-	IF EXISTS(SELECT FROM suseCoCoAttestationResult WHERE status = 'PENDING' AND report_id = NEW.report_id) THEN
+	IF EXISTS(SELECT FROM suseCoCoAttestationResult WHERE status NOT IN ('FAILED', 'SUCCEEDED') AND report_id = NEW.report_id) THEN
 		return new;
 	ELSIF EXISTS(SELECT FROM suseCoCoAttestationResult WHERE status = 'FAILED' AND report_id = NEW.report_id) THEN
 		UPDATE suseServerCoCoAttestationReport
@@ -15,6 +15,7 @@ BEGIN
 	return new;
 END;
 $$ language plpgsql;
+
 
 CREATE TRIGGER
 suse_cocoatt_res_up_trig
@@ -37,3 +38,21 @@ AFTER INSERT OR UPDATE OF status ON suseCoCoAttestationResult
 FOR EACH ROW
 WHEN (NEW.status = 'PENDING')
 EXECUTE PROCEDURE suse_cocoatt_notify_pending_trig_fun();
+
+
+
+CREATE OR REPLACE FUNCTION suse_cocoatt_notify_requested_trig_fun() RETURNS TRIGGER AS
+$$
+BEGIN
+    NOTIFY pendingAttestationResult;
+    RETURN NEW;
+END;
+$$ language plpgsql;
+
+
+CREATE TRIGGER
+suse_cocoatt_notify_requested_trig
+AFTER INSERT OR UPDATE OF status ON suseCoCoAttestationResult
+FOR EACH ROW
+WHEN (NEW.status = 'REQUESTED')
+EXECUTE PROCEDURE suse_cocoatt_notify_requested_trig_fun();

--- a/schema/spacewalk/susemanager-schema.changes.carlo.uyuni-new-coco-attestation
+++ b/schema/spacewalk/susemanager-schema.changes.carlo.uyuni-new-coco-attestation
@@ -1,0 +1,1 @@
+- updated tables for CoCo attestation restructuring

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.7-to-susemanager-schema-5.2.8/900-coco-db-modificatons.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.7-to-susemanager-schema-5.2.8/900-coco-db-modificatons.sql
@@ -1,0 +1,89 @@
+
+-- coco database modifications
+
+-- CONFIGURATION TABLE
+
+-- configuration table: add in_data column
+ALTER TABLE suseServerCocoAttestationConfig ADD COLUMN IF NOT EXISTS
+    in_data jsonb NOT NULL default '{}';
+
+-- RESULT TABLE
+
+-- result table: add new states
+ALTER TABLE suseCoCoAttestationResult
+DROP CONSTRAINT suse_cocoatt_res_st_ck,
+ADD  CONSTRAINT suse_cocoatt_res_st_ck CHECK(status IN ('PENDING', 'SUCCEEDED', 'FAILED', 'REQUESTED', 'QUEUED', 'SUBMITTED'));
+
+
+-- result table: add env_type column
+ALTER TABLE suseCoCoAttestationResult ADD COLUMN IF NOT EXISTS
+    env_type NUMERIC NOT NULL default 0;
+
+-- result table: update env_type column with corresponding report values
+UPDATE suseCoCoAttestationResult res
+SET env_type = rpt.env_type
+FROM suseServerCocoAttestationReport rpt
+WHERE rpt.id = res.report_id;
+
+-- result table: change trigger to set report status depending on result ones
+CREATE OR REPLACE FUNCTION suse_cocoatt_res_up_trig_fun() RETURNS TRIGGER AS
+$$
+BEGIN
+	IF EXISTS(SELECT FROM suseCoCoAttestationResult WHERE status NOT IN ('FAILED', 'SUCCEEDED') AND report_id = NEW.report_id) THEN
+		return new;
+	ELSIF EXISTS(SELECT FROM suseCoCoAttestationResult WHERE status = 'FAILED' AND report_id = NEW.report_id) THEN
+		UPDATE suseServerCoCoAttestationReport
+		SET status = 'FAILED'
+		WHERE id = NEW.report_id;
+	ELSE
+		UPDATE suseServerCoCoAttestationReport
+		SET status = 'SUCCEEDED'
+		WHERE id = NEW.report_id;
+	END IF;
+	return new;
+END;
+$$ language plpgsql;
+
+DROP TRIGGER IF EXISTS suse_cocoatt_res_up_trig ON suseCoCoAttestationResult;
+
+CREATE TRIGGER
+suse_cocoatt_res_up_trig
+AFTER UPDATE ON suseCoCoAttestationResult
+FOR EACH ROW
+WHEN (OLD.status IS DISTINCT FROM NEW.status)
+EXECUTE PROCEDURE suse_cocoatt_res_up_trig_fun();
+
+
+
+-- result table: add notification trigger on REQUESTED status
+CREATE OR REPLACE FUNCTION suse_cocoatt_notify_requested_trig_fun() RETURNS TRIGGER AS
+$$
+BEGIN
+    NOTIFY pendingAttestationResult;
+    RETURN NEW;
+END;
+$$ language plpgsql;
+
+
+DROP TRIGGER IF EXISTS suse_cocoatt_notify_requested_trig ON suseCoCoAttestationResult;
+
+
+CREATE TRIGGER
+suse_cocoatt_notify_requested_trig
+AFTER INSERT OR UPDATE OF status ON suseCoCoAttestationResult
+FOR EACH ROW
+WHEN (NEW.status = 'REQUESTED')
+EXECUTE PROCEDURE suse_cocoatt_notify_requested_trig_fun();
+
+
+-- result table: add in_data column
+ALTER TABLE suseCoCoAttestationResult ADD COLUMN IF NOT EXISTS
+    in_data jsonb NOT NULL default '{}';
+
+
+-- REPORT TABLE
+
+-- report table: add config_data column
+ALTER TABLE suseServerCoCoAttestationReport ADD COLUMN IF NOT EXISTS
+    config_data jsonb NOT NULL default '{}';
+

--- a/susemanager-utils/susemanager-sls/salt/cocoattest/coco_ibm_pvattest.sls
+++ b/susemanager-utils/susemanager-sls/salt/cocoattest/coco_ibm_pvattest.sls
@@ -1,0 +1,41 @@
+include:
+  - channels
+
+mgr_ibmpvattest_create_attestdir:
+  file.directory:
+    - name: /tmp/cocoattest_ibmpvattest
+    - dir_mode: 700
+
+mgr_ibmpvattest_inst_pvattest:
+  pkg.latest:
+    - pkgs:
+      - s390-tools
+    - require:
+      - sls: channels
+
+mgr_ibmpvattest_write_attestation_request:
+  cmd.run:
+    - name: /usr/bin/echo "{{ salt['pillar.get']('attestation_data:attestation_request') }}" | /usr/bin/base64 -d > /tmp/cocoattest_ibmpvattest/attestation_request.bin
+    - onlyif: /usr/bin/test -x /usr/bin/base64
+    - require:
+      - file: mgr_ibmpvattest_create_attestdir
+
+mgr_ibmpvattest_create_pvattest_response:
+  cmd.run:
+    - name: /usr/bin/pvattest perform -i /tmp/cocoattest_ibmpvattest/attestation_request.bin -o /tmp/cocoattest_ibmpvattest/attestation_response.bin
+    - require:
+      - cmd: mgr_ibmpvattest_write_attestation_request
+      - file: mgr_ibmpvattest_create_attestdir
+
+mgr_ibmpvattest_pvattest_response:
+  cmd.run:
+    - name: /usr/bin/cat /tmp/cocoattest_ibmpvattest/attestation_response.bin | /usr/bin/base64
+    - require:
+      - cmd: mgr_ibmpvattest_create_pvattest_response
+      - file: mgr_ibmpvattest_create_attestdir
+
+mgr_ibmpvattest_cleanup_attest:
+  file.absent:
+    - name: /tmp/cocoattest_ibmpvattest
+    - require:
+      - file: mgr_ibmpvattest_create_attestdir

--- a/susemanager-utils/susemanager-sls/salt/cocoattest/coco_secure_boot.sls
+++ b/susemanager-utils/susemanager-sls/salt/cocoattest/coco_secure_boot.sls
@@ -1,0 +1,17 @@
+include:
+  - channels
+
+mgr_secureboot_inst_mokutil:
+  pkg.latest:
+    - pkgs:
+      - mokutil
+    - require:
+      - sls: channels
+
+mgr_secureboot_enabled:
+  cmd.run:
+    - name: /usr/bin/mokutil --sb-state
+    - success_retcodes:
+      - 255
+      - 0
+      - 1

--- a/susemanager-utils/susemanager-sls/salt/cocoattest/coco_sev_snp.sls
+++ b/susemanager-utils/susemanager-sls/salt/cocoattest/coco_sev_snp.sls
@@ -1,0 +1,54 @@
+include:
+  - channels
+
+mgr_sevsnp_create_attestdir:
+  file.directory:
+    - name: /tmp/cocoattest_sevsnp
+    - dir_mode: 700
+
+mgr_sevsnp_inst_snpguest:
+  pkg.latest:
+    - pkgs:
+      - snpguest
+    - require:
+      - sls: channels
+
+mgr_sevsnp_write_request_data:
+  cmd.run:
+    - name: /usr/bin/echo "{{ salt['pillar.get']('attestation_data:nonce') }}" | /usr/bin/base64 -d > /tmp/cocoattest_sevsnp/random_user_nonce.bin
+    - onlyif: /usr/bin/test -x /usr/bin/base64
+    - require:
+      - file: mgr_sevsnp_create_attestdir
+
+mgr_sevsnp_create_snpguest_response:
+  cmd.run:
+    - name: /usr/bin/snpguest report /tmp/cocoattest_sevsnp/response.bin /tmp/cocoattest_sevsnp/random_user_nonce.bin
+    - require:
+      - cmd: mgr_sevsnp_write_request_data
+      - file: mgr_sevsnp_create_attestdir
+
+mgr_sevsnp_snpguest_response:
+  cmd.run:
+    - name: /usr/bin/cat /tmp/cocoattest_sevsnp/response.bin | /usr/bin/base64
+    - require:
+      - cmd: mgr_sevsnp_create_snpguest_response
+      - file: mgr_sevsnp_create_attestdir
+
+mgr_sevsnp_create_vlek_certificate:
+  cmd.run:
+    - name: /usr/bin/snpguest certificates PEM /tmp/cocoattest_sevsnp
+    - require:
+      - file: mgr_sevsnp_create_attestdir
+
+mgr_sevsnp_vlek_certificate:
+  cmd.run:
+    - name: /usr/bin/cat /tmp/cocoattest_sevsnp/vlek.pem
+    - require:
+      - cmd: mgr_sevsnp_create_vlek_certificate
+      - file: mgr_sevsnp_create_attestdir
+
+mgr_sevsnp_cleanup_attest:
+  file.absent:
+    - name: /tmp/cocoattest_sevsnp
+    - require:
+      - file: mgr_sevsnp_create_attestdir

--- a/susemanager-utils/susemanager-sls/salt/cocoattest/requestdata.sls
+++ b/susemanager-utils/susemanager-sls/salt/cocoattest/requestdata.sls
@@ -1,66 +1,18 @@
 include:
-  - channels
 
-mgr_create_attestdir:
-  file.directory:
-    - name: /tmp/cocoattest
-    - dir_mode: 700
+{% for result_type in salt['pillar.get']('attestation_data:result_types', []) %}
 
-{% if salt['pillar.get']('attestation_data:environment_type', 'NONE') not in ['NONE'] %}
+{%- if result_type  == 'SECURE_BOOT' %}
+ - .coco_secure_boot
+{%- endif %}
 
-mgr_inst_snpguest:
-  pkg.latest:
-    - pkgs:
-      - snpguest
-      - mokutil
-    - require:
-      - sls: channels
+{%- if result_type  == 'SEV_SNP' %}
+ - .coco_sev_snp
+{%- endif %}
 
-mgr_write_request_data:
-  cmd.run:
-    - name: /usr/bin/echo "{{ salt['pillar.get']('attestation_data:nonce') }}" | /usr/bin/base64 -d > /tmp/cocoattest/request-data.txt
-    - onlyif: /usr/bin/test -x /usr/bin/base64
-    - require:
-      - file: mgr_create_attestdir
+{%- if result_type  == 'IBM_PVATTEST' %}
+ - .coco_ibm_pvattest
+{%- endif %}
 
-mgr_create_snpguest_report:
-  cmd.run:
-    - name: /usr/bin/snpguest report /tmp/cocoattest/report.bin /tmp/cocoattest/request-data.txt
-    - require:
-      - cmd: mgr_write_request_data
-      - file: mgr_create_attestdir
 
-mgr_snpguest_report:
-  cmd.run:
-    - name: /usr/bin/cat /tmp/cocoattest/report.bin | /usr/bin/base64
-    - require:
-      - cmd: mgr_create_snpguest_report
-      - file: mgr_create_attestdir
-
-mgr_create_vlek_certificate:
-  cmd.run:
-    - name: /usr/bin/snpguest certificates PEM /tmp/cocoattest
-    - require:
-      - file: mgr_create_attestdir
-
-mgr_vlek_certificate:
-  cmd.run:
-    - name: /usr/bin/cat /tmp/cocoattest/vlek.pem
-    - require:
-      - cmd: mgr_create_vlek_certificate
-      - file: mgr_create_attestdir
-
-mgr_secureboot_enabled:
-  cmd.run:
-    - name: /usr/bin/mokutil --sb-state
-    - success_retcodes:
-      - 255
-      - 0
-
-{% endif %}
-
-mgr_cleanup_attest:
-  file.absent:
-    - name: /tmp/cocoattest
-    - require:
-      - file: mgr_create_attestdir
+{% endfor %}

--- a/susemanager-utils/susemanager-sls/salt/cocoattest/requestdata.sls
+++ b/susemanager-utils/susemanager-sls/salt/cocoattest/requestdata.sls
@@ -23,18 +23,18 @@ mgr_write_request_data:
     - require:
       - file: mgr_create_attestdir
 
-mgr_create_snpguest_report:
+mgr_create_snpguest_response:
   cmd.run:
-    - name: /usr/bin/snpguest report /tmp/cocoattest/report.bin /tmp/cocoattest/request-data.txt
+    - name: /usr/bin/snpguest report /tmp/cocoattest/response.bin /tmp/cocoattest/request-data.txt
     - require:
       - cmd: mgr_write_request_data
       - file: mgr_create_attestdir
 
-mgr_snpguest_report:
+mgr_snpguest_response:
   cmd.run:
-    - name: /usr/bin/cat /tmp/cocoattest/report.bin | /usr/bin/base64
+    - name: /usr/bin/cat /tmp/cocoattest/response.bin | /usr/bin/base64
     - require:
-      - cmd: mgr_create_snpguest_report
+      - cmd: mgr_create_snpguest_response
       - file: mgr_create_attestdir
 
 mgr_create_vlek_certificate:


### PR DESCRIPTION
## What does this PR change?

This PR changes the Confidential computing attestation mechanism on the MLM server side, to prepare the support for more attestation types than the only one currently supported (AMD). In particular, this is a preliminary work that forms the basis to support IBM z series CoCo attestation.

This PR is into a chain of PRs:

CoCo attestation, MLM server base part: https://github.com/uyuni-project/uyuni/pull/11788
On top of that: MLM server IBM part: https://github.com/uyuni-project/uyuni/pull/11867

CoCo attestation, microservices base part: https://github.com/uyuni-project/uyuni/pull/11868
On top of that: microservices IBM part: https://github.com/uyuni-project/uyuni/pull/11856

For all the solution details, please see [RFC: Confidential Compute Attestation for IBM Z series](https://github.com/uyuni-project/uyuni-rfc/pull/113)

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30374
Port(s): # 
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
