### PR TITLE
Fix git pillar feature

### DIFF
--- a/testsuite/features/upload_files/salt_git_pillar_setup.sh
+++ b/testsuite/features/upload_files/salt_git_pillar_setup.sh
@@ -39,6 +39,7 @@ EOF
 	git commit -m "initial commit"
 
 	# Store Salt SSH key as authorized for user root
+	touch /root/.ssh/authorized_keys
 	cp /root/.ssh/authorized_keys /root/.ssh/authorized_keys_backup_gitpillar
 	cat /var/lib/salt/.ssh/mgr_ssh_id.pub >> /root/.ssh/authorized_keys
 


### PR DESCRIPTION
## What does this PR change?

### Current issue:

<details>

```cucumber

Repository priorities are without effect. All enabled repositories share the same priority.
'
    And I add repository "SLE-Module-Basesystem15-SP7-Pool" with url "http://minima-mirror-ci-bv.mgr.suse.de/SUSE/Products/SLE-Module-Basesystem/15-SP7/x86_64/product/" on "server" withouterror control   # features/step_definitions/command_steps.rb:856
      This scenario took: 1 seconds

  @test_issue
  Scenario: Preparing Git pillar configuration for Salt master                      # features/secondary/srv_salt_git_pillar.feature:17
      This scenario ran at: 2026-04-20 03:28:53 +0200
Initializing a remote node for 'localhost'.
Host 'localhost' is alive with determined hostname suma-ci-50-controller and FQDN suma-ci-50-controller.mgr.suse.de
Node: suma-ci-50-controller, OS Version: 15.6, Family: opensuse-leap
Node: suma-ci-50-controller, OS Version: 15.6, Family: opensuse-leap
    When I setup a git_pillar environment on the Salt master                        # features/step_definitions/salt_steps.rb:75
      FAIL: mgrctl exec -i 'sh /tmp/salt_git_pillar_setup.sh setup' returned status code = 1.
      Output:
      Setting up git_pillar environment and restarting Salt master and Salt API
      Refreshing service 'container-suseconnect-zypp'.
      Building repository 'SLE-Module-Basesystem15-SP7-Pool' cache [....done]
      Building repository 'SLE-Module-Basesystem15-SP7-Updates' cache [....done]
      Loading repository data...
      Reading installed packages...
      'git-core' is already installed.
      No update candidate for 'git-core-2.51.0-150600.3.15.1.x86_64'. The highest available version is already installed.
      Resolving package dependencies...
      Nothing to do.
      Initialized empty Git repository in /tmp/test_salt_git_pillar.git/.git/
      [master (root-commit) 9b8a40f] initial commit
       Committer: root <root@uyuni-server.mgr.internal>
      Your name and email address were configured automatically based
      on your username and hostname. Please check that they are accurate.
      You can suppress this message by setting them explicitly. Run the
      following command and follow the instructions in your editor to edit
      your configuration file:

          git config --global --edit

      After doing this, you may fix the identity used for this commit with:

          git commit --amend --reset-author

       2 files changed, 4 insertions(+)
       create mode 100644 test_pillar.sls
       create mode 100644 top.sls
       (ScriptError)
      ./features/support/remote_node.rb:169:in `run_local'
      ./features/support/remote_node.rb:117:in `run'
      ./features/step_definitions/salt_steps.rb:83:in `/^I setup a git_pillar environment on the Salt master$/'
      features/secondary/srv_salt_git_pillar.feature:18:in `I setup a git_pillar environment on the Salt master'
```      

</details>

### Fix explanation

Fix Git pillar setup script failing on containerized SUMA (testsuite/features/upload_files/salt_git_pillar_setup.sh)

The setup script failed at the cp /root/.ssh/authorized_keys ... line because in a fresh containerized SUMA deployment, /root/.ssh/authorized_keys does not exist (the directory contains only Salt-related keys). With set -e, the failing cp immediately exits the script with code 1.

Adding touch /root/.ssh/authorized_keys before the cp ensures the file exists — creating an empty one if needed — before it is backed up and appended to.

### Result after fix

<details>

