### PR TITLE
Postponing action execution if not ready to run

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/action/Action.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/Action.java
@@ -677,5 +677,14 @@ public class Action extends BaseDomainHelper implements Serializable, WebSocketA
         return false; //default
     }
 
+    /**
+     * checks whether the action is ready to run: if not, the action execution will be postponed by some seconds
+     * see MinionActionExecutor.execute()
+     * @return true if the action is ready to run
+     */
+    public boolean isReadyToRun() {
+        return true; //default
+    }
+
 }
 

--- a/java/core/src/main/java/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
+++ b/java/core/src/main/java/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
@@ -108,27 +108,54 @@ public class MinionActionExecutor extends RhnJavaJob {
         }
 
         Action action = ActionFactory.lookupById(actionId);
+        long queuedServerActionsNumber = countQueuedServerActions(action);
 
         if (log.isDebugEnabled()) {
-            log.debug("Number of Queued Server Actions for {}: {}", actionId, countQueuedServerActions(action));
+            log.debug("Number of Queued Server Actions for {}: {}", actionId, queuedServerActionsNumber);
         }
 
         // HACK: it is possible that this Taskomatic task triggered before the corresponding Action was really
         // COMMITted in the database. If it is the case, reschedule the Job.
+        // Also: the Action could not be ready for execution yet. If this is the case, reschedule the Job as well
         int retryCount = (Integer) context.getTrigger().getJobDataMap().getOrDefault("retryCount", 1);
+        boolean failedNoServerActionsYet = (0 == queuedServerActionsNumber);
+        boolean failedNotReadyToRun = ((null != action) && (!action.isReadyToRun()));
 
-        if (retryCount <= MAX_RETRIES && countQueuedServerActions(action) == 0) {
-            log.debug("Couldn't find queued actions for action {}, scheduling retry {} of {}",
-                actionId, retryCount, MAX_RETRIES
-            );
+        if ((retryCount <= MAX_RETRIES) && (failedNoServerActionsYet || failedNotReadyToRun)) {
+            if (failedNoServerActionsYet) {
+                log.debug("Couldn't find queued actions for action {}, scheduling retry {} of {}",
+                        actionId, retryCount, MAX_RETRIES);
+            }
+            else {
+                log.debug("Action {} is not yet ready to run, scheduling retry {} of {}",
+                        actionId, retryCount, MAX_RETRIES);
+            }
             try {
                 // The retry interval gradually increases based on the number of retries.
+                // With 25 max retries, it can be rescheduled at max 1+2+3+...+25 seconds, that is 5 min 25 s
                 TaskoQuartzHelper.rescheduleJob(context, retryCount, retryCount);
                 return;
             }
             catch (SchedulerException e) {
                 log.error("Error scheduling retry job for action {}.", actionId, e);
             }
+        }
+
+        if (failedNotReadyToRun) {
+            log.debug("Action {} is not yet ready to run after {} retries, marking it as failed",
+                    actionId, MAX_RETRIES);
+
+            // although this null check is already included in failedNotReadyToRun,
+            // it's an indirect check, so we leave it as a redundancy safety net
+            if (null != action) {
+                action.getServerActions().forEach(
+                        sa -> {
+                            sa.setStatusFailed();
+                            sa.setResultMsg("Action is not yet ready to run after %d retries".formatted(MAX_RETRIES));
+                            sa.setResultCode(-1L);
+                        });
+            }
+            return;
         }
 
         if (action == null) {


### PR DESCRIPTION
## What does this PR change?

This implementation makes possible for an action execution to be postponed if the Action is not yet ready to run, i.e if the implementation of the Action method `isReadyToRun() `returns false.

This sums up to the condition where a Taskomatic task was triggered before the corresponding Action was actually committed in the database.

In both cases, the quartz event scheduling the Action execution is postponed in time by a number of seconds equal to the retry count (that is 1 second the first time, 2 seconds the second time and so on) up to a maximum of 25 retries (totaling 5 min 25 sec maximum)

This implementation is made with the CoCo attestation action in mind (it could not have all the input data to be ready to execute at scheduling time), but it can be used in future more in general cases, when for any reason, the Action could not be immediately ready to be executed.


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/30374
Port(s): 
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
