### PR TITLE
Avoid Salt-SSH matching hang when target is a direct hostname of a non-SSH minion (bsc#1226578)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/websocket/RemoteMinionCommands.java
+++ b/java/core/src/main/java/com/suse/manager/webui/websocket/RemoteMinionCommands.java
@@ -154,7 +154,16 @@ public class RemoteMinionCommands {
                 String target = StringUtils.trim(msg.getTarget());
 
                 Optional<CompletionStage<Map<String, Result<Boolean>>>> resSSH =
-                        SALT_API.matchAsyncSSH(target, failAfter);
+                        StringUtils.containsAny(target, '*', '?', '[', ']') ?
+                        // If we detect a glob pattern, we use Salt to match it
+                        SALT_API.matchAsyncSSH(target, failAfter) :
+                        // If it's not a glob pattern, we do a direct lookup. This is to avoid the Salt-SSH behavior
+                        // that tries to connect to any direct hostname, regardless of whether it is in
+                        // the roster or not
+                        MinionServerFactory.findByMinionId(target)
+                                .filter(MinionServer::isSSHPush)
+                                .map(minion -> CompletableFuture.completedFuture(
+                                        Collections.singletonMap(target, Result.success(true))));
 
                 Map<String, CompletionStage<Result<Boolean>>> res = SALT_API.matchAsync(target, failAfter);
                 if (res.isEmpty() && resSSH.isEmpty()) {

--- a/java/spacewalk-java.changes.kwalter.bsc1226578
+++ b/java/spacewalk-java.changes.kwalter.bsc1226578
@@ -1,0 +1,1 @@
+- Fix Remote Commands hang on direct hostname (bsc#1226578)


### PR DESCRIPTION
## What does this PR change?

This fixes an issue with salt ssh hanging if the target is a non salt ssh system

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24647

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
