### PR TITLE
security(saml2): default signature algorithm to rsa-sha256

### DIFF
--- a/java/conf/rhn_java_sso.conf
+++ b/java/conf/rhn_java_sso.conf
@@ -101,9 +101,9 @@ onelogin.saml2.idp.x509cert = -----BEGIN CERTIFICATE----- YOUR-IDP-ENTITY-X509-C
 #
 # If a fingerprint is provided, then the certFingerprintAlgorithm is required in order to
 # let the toolkit know which Algorithm was used. Possible values: sha1, sha256, sha384 or sha512
-# 'sha1' is the default value.
-# onelogin.saml2.idp.certfingerprint = 
-# onelogin.saml2.idp.certfingerprint_algorithm = sha1
+# The toolkit default is 'sha1'; the value recommended (and shown below) is 'sha256'.
+# onelogin.saml2.idp.certfingerprint =
+# onelogin.saml2.idp.certfingerprint_algorithm = sha256
 
 
 # Security settings
@@ -161,7 +161,7 @@ onelogin.saml2.security.want_xml_validation = true
 #  'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
 #  'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384'
 #  'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'
-onelogin.saml2.security.signature_algorithm = http://www.w3.org/2000/09/xmldsig#rsa-sha1
+onelogin.saml2.security.signature_algorithm = http://www.w3.org/2001/04/xmldsig-more#rsa-sha256
 
 # Organization
 onelogin.saml2.organization.name = SP YOUR-PRODUCT

--- a/java/spacewalk-java.changes.szachovy.saml2-sha256-signature
+++ b/java/spacewalk-java.changes.szachovy.saml2-sha256-signature
@@ -1,0 +1,1 @@
+- Default SAML2 signature algorithm to rsa-sha256 on fresh installs


### PR DESCRIPTION
## What does this PR change?

- `rhn_java_sso.conf`: switch `onelogin.saml2.security.signature_algorithm` from `rsa-sha1` to `rsa-sha256`.
- Update the `onelogin.saml2.idp.certfingerprint_algorithm` default comment to `sha256`.

A freshly installed SP no longer signs SAML2 messages with SHA-1.

Part of the Rancher security team compliance requirement: SUSE/spacewalk#30199.

Splits out the SAML2 portion of #11709 as a minimal, independently reviewable change.

### Test plan
- [ ] Fresh install verifies default SAML2 config uses rsa-sha256.
- [ ] Existing installations with explicit `signature_algorithm` values are unaffected.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30199
Port(s): https://github.com/SUSE/spacewalk/pull/30722

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
