### PR TITLE
Fix supportconfig extraction for mgradm support config output

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1064,10 +1064,11 @@ end
 When(/I obtain and extract the supportconfig from the server$/) do
   supportconfig_path = '/root/server-supportconfig.tar.gz'
   test_runner_file = '/root/server-supportconfig.tar.gz'
+  localhost = get_target('localhost')
   get_target('server').scp_download(supportconfig_path, test_runner_file)
-  `rm -rf /root/server-supportconfig`
-  `mkdir /root/server-supportconfig && tar xzvf /root/server-supportconfig.tar.gz -C /root/server-supportconfig`
-  `mv /root/server-supportconfig/scc_*/ /root/server-supportconfig/uyuni-server-supportconfig/`
+  localhost.run('rm -rf /root/server-supportconfig')
+  localhost.run('mkdir /root/server-supportconfig && tar xzvf /root/server-supportconfig.tar.gz -C /root/server-supportconfig')
+  localhost.run('mv /root/server-supportconfig/scc_*/*/ /root/server-supportconfig/uyuni-server-supportconfig/')
 end
 
 When(/I remove the autoinstallation files from the server$/) do
@@ -1837,5 +1838,5 @@ end
 
 Then(/^I remove test supportconfig on "([^"]*)"$/) do |host|
   node = get_target(host)
-  node.run('rm /root/server-supportconfig -rf')
+  node.run('rm -rf /root/server-supportconfig')
 end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1067,9 +1067,7 @@ When(/I obtain and extract the supportconfig from the server$/) do
   get_target('server').scp_download(supportconfig_path, test_runner_file)
   `rm -rf /root/server-supportconfig`
   `mkdir /root/server-supportconfig && tar xzvf /root/server-supportconfig.tar.gz -C /root/server-supportconfig`
-  `mv /root/server-supportconfig/scc_* /root/server-supportconfig/test-server`
-  `tar xJvf /root/server-supportconfig/test-server/*supportconfig.txz -C /root/server-supportconfig`
-  `mv /root/server-supportconfig/scc_suse_*/ /root/server-supportconfig/uyuni-server-supportconfig/`
+  `mv /root/server-supportconfig/scc_*/ /root/server-supportconfig/uyuni-server-supportconfig/`
 end
 
 When(/I remove the autoinstallation files from the server$/) do


### PR DESCRIPTION
## What does this PR change?

Fix supportconfig extraction for mgradm support config output

The step I obtain and extract the supportconfig from the server was written for the traditional supportconfig format, which wraps files in a nested .txz inside a scc_suse_* directory. mgradm support config produces a different structure: a flat tar.gz where the outer directory uses a hostname-based name (scc_<hostname>_<date>/) containing an inner container directory (<container-name>/) that holds the actual files.

This caused two silent failures:
1. The inner .txz extraction step found nothing to extract
2. The scc_suse_*/ glob never matched (uyuni CI servers have a hostname-based prefix, not scc_suse_)

Both commands failed silently because they were run via Ruby backticks, which discard the exit code. The path /root/server-supportconfig/uyuni-server-supportconfig/ was never created, so mgr-health-check exited immediately with
"Supportconfig path not accessible". This broke 3 secondary-phase scenarios across 4 consecutive uyuni builds (3700–3703).

Changes:
- Replace the 3-step extraction chain with a single scc_*/*/ glob, which correctly targets the inner container directory where basic-environment.txt lives — the level mgr-health-check requires
- Replace Ruby backticks with get_target('localhost').run() so extraction failures raise immediately at the right scenario, not downstream
- Fix rm /root/server-supportconfig -rf → rm -rf /root/server-supportconfig (flags before path)

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30401
Port(s):
 - 5.1: https://github.com/SUSE/spacewalk/pull/30402
 - 5.0: https://github.com/SUSE/spacewalk/pull/30403

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
