### PR TITLE
Fix and improve Health Check supportconfig tests

### DIFF
--- a/testsuite/features/secondary/srv_health_check_supportconfig.feature
+++ b/testsuite/features/secondary/srv_health_check_supportconfig.feature
@@ -22,12 +22,12 @@ Feature: Health Check tool based on a supportconfig
     And I wait until port "3000" is listening on "localhost" host
 
   Scenario: Health Check containers are exposing expected metrics
-    Then I check that the health check tool exposes the expected metrics on "localhost"
+    When I check that the health check tool exposes the expected metrics on "localhost"
 
   Scenario: Health Check Grafana dashboard is accessible
-    Then I check that the health check Grafana dashboard is accessible on "localhost"
+    When I check that the health check Grafana dashboard is accessible on "localhost"
 
   Scenario: I can stop the Health Check tool
-    When I stop health check tool on "localhost"
+    When I stop the health check tool on "localhost"
     Then I check that the health check tool is not running on "localhost"
-    And I remove test supportconfig on "localhost"
+    When I remove test supportconfig on "localhost"

--- a/testsuite/features/secondary/srv_health_check_supportconfig.feature
+++ b/testsuite/features/secondary/srv_health_check_supportconfig.feature
@@ -13,7 +13,7 @@ Feature: Health Check tool based on a supportconfig
 
   Scenario: Execute Health Check tool with server supportconfig
     When I start the health check tool with the extracted supportconfig on "localhost"
-    Then I check that the health check tool is running on "localhost"
+    Then the health check tool should be running on "localhost"
 
   Scenario: Health Check containers are healthy and running
     When I wait until port "9000" is listening on "localhost" host
@@ -22,12 +22,12 @@ Feature: Health Check tool based on a supportconfig
     And I wait until port "3000" is listening on "localhost" host
 
   Scenario: Health Check containers are exposing expected metrics
-    When I check that the health check tool exposes the expected metrics on "localhost"
+    Then the health check tool should expose the expected metrics on "localhost"
 
   Scenario: Health Check Grafana dashboard is accessible
-    When I check that the health check Grafana dashboard is accessible on "localhost"
+    Then the health check Grafana dashboard should be accessible on "localhost"
 
   Scenario: I can stop the Health Check tool
     When I stop the health check tool on "localhost"
-    Then I check that the health check tool is not running on "localhost"
+    Then the health check tool should not be running on "localhost"
     When I remove test supportconfig on "localhost"

--- a/testsuite/features/secondary/srv_health_check_supportconfig.feature
+++ b/testsuite/features/secondary/srv_health_check_supportconfig.feature
@@ -12,7 +12,7 @@ Feature: Health Check tool based on a supportconfig
     Then I obtain and extract the supportconfig from the server
 
   Scenario: Execute Health Check tool with server supportconfig
-    When I start the health check tool with supportconfig "/root/server-supportconfig/uyuni-server-supportconfig/" on "localhost"
+    When I start the health check tool with the extracted supportconfig on "localhost"
     Then I check that the health check tool is running on "localhost"
 
   Scenario: Health Check containers are healthy and running
@@ -21,8 +21,11 @@ Feature: Health Check tool based on a supportconfig
     And I wait until port "9081" is listening on "localhost" host
     And I wait until port "3000" is listening on "localhost" host
 
-  Scenario: Health Check containers are exposing metrics
-    Then I check that the health check tool exposes metrics on "localhost"
+  Scenario: Health Check containers are exposing expected metrics
+    Then I check that the health check tool exposes the expected metrics on "localhost"
+
+  Scenario: Health Check Grafana dashboard is accessible
+    Then I check that the health check Grafana dashboard is accessible on "localhost"
 
   Scenario: I can stop the Health Check tool
     When I stop health check tool on "localhost"