```cucumber
 2 files changed, 4 insertions(+)
 create mode 100644 test_pillar.sls
 create mode 100644 top.sls
ssh-keygen: generating new host keys: RSA ECDSA ED25519
'
    When I setup a git_pillar environment on the Salt master                        # features/step_definitions/salt_steps.rb:75
Initializing a remote node for 'sle_minion'.
Host 'sle_minion' is alive with determined hostname suma-ci-50-suse-minion and FQDN suma-ci-50-suse-minion.mgr.suse.de
Node: suma-ci-50-suse-minion, OS Version: 15-SP7, Family: sles
Node: suma-ci-50-suse-minion, OS Version: 15-SP7, Family: sles
    And I wait until Salt master can reach "sle_minion"                             # features/step_definitions/salt_steps.rb:110
    Then file "/etc/salt/master.d/zz-testing-gitpillar.conf" should exist on server # features/step_definitions/file_management_steps.rb:22
      This scenario took: 8 seconds

  @under_debugging
  Scenario: Check for the expected pillar data after enabling Git pillar             # features/secondary/srv_salt_git_pillar.feature:23
      This scenario ran at: 2026-04-20 03:30:14 +0200
    When I refresh the pillar data                                                   # features/step_definitions/salt_steps.rb:354
    Then the pillar data for "git_pillar_foobar" should be "12345" on "sle_minion"   # features/step_definitions/salt_steps.rb:373
    And the pillar data for "org_id" should be "1" on "sle_minion"                   # features/step_definitions/salt_steps.rb:373
    And the pillar data for "git_pillar_foobar" should be "12345" on the Salt master # features/step_definitions/salt_steps.rb:408
      This scenario took: 5 seconds

  Scenario: Cleanup: Remove Git pillar configuration for Salt master                    # features/secondary/srv_salt_git_pillar.feature:29
      This scenario ran at: 2026-04-20 03:30:19 +0200
mgrctl exec -i 'sh /tmp/salt_git_pillar_setup.sh clean' returned status code = 0.
Output:
'Cleaning git_pillar environment and restarting Salt master and Salt API
'
    When I clean up the git_pillar environment on the Salt master                       # features/step_definitions/salt_steps.rb:86
    And I wait until Salt master can reach "sle_minion"                                 # features/step_definitions/salt_steps.rb:110
    Then file "/etc/salt/master.d/zz-testing-gitpillar.conf" should not exist on server # features/step_definitions/file_management_steps.rb:36
      This scenario took: 4 seconds

  Scenario: Cleanup: Check for the expected pillar data after disabling Git pillar # features/secondary/srv_salt_git_pillar.feature:34
      This scenario ran at: 2026-04-20 03:30:23 +0200
    When I refresh the pillar data                                                 # features/step_definitions/salt_steps.rb:354
    Then the pillar data for "git_pillar_foobar" should be empty on "sle_minion"   # features/step_definitions/salt_steps.rb:393
    And the pillar data for "org_id" should be "1" on "sle_minion"                 # features/step_definitions/salt_steps.rb:373
    And the pillar data for "git_pillar_foobar" should be empty on the Salt master # features/step_definitions/salt_steps.rb:403
      This scenario took: 4 seconds

  Scenario: Pre-Cleanup: Disabling repositories for uninstalling git-core                            # features/secondary/srv_salt_git_pillar.feature:40
      This scenario ran at: 2026-04-20 03:30:27 +0200
mgrctl exec -i 'zypper removerepo SLE-Module-Basesystem15-SP7-Updates' returned status code = 0.
Output:
'Removing repository 'SLE-Module-Basesystem15-SP7-Updates' [...........done]
Repository 'SLE-Module-Basesystem15-SP7-Updates' has been removed.
'
    When I remove repository "SLE-Module-Basesystem15-SP7-Updates" on "server" without error control # features/step_definitions/command_steps.rb:868
mgrctl exec -i 'zypper removerepo SLE-Module-Basesystem15-SP7-Pool' returned status code = 0.
Output:
'Removing repository 'SLE-Module-Basesystem15-SP7-Pool' [...........done]
Repository 'SLE-Module-Basesystem15-SP7-Pool' has been removed.
'
    And I remove repository "SLE-Module-Basesystem15-SP7-Pool" on "server" without error control     # features/step_definitions/command_steps.rb:868
      This scenario took: 1 seconds

6 scenarios (6 passed)
18 steps (18 passed)
```

</details>

###

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/30365
 - 5.0: https://github.com/SUSE/spacewalk/pull/30353

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
