### PR TITLE
Add event check for automatic Ansible inventory refresh after enabling control node

### DIFF
--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -30,6 +30,10 @@ Feature: Operate an Ansible control node in a normal minion
     And I click on "Update Properties"
     Then I wait until I see "Ansible Control Node type has been applied." text
 
+  Scenario: Check that the automatic Ansible inventory refresh succeeds
+    Given I am on the Systems overview page of this "sle_minion"
+    And I wait until event "Refresh Ansible inventories scheduled by (system)" is completed
+
   Scenario: Apply highstate and check that Ansible is installed
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "States" in the content area

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -25,6 +25,7 @@ Feature: Operate an Ansible control node in a normal minion
 
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "sle_minion"
+    And I store the current last event id for "sle_minion"
     When I follow "Properties" in the content area
     And I check "ansible_control_node"
     And I click on "Update Properties"
@@ -32,7 +33,7 @@ Feature: Operate an Ansible control node in a normal minion
 
   Scenario: Check that the automatic Ansible inventory refresh succeeds
     Given I am on the Systems overview page of this "sle_minion"
-    And I wait until event "Refresh Ansible inventories scheduled by (system)" is completed
+    Then I wait until a new "Refresh Ansible inventories scheduled by (system)" event is completed for "sle_minion"
 
   Scenario: Apply highstate and check that Ansible is installed
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -25,15 +25,15 @@ Feature: Operate an Ansible control node in a normal minion
 
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "sle_minion"
-    And I store the current last event id for "sle_minion"
-    When I follow "Properties" in the content area
+    When I store the current last event id for "sle_minion"
+    And I follow "Properties" in the content area
     And I check "ansible_control_node"
     And I click on "Update Properties"
     Then I wait until I see "Ansible Control Node type has been applied." text
 
   Scenario: Check that the automatic Ansible inventory refresh succeeds
     Given I am on the Systems overview page of this "sle_minion"
-    Then I wait until a new "Refresh Ansible inventories scheduled by (system)" event is completed for "sle_minion"
+    When I wait until a new "Refresh Ansible inventories scheduled by (system)" event is completed for "sle_minion"
 
   Scenario: Apply highstate and check that Ansible is installed
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2021-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@skip_if_github_validation
 @scope_ansible
 @sle_minion
 Feature: Operate an Ansible control node in a normal minion
@@ -25,10 +26,15 @@ Feature: Operate an Ansible control node in a normal minion
 
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Properties" in the content area
+    When I store the current last event id for "sle_minion"
+    And I follow "Properties" in the content area
     And I check "ansible_control_node"
     And I click on "Update Properties"
     Then I wait until I see "Ansible Control Node type has been applied." text
+
+  Scenario: Check that the automatic Ansible inventory refresh succeeds
+    Given I am on the Systems overview page of this "sle_minion"
+    When I wait until a new "Refresh Ansible inventories scheduled by (system)" event is completed for "sle_minion"
 
   Scenario: Apply highstate and check that Ansible is installed
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_salt_lock_packages.feature
+++ b/testsuite/features/secondary/min_salt_lock_packages.feature
@@ -88,12 +88,12 @@ Feature: Lock packages on SLES salt minion
     And I follow "Lock / Unlock"
     And I enter "milkyway-dummy-2.0-1.1" as the filtered package name
     And I click on the filter button
-    And I save the ID of the last event for "sle_minion"
+    And I store the current last event id for "sle_minion"
     When I check row with "milkyway-dummy-2.0-1.1" and arch of "sle_minion"
     And I click on "Lock"
     Then I should see a "Packages has been requested for being locked." text
     And package "milkyway-dummy-2.0-1.1" is reported as pending to be locked