--- a/testsuite/features/secondary/srv_health_check_supportconfig.feature
+++ b/testsuite/features/secondary/srv_health_check_supportconfig.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SUSE LLC
+# Copyright (c) 2025-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_salt

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1060,7 +1060,11 @@ When(/I obtain and extract the supportconfig from the server$/) do
   get_target('server').scp_download(supportconfig_path, test_runner_file)
   localhost.run('rm -rf /root/server-supportconfig')
   localhost.run('mkdir /root/server-supportconfig && tar xzvf /root/server-supportconfig.tar.gz -C /root/server-supportconfig')
-  localhost.run('mv /root/server-supportconfig/scc_*/*/ /root/server-supportconfig/uyuni-server-supportconfig/')
+  localhost.run('mv /root/server-supportconfig/scc_*/uyuni-server-container-*/ /root/server-supportconfig/uyuni-server-supportconfig')
+  file_count, _code = localhost.run('ls /root/server-supportconfig/uyuni-server-supportconfig/ | wc -l', check_errors: false)
+  raise 'Extracted supportconfig is empty or inaccessible' unless file_count.strip.to_i.positive?
+
+  add_context(:supportconfig_path, '/root/server-supportconfig/uyuni-server-supportconfig')
 end
 
 When(/I remove the autoinstallation files from the server$/) do
@@ -1795,9 +1799,19 @@ When(/^I start the health check tool with supportconfig "([^"]*)" on "([^"]*)"$/
   node.run("mgr-health-check -v -s #{supportconfig} start", check_errors: true, verbose: true)
 end
 
+When(/^I start the health check tool with the extracted supportconfig on "([^"]*)"$/) do |host|
+  supportconfig_path = get_context(:supportconfig_path)
+  raise 'No supportconfig path in context - did the extraction step succeed?' if supportconfig_path.nil? || supportconfig_path.empty?
+
+  node = get_target(host)
+  node.run("mgr-health-check -v -s #{supportconfig_path} start", check_errors: true, verbose: true)
+end
+
 When(/^I stop health check tool on "([^"]*)"$/) do |host|
   node = get_target(host)
-  node.run('mgr-health-check stop', check_errors: true, verbose: true)
+  node.run('mgr-health-check stop', check_errors: false, verbose: true)
+  node.run('podman rm -f health_check_loki health_check_promtail health_check_supportconfig_exporter health-check-grafana', check_errors: false)
+  node.run('podman network rm -f health-check-network', check_errors: false)
 end
 
 Then(/^the word "([^']*)" does not occur more than (\d+) times in "(.*)" on "([^"]*)"$/) do |word, threshold, path, host|
@@ -1823,6 +1837,20 @@ Then(/^I check that the health check tool exposes metrics on "([^"]*)"$/) do |ho
   node.run("curl -s localhost:9000/metrics.json | python3 -c 'import sys, json; print(json.load(sys.stdin).keys())'", check_errors: true, verbose: true)
 end
 
+Then(/^I check that the health check tool exposes the expected metrics on "([^"]*)"$/) do |host|
+  node = get_target(host)
+  expected_keys = %w[java_config config apache postgresql hw memory disk salt_configuration salt_keys salt_jobs misc]
+  output, _code = node.run("curl -s localhost:9000/metrics.json | python3 -c 'import sys, json; print(list(json.load(sys.stdin).keys()))'", check_errors: true, verbose: true)
+  missing_keys = expected_keys.reject { |key| output.include?(key) }
+  raise "Health check metrics missing expected keys: #{missing_keys.join(', ')}" unless missing_keys.empty?
+end
+
+Then(/^I check that the health check Grafana dashboard is accessible on "([^"]*)"$/) do |host|
+  node = get_target(host)
+  http_code, _code = node.run("curl -s -o /dev/null -w '%{http_code}' localhost:3000", check_errors: true)
+  raise "Grafana dashboard not accessible: expected HTTP 200, got #{http_code.strip}" unless http_code.strip == '200'
+end
+
 Then(/^I check that the health check tool (is|is not) running on "([^"]*)"$/) do |action, host|
   node = get_target(host)
   node.run("test $(podman ps | grep health-check | wc -l) == #{action == 'is' ? '4' : '0'}", check_errors: true, verbose: true)
