### PR TITLE
Fix a massive memory allocation causing peaks of memory usage on the controller

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -810,12 +810,19 @@ When(/^I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINI
   # therefore we use a non-standard timeout
   repeat_until_timeout(timeout: 800, message: 'Task does not look FINISHED yet') do
     visit current_url
-    # get all texts in the table column under the "Status" header
-    status_tds = '//tr/td[count(//th[contains(*/text(), \'Status\')]/preceding-sibling::*) + 1]'
+
+    # Scope to the specific table containing both headers
+    base_table = "//table[.//th[contains(*/text(), 'Status')] and .//th[contains(*/text(), 'Start Time')]]"
+
+    # Dynamically find the column indexes within that specific table
+    status_col = "#{base_table}//th[contains(*/text(), 'Status')]/preceding-sibling::*"
+    start_time_col = "#{base_table}//th[contains(*/text(), 'Start Time')]/preceding-sibling::*"
+
+    # Extract only the first 10 data rows from the body of that specific table
+    status_tds = "#{base_table}//tbody/tr[position() <= 10]/td[count(#{status_col}) + 1]"
     statuses = all(:xpath, status_tds).map(&:text)
 
-    # get all texts in the table column under the "Start time" header
-    start_time_tds = '//tr/td[count(//th[contains(*/text(), \'Start Time\')]/preceding-sibling::*) + 1]'
+    start_time_tds = "#{base_table}//tbody/tr[position() <= 10]/td[count(#{start_time_col}) + 1]"
     start_times = all(:xpath, start_time_tds).map(&:text)
 
     # disregard any number of initial unimportant rows, that is:
@@ -825,15 +832,15 @@ When(/^I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINI
       statuses.zip(start_times).drop_while do |status, start_time|
         (status == 'INTERRUPTED' && (start_time.empty? || start_time == 'Task never started')) || status == 'SKIPPED'
       end
-    first_non_skipped = result.first.first
 
-    # halt in case we are done, or if an error is detected
+    first_non_skipped = result.first&.first
+
     break if first_non_skipped == 'FINISHED'
     raise('Taskomatic task was INTERRUPTED') if first_non_skipped == 'INTERRUPTED'
 
-    # otherwise either no row is shown yet, or the task is still RUNNING
-    # continue waiting
-    sleep 1
+    # Wait 5 seconds instead of 1 second between full page reloads.
+    # A background task cache refresh takes a while, checking every second is unnecessary overhead.
+    sleep 5
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

This PR addresses a severe memory consumption issue on the test runner during long-running background operations, specifically when waiting for Taskomatic schedules to complete. 

### 🔍 Evidence of the Issue
During recent acceptance test runs, monitoring of the test runner's resources showed a massive spike in memory usage, hitting an absolute peak of **86.5% RAM** (up from a baseline of ~23%). By correlating the resource monitoring timestamps with the test report, this peak was isolated to the execution of the scenario: `Pre-requisite: ensure the errata cache is computed before software states tests`.

The exact step causing the memory bloat was:
`When I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows`

### 💡 Root Cause Analysis
The original step definition acted as a memory leak due to two factors compounding within the `repeat_until_timeout` loop:

1. **Massive Object Allocation in Ruby:** The step used `all(:xpath, ...).map(&:text)` to fetch the status and start time of *every single row* in the task history table. On instances with heavy test data, this table can contain thousands of rows. Fetching them resulted in Capybara creating thousands of DOM Node objects and Ruby instantiating thousands of String objects. 
2. **Aggressive 1-Second Polling:**
   Because the loop had a `sleep 1` interval, Capybara was forced to execute a `visit current_url` (full page reload and re-render) and recreate those thousands of Ruby objects every single second. The Ruby Garbage Collector was completely overwhelmed by this allocation rate, causing the runner's memory to balloon continuously until the task finished.

### 🛠️ Solution & Optimizations
Since the Ruby logic ultimately only evaluates the top non-skipped row (`first_non_skipped = result.first.first`), there is no need to serialize the entire table.

1. **XPath Constraint:** Modified the XPath selectors to only query the top 10 rows (`[position() <= 10]`). This stops Capybara from needlessly parsing thousands of hidden rows into memory, drastically reducing the Ruby memory footprint.
2. **Reduced Polling Frequency:** Increased the `sleep` interval from `1` second to `5` seconds. Since backend tasks like errata cache generation inherently take time, constantly reloading the DOM every second provides no value and only adds CPU/RAM overhead to the test runner. 

These changes keep the test runner's memory profile completely flat while maintaining the exact same functional check.

<img width="2672" height="1521" src="https://github.com/user-attachments/assets/076fb9fb-fc1c-49ee-9c97-820a84598a83" />

<img width="2672" height="1521" src="https://github.com/user-attachments/assets/6d9ba4bd-13d7-47d3-bcce-5159039168d4" />

(Note the change of timezone)
```
[2026-04-22T23:50:16.835Z] Scenario: Pre-requisite: ensure the errata cache is computed before software states tests               [90m# features/secondary/min_salt_software_states.feature:24[0m
[2026-04-22T23:50:16.835Z] [36mThis scenario ran at: 2026-04-23 01:50:12 +0200[0m
[2026-04-22T23:50:16.835Z] [32mGiven I am on the Systems overview page of this "[32m[1msle_minion[0m[0m[32m"[90m                                          # features/step_definitions/navigation_steps.rb:491[0m[0m
[2026-04-22T23:50:16.835Z] [32mWhen I follow "[32m[1mSoftware[0m[0m[32m" in the [32m[1mcontent area[0m[0m[32m[90m                                                          # features/step_definitions/navigation_steps.rb:373[0m[0m
[2026-04-22T23:50:16.835Z] [32mAnd I follow "[32m[1mList / Remove[0m[0m[32m" in the [32m[1mcontent area[0m[0m[32m[90m                                                      # features/step_definitions/navigation_steps.rb:373[0m[0m
[2026-04-22T23:50:16.835Z] [32mAnd I enter "[32m[1mandromeda-dummy[0m[0m[32m" as the filtered package name[90m                                            # features/step_definitions/navigation_steps.rb:948[0m[0m
[2026-04-22T23:50:16.835Z] [32mAnd I click on the filter button until page does contain "[32m[1mandromeda-dummy-1.0[0m[0m[32m" text[90m                   # features/step_definitions/navigation_steps.rb:934[0m[0m
[2026-04-22T23:50:16.835Z] [32mWhen I follow the left menu "[32m[1mAdmin > Task Schedules[0m[0m[32m"[90m                                                  # features/step_definitions/navigation_steps.rb:413[0m[0m
[2026-04-22T23:53:53.233Z] [32mAnd I follow "[32m[1merrata-cache-default[0m[0m[32m"[90m                                                                   # features/step_definitions/navigation_steps.rb:358[0m[0m
[2026-04-22T23:53:53.233Z] [32mAnd I follow "[32m[1merrata-cache-bunch[0m[0m[32m"[90m                                                                     # features/step_definitions/navigation_steps.rb:358[0m[0m
[2026-04-22T23:53:53.233Z] [32mThen I click on "[32m[1mSingle Run Schedule[0m[0m[32m"[90m                                                                 # features/step_definitions/navigation_steps.rb:307[0m[0m
[2026-04-22T23:53:53.233Z] [32mAnd I should see a "[32m[1mbunch was scheduled[0m[0m[32m" text[90m                                                         # features/step_definitions/navigation_steps.rb:681[0m[0m
[2026-04-22T23:53:53.233Z] [32mThen I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows[90m # features/step_definitions/navigation_steps.rb:801[0m[0m
```


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- [x] Manager-5.1 https://github.com/SUSE/spacewalk/pull/30415

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
