### PR TITLE
Collect stop sshd service after git_pillar setup cleanup

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 SUSE LLC
+# Copyright 2015-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 ### This file contains all step definitions concerning Salt and bootstrapping
@@ -85,8 +85,12 @@ end
 
 When(/^I clean up the git_pillar environment on the Salt master$/) do
   file = 'salt_git_pillar_setup.sh'
+  source = "#{File.dirname(__FILE__)}/../upload_files/#{file}"
+  dest = "/tmp/#{file}"
+  success = file_inject(get_target('server'), source, dest)
+  raise ScriptError, 'File injection failed' unless success
 
-  # Execute "salt_git_pillar_setup.sh setup" on the server
+  # Execute "salt_git_pillar_setup.sh clean" on the server
   get_target('server').run("sh /tmp/#{file} clean", check_errors: true, verbose: true)
 end
 

--- a/testsuite/features/upload_files/salt_git_pillar_setup.sh
+++ b/testsuite/features/upload_files/salt_git_pillar_setup.sh
@@ -45,7 +45,7 @@ EOF
 
 	# Start SSHd service
 	ssh-keygen -A
-	/usr/sbin/sshd -D &
+	systemctl start sshd
 
 	mkdir -p /etc/salt/master.d/
 	cat << 'EOF' > /etc/salt/master.d/zz-testing-gitpillar.conf
@@ -67,6 +67,6 @@ if [ "$1" == "clean" ]; then
 	rm /etc/salt/master.d/zz-testing-gitpillar.conf
 	cp /root/.ssh/authorized_keys_backup_gitpillar /root/.ssh/authorized_keys
 	rm /root/.ssh/authorized_keys_backup_gitpillar
-	pkill sshd
+	systemctl stop sshd
 	systemctl restart salt-master salt-api
 fi


### PR DESCRIPTION
## What does this PR change?

### Summary

- Replace `sshd -D &` with `systemctl start sshd` in `salt_git_pillar_setup.sh` so the SSH daemon persists after the `mgrctl exec` session ends — fixes the root cause where Salt master
couldn't fetch git pillar data because sshd was dead
- Re-upload the setup script before running cleanup in `salt_steps.rb` — fixes exit code 127 when `/tmp/salt_git_pillar_setup.sh` no longer exists at cleanup time
- Replace `pkill sshd` with `systemctl stop sshd` in cleanup to avoid killing unrelated SSH processes
- Add `touch /root/.ssh/authorized_keys` before backup to handle the case where the file doesn't exist yet

### Context

The "Salt master integration with Git pillar" feature was failing with three cascading errors:

1. **Pillar data not found** — `sshd -D &` was started as a background process inside a `mgrctl exec` session. When the session ended, sshd was killed. Salt master then couldn't SSH to
`localhost` to fetch the git pillar repo, so `git_pillar_foobar` was never populated.
2. **Exit code 127 on cleanup** — the cleanup step ran `sh /tmp/salt_git_pillar_setup.sh clean` without re-uploading the script first. The file was gone from `/tmp/`.
3. **YAML syntax error** — cascading from (2), the git pillar config was never removed, causing malformed pillar output.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28578
Port(s):
 - 5.1: https://github.com/SUSE/spacewalk/pull/30505
 - 5.0: https://github.com/SUSE/spacewalk/pull/30506

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