-    When I wait until the new "Lock packages scheduled" event is completed for "sle_minion"
+    When I wait until a new "Lock packages scheduled" event is completed for "sle_minion"
     Then "hoag-dummy-1.1-1.1" should be locked on "sle_minion"
     And "milkyway-dummy-2.0-1.1" should be locked on "sle_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1810,7 +1810,7 @@ When(/^I store the current last event id for "([^"]*)"$/) do |host|
   add_context(:last_event_baseline, get_last_event(host))
 end
 
-Then(/^I wait until a new "([^"]*)" event is completed for "([^"]*)"$/) do |event_summary, host|
+When(/^I wait until a new "([^"]*)" event is completed for "([^"]*)"$/) do |event_summary, host|
   baseline = get_context(:last_event_baseline)
   raise 'No baseline event stored - did the previous scenario run the store step?' if baseline.nil?
 
@@ -1822,7 +1822,7 @@ Then(/^I wait until a new "([^"]*)" event is completed for "([^"]*)"$/) do |even
   wait_action_complete(last_event['id'])
 end
 
-Then(/^I upgrade "([^"]*)" with the last "([^"]*)" version$/) do |host, package|
+When(/^I upgrade "([^"]*)" with the last "([^"]*)" version$/) do |host, package|
   system_name = get_system_name(host)
   last_event_before_upgrade = get_last_event(host)
   last_event = last_event_before_upgrade

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1806,6 +1806,22 @@ Then(/^the word "([^']*)" does not occur more than (\d+) times in "(.*)" on "([^
   raise "The word #{word} occured #{occurences} times, which is more more than #{threshold} times in file #{path}" if occurences > threshold
 end
 
+When(/^I store the current last event id for "([^"]*)"$/) do |host|
+  add_context(:last_event_baseline, get_last_event(host))
+end
+
+Then(/^I wait until a new "([^"]*)" event is completed for "([^"]*)"$/) do |event_summary, host|
+  baseline = get_context(:last_event_baseline)
+  raise 'No baseline event stored - did the previous scenario run the store step?' if baseline.nil?
+
+  last_event = baseline
+  repeat_until_timeout(message: "Waiting for new '#{event_summary}' event to be created") do
+    last_event = get_last_event(host)
+    break if last_event['id'] > baseline['id'] && last_event['summary'].include?(event_summary)
+  end
+  wait_action_complete(last_event['id'])
+end
+
 Then(/^I upgrade "([^"]*)" with the last "([^"]*)" version$/) do |host, package|
   system_name = get_system_name(host)
   last_event_before_upgrade = get_last_event(host)

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1846,9 +1846,30 @@ Then(/^the word "([^']*)" does not occur more than (\d+) times in "(.*)" on "([^
   raise "The word #{word} occured #{occurences} times, which is more more than #{threshold} times in file #{path}" if occurences > threshold
 end
 
+When(/^I store the current last event id for "([^"]*)"$/) do |host|
+  add_context(:last_event_baseline, get_last_events(host).first)
+end
+
+When(/^I wait until a new "([^"]*)" event is completed for "([^"]*)"$/) do |event_summary, host|
+  baseline = get_context(:last_event_baseline)
+  raise 'No baseline event stored - did the previous scenario run the store step?' if baseline.nil?
+
+  target_event = nil
+  repeat_until_timeout(message: "Waiting for new '#{event_summary}' event to be created for #{host}") do
+    target_event =
+      get_last_events(host, 10).find do |e|
+        e["id"] > baseline["id"] && e["summary"].include?(event_summary)
+      end
+    break if target_event
+
+    sleep 2
+  end
+  wait_action_complete(target_event['id'])
+end
+
 When(/^I (upgrade|install) "([^"]*)" on "([^"]*)" using the API$/) do |action, package, host|
   system_name = get_system_name(host)
-  last_event_before_action = get_last_event(host)
+  last_event_before_action = get_last_events(host).first
   last_event = last_event_before_action
   case action
   when 'upgrade'
@@ -1857,7 +1878,7 @@ When(/^I (upgrade|install) "([^"]*)" on "([^"]*)" using the API$/) do |action, p
     trigger_install(system_name, package)
   end
   repeat_until_timeout(timeout: DEFAULT_TIMEOUT, message: 'Waiting for the new event to be created') do
-    last_event = get_last_event(host)
+    last_event = get_last_events(host).first
     break if last_event['id'] > last_event_before_action['id'] && (last_event['summary'].include? 'Package Install/Upgrade')
   end
   wait_action_complete(last_event['id'])
@@ -1865,11 +1886,11 @@ end
 
 When(/^I remove "([^"]*)" on "([^"]*)" using the API$/) do |package, host|
   system_name = get_system_name(host)
-  last_event_before_action = get_last_event(host)
+  last_event_before_action = get_last_events(host).first
   last_event = last_event_before_action
   trigger_remove(system_name, package)
   repeat_until_timeout(timeout: DEFAULT_TIMEOUT, message: 'Waiting for the new event to be created') do
-    last_event = get_last_event(host)
+    last_event = get_last_events(host).first
     break if last_event['id'] > last_event_before_action['id'] && (last_event['summary'].include? 'Package Removal')
   end
   wait_action_complete(last_event['id'])

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -174,27 +174,6 @@ When(/^I wait at most (\d+) seconds until event "([^"]*)" is completed$/) do |fi
   step %(I wait 180 seconds until the event is picked up and #{final_timeout} seconds until the event "#{event}" is completed)
 end
 
-When(/^I save the ID of the last event for "(.*?)"$/) do |host|
-  add_context('last_event_before_action', get_last_event(host)['id'])
-end
-
-When(/^I wait until the new "([^"]*)" event is completed for "(.*?)"$/) do |event_text, host|
-  checkpoint_id = get_context('last_event_before_action')
-  raise ScriptError, "Checkpoint event ID not found — run 'I save the ID of the last event for \"#{host}\"' before this step" if checkpoint_id.nil?
-
-  node = get_target(host)
-  system_id = get_system_id(node)
-  new_event = nil
-  repeat_until_timeout(message: "New '#{event_text}' event not found for #{host}") do
-    events = $api_test.system.get_event_history(system_id, 0, 10)
-    new_event = events.find { |e| e['id'] > checkpoint_id && e['summary'].include?(event_text) }
-    break if new_event
-
-    sleep 2
-  end
-  wait_action_complete(new_event['id'])
-end
-
 When(/^I wait until I see the event "([^"]*)" completed during last minute, refreshing the page$/) do |event|
   repeat_until_timeout(message: "Couldn't find the event #{event}") do
     now = Time.now

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -925,6 +925,13 @@ end
 # @param timeout [Integer] The maximum time to wait for the action to complete, in seconds. Defaults to `DEFAULT_TIMEOUT`.
 def wait_action_complete(actionid, timeout: DEFAULT_TIMEOUT)
   repeat_until_timeout(timeout: timeout, message: 'Action was not found among completed actions') do
