### PR TITLE
  Fix screenshots in After hook 

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -157,10 +157,22 @@ After do |scenario|
         Capybara.current_session.driver.quit
         visit Capybara.app_host
         log 'Web driver has been restarted'
-      elsif web_session_is_active?
-        handle_screenshot_and_relog(scenario, current_epoch)
       else
-        warn 'There is no active web session; unable to take a screenshot or relog.'
+        # web_session_is_active? can raise WebDriverError if the session went stale
+        # after a long-running step (e.g. bootstrap timeout). Rescue it so the After
+        # hook does not fail and swallow the screenshot opportunity.
+        session_active =
+          begin
+            web_session_is_active?
+          rescue Selenium::WebDriver::Error::WebDriverError => e
+            log "WebDriver session went stale when checking for active session: #{e.message}"
+            false
+          end
+        if session_active
+          handle_screenshot_and_relog(scenario, current_epoch)
+        else
+          warn 'There is no active web session; unable to take a screenshot or relog.'
+        end
       end
     ensure
       print_server_logs


### PR DESCRIPTION
## What does this PR change?

### Problem

Two issues made debugging init_clients failures difficult:

1. Bootstrap failures produce no screenshot

When a bootstrap scenario times out (e.g. "Bootstrap a Red Hat-like minion" waiting 250s for the minion to appear in the system list), the WebDriver session goes stale. The After hook then called web_session_is_active?, which internally calls page.has_selector? — this raises Selenium::WebDriver::Error::WebDriverError on a stale session. That exception propagated up
through the elsif branch unhandled, causing the After hook itself to fail. No screenshot was taken, no embedding was done in the JSON, and the failure was silent. This was confirmed by the after hook showing status: "failed" in the Cucumber JSON output.

2. Screenshots are not stored in the per-build results folder

handle_screenshot_and_relog used a hardcoded relative path screenshots/, which resolves to the testsuite root  (/root/spacewalk/testsuite/screenshots/). Screenshots were never copied into results/{build_number}/screenshots/, making them invisible when browsing a specific build's results.

### Solution

features/support/env.rb

- Evaluate web_session_is_active? inside its own rescue Selenium::WebDriver::Error::WebDriverError block. On a stale session it logs the error and returns false instead of propagating, keeping the After hook alive so the screenshot path is still attempted (if the session can be recovered) or the warning is cleanly emitted. 

### Testing

Patch apply for run https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-main-dev-acceptance-tests-podman/24/
For run https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-main-dev-acceptance-tests-podman/23/ the screenshot is not visible.
For https://uyuni-ci-main-podman-controller.mgr.suse.de/results/24/output_20260420014828-init_clients-2.html?hide=passed, we see the screenshot.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/30369
 - 5.0: https://github.com/SUSE/spacewalk/pull/30370
 - 4.3: https://github.com/SUSE/spacewalk/pull/30371

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
