### PR TITLE
Fix SCAP XSLT transformation failure on certain JRE configurations

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/manager/audit/ScapManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/audit/ScapManager.java
@@ -482,12 +482,18 @@ public class ScapManager extends BaseManager {
 
             TransformerFactory factory = TransformerFactory.newInstance();
 
-            //disable access to external entities in xml parsing
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
-
-            //secure processing
+            // Protect against XXE attacks
             factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            try {
+                // Disable access to external entities and stylesheets
+                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            }
+            catch (IllegalArgumentException e) {
+                LOGGER.warn("XML Parser does not support disabling external entities. " +
+                        "XXE protection might be incomplete. Error: {}", e.getMessage());
+            }
 
             Transformer transformer = factory.newTransformer(xslStream);
             transformer.transform(in, out);
@@ -551,17 +557,26 @@ public class ScapManager extends BaseManager {
     private static void applyXsltTransformation(InputStream xmlIn, InputStream xsltIn, OutputStream out) {
         try {
             TransformerFactory factory = TransformerFactory.newInstance();
+            // Protect against XXE attacks
             factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            try {
+                // Disable access to external entities and stylesheets
+                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            }
+            catch (IllegalArgumentException e) {
+                LOGGER.warn("XML Parser does not support disabling external DTDs. " +
+                        "XXE protection might be incomplete. Error: {}", e.getMessage());
+            }
             StreamSource xmlSource = new StreamSource(xmlIn);
             StreamSource xsltSource = new StreamSource(xsltIn);
             StreamResult result = new StreamResult(out);
             Transformer transformer = factory.newTransformer(xsltSource);
             transformer.transform(xmlSource, result);
         }
-        catch (TransformerException | IllegalArgumentException e) {
-            throw new RuntimeException("XSL transform failed or insecure factory configuration", e);
+        catch (TransformerException e) {
+            throw new RuntimeException("XSL transform failed", e);
         }
     }
     /**

--- a/java/spacewalk-java.changes.abid.fix-issue-with-transformation
+++ b/java/spacewalk-java.changes.abid.fix-issue-with-transformation
@@ -1,0 +1,1 @@
+- Fix the JRE-dependent issue with transformation


### PR DESCRIPTION

## What does this PR change?

The setAttribute calls for ACCESS_EXTERNAL_DTD and ACCESS_EXTERNAL_STYLESHEET throw IllegalArgumentException on XML parser implementations that don't support these attributes . The code was treating this as a fatal error. Move that to warning now. It's a JRE-Dependent issue.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
