### PR TITLE
Set podman secrets for proxy directly from salt

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/proxy/apply_proxy_config.sls
+++ b/susemanager-utils/susemanager-sls/salt/proxy/apply_proxy_config.sls
@@ -3,6 +3,8 @@
 {%- set mgrpxy_operation = 'install' if not mgrpxy_installed or 'Error: no installed proxy detected' in mgrpxy_status_output else 'upgrade' %}
 {%- set transactional = grains['transactional'] %}
 {%- set installPackages = not (pillar.get('registries') is mapping and pillar.get('registries') | length > 0) %}
+{# do not use secrets on transactional system or on legacy proxy #}
+{%- set use_secrets = not (transactional or mgrpxy_installed and salt['pkg.version_cmp'](mgrpxy_installed, '5.2.6') < 0) %}
 
 podman_installed:
   pkg.installed:
@@ -23,8 +25,10 @@ mgrpxy_installed:
     - template: jinja
     - contents: |
         server: {{ pillar['server'] }}
+        {%- if not use_secrets %}
         ca_crt: |
           {{ pillar['ca_crt'] | replace('\\n', '\n') | indent(10) }}
+        {%- endif %}
         proxy_fqdn: {{ pillar['proxy_fqdn'] }}
         max_cache_size_mb: {{ pillar['max_cache_size_mb']|int }}
         server_version: "{{ pillar['server_version'] }}"
@@ -42,10 +46,12 @@ mgrpxy_installed:
     - contents: |
         httpd:
           system_id: {{ pillar['httpd']['system_id'] }}
+          {%- if not use_secrets %}
           server_crt: |
             {{ pillar['httpd']['server_crt'] | replace('\\n', '\n') | indent(12) }}
           server_key: |
             {{ pillar['httpd']['server_key'] | replace('\\n', '\n') | indent(12) }}
+          {%- endif %}
 
 /etc/uyuni/proxy/ssh.yaml:
   file.managed:
@@ -95,6 +101,29 @@ install_proxy_packages:
 {% if salt['pillar.get']('registries:proxy-tftpd:url') and salt['pillar.get']('registries:proxy-tftpd:tag') %}
   {% do args.append("--tftpd-image " ~ salt['pillar.get']('registries:proxy-tftpd:url') ~ " --tftpd-tag " ~ salt['pillar.get']('registries:proxy-tftpd:tag')) %}
 {% endif %}
+
+{%- if use_secrets %}
+uyuni-ca-secret:
+  cmd.run:
+    - name: /usr/bin/podman secret rm -i uyuni-ca ; /usr/bin/podman secret create uyuni-ca -
+    - stdin: {{ pillar['ca_crt'] | replace('\\n', '\n') | json }}
+    - require:
+      - pkg: podman_installed
+
+uyuni-proxy-cert-secret:
+  cmd.run:
+    - name: /usr/bin/podman secret rm -i uyuni-proxy-cert ; /usr/bin/podman secret create uyuni-proxy-cert -
+    - stdin: {{ pillar['httpd']['server_crt'] | replace('\\n', '\n') | json }}
+    - require:
+      - pkg: podman_installed
+
+uyuni-proxy-key-secret:
+  cmd.run:
+    - name: /usr/bin/podman secret rm -i uyuni-proxy-key ; /usr/bin/podman secret create uyuni-proxy-key -
+    - stdin: {{ pillar['httpd']['server_key'] | replace('\\n', '\n') | json }}
+    - require:
+      - pkg: podman_installed
+{%- endif %}
 
 {% if transactional %}
 
@@ -157,5 +186,10 @@ apply_proxy_configuration:
       - file: /etc/uyuni/proxy/ssh.yaml
       - pkg: podman_installed
       - pkg: mgrpxy_installed
+      {%- if use_secrets %}
+      - cmd: uyuni-ca-secret
+      - cmd: uyuni-proxy-cert-secret
+      - cmd: uyuni-proxy-key-secret
+      {%- endif %}
 
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.nadvornik.secrets_sls
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.nadvornik.secrets_sls
@@ -1,0 +1,1 @@
+- Set podman secrets for proxy directly from salt


### PR DESCRIPTION
## What does this PR change?

When a proxy is configured via salt, it creates podman secrets with certificates directly, without storing them in config.
On transactional systems the secrets can't be modified from salt directly, so the fallback is to write the certs to config as before and mgrpxy moves them to secrets after reboot.
On legacy 5.1 proxy there is no change, the certs stay in config until upgrade to 5.2.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29409

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