+    failed = $api_test.schedule.list_failed_actions
+    if failed.any? { |a| a['id'] == actionid }
+      failed_systems = $api_test.schedule.list_failed_systems(actionid)
+      details = failed_systems.map { |s| "#{s['server_name']}: #{s['message']}" }.join('; ')
+      raise "Action #{actionid} failed: #{details}"
+    end
+
     list = $api_test.schedule.list_completed_actions
     break if list.any? { |a| a['id'] == actionid }
 
@@ -962,13 +969,15 @@ def api_unlock
   end
 end
 
-# Function to get the highest event ID (latest event)
+# Function to get the most recent events for a system
 #
-# @param host String The hostname of the requested system
-def get_last_event(host)
+# @param host [String] The hostname of the requested system
+# @param count [Integer] The number of recent events to return (default: 1)
+# @return [Array<Hash>] The most recent events, newest first
+def get_last_events(host, count = 1)
   node = get_target(host)
   system_id = get_system_id(node)
-  $api_test.system.get_event_history(system_id, 0, 1)[0]
+  $api_test.system.get_event_history(system_id, 0, count)
 end
 
 # Function to trigger the upgrade command


### PR DESCRIPTION
## What does this PR change?

### Summary

- Add a scenario that waits for the automatic "Refresh Ansible inventories scheduled by (system)" event to complete after enabling the Ansible control node system type
- This detects failures caused by the backend auto-registering `/etc/ansible/hosts` as a default inventory path even when the file doesn't exist on the minion (see linked bug report)
- Without this check, the failure only surfaces ~10 scenarios later as a silent timeout on "Display inventories", making root cause difficult to identify

### Context

When the Ansible control node entitlement is applied, `AnsibleManager.createDefaultPaths()` unconditionally registers `/etc/ansible/hosts` as a default inventory. On modern systems this
file doesn't exist, so the automatic refresh event fails. Previously the test didn't check this event, causing a cascading timeout much later.

BSC: https://bugzilla.suse.com/show_bug.cgi?id=1262715

### Note

This change introduce a new concept to check event using the API. It breaks two improvements:
 - more precise event detection, because we save the event ID, we will not detect old Event
 - add capacity to detect failing event, when an event is failing, it will not wait the full timeout => fast fail

I also try to make sure the failures are still readeable because we will have a screenshot.

Example of failure:
 
 ```
   Scenario: Check that the automatic Ansible inventory refresh succeeds                                             # features/secondary/min_ansible_control_node.feature:34
      This scenario ran at: 2026-05-19 01:22:47 +0200
    Given I am on the Systems overview page of this "sle_minion"                                                    # features/step_definitions/navigation_steps.rb:498
    When I wait until a new "Refresh Ansible inventories scheduled by (system)" event is completed for "sle_minion" # features/step_definitions/command_steps.rb:1813
      Action 664 failed: mlm-ci-head-podman-suse-minion.mgr.suse.de: ERROR: Inventory file not found: /etc/ansible/hosts (RuntimeError)
      ./features/support/commonlib.rb:937:in `block in wait_action_complete'
      ./features/support/commonlib.rb:100:in `block in repeat_until_timeout'
      ./features/support/commonlib.rb:89:in `repeat_until_timeout'
      ./features/support/commonlib.rb:932:in `wait_action_complete'
      ./features/step_definitions/command_steps.rb:1822:in `/^I wait until a new "([^"]*)" event is completed for "([^"]*)"$/'
      features/secondary/min_ansible_control_node.feature:36:in `I wait until a new "Refresh Ansible inventories scheduled by (system)" event is completed for "sle_minion"'
=> /var/log/rhn/rhn_web_ui.log
```

### Note 2:

The test is supposed to fail until https://bugzilla.suse.com/show_bug.cgi?id=1262715 is fixed. Disable in github action to not break it.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30427
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/30503
 - 5.0: https://github.com/SUSE/spacewalk/pull/30504

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
