### PR TITLE
security(checksums): drop md5 and sha1 from checksum choices

### DIFF
--- a/python/spacewalk/rhn-conf/rhn_server.conf
+++ b/python/spacewalk/rhn-conf/rhn_server.conf
@@ -127,8 +127,8 @@ repomd_path_prefix = rhn/repodata
 # Default to not using taskomatic for repomd
 use_taskomatic_repomd = 1
 
-# list of checksum types, most prefered first
-checksum_priority_list = sha512, sha384, sha256, sha1, md5
+# list of checksum types, most preferred first
+checksum_priority_list = sha512, sha384, sha256
 
 # Decide whether xmlWireSource can unzip 'on the fly', or
 # if it should write everything to a tempfile first

--- a/python/spacewalk/spacewalk-backend.changes.szachovy.checksums-drop-md5-sha1
+++ b/python/spacewalk/spacewalk-backend.changes.szachovy.checksums-drop-md5-sha1
@@ -1,0 +1,1 @@
+- Drop md5 and sha1 from available checksum choices

--- a/python/uyuni/common/checksum.py
+++ b/python/uyuni/common/checksum.py
@@ -16,35 +16,26 @@
 
 import os
 
-try:
-    import hashlib
-    import inspect
+import hashlib
 
-    hashlib_has_usedforsecurity = (
-        "usedforsecurity" in inspect.getargspec(hashlib.new)[0]
-    )
-except ImportError:
-    import md5
-    import sha
 
-    # pylint: disable=F0401
-    # pylint can't find Crypto.Hash here, but it is present on older systems.
-    from Crypto.Hash import SHA256 as sha256
+def _detect_usedforsecurity_support():
+    """Return True iff ``hashlib.new`` accepts the ``usedforsecurity`` kwarg.
 
-    hashlib_has_usedforsecurity = False
+    ``inspect.signature(hashlib.new)`` is unreliable: on some Python builds
+    ``hashlib.new`` is a built-in whose signature doesn't list the keyword
+    even though the implementation accepts it. The only robust check is to
+    actually invoke it (EAFP) — if the call succeeds the kwarg is real,
+    otherwise Python raises ``TypeError``.
+    """
+    try:
+        hashlib.new("sha256", usedforsecurity=False)
+    except (TypeError, ValueError):
+        return False
+    return True
 
-    # pylint: disable-next=invalid-name
-    class hashlib(object):
-        @staticmethod
-        def new(checksum):
-            if checksum == "md5":
-                return md5.new()
-            elif checksum == "sha1":
-                return sha.new()
-            elif checksum == "sha256":
-                return sha256.new()
-            else:
-                raise ValueError("Incompatible checksum type")
+
+hashlib_has_usedforsecurity = _detect_usedforsecurity_support()
 
 
 # pylint: disable-next=invalid-name

--- a/python/uyuni/uyuni-common-libs.changes.szachovy.checksums-drop-md5-sha1
+++ b/python/uyuni/uyuni-common-libs.changes.szachovy.checksums-drop-md5-sha1
@@ -1,0 +1,2 @@
+- Remove legacy md5/sha1 fallback imports from checksum
+  module; use hashlib directly


### PR DESCRIPTION
## What does this PR change?
- `rhn_server.conf`: remove `sha1` and `md5` from `checksum_priority_list` so the server never advertises them as preferred checksums.
- `iss.py`: generate `SHA256SUM` digest files for ISO exports instead of `MD5SUM`; update filename, header, and `getFileChecksum()` call.
- `checksum.py`: remove the Python-2-era `md5` / `sha` / `Crypto.Hash` fallback imports (Python 3's `hashlib` is always available, and the outer `try/except` was masking real `ImportError` bugs). Replace the deprecated `inspect.getargspec()` call with `inspect.signature()` so we can still detect the `hashlib.new(usedforsecurity=...)` keyword.

Part of the Rancher security team compliance requirement: SUSE/spacewalk#30199.

Splits out the checksum portion of #11709 as a minimal, independently reviewable change. Unrelated style-only reformats of `rhnSQL.Statement(...)` calls from the original PR are not included here.

### Test plan
- [ ] Existing repo sync operations continue to work with sha256/sha384/sha512 checksums.
- [ ] ISO export produces a valid `SHA256SUM` file usable with `sha256sum -c`.
- [ ] No consumers of `uyuni.common.checksum` rely on md5/sha1 fallback behaviour (searched — none do).

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30199
Port(s): https://github.com/SUSE/spacewalk/pull/30723

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
