### PR TITLE
Align Rocky ISO image paths

### DIFF
--- a/testsuite/features/build_validation/add_non_MU_repositories/rocky8_minion_add_iso.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/rocky8_minion_add_iso.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 SUSE LLC
+# Copyright (c) 2021-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @rocky8_minion
@@ -8,7 +8,7 @@ Feature: Add the Rocky 8 distribution custom repositories
   I want to filter them out to remove the modules information
 
   Scenario: Download the iso of Rocky 8 DVD and mount it on the server
-    When I mount as "rocky-8-iso" the ISO from "http://mirror.chpc.utah.edu/pub/rocky/8/isos/x86_64/Rocky-x86_64-dvd.iso" in the server, validating its checksum
+    When I mount as "rocky-8-iso" the ISO from "http://mirror.chpc.utah.edu/pub/rocky/8/isos/x86_64/Rocky-8-latest-x86_64-dvd.iso" in the server, validating its checksum
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section


### PR DESCRIPTION
## What does this PR change?

Align ISO paths between rocky 8, 9, and 10.

Matches changes on the mirror:
```
minima-mirror-ci-bv:/var/log # ls /srv/mirror/pub/rocky/*/isos/x86_64/
/srv/mirror/pub/rocky/10/isos/x86_64/:
Rocky-10-latest-x86_64-dvd.iso  Rocky-10-latest-x86_64-dvd.iso.CHECKSUM

/srv/mirror/pub/rocky/8/isos/x86_64/:
Rocky-8-latest-x86_64-dvd.iso  Rocky-8-latest-x86_64-dvd.iso.CHECKSUM

/srv/mirror/pub/rocky/9/isos/x86_64/:
Rocky-9-latest-x86_64-dvd.iso  Rocky-9-latest-x86_64-dvd.iso.CHECKSUM
```

## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes.

- [x] **DONE**


## Test coverage

Cucumber tests were fixed.

- [x] **DONE**

## Links

Port(s):
 * 5.1: https://github.com/SUSE/spacewalk/pull/30406
 * 5.0: https://github.com/SUSE/spacewalk/pull/30405
 * 4.3: https://github.com/SUSE/spacewalk/pull/30404

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
