### PR TITLE
fix gpg key import on first key deploy (bsc#1259482)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
@@ -116,9 +116,9 @@ mgr_deploy_{{ keyname }}:
 {%- if args['gpgkeyurl'] is defined %}
 {%- set keys = args['gpgkeyurl'].split(' ') %}
 {%- for gpgkey in keys %}
-{%- set keyexists = gpgkey.startswith('file://') and salt['file.file_exists'](gpgkey[7:]) or gpgkey.startswith('http') %}
+{%- set is_valid_url = gpgkey.startswith('file://') or gpgkey.startswith('http') %}
 {%- set gpgkey = gpgkey|replace(pillar.get('mgr_origin_server', 'no-replace-origin-not-found'), pillar.get('mgr_server', '')) %}
-{%- if keyexists and gpgkey not in gpg_urls %}
+{%- if is_valid_url and gpgkey not in gpg_urls %}
 {{ gpg_urls.append(gpgkey) | default("", True) }}
 {%- endif %}
 {%- endfor %}
@@ -130,4 +130,9 @@ mgr_deploy_{{ keyname }}:
   module.run:
     - name: pkg.add_repo_key
     - path: {{ url }}
+    {%- if url.startswith('file://') %}
+    - onlyif:
+      - fun: file.file_exists
+        path: {{ url[7:] }}
+    {%- endif %}
 {%- endfor %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.kwalter.bsc1259482
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.kwalter.bsc1259482
@@ -1,0 +1,1 @@
+- Fix gpg key import on first key deploy (bsc#1259482)


### PR DESCRIPTION
## What does this PR change?

fixes an issue where if a gpg keys don't get imported in the same run they are deployed to the system. This is because the gpg key file exits check is done before any of the keys are deployed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29986

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
