### PR TITLE
Include the URL of the GH card from the Status Board

### DIFF
--- a/testsuite/ext-tools/collect_and_tag_flaky_tests.rb
+++ b/testsuite/ext-tools/collect_and_tag_flaky_tests.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 SUSE LLC.
+# Copyright (c) 2026 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 # Collect all the issues from a GitHub project board column
@@ -33,6 +33,7 @@ def fetch_github_issues(organization, project_number, column, headers)
                     content {
                       ... on Issue {
                         title
+                        url
                       }
                     }
                   }
@@ -45,7 +46,7 @@ def fetch_github_issues(organization, project_number, column, headers)
     }
   GRAPHQL
 
-  gh_card_titles = []
+  gh_cards = []
 
   loop do
     request_body = {
@@ -71,7 +72,10 @@ def fetch_github_issues(organization, project_number, column, headers)
 
           if status_field && status_field['item'] && status_field['item']['content']
             issue_title = status_field['item']['content']['title']
-            gh_card_titles.push(issue_title)
+            issue_url = status_field['item']['content']['url']
+            next if issue_title.to_s.empty? || issue_url.to_s.empty?
+
+            gh_cards.push({ title: issue_title, url: issue_url })
             puts "\e[36mCard found\e[0m => #{issue_title}"
           else
             puts "No data found in the GraphQL response for this item.: #{item}"
@@ -91,18 +95,20 @@ def fetch_github_issues(organization, project_number, column, headers)
     end
   end
 
-  gh_card_titles
+  gh_cards
 end
 
 # Function to tag Cucumber feature files
-def tag_cucumber_feature_files(directory_path, gh_card_titles, tag, regex_on_gh_card_title)
+def tag_cucumber_feature_files(directory_path, gh_cards, tag, regex_on_gh_card_title)
   features_tagged = 0
   scenarios_tagged = 0
 
   Find.find(directory_path) do |cucumber_file_path|
     next unless File.extname(cucumber_file_path) == '.feature'
 
-    gh_card_titles.each do |title|
+    gh_cards.each do |card|
+      title = card[:title]
+      url = card[:url]
       feature_matched = false
       matches = regex_on_gh_card_title.match(title)
       next if matches.nil?
@@ -112,9 +118,18 @@ def tag_cucumber_feature_files(directory_path, gh_card_titles, tag, regex_on_gh_
 
       temp_file_path = 'temp_file'
       previous_line = ''
+      lines = File.readlines(cucumber_file_path)
+      skip_next_line = false
       File.open(temp_file_path, 'w') do |temp_file|
-        File.foreach(cucumber_file_path).with_index do |line, _index|
-          feature_match = line.include?(match_feature) && !previous_line.include?("@#{tag}")
+        lines.each_with_index do |line, index|
+          if skip_next_line
+            skip_next_line = false
+            previous_line = line
+            next
+          end
+
+          feature_line_match = line.include?(match_feature)
+          feature_match = feature_line_match && !previous_line.include?("@#{tag}")
           scenario_match = line.include?(match_scenario) && !previous_line.include?("@#{tag}")
 
           if feature_match
@@ -131,6 +146,18 @@ def tag_cucumber_feature_files(directory_path, gh_card_titles, tag, regex_on_gh_
             # Do nothing
           end
           temp_file.puts(line)
+          if feature_line_match
+            related_card_line = "  * Related GitHub Card: #{url}\n"
+            next_line = lines[index + 1]
+            if next_line&.match?(/^\s*\* Related GitHub Card:/)
+              skip_next_line = true
+              if next_line != related_card_line
+                temp_file.puts(related_card_line)
+              end
+            else
+              temp_file.puts(related_card_line)
+            end
+          end
           previous_line = line
         end
       end
@@ -163,7 +190,10 @@ def main
     token = github_credentials.password unless github_credentials.nil?
   end
 
-  exit(1) if token.nil?
+  if token.nil?
+    puts 'GitHub token not found. Please set the GITHUB_TOKEN environment variable or add your credentials to the .netrc file.'
+    exit(1)
+  end
 
   organization = 'SUSE'
   project_number = 23
@@ -182,10 +212,10 @@ def main
   }
 
   columns.each do |column, tag|
-    gh_card_titles = fetch_github_issues(organization, project_number, column, headers)
-    puts ">> Found #{gh_card_titles.length} issues in the '#{column}' column of the GitHub project board."
-    unless gh_card_titles.empty?
-      features_tagged, scenarios_tagged = tag_cucumber_feature_files(directory_path, gh_card_titles, tag, regex_on_gh_card_title)
+    gh_cards = fetch_github_issues(organization, project_number, column, headers)
+    puts ">> Found #{gh_cards.length} issues in the '#{column}' column of the GitHub project board."
+    unless gh_cards.empty?
+      features_tagged, scenarios_tagged = tag_cucumber_feature_files(directory_path, gh_cards, tag, regex_on_gh_card_title)
       puts ">> Tagged #{features_tagged} feature and #{scenarios_tagged} scenarios with the '#{tag}' tag."
     end
   end

--- a/testsuite/podman_runner/06_collect_and_tag_flaky_tests_in_controller.sh
+++ b/testsuite/podman_runner/06_collect_and_tag_flaky_tests_in_controller.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -xe
+set -e
 
 if [[ "$(uname)" == "Darwin" ]]; then
   PODMAN_CMD="podman"
@@ -7,6 +7,8 @@ else
   PODMAN_CMD="sudo -i podman"
 fi
 
-if [[ "$GITHUB_TOKEN" ]]; then
-  $PODMAN_CMD exec controller bash --login -c "export GITHUB_TOKEN=${GITHUB_TOKEN} && cd /testsuite && rake utils:collect_and_tag_flaky_tests"
+if [[ -n "$GITHUB_TOKEN" ]]; then
+  echo "Running flaky tests collection..."
+  set +x
+  $PODMAN_CMD exec -e GITHUB_TOKEN="$GITHUB_TOKEN" controller bash --login -c "cd /testsuite && rake utils:collect_and_tag_flaky_tests"
 fi


### PR DESCRIPTION
## What does this PR change?

This pull request enhances the `collect_and_tag_flaky_tests.rb` script to improve how GitHub issues are collected and referenced when tagging Cucumber feature files. The main improvement is that the script now collects both the issue title and URL for each GitHub card, and it adds a reference to the related GitHub card directly in the feature files when a match is found.

**Enhancements to GitHub Issue Collection and Tagging:**

* The script now fetches both the `title` and `url` for each GitHub issue from the project board, instead of just the title.
* The internal data structure for issues has changed from a list of titles to a list of hashes containing both `title` and `url`. [[1]](diffhunk://#diff-314134bb1303495ef9f84bd6ab6b1236f919cc8f388ecee1d0bcc7427e579277L48-R49) [[2]](diffhunk://#diff-314134bb1303495ef9f84bd6ab6b1236f919cc8f388ecee1d0bcc7427e579277L74-R76) [[3]](diffhunk://#diff-314134bb1303495ef9f84bd6ab6b1236f919cc8f388ecee1d0bcc7427e579277L94-R109)
* When tagging feature files, the script now inserts a line referencing the related GitHub card (including its URL) whenever a feature matches a card.

**Code Modernization and Maintenance:**

* Updated the copyright year in the script header.
* Updated all relevant method signatures and invocations to use the new data structure for GitHub cards.

These changes make it easier to trace tagged features back to their corresponding GitHub issues, improving traceability and maintainability.


## GUI diff

It will include the URL after the Feature title.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

Ports:
- [ ] Manager-5.1


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
