### PR TITLE
Update the json result to match client name and not number

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -1,9 +1,10 @@
-# Copyright (c) 2013-2024 SUSE LLC.
+# Copyright (c) 2013-2026 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'rake'
 require 'rubygems'
 require 'yaml'
+require 'json'
 require 'cucumber/rake/task'
 require 'rake/task'
 require 'parallel'
@@ -73,10 +74,45 @@ namespace :parallel do
       include_profiles = profiles.nil? ? '--profile default' : "--profile #{profiles.gsub(',', ' --profile ')}"
       tags = ENV.fetch('TAGS', nil)
       include_tags = tags.nil? ? '' : "--tags #{tags}"
+      # Create a per-build screenshots folder and pass it to Cucumber workers via env var.
+      screenshot_dir = "#{result_folder}/screenshots"
+      sh "mkdir -p #{screenshot_dir}", verbose: false
+      old_screenshot_dir = ENV['SCREENSHOT_DIR']
+      ENV['SCREENSHOT_DIR'] = screenshot_dir
       cucumber_opts = "#{include_profiles} #{include_tags} #{html_results} #{json_results} #{junit_results} -f CustomFormatter::PrettyFormatter -r features "
       # Publish the results in reports.cucumber.io if the environment variable PUBLISH_CUCUMBER_REPORT is set
       cucumber_opts << ' --publish' if ENV['PUBLISH_CUCUMBER_REPORT'] == 'true'
-      sh "bundle exec parallel_cucumber -n 6 -o '#{cucumber_opts}' #{features}"
+      # Capture test failures so the rename step always runs before re-raising.
+      cucumber_error = nil
+      begin
+        sh "bundle exec parallel_cucumber -n 6 -o '#{cucumber_opts}' #{features}"
+      rescue RuntimeError => e
+        cucumber_error = e
+      ensure
+        ENV['SCREENSHOT_DIR'] = old_screenshot_dir
+      end
+      Dir.glob("#{result_folder}/output_#{timestamp}-#{run_set}-*.json").each do |json_file|
+        next unless File.size?(json_file)
+
+        begin
+          data = JSON.parse(File.read(json_file))
+          next if data.empty? || data.first['uri'].nil? || data.length != 1
+
+          client_name = File.basename(data.first['uri'], '.feature')
+          # Use \d* (zero or more digits) to handle both the empty TEST_ENV_NUMBER case
+          # (produces "-.json") and the standard numeric case (produces "-2.json", etc.).
+          new_json = json_file.sub(/-\d*\.json$/, "-#{client_name}.json")
+          next if json_file == new_json
+
+          File.rename(json_file, new_json)
+          html_file = json_file.sub(/\.json$/, '.html')
+          new_html = new_json.sub(/\.json$/, '.html')
+          File.rename(html_file, new_html) if File.exist?(html_file)
+        rescue JSON::ParserError, SystemCallError => e
+          warn "Failed to rename result files for #{json_file}: #{e.class}: #{e.message}"
+        end
+      end
+      raise cucumber_error if cucumber_error
     end
   end
 end

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -2,6 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 require 'English'
+require 'fileutils'
 require 'rubygems'
 require 'tmpdir'
 require 'base64'
@@ -185,8 +186,9 @@ end
 
 # Take a screenshot and try to log back at suse manager server
 def handle_screenshot_and_relog(scenario, current_epoch)
-  Dir.mkdir('screenshots') unless File.directory?('screenshots')
-  path = "screenshots/#{scenario.name.tr(' ./', '_')}.png"
+  screenshot_dir = ENV.fetch('SCREENSHOT_DIR', 'screenshots')
+  FileUtils.mkdir_p(screenshot_dir)
+  path = "#{screenshot_dir}/#{scenario.name.tr(' ./', '_')}.png"
   begin
     click_details_if_present
     page.driver.browser.save_screenshot(path)


### PR DESCRIPTION
## What does this PR change?

### Problem

Parallel init_clients output files are named by worker number, not client name

parallel_cucumber -n 6 assigns each worker a sequential $TEST_ENV_NUMBER. Output files end up as output_TIMESTAMP-init_clients-2.json, output_TIMESTAMP-init_clients-5.json, etc. These numbers are arbitrary and change between runs, making it impossible to know which file corresponds to which client without opening each one.

### Solution

Rakefile

 - Before launching parallel_cucumber, the parallel task creates results/{build}/screenshots/ and exports it as SCREENSHOT_DIR. This env var is inherited by all worker subprocesses, so every parallel worker saves screenshots directly into the per-build folder.
 - After parallel_cucumber completes, the task renames each numbered output file using the uri field from the first feature in the JSON (e.g. features/init_clients/min_rhlike_salt.feature → output_TIMESTAMP-init_clients-min_rhlike_salt.json). The bare - file (no numeric suffix) is excluded by the glob pattern [0-9]*.
 - The rename block is wrapped in a begin/rescue around the parallel_cucumber call. Without this, Rake's sh raises immediately on any non-zero exit code (which is the normal case whenever tests fail), skipping the rename entirely. The error is captured, the rename runs unconditionally, then the error is re-raised so CI still reports failure correctly. This was the root cause of build 24 still showing numbered files despite the fix being deployed.

### New naming in controller:
<img width="471" height="149" alt="image" src="https://github.com/user-attachments/assets/a16bb6b7-1ba0-4602-abff-ca1b4b5e1edf" />

### Old naming in controller:

<img width="385" height="188" alt="image" src="https://github.com/user-attachments/assets/cc10a433-cc2f-41fd-b792-558c4437f6b5" />

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/30366
 - 5.0: https://github.com/SUSE/spacewalk/pull/30367
 - 4.3: https://github.com/SUSE/spacewalk/pull/30368

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