@@ -1831,4 +1859,5 @@ end
 Then(/^I remove test supportconfig on "([^"]*)"$/) do |host|
   node = get_target(host)
   node.run('rm -rf /root/server-supportconfig')
+  node.run('rm -rf /root/server-supportconfig.tar.gz')
 end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1807,7 +1807,7 @@ When(/^I start the health check tool with the extracted supportconfig on "([^"]*
   node.run("mgr-health-check -v -s #{supportconfig_path} start", check_errors: true, verbose: true)
 end
 
-When(/^I stop health check tool on "([^"]*)"$/) do |host|
+When(/^I stop the health check tool on "([^"]*)"$/) do |host|
   node = get_target(host)
   node.run('mgr-health-check stop', check_errors: false, verbose: true)
   node.run('podman rm -f health_check_loki health_check_promtail health_check_supportconfig_exporter health-check-grafana', check_errors: false)
@@ -1837,7 +1837,7 @@ Then(/^I check that the health check tool exposes metrics on "([^"]*)"$/) do |ho
   node.run("curl -s localhost:9000/metrics.json | python3 -c 'import sys, json; print(json.load(sys.stdin).keys())'", check_errors: true, verbose: true)
 end
 
-Then(/^I check that the health check tool exposes the expected metrics on "([^"]*)"$/) do |host|
+When(/^I check that the health check tool exposes the expected metrics on "([^"]*)"$/) do |host|
   node = get_target(host)
   expected_keys = %w[java_config config apache postgresql hw memory disk salt_configuration salt_keys salt_jobs misc]
   output, _code = node.run("curl -s localhost:9000/metrics.json | python3 -c 'import sys, json; [print(k) for k in json.load(sys.stdin).keys()]'", check_errors: true, verbose: true)
@@ -1846,19 +1846,19 @@ Then(/^I check that the health check tool exposes the expected metrics on "([^"]
   raise "Health check metrics missing expected keys: #{missing_keys.join(', ')}" unless missing_keys.empty?
 end
 
-Then(/^I check that the health check Grafana dashboard is accessible on "([^"]*)"$/) do |host|
+When(/^I check that the health check Grafana dashboard is accessible on "([^"]*)"$/) do |host|
   node = get_target(host)
   http_code, code = node.run("curl -s -o /dev/null -w '%{http_code}' localhost:3000", check_errors: false)
   raise "Grafana dashboard not accessible: curl failed with exit code #{code}" unless code.zero?
   raise "Grafana dashboard not accessible: expected HTTP 200, got #{http_code.strip}" unless http_code.strip == '200'
 end
 
-Then(/^I check that the health check tool (is|is not) running on "([^"]*)"$/) do |action, host|
+When(/^I check that the health check tool (is|is not) running on "([^"]*)"$/) do |action, host|
   node = get_target(host)
   node.run("test $(podman ps | grep health-check | wc -l) == #{action == 'is' ? '4' : '0'}", check_errors: true, verbose: true)
 end
 
-Then(/^I remove test supportconfig on "([^"]*)"$/) do |host|
+When(/^I remove test supportconfig on "([^"]*)"$/) do |host|
   node = get_target(host)
   node.run('rm -rf /root/server-supportconfig')
   node.run('rm -rf /root/server-supportconfig.tar.gz')

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1840,14 +1840,16 @@ end
 Then(/^I check that the health check tool exposes the expected metrics on "([^"]*)"$/) do |host|
   node = get_target(host)
   expected_keys = %w[java_config config apache postgresql hw memory disk salt_configuration salt_keys salt_jobs misc]
