### PR TITLE
Disable TFTP by default in the server chart

### DIFF
--- a/containers/server-helm/server-helm.changes.cbosdo.k8s-disable-tftp
+++ b/containers/server-helm/server-helm.changes.cbosdo.k8s-disable-tftp
@@ -1,0 +1,1 @@
+- Disable TFTP by default

--- a/containers/server-helm/tests/node_selector_test.yaml
+++ b/containers/server-helm/tests/node_selector_test.yaml
@@ -132,6 +132,7 @@ tests:
       global:
         fqdn: "test.example.com"
       tftp:
+        enable: true
         nodeName: "tftp-node"
         nodeSelector:
           "node": "tftp"
@@ -366,6 +367,8 @@ tests:
     set:
       global:
         fqdn: "test.example.com"
+      tftp:
+        enable: true
       placement:
         nodeName: "global-fallback-node"
         nodeSelector:

--- a/containers/server-helm/values.yaml
+++ b/containers/server-helm/values.yaml
@@ -136,7 +136,7 @@ tftp:
   # Leave undefined to use the default
   tag:
   # enable or disable the TFTP server.
-  enable: true
+  enable: false
 
   # Use the host network to bypass the Kubernetes network layers.
   # This may be needed if not using a LoadBalancer for the TFTP server.


### PR DESCRIPTION
## What does this PR change?

podman new installations have tftp server disabled by default. Align the server helm chart too.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
