### PR TITLE
Try to fix the screenshot issue. Fix the client naming.

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -4,6 +4,7 @@
 require 'rake'
 require 'rubygems'
 require 'yaml'
+require 'json'
 require 'cucumber/rake/task'
 require 'rake/task'
 require 'parallel'
@@ -73,10 +74,50 @@ namespace :parallel do
       include_profiles = profiles.nil? ? '--profile default' : "--profile #{profiles.gsub(',', ' --profile ')}"
       tags = ENV.fetch('TAGS', nil)
       include_tags = tags.nil? ? '' : "--tags #{tags}"
+      # Create a per-build screenshots folder and pass it to Cucumber workers via env var.
+      # The screenshot support code (env.rb) reads SCREENSHOT_DIR to know where to save files.
+      screenshot_dir = "#{result_folder}/screenshots"
+      sh "mkdir -p #{screenshot_dir}", verbose: false
+      old_screenshot_dir = ENV['SCREENSHOT_DIR']
+      ENV['SCREENSHOT_DIR'] = screenshot_dir
       cucumber_opts = "#{include_profiles} #{include_tags} #{html_results} #{json_results} #{junit_results} -f CustomFormatter::PrettyFormatter -r features "
       # Publish the results in reports.cucumber.io if the environment variable PUBLISH_CUCUMBER_REPORT is set
       cucumber_opts << ' --publish' if ENV['PUBLISH_CUCUMBER_REPORT'] == 'true'
-      sh "bundle exec parallel_cucumber -n 6 -o '#{cucumber_opts}' #{features}"
+      # Capture test failures so the rename step always runs before re-raising.
+      # parallel_cucumber exits non-zero when any test fails, which would cause
+      # Rake's sh to raise immediately and skip the rename block.
+      cucumber_error = nil
+      begin
+        sh "bundle exec parallel_cucumber -n 6 -o '#{cucumber_opts}' #{features}"
+      rescue => cucumber_error # rubocop:disable Naming/RescuedExceptionsVariableName
+        nil
+      ensure
+        ENV['SCREENSHOT_DIR'] = old_screenshot_dir
+      end
+      # Rename output files from the opaque TEST_ENV_NUMBER suffix to the client name
+      # extracted from the feature URI inside each JSON (e.g. min_rhlike_salt.feature → min_rhlike_salt).
+      # Only rename when the JSON contains exactly one feature: multi-feature workers keep
+      # their numeric suffix since data.first['uri'] would only represent one of many features.
+      Dir.glob("#{result_folder}/output_#{timestamp}-#{run_set}-[0-9]*.json").each do |json_file|
+        next unless File.size?(json_file)
+
+        begin
+          data = JSON.parse(File.read(json_file))
+          next if data.empty? || data.first['uri'].nil? || data.length != 1
+
+          client_name = File.basename(data.first['uri'], '.feature')
+          new_json = json_file.sub(/-\d+\.json$/, "-#{client_name}.json")
+          next if json_file == new_json
+
+          File.rename(json_file, new_json)
+          html_file = json_file.sub(/\.json$/, '.html')
+          new_html = new_json.sub(/\.json$/, '.html')
+          File.rename(html_file, new_html) if File.exist?(html_file)
+        rescue JSON::ParserError, SystemCallError => e
+          warn "Failed to rename result files for #{json_file}: #{e.class}: #{e.message}"
+        end
+      end
+      raise cucumber_error if cucumber_error
     end
   end
 end

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -4,6 +4,7 @@
 require 'rake'
 require 'rubygems'
 require 'yaml'
+require 'json'
 require 'cucumber/rake/task'
 require 'rake/task'
 require 'parallel'
@@ -73,10 +74,31 @@ namespace :parallel do
       include_profiles = profiles.nil? ? '--profile default' : "--profile #{profiles.gsub(',', ' --profile ')}"
       tags = ENV.fetch('TAGS', nil)
       include_tags = tags.nil? ? '' : "--tags #{tags}"
+      # Create a per-build screenshots folder and pass it to Cucumber workers via env var
+      screenshot_dir = "#{result_folder}/screenshots"
+      sh "mkdir -p #{screenshot_dir}", verbose: false
+      ENV['SCREENSHOT_DIR'] = screenshot_dir
       cucumber_opts = "#{include_profiles} #{include_tags} #{html_results} #{json_results} #{junit_results} -f CustomFormatter::PrettyFormatter -r features "
       # Publish the results in reports.cucumber.io if the environment variable PUBLISH_CUCUMBER_REPORT is set
       cucumber_opts << ' --publish' if ENV['PUBLISH_CUCUMBER_REPORT'] == 'true'
       sh "bundle exec parallel_cucumber -n 6 -o '#{cucumber_opts}' #{features}"