-  output, _code = node.run("curl -s localhost:9000/metrics.json | python3 -c 'import sys, json; print(list(json.load(sys.stdin).keys()))'", check_errors: true, verbose: true)
-  missing_keys = expected_keys.reject { |key| output.include?(key) }
+  output, _code = node.run("curl -s localhost:9000/metrics.json | python3 -c 'import sys, json; [print(k) for k in json.load(sys.stdin).keys()]'", check_errors: true, verbose: true)
+  actual_keys = output.strip.split("\n")
+  missing_keys = expected_keys - actual_keys
   raise "Health check metrics missing expected keys: #{missing_keys.join(', ')}" unless missing_keys.empty?
 end
 
 Then(/^I check that the health check Grafana dashboard is accessible on "([^"]*)"$/) do |host|
   node = get_target(host)
-  http_code, _code = node.run("curl -s -o /dev/null -w '%{http_code}' localhost:3000", check_errors: true)
+  http_code, code = node.run("curl -s -o /dev/null -w '%{http_code}' localhost:3000", check_errors: false)
+  raise "Grafana dashboard not accessible: curl failed with exit code #{code}" unless code.zero?
   raise "Grafana dashboard not accessible: expected HTTP 200, got #{http_code.strip}" unless http_code.strip == '200'
 end
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1837,7 +1837,7 @@ Then(/^I check that the health check tool exposes metrics on "([^"]*)"$/) do |ho
   node.run("curl -s localhost:9000/metrics.json | python3 -c 'import sys, json; print(json.load(sys.stdin).keys())'", check_errors: true, verbose: true)
 end
 
-When(/^I check that the health check tool exposes the expected metrics on "([^"]*)"$/) do |host|
+Then(/^the health check tool should expose the expected metrics on "([^"]*)"$/) do |host|
   node = get_target(host)
   expected_keys = %w[java_config config apache postgresql hw memory disk salt_configuration salt_keys salt_jobs misc]
   output, _code = node.run("curl -s localhost:9000/metrics.json | python3 -c 'import sys, json; [print(k) for k in json.load(sys.stdin).keys()]'", check_errors: true, verbose: true)
@@ -1846,14 +1846,14 @@ When(/^I check that the health check tool exposes the expected metrics on "([^"]
   raise "Health check metrics missing expected keys: #{missing_keys.join(', ')}" unless missing_keys.empty?
 end
 
-When(/^I check that the health check Grafana dashboard is accessible on "([^"]*)"$/) do |host|
+Then(/^the health check Grafana dashboard should be accessible on "([^"]*)"$/) do |host|
   node = get_target(host)
   http_code, code = node.run("curl -s -o /dev/null -w '%{http_code}' localhost:3000", check_errors: false)
   raise "Grafana dashboard not accessible: curl failed with exit code #{code}" unless code.zero?
   raise "Grafana dashboard not accessible: expected HTTP 200, got #{http_code.strip}" unless http_code.strip == '200'
 end
 
-When(/^I check that the health check tool (is|is not) running on "([^"]*)"$/) do |action, host|
+Then(/^the health check tool (should be|should not be) running on "([^"]*)"$/) do |action, host|
   node = get_target(host)
   node.run("test $(podman ps | grep health-check | wc -l) == #{action == 'is' ? '4' : '0'}", check_errors: true, verbose: true)
 end


### PR DESCRIPTION
## What does this PR change?

The mgradm support config output contains multiple subdirectories inside scc_*/ (both uyuni-server-container-* and scc_host-support-config-*). The previous glob scc_*/*/ matched both, causing mv to fail with "target is not a directory" when the destination didn't yet exist.

### Bug fix:
- Use specific glob scc_*/uyuni-server-container-*/ to target only the Uyuni container supportconfig

### Improvements:
- Verify the extracted supportconfig directory is non-empty before proceeding; propagate the resolved path between scenarios via add_context/get_context
- Assert all 11 expected metric keys in the exporter response, not just valid JSON
- Add a scenario verifying the Grafana dashboard returns HTTP 200
- Make mgr-health-check stop idempotent: check_errors: false + force-remove containers and network as fallback for partial starts
- Clean up the .tar.gz file in the teardown step

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30401
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/30508
 - 5.0: https://github.com/SUSE/spacewalk/pull/30507

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
