### PR TITLE
testsuite: prevent race condition when checking reposync logs

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -109,10 +109,9 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     Then the SLE15 SP7 product should be added
+    When I use spacewalk-common-channel to add channel "sles15-sp7-devel-uyuni-client" with arch "x86_64"
     And I wait until I see "SUSE Linux Enterprise Server 15 SP7 x86_64" product has been added
     And I wait until all synchronized channels for "sles15-sp7" have finished
-    When I use spacewalk-common-channel to add channel "sles15-sp7-devel-uyuni-client" with arch "x86_64"
-    And I wait until the channel "sles15-sp7-devel-uyuni-client-x86_64" has been synced
       # TODO: Refactor the scenarios in order to not require a full synchronization of SLES 15 SP7 product in Uyuni
     # When I kill running spacewalk-repo-sync for "sles15-sp7"
 

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -109,9 +109,10 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     Then the SLE15 SP7 product should be added
-    When I use spacewalk-common-channel to add channel "sles15-sp7-devel-uyuni-client" with arch "x86_64"
     And I wait until I see "SUSE Linux Enterprise Server 15 SP7 x86_64" product has been added
     And I wait until all synchronized channels for "sles15-sp7" have finished
+    When I use spacewalk-common-channel to add channel "sles15-sp7-devel-uyuni-client" with arch "x86_64"
+    And I wait until the channel "sles15-sp7-devel-uyuni-client-x86_64" has been synced
       # TODO: Refactor the scenarios in order to not require a full synchronization of SLES 15 SP7 product in Uyuni
     # When I kill running spacewalk-repo-sync for "sles15-sp7"
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -166,7 +166,7 @@ When(/^I use spacewalk-common-channel to add channel "([^"]*)" with arch "([^"]*
     # The URL of the repo has been bypassed. We must kill running reposync and trigger it again
     channel_label = "#{child_channel}-#{arch}"
     kill_reposync_for_channel(channel_label)
-    get_target('server').run("spacecmd -u admin -p admin softwarechannel_syncrepos #{channel_label}")
+    get_target('server').run("spacecmd -u admin -p admin softwarechannel_syncrepos #{channel_label}", check_errors: false, verbose: true)
   end
 end
 
@@ -183,7 +183,7 @@ When(/^I use spacewalk-common-channel to add all "([^"]*)" channels with arch "(
     next unless product_version_full == 'uyuni-main' && bypass_channel_repo_if_needed(os_product_version_channel)
     # The URL of the repo has been bypassed. We must kill running reposync and trigger it again
     kill_reposync_for_channel(os_product_version_channel)
-    get_target('server').run("spacecmd -u admin -p admin softwarechannel_syncrepos #{os_product_version_channel}")
+    get_target('server').run("spacecmd -u admin -p admin softwarechannel_syncrepos #{os_product_version_channel}", check_errors: false, verbose: true)
   end
 end
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -166,7 +166,7 @@ When(/^I use spacewalk-common-channel to add channel "([^"]*)" with arch "([^"]*
     # The URL of the repo has been bypassed. We must kill running reposync and trigger it again
     channel_label = "#{child_channel}-#{arch}"
     kill_reposync_for_channel(channel_label)
-    get_target('server').run("spacewalk-repo-sync -c #{channel_label}", check_errors: false, verbose: true)
+    get_target('server').run("spacecmd -u admin -p admin softwarechannel_syncrepos #{channel_label}")
   end
 end
 
@@ -183,7 +183,7 @@ When(/^I use spacewalk-common-channel to add all "([^"]*)" channels with arch "(
     next unless product_version_full == 'uyuni-main' && bypass_channel_repo_if_needed(os_product_version_channel)
     # The URL of the repo has been bypassed. We must kill running reposync and trigger it again
     kill_reposync_for_channel(os_product_version_channel)
-    get_target('server').run("spacewalk-repo-sync -c #{os_product_version_channel}", check_errors: false, verbose: true)
+    get_target('server').run("spacecmd -u admin -p admin softwarechannel_syncrepos #{os_product_version_channel}")
   end
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -732,7 +732,18 @@ def channel_packages_are_downloaded?(channel_name)
     return true if $custom_repositories[client].nil? && client != 'monitoring_server'
   end
   log_tmp_file = '/tmp/reposync.log'
-  get_target('server').extract('/var/log/rhn/reposync.log', log_tmp_file)
+  # Copy reposync logs to /tmp/ to prevent race condition and error when calling .extract()
+  # if the reposync log file is being updated during the underlying "mgrctl cp" call:
+  #
+  # https://github.com/uyuni-project/uyuni-tools/issues/772
+  #
+  # INF Starting mgrctl cp server:/var/log/rhn/reposync.log /tmp/reposync.log
+  # INF Error: 1 error occurred:
+  #  * copying from container: copier: get: "/var/log/rhn/reposync.log": copying /var/log/rhn/reposync.log: archive/tar: write too long
+  # (ScriptError)
+  #
+  get_target('server').run('cp /var/log/rhn/reposync.log /tmp/testsuite_reposync_check.log')
+  get_target('server').extract('/tmp/testsuite_reposync_check.log', log_tmp_file)
   unless File.exist?(log_tmp_file) && !File.empty?(log_tmp_file)
     log "DEBUG: Log file #{log_tmp_file} is missing or empty."
     return false


### PR DESCRIPTION
## What does this PR change?

This PR fixes a potential race condition in the testsuite that can happen while waiting for reposync executions to finish:

```
FAIL: mgrctl cp server:/var/log/rhn/reposync.log /tmp/reposync.log returned status code = 1.
Output:
4:16PM INF Starting mgrctl cp server:/var/log/rhn/reposync.log /tmp/reposync.log
4:16PM INF Error: 1 error occurred:
	* copying from container: copier: get: "/var/log/rhn/reposync.log": copying /var/log/rhn/reposync.log: archive/tar: write too long
 (ScriptError)
./features/support/remote_node.rb:172:in `run_local'
./features/support/remote_node.rb:255:in `extract'
./features/support/commonlib.rb:735:in `channel_packages_are_downloaded?'
./features/support/commonlib.rb:702:in `block (2 levels) in wait_for_channels'
./features/support/commonlib.rb:702:in `reject!'
./features/support/commonlib.rb:702:in `block in wait_for_channels'
./features/support/commonlib.rb:100:in `block in repeat_until_timeout'
./features/support/commonlib.rb:89:in `repeat_until_timeout'
./features/support/commonlib.rb:700:in `wait_for_channels'
./features/step_definitions/command_steps.rb:433:in `/^I wait until all synchronized channels for "([^"]*)" have finished$/'
features/reposync/srv_sync_products.feature:114:in `I wait until all synchronized channels for "sles15-sp7" have finished'
```

It seems this race condition happens, when `mgrctl cp` is trying to transfer a file at the same time that this same file is being written. This can trigger this race condition.

To avoid this, this PR makes testsuite to copy the `/var/log/rhn/reposync.log` file to a temporal file before extracting it from the container.

I've also reported this issue to "uyuni-tools", so this can be fixed also there: https://github.com/uyuni-project/uyuni-tools/issues/772

Additionally, this PR makes bypass mechanism to not trigger reposync execution manually, but instead, delegate the reposync execution to taskomatic. This prevents other scheduled executions from taskomatic to fail as other reposync instance is manually running, leading to some expected channels not being synced.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite changes**

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28911

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
