### PR TITLE
Add global storage class value to the server helm chart

### DIFF
--- a/containers/server-helm/README.md
+++ b/containers/server-helm/README.md
@@ -60,6 +60,12 @@ They all are using the `ReadWriteOnce` access mode and can be configured in the 
 Changing the default volume sizes according to the distributions you plan to synchronize and manage is recommended.
 See the [requirements documentation](https://www.uyuni-project.org/uyuni-docs/en/uyuni/installation-and-upgrade/uyuni-install-requirements.html) for more information.
 
+The `volumes.storageClass` can be used to change the storage class of all the persistent volume claims.
+This would be overridden by each claim's `volumes.<claim>.storageClass` value.
+
+The storage class supports a special `"-"` value to force the storage class to the empty string.
+This is different from the `""` value representing the default storage class by not setting any storage class at all.
+
 ### Node Tuning
 
 For each of the components it is possible to tune the node where the pod will be scheduled.

--- a/containers/server-helm/server-helm.changes.cbosdo.global-storageclass
+++ b/containers/server-helm/server-helm.changes.cbosdo.global-storageclass
@@ -1,0 +1,1 @@
+- Add global storageClass value (bsc#1263089)

--- a/containers/server-helm/templates/_helpers.tpl
+++ b/containers/server-helm/templates/_helpers.tpl
@@ -15,6 +15,7 @@
 {{- end -}}
 
 {{/* uyuni.pvc writes the manifest for a PVC. */}}
+{{/*   "root", the top context, */}}
 {{/*   "name", the volume name, */}}
 {{/*   "volume", the volume config data dictionary of the volume, */}}
 {{/*   "defaultSize", the default size of the volume in case the user messes it up in the values, */}}
@@ -35,11 +36,15 @@ metadata:
 {{ toYaml .volume.annotations | nindent 4 }}
 {{- end }}
 spec:
+{{- $storageClass := .root.Values.volumes.storageClass }}
 {{- if .volume.storageClass }}
-  {{- if eq "-" .volume.storageClass }}
+  {{ $storageClass = .volume.storageClass }}
+{{- end }}
+{{- if $storageClass }}
+  {{- if eq "-" $storageClass }}
   storageClassName: ""
   {{- else }}
-  storageClassName: {{ .volume.storageClass | quote }}
+  storageClassName: {{ $storageClass | quote }}
   {{- end }}
 {{- end }}
   accessModes:

--- a/containers/server-helm/tests/pvc_test.yaml
+++ b/containers/server-helm/tests/pvc_test.yaml
@@ -46,6 +46,46 @@ tests:
         documentSelector:
           path: metadata.name
           value: var-pgsql18
+  
+  - it: should support global custom storageClass
+    set:
+      global.fqdn: uyuni.example.com
+      volumes:
+        storageClass: "fast-ssd"
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: "fast-ssd"
+        documentSelector:
+          path: metadata.name
+          value: var-pgsql18
+      - equal:
+          path: spec.storageClassName
+          value: "fast-ssd"
+        documentSelector:
+          path: metadata.name
+          value: var-cache
+  
+  - it: should support global custom storageClass overrides
+    set:
+      global.fqdn: uyuni.example.com
+      volumes:
+        storageClass: "fast-ssd"
+        var-cache:
+          storageClass: "foo"
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: "fast-ssd"
+        documentSelector:
+          path: metadata.name
+          value: var-pgsql18
+      - equal:
+          path: spec.storageClassName
+          value: "foo"
+        documentSelector:
+          path: metadata.name
+          value: var-cache
 
   - it: should render extraLabels and annotations when provided
     set:

--- a/containers/server-helm/values.schema.json
+++ b/containers/server-helm/values.schema.json
@@ -112,6 +112,10 @@
       "type": "object",
       "description": "Defines the volume claims for the server components",
       "properties": {
+        "storageClass": {
+          "type": ["string", "null"],
+          "description": "default storage class to use for the volume claims"
+        },
         "var-pgsql": { "$ref": "#/definitions/volumeConfig" },
         "var-spacewalk": { "$ref": "#/definitions/volumeConfig" },
         "var-cache": { "$ref": "#/definitions/volumeConfig" },

--- a/containers/server-helm/values.yaml
+++ b/containers/server-helm/values.yaml
@@ -213,6 +213,9 @@ db:
 
 # Configuration of the persistent volume claims.
 volumes:
+  # Default storage class name to use for all the claims
+  storageClass:
+
   # var-pgsql is the volume for the database,
   # a fast and big enough persistent volume will be needed.
   var-pgsql:


### PR DESCRIPTION
## What does this PR change?

If the user doesn't want to use the default storage class of the cluster, but another one for all or most of the Uyuni PVs, he would have to set it for each volume. This would be too painful to do, so add a volumes.storageClass that can be overridden for each volume. (bsc#1263089)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: the chart README has been updated and this is the reference for the values documentation.

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30479
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
