### PR TITLE
use API instead of UI for system deletion

### DIFF
--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -68,7 +68,7 @@ Feature: Bootstrapping with reactivation key
   Scenario: Cleanup: delete SLES minion after reactivation tests
     When I delete "sle_minion" system using the api
     Then "sle_minion" should not be registered
-    And I perform a full salt minion cleanup on "sle_minion"
+    When I perform a full salt minion cleanup on "sle_minion"
 
   Scenario: Cleanup: bootstrap a SLES minion after reactivation tests
     And I follow the left menu "Systems > Bootstrapping"
@@ -81,6 +81,6 @@ Feature: Bootstrapping with reactivation key
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
     And I wait until I see "Bootstrap process initiated." text
-    And I follow the left menu "Systems > System List > All"
+    When I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "sle_minion", refreshing the page
     And I wait until onboarding is completed for "sle_minion"

--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -67,8 +67,8 @@ Feature: Bootstrapping with reactivation key
 
   Scenario: Cleanup: delete SLES minion after reactivation tests
     When I delete "sle_minion" system using the api
-    And I perform a full salt minion cleanup on "sle_minion"
     Then "sle_minion" should not be registered
+    And I perform a full salt minion cleanup on "sle_minion"
 
   Scenario: Cleanup: bootstrap a SLES minion after reactivation tests
     And I follow the left menu "Systems > Bootstrapping"

--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -66,16 +66,11 @@ Feature: Bootstrapping with reactivation key
     And I wait until event "Apply states [certs, channels, packages, services.salt-minion] scheduled" is completed
 
   Scenario: Cleanup: delete SLES minion after reactivation tests
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
-    And I wait until Salt client is inactive on "sle_minion"
+    When I delete "sle_minion" system using the api
+    And I perform a full salt minion cleanup on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Cleanup: bootstrap a SLES minion after reactivation tests
-    When I perform a full salt minion cleanup on "sle_minion"
     And I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle_minion" as "hostname"


### PR DESCRIPTION
## What does this PR change?

Delete system is taking 4 minutes (know issue). For the cleanup tag, use the API to speed up the test and avoid subsequent issue when deleting and adding back minion (create lot of subsequent failures).

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30305
Port(s): 
  - only visible for uyuni

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