+      # Rename output files from the opaque TEST_ENV_NUMBER suffix to the client name
+      # extracted from the feature URI inside each JSON (e.g. min_rhlike_salt.feature → min_rhlike_salt).
+      Dir.glob("#{result_folder}/output_#{timestamp}-#{run_set}-[0-9]*.json").each do |json_file|
+        next unless File.size?(json_file)
+
+        data = JSON.parse(File.read(json_file))
+        next if data.empty? || data.first['uri'].nil?
+
+        client_name = File.basename(data.first['uri'], '.feature')
+        new_json = json_file.sub(/-\d+\.json$/, "-#{client_name}.json")
+        next if json_file == new_json
+
+        File.rename(json_file, new_json)
+        html_file = json_file.sub(/\.json$/, '.html')
+        new_html = new_json.sub(/\.json$/, '.html')
+        File.rename(html_file, new_html) if File.exist?(html_file)
+      end
     end
   end
 end

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -81,7 +81,15 @@ namespace :parallel do
       cucumber_opts = "#{include_profiles} #{include_tags} #{html_results} #{json_results} #{junit_results} -f CustomFormatter::PrettyFormatter -r features "
       # Publish the results in reports.cucumber.io if the environment variable PUBLISH_CUCUMBER_REPORT is set
       cucumber_opts << ' --publish' if ENV['PUBLISH_CUCUMBER_REPORT'] == 'true'
-      sh "bundle exec parallel_cucumber -n 6 -o '#{cucumber_opts}' #{features}"
+      # Capture test failures so the rename step always runs before re-raising.
+      # parallel_cucumber exits non-zero when any test fails, which would cause
+      # Rake's sh to raise immediately and skip the rename block.
+      cucumber_error = nil
+      begin
+        sh "bundle exec parallel_cucumber -n 6 -o '#{cucumber_opts}' #{features}"
+      rescue => cucumber_error # rubocop:disable Naming/RescuedExceptionsVariableName
+        nil
+      end
       # Rename output files from the opaque TEST_ENV_NUMBER suffix to the client name
       # extracted from the feature URI inside each JSON (e.g. min_rhlike_salt.feature → min_rhlike_salt).
       Dir.glob("#{result_folder}/output_#{timestamp}-#{run_set}-[0-9]*.json").each do |json_file|
@@ -99,6 +107,7 @@ namespace :parallel do
         new_html = new_json.sub(/\.json$/, '.html')
         File.rename(html_file, new_html) if File.exist?(html_file)
       end
+      raise cucumber_error if cucumber_error
     end
   end
 end

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -157,10 +157,21 @@ After do |scenario|
         Capybara.current_session.driver.quit
         visit Capybara.app_host
         log 'Web driver has been restarted'
-      elsif web_session_is_active?
-        handle_screenshot_and_relog(scenario, current_epoch)
       else
-        warn 'There is no active web session; unable to take a screenshot or relog.'
+        # web_session_is_active? can raise WebDriverError if the session went stale
+        # after a long-running step (e.g. bootstrap timeout). Rescue it so the After
+        # hook does not fail and swallow the screenshot opportunity.
+        session_active = begin
+                           web_session_is_active?
+                         rescue Selenium::WebDriver::Error::WebDriverError => e
+                           log "WebDriver session went stale when checking for active session: #{e.message}"
+                           false
+                         end
+        if session_active
+          handle_screenshot_and_relog(scenario, current_epoch)
+        else
+          warn 'There is no active web session; unable to take a screenshot or relog.'
+        end
       end
     ensure
       print_server_logs
@@ -185,8 +196,9 @@ end
 
 # Take a screenshot and try to log back at suse manager server
 def handle_screenshot_and_relog(scenario, current_epoch)
