### PR TITLE
testsuite: uyuni-main: bypass repo URL for channels added via "spacewalk-common-channels"

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -167,7 +167,7 @@ When(/^I use spacewalk-common-channel to add channel "([^"]*)" with arch "([^"]*
     channel_label = "#{child_channel}-#{arch}"
     steps %(
       When I kill running spacewalk-repo-sync for "#{channel_label}" channel
-      When I use spacewalk-repo-sync to sync channel "#{channel_label}"
+      And I use spacewalk-repo-sync to sync channel "#{channel_label}"
     )
   end
 end
@@ -186,7 +186,7 @@ When(/^I use spacewalk-common-channel to add all "([^"]*)" channels with arch "(
       # The URL of the repo has been bypassed. We must kill running reposync and trigger it again
       steps %(
         When I kill running spacewalk-repo-sync for "#{os_product_version_channel}" channel
-        When I use spacewalk-repo-sync to sync channel "#{os_product_version_channel}"
+        And I use spacewalk-repo-sync to sync channel "#{os_product_version_channel}"
       )
     end
   end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -165,10 +165,8 @@ When(/^I use spacewalk-common-channel to add channel "([^"]*)" with arch "([^"]*
   if product_version_full == 'uyuni-main' && bypass_channel_repo_if_needed("#{child_channel}-#{arch}")
     # The URL of the repo has been bypassed. We must kill running reposync and trigger it again
     channel_label = "#{child_channel}-#{arch}"
-    steps %(
-      When I kill running spacewalk-repo-sync for "#{channel_label}" channel
-      And I use spacewalk-repo-sync to sync channel "#{channel_label}"
-    )
+    kill_reposync_for_channel(channel_label)
+    get_target('server').run("spacewalk-repo-sync -c #{channel_label}", check_errors: false, verbose: true)
   end
 end
 
@@ -184,10 +182,8 @@ When(/^I use spacewalk-common-channel to add all "([^"]*)" channels with arch "(
     log "Channel #{os_product_version_channel} added"
     next unless product_version_full == 'uyuni-main' && bypass_channel_repo_if_needed(os_product_version_channel)
     # The URL of the repo has been bypassed. We must kill running reposync and trigger it again
-    steps %(
-      When I kill running spacewalk-repo-sync for "#{os_product_version_channel}" channel
-      And I use spacewalk-repo-sync to sync channel "#{os_product_version_channel}"
-    )
+    kill_reposync_for_channel(os_product_version_channel)
+    get_target('server').run("spacewalk-repo-sync -c #{os_product_version_channel}", check_errors: false, verbose: true)
   end
 end
 
@@ -394,25 +390,7 @@ When(/^I kill running spacewalk-repo-sync for "([^"]*)"$/) do |os_product_versio
 end
 
 When(/^I kill running spacewalk-repo-sync for "([^"]*)" channel$/) do |channel|
-  time_spent = 0
-  checking_rate = 5
-  repeat_until_timeout(timeout: 60, message: 'Some reposync processes were not killed properly', dont_raise: true) do
-    command_output, _code = get_target('server').run('ps axo pid,cmd | grep spacewalk-repo-sync | grep -v grep', verbose: true, check_errors: false)
-    process = command_output.split("\n")[0]
-    channel_synchronizing = process.split[5].strip
-    if process.nil?
-      log "#{time_spent / 60} minutes waiting for '#{channel}' channel to start its repo-sync processes." if ((time_spent += checking_rate) % 60).zero?
-      sleep checking_rate
-      next
-    elsif channel_synchronizing == channel
-      pid = process.split[0]
-      get_target('server').run("kill #{pid}", verbose: true, check_errors: false)
-      log "Reposync of channel #{channel} killed"
-      break
-    else
-      log "Warning: Repo-sync process for channel '#{channel_synchronizing}' running."
-    end
-  end
+  kill_reposync_for_channel(channel)
 end
 
 Then(/^the reposync logs should not report errors$/) do

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -182,7 +182,7 @@ When(/^I use spacewalk-common-channel to add all "([^"]*)" channels with arch "(
     command = "spacewalk-common-channels -u admin -p admin -a #{architecture} #{os_product_version_channel.gsub("-#{architecture}", '')}"
     get_target('server').run(command, verbose: true)
     log "Channel #{os_product_version_channel} added"
-    if product_version_full == 'uyuni-main' && bypass_channel_repo_if_needed("#{os_product_version_channel}")
+    if product_version_full == 'uyuni-main' && bypass_channel_repo_if_needed(os_product_version_channel)
       # The URL of the repo has been bypassed. We must kill running reposync and trigger it again
       steps %(
         When I kill running spacewalk-repo-sync for "#{os_product_version_channel}" channel

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -162,6 +162,14 @@ end
 When(/^I use spacewalk-common-channel to add channel "([^"]*)" with arch "([^"]*)"$/) do |child_channel, arch|
   command = "spacewalk-common-channels -u admin -p admin -a #{arch} #{child_channel}"
   $command_output, _code = get_target('server').run(command)
+  if product_version_full == 'uyuni-main' && bypass_channel_repo_if_needed("#{child_channel}-#{arch}")
+    # The URL of the repo has been bypassed. We must kill running reposync and trigger it again
+    channel_label = "#{child_channel}-#{arch}"
+    steps %(
+      When I kill running spacewalk-repo-sync for "#{channel_label}" channel
+      When I use spacewalk-repo-sync to sync channel "#{channel_label}"
+    )
+  end
 end
 
 When(/^I use spacewalk-common-channel to add all "([^"]*)" channels with arch "([^"]*)"$/) do |channel, architecture|
@@ -174,6 +182,13 @@ When(/^I use spacewalk-common-channel to add all "([^"]*)" channels with arch "(
     command = "spacewalk-common-channels -u admin -p admin -a #{architecture} #{os_product_version_channel.gsub("-#{architecture}", '')}"
     get_target('server').run(command, verbose: true)
     log "Channel #{os_product_version_channel} added"
+    if product_version_full == 'uyuni-main' && bypass_channel_repo_if_needed("#{os_product_version_channel}")
+      # The URL of the repo has been bypassed. We must kill running reposync and trigger it again
+      steps %(
+        When I kill running spacewalk-repo-sync for "#{os_product_version_channel}" channel
+        When I use spacewalk-repo-sync to sync channel "#{os_product_version_channel}"
+      )
+    end
   end
 end
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -182,13 +182,12 @@ When(/^I use spacewalk-common-channel to add all "([^"]*)" channels with arch "(
     command = "spacewalk-common-channels -u admin -p admin -a #{architecture} #{os_product_version_channel.gsub("-#{architecture}", '')}"
     get_target('server').run(command, verbose: true)
     log "Channel #{os_product_version_channel} added"
-    if product_version_full == 'uyuni-main' && bypass_channel_repo_if_needed(os_product_version_channel)
-      # The URL of the repo has been bypassed. We must kill running reposync and trigger it again
-      steps %(
-        When I kill running spacewalk-repo-sync for "#{os_product_version_channel}" channel
-        And I use spacewalk-repo-sync to sync channel "#{os_product_version_channel}"
-      )
-    end
+    next unless product_version_full == 'uyuni-main' && bypass_channel_repo_if_needed(os_product_version_channel)
+    # The URL of the repo has been bypassed. We must kill running reposync and trigger it again
+    steps %(
+      When I kill running spacewalk-repo-sync for "#{os_product_version_channel}" channel
+      And I use spacewalk-repo-sync to sync channel "#{os_product_version_channel}"
+    )
   end
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -349,6 +349,31 @@ def generate_repository_name(repo_url)
   repo_name[0...64] # HACK: Due to the 64 characters size limit of a repository label
 end
 
+# Update the URL for a given repository
+#
+# @param repo [String] The name of the repository to update
+# @param url [String] The new URL to set for this repository
+def update_repository_url(repo, url)
+  get_target('server').run("spacecmd -u admin -p admin repo_updateurl \"#{repo}\" #{url}", check_errors: false)
+end
+
+# Check whether a bypass of the repository URL is needed for the given channel
+# in case of running tests for uyuni-main
+#
+# @param channel_label [String] The label of the channel to check
+# @return [Boolean, nil] Return true if repo has been updated
+def bypass_channel_repo_if_needed(channel_label)
+  return unless UYUNI_MAIN_REPO_URL_BYPASS.key?(channel_label)
+  return unless product_version_full == 'uyuni-main'
+
+  log "The repo URL for channel #{channel_label} must be bypassed for Uyuni:Main"
+  repo, code = get_target('server').run("spacecmd -q -u admin -p admin softwarechannel_listrepos #{channel_label}", check_errors: true)
+  bypass_url = UYUNI_MAIN_REPO_URL_BYPASS[channel_label]
+  update_repository_url(repo.strip, bypass_url)
+  log "Bypassed repo URL for channel #{channel_label} to #{bypass_url}"
+  return true
+end
+
 #
 # Extracts logs from a given node.
 #

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -349,6 +349,31 @@ def generate_repository_name(repo_url)
   repo_name[0...64] # HACK: Due to the 64 characters size limit of a repository label
 end
 
+# Kill spacewalk-repo-sync execution for a given channel
+#
+# @param channel [String] The channel label of the channel to kill reposync execution
+def kill_reposync_for_channel(channel)
+  time_spent = 0
+  checking_rate = 5
+  repeat_until_timeout(timeout: 60, message: 'Some reposync processes were not killed properly', dont_raise: true) do
+    command_output, _code = get_target('server').run('ps axo pid,cmd | grep spacewalk-repo-sync | grep -v grep', verbose: true, check_errors: false)
+    process = command_output.split("\n")[0]
+    channel_synchronizing = process.split[5].strip
+    if process.nil?
+      log "#{time_spent / 60} minutes waiting for '#{channel}' channel to start its repo-sync processes." if ((time_spent += checking_rate) % 60).zero?
+      sleep checking_rate
+      next
+    elsif channel_synchronizing == channel
+      pid = process.split[0]
+      get_target('server').run("kill #{pid}", verbose: true, check_errors: false)
+      log "Reposync of channel #{channel} killed"
+      break
+    else
+      log "Warning: Repo-sync process for channel '#{channel_synchronizing}' running."
+    end
+  end
+end
+
 # Update the URL for a given repository
 #
 # @param repo [String] The name of the repository to update

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -367,11 +367,11 @@ def bypass_channel_repo_if_needed(channel_label)
   return unless product_version_full == 'uyuni-main'
 
   log "The repo URL for channel #{channel_label} must be bypassed for Uyuni:Main"
-  repo, code = get_target('server').run("spacecmd -q -u admin -p admin softwarechannel_listrepos #{channel_label}", check_errors: true)
+  repo, _code = get_target('server').run("spacecmd -q -u admin -p admin softwarechannel_listrepos #{channel_label}", check_errors: true)
   bypass_url = UYUNI_MAIN_REPO_URL_BYPASS[channel_label]
   update_repository_url(repo.strip, bypass_url)
   log "Bypassed repo URL for channel #{channel_label} to #{bypass_url}"
-  return true
+  true
 end
 
 #

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -1797,3 +1797,35 @@ EMPTY_CHANNELS = %w[
   managertools-sle15-updates-x86_64-sp4
   managertools-beta-sle15-updates-x86_64-sp4
 ].freeze
+
+UYUNI_MAIN_REPO_URL_BYPASS = {
+  'almalinux8-uyuni-client-devel-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/EL_8/',
+  'almalinux9-uyuni-client-devel-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/EL_9/',
+  'amazonlinux2023-uyuni-client-devel-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/EL_9/',
+  'centos7-uyuni-client-devel-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/CentOS_7/',
+  'debian-12-amd64-uyuni-client-devel' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/Debian_12-debbuild/',
+  'opensuse_leap15_6-uyuni-client-devel-aarch64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/openSUSE_Leap_15.0/',
+  'opensuse_leap15_6-uyuni-client-devel-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/openSUSE_Leap_15.0/',
+  'opensuse_micro5_5-uyuni-client-devel-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/openSUSE_Leap_15.0/',
+  'opensuse_tumbleweed-uyuni-client-devel-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/openSUSE_Tumbleweed/',
+  'oraclelinux9-uyuni-client-devel-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/EL_9/',
+  'rockylinux8-uyuni-client-devel-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/EL_8/',
+  'rockylinux9-uyuni-client-devel-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/EL_9/',
+  'sl-micro-6.0-devel-uyuni-client-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SL-Micro6/',
+  'sl-micro-6.1-devel-uyuni-client-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SL-Micro6/',
+  'sl-micro-6.2-devel-uyuni-client-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_16/',
+  'sle-micro-5.3-devel-uyuni-client-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_15/',
+  'sle-micro-5.4-devel-uyuni-client-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_15/',
+  'sle-micro-5.5-devel-uyuni-client-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_15/',
+  'sles12-sp5-uyuni-client-devel-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_12/',
+  'sles15-sp3-devel-uyuni-client-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_15/',
+  'sles15-sp4-devel-uyuni-client-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_15/',
+  'sles15-sp5-devel-uyuni-client-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_15/',
+  'sles15-sp6-devel-uyuni-client-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_15/',
+  'sles15-sp7-devel-uyuni-client-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_15/',
+  'sles16-devel-uyuni-client-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_16/',
+  'suse-microos-5.2-devel-uyuni-client-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_15/',
+  'ubuntu-2204-amd64-uyuni-client-devel' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/xUbuntu_22.04-debbuild/',
+  'ubuntu-2404-amd64-uyuni-client-devel' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/xUbuntu_24.04-debbuild/',
+  'uyuni-proxy-devel-tumbleweed-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/'
+}.freeze


### PR DESCRIPTION
## What does this PR change?

This PR makes testsuite to bypass the default repo URL only when channels are added via `spacewalk-common-channels` CLI, as the default ones are pointing to `Uyuni:Master` instead of `Uyuni:Main` repos.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **changes only for testsuite**

- [x] **DONE**

## Test coverage
- No tests: **changes only for testsuite**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28911

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