-  Dir.mkdir('screenshots') unless File.directory?('screenshots')
-  path = "screenshots/#{scenario.name.tr(' ./', '_')}.png"
+  screenshot_dir = ENV.fetch('SCREENSHOT_DIR', 'screenshots')
+  Dir.mkdir(screenshot_dir) unless File.directory?(screenshot_dir)
+  path = "#{screenshot_dir}/#{scenario.name.tr(' ./', '_')}.png"
   begin
     click_details_if_present
     page.driver.browser.save_screenshot(path)

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -157,10 +157,22 @@ After do |scenario|
         Capybara.current_session.driver.quit
         visit Capybara.app_host
         log 'Web driver has been restarted'
-      elsif web_session_is_active?
-        handle_screenshot_and_relog(scenario, current_epoch)
       else
-        warn 'There is no active web session; unable to take a screenshot or relog.'
+        # web_session_is_active? can raise WebDriverError if the session went stale
+        # after a long-running step (e.g. bootstrap timeout). Rescue it so the After
+        # hook does not fail and swallow the screenshot opportunity.
+        session_active =
+          begin
+            web_session_is_active?
+          rescue Selenium::WebDriver::Error::WebDriverError => e
+            log "WebDriver session went stale when checking for active session: #{e.message}"
+            false
+          end
+        if session_active
+          handle_screenshot_and_relog(scenario, current_epoch)
+        else
+          warn 'There is no active web session; unable to take a screenshot or relog.'
+        end
       end
     ensure
       print_server_logs

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -185,8 +185,9 @@ end
 
 # Take a screenshot and try to log back at suse manager server
 def handle_screenshot_and_relog(scenario, current_epoch)
-  Dir.mkdir('screenshots') unless File.directory?('screenshots')
-  path = "screenshots/#{scenario.name.tr(' ./', '_')}.png"
+  screenshot_dir = ENV.fetch('SCREENSHOT_DIR', 'screenshots')
+  Dir.mkdir(screenshot_dir) unless File.directory?(screenshot_dir)
+  path = "#{screenshot_dir}/#{scenario.name.tr(' ./', '_')}.png"
   begin
     click_details_if_present
     page.driver.browser.save_screenshot(path)


### PR DESCRIPTION
## What does this PR change?

### Problem

Three issues made debugging init_clients failures difficult:

1. Bootstrap failures produce no screenshot

When a bootstrap scenario times out (e.g. "Bootstrap a Red Hat-like minion" waiting 250s for the minion to appear in the system list), the WebDriver session goes stale. The After hook then called web_session_is_active?, which internally calls page.has_selector? — this raises Selenium::WebDriver::Error::WebDriverError on a stale session. That exception propagated up
through the elsif branch unhandled, causing the After hook itself to fail. No screenshot was taken, no embedding was done in the JSON, and the failure was silent. This was confirmed by the after hook showing status: "failed" in the Cucumber JSON output.

2. Screenshots are not stored in the per-build results folder

handle_screenshot_and_relog used a hardcoded relative path screenshots/, which resolves to the testsuite root  /root/spacewalk/testsuite/screenshots/). Screenshots were never copied into results/{build_number}/screenshots/, making them invisible when browsing a specific build's results.

3. Parallel init_clients output files are named by worker number, not client name

parallel_cucumber -n 6 assigns each worker a sequential $TEST_ENV_NUMBER. Output files end up as output_TIMESTAMP-init_clients-2.json, output_TIMESTAMP-init_clients-5.json, etc. These numbers are arbitrary and change between runs, making it impossible to know which file corresponds to which client without opening each one.

### Solution

features/support/env.rb

- Evaluate web_session_is_active? inside its own rescue Selenium::WebDriver::Error::WebDriverError block. On a stale session it logs the error and returns false instead of propagating, keeping the After hook alive so the screenshot path is still attempted (if the session can be recovered) or the warning is cleanly emitted.
- handle_screenshot_and_relog reads the screenshot directory from ENV['SCREENSHOT_DIR'], defaulting to 'screenshots' for backwards compatibility with serial runs.

Rakefile

- Before launching parallel_cucumber, the parallel task creates results/{build}/screenshots/ and exports it as SCREENSHOT_DIR. This env var is inherited by all worker subprocesses, so every parallel worker saves screenshots directly into the per-build folder.
- After parallel_cucumber completes, the task renames each numbered output file using the uri field from the first feature in the JSON (e.g. features/init_clients/min_rhlike_salt.feature→ output_TIMESTAMP-init_clients-min_rhlike_salt.json). The bare - file (no numeric suffix) is excluded by the glob pattern [0-9]*.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
