### PR TITLE
Test external CA on RKE2 server and proxy

### DIFF
--- a/testsuite/features/kubernetes/srv_rke2_external_ca.feature
+++ b/testsuite/features/kubernetes/srv_rke2_external_ca.feature
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+# Verifies that MLM supports replacing the self-signed CA with an externally
+# provided one on both the server and proxy RKE2 clusters.
+
+@rke2
+Feature: RKE2 External CA Replacement
+
+  Scenario: Pre-requisite: Back up CA certificates before external CA replacement
+    Given The Kubernetes cluster is ready on "server"
+    And I back up the CA certificates on the server and proxy
+
+  Scenario: Replace self-signed CA with an external CA
+    When I generate an external CA on "server"
+    And I replace the uyuni-ca secret with the external CA on "server"
+    And I delete the leaf certificate secrets on "server"
+    Then the "uyuni-cert" secret on "server" should be re-issued within 10 minutes
+    And the "db-cert" secret on "server" should be re-issued within 5 minutes
+    And the "uyuni-cert" certificate on "server" should be signed by the external CA
+    And the "db-cert" certificate on "server" should be signed by the external CA
+
+  Scenario: Verify server deployments recover after CA replacement
+    Then the "db" deployment on "server" should become ready within 5 minutes
+    And the "uyuni" deployment on "server" should become ready within 15 minutes
+
+  Scenario: Inject external CA into proxy cluster
+    Given The Kubernetes cluster is ready on "proxy"
+    When I re-generate the proxy certificate on the server using the external CA
+    And I transfer the proxy certificate from the server to "proxy"
+    And I update the uyuni-ca configmap on "proxy" with the external CA
+    Then the "proxy-cert" certificate on "proxy" should be signed by the external CA
+
+  Scenario: Verify proxy deployments recover after CA replacement
+    Then the "uyuni-proxy" deployment on "proxy" should become ready within 10 minutes
+    And the "uyuni-proxy-tftp" deployment on "proxy" should become ready within 10 minutes
+
+  Scenario: Cleanup: Restore original CA certificates after external CA tests
+    When I restore the original CA certificates on the server and proxy

--- a/testsuite/features/step_definitions/rke2_steps.rb
+++ b/testsuite/features/step_definitions/rke2_steps.rb
@@ -1,4 +1,4 @@
-# Copyright 2026 SUSE LLC
+# Copyright (c) 2026 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 Given('The first-time setup job is successful') do
@@ -24,4 +24,212 @@ end
 
 And(/^(?:the|I wait until the) "(.*)" deployment on "(.*)" (?:becomes|should become) ready within (.*) minutes$/) do |name, target, mins|
   wait_for_deployment(target, name, mins.to_i)
+end
+
+### External CA setup and teardown steps
+
+Given('I back up the CA certificates on the server and proxy') do
+  backup_dir = '/root/ca-backup'
+  ca_dir = '/root/test-external-ca'
+  ca_cn = 'External Test CA'
+
+  add_context(:backup_dir, backup_dir)
+  add_context(:external_ca_dir, ca_dir)
+  add_context(:external_ca_cn, ca_cn)
+
+  server = get_target('server')
+  server.run_local("mkdir -p #{backup_dir}")
+
+  _out, code = server.run_local(
+    "kubectl get secret uyuni-ca -n cert-manager -o yaml --show-managed-fields=false > #{backup_dir}/uyuni-ca-secret.yaml"
+  )
+  raise SystemCallError, 'Failed to backup uyuni-ca secret' unless code.zero?
+
+  _out, code = server.run_local(
+    "kubectl get certificate uyuni-ca -n cert-manager -o yaml --show-managed-fields=false > #{backup_dir}/uyuni-ca-cert.yaml"
+  )
+  raise SystemCallError, 'Failed to backup uyuni-ca Certificate CR' unless code.zero?
+
+  begin
+    proxy = get_target('proxy')
+    proxy.run_local("mkdir -p #{backup_dir}")
+    proxy.run_local(
+      "kubectl get configmap uyuni-ca -n uyuni -o yaml > #{backup_dir}/uyuni-ca-configmap.yaml",
+      check_errors: false
+    )
+  rescue StandardError
+    $stdout.puts 'Proxy configmap backup skipped (proxy not available yet)'
+  end
+end
+
+When('I restore the original CA certificates on the server and proxy') do
+  backup_dir = get_context(:backup_dir)
+  ca_dir = get_context(:external_ca_dir)
+  server = get_target('server')
+
+  server.run_local('kubectl delete certificate uyuni-ca -n cert-manager --ignore-not-found')
+  server.run_local('kubectl delete secret uyuni-ca -n cert-manager --ignore-not-found')
+  server.run_local("kubectl apply -f #{backup_dir}/uyuni-ca-secret.yaml")
+  server.run_local("kubectl apply -f #{backup_dir}/uyuni-ca-cert.yaml")
+
+  server.run_local('kubectl delete secret uyuni-cert db-cert proxy-cert -n uyuni --ignore-not-found')
+  %w[uyuni-cert db-cert].each do |cert|
+    server.run_local(
+      "kubectl get certificate #{cert} -n uyuni -o yaml --show-managed-fields=false > /tmp/#{cert}-cr.yaml"
+    )
+    server.run_local("kubectl delete certificate #{cert} -n uyuni --ignore-not-found")
+    server.run_local("kubectl apply -f /tmp/#{cert}-cr.yaml")
+  end
+  server.run_local('kubectl delete certificate proxy-cert -n uyuni --ignore-not-found')
+
+  repeat_until_timeout(timeout: 300, message: 'uyuni-cert was not re-issued during restore') do
+    _out, code = server.run_local('kubectl get secret uyuni-cert -n uyuni', check_errors: false)
+    break if code.zero?
+
+    sleep 5
+  end
+
+  local_ca = Tempfile.new('uyuni-restored-ca')
+  remote_ca = "/tmp/uyuni-restored-ca-#{$PROCESS_ID}.crt"
+  begin
+    server.run_local("kubectl get secret uyuni-ca -n cert-manager -o jsonpath='{.data.tls\\.crt}' | base64 -d > #{remote_ca}")
+    file_extract(server, remote_ca, local_ca.path)
+    server.run_local("rm -f #{remote_ca}")
+    FileUtils.cp(local_ca.path, "/etc/pki/trust/anchors/#{server.full_hostname}.cert")
+    raise ScriptError, 'Failed to update CA certificates' unless system('update-ca-certificates')
+  ensure
+    local_ca.close
+    local_ca.unlink
+  end
+
+  server.run_local("rm -rf #{backup_dir} #{ca_dir}")
+
+  begin
+    proxy = get_target('proxy')
+    proxy.run_local(
+      "test -f #{backup_dir}/uyuni-ca-configmap.yaml && kubectl apply -f #{backup_dir}/uyuni-ca-configmap.yaml --force",
+      check_errors: false
+    )
+    proxy.run_local('kubectl delete secret proxy-cert -n uyuni --ignore-not-found', check_errors: false)
+    proxy.run_local("rm -rf #{backup_dir}", check_errors: false)
+  rescue StandardError
+    $stdout.puts 'Proxy restore skipped (proxy not available)'
+  end
+end
+
+### External CA replacement steps
+
+When(/^I generate an external CA on "(.*)"$/) do |target|
+  ca_dir = get_context(:external_ca_dir)
+  ca_cn = get_context(:external_ca_cn)
+  get_target(target).run_local("mkdir -p #{ca_dir}")
+  _out, code = get_target(target).run_local(
+    "openssl ecparam -genkey -name prime256v1 -noout -out #{ca_dir}/ca.key && " \
+    "openssl req -new -x509 -key #{ca_dir}/ca.key -out #{ca_dir}/ca.crt " \
+    "-days 3650 -subj '/C=DE/ST=Bayern/L=Nurnberg/O=#{ca_cn}/OU=Testing/CN=External CA'"
+  )
+  raise SystemCallError, 'Failed to generate external CA' unless code.zero?
+end
+
+When(/^I replace the uyuni-ca secret with the external CA on "(.*)"$/) do |target|
+  ca_dir = get_context(:external_ca_dir)
+  get_target(target).run_local('kubectl delete certificate uyuni-ca -n cert-manager --ignore-not-found')
+  get_target(target).run_local('kubectl delete secret uyuni-ca -n cert-manager --ignore-not-found')
+  cmd = 'kubectl create secret tls uyuni-ca -n cert-manager ' \
+        "--cert=#{ca_dir}/ca.crt --key=#{ca_dir}/ca.key"
+  _out, code = get_target(target).run_local(cmd)
+  raise SystemCallError, 'Failed to replace uyuni-ca secret' unless code.zero?
+end
+
+When(/^I delete the leaf certificate secrets on "(.*)"$/) do |target|
+  _out, code = get_target(target).run_local(
+    'kubectl delete secret uyuni-cert db-cert -n uyuni --ignore-not-found'
+  )
+  raise SystemCallError, 'Failed to delete leaf certificate secrets' unless code.zero?
+end
+
+Then(/^the "(.*)" secret on "(.*)" should be re-issued within (\d+) minutes$/) do |secret, target, mins|
+  repeat_until_timeout(timeout: mins.to_i * 60, message: "Secret #{secret} was not re-issued") do
+    _out, code = get_target(target).run_local("kubectl get secret #{secret} -n uyuni", check_errors: false)
+    break if code.zero?
+
+    sleep 5
+  end
+end
+
+Then(/^the "(.*)" certificate on "(.*)" should be signed by the external CA$/) do |secret, target|
+  ca_cn = get_context(:external_ca_cn)
+  issuer, code = get_target(target).run_local(
+    "kubectl get secret #{secret} -n uyuni -o jsonpath='{.data.tls\\.crt}' | base64 -d | openssl x509 -noout -issuer"
+  )
+  raise SystemCallError, "Failed to read issuer from #{secret}" unless code.zero?
+  raise ScriptError, "#{secret} not signed by external CA. Issuer: #{issuer}" unless issuer.include?(ca_cn)
+end
+
+When(/^I re-generate the proxy certificate on the server using the external CA$/) do
+  proxy_fqdn = get_target('proxy').full_hostname
+
+  get_target('server').run_local('kubectl delete certificate proxy-cert -n uyuni --ignore-not-found')
+  get_target('server').run_local('kubectl delete secret proxy-cert -n uyuni --ignore-not-found')
+
+  certificate = render_certificate_yaml(
+    name: 'proxy-cert',
+    secret_name: 'proxy-cert',
+    fqdn: proxy_fqdn,
+    namespace: 'uyuni',
+    issuer_name: 'uyuni-issuer',
+    issuer_kind: 'ClusterIssuer',
+    issuer_group: 'cert-manager.io',
+    is_ca: false
+  )
+  _out, code = get_target('server').run_local("cat <<'CERT_EOF' | kubectl apply -f -\n#{certificate}\nCERT_EOF")
+  raise SystemCallError, 'Failed to create proxy-cert Certificate resource' unless code.zero?
+
+  repeat_until_timeout(timeout: 600, message: 'proxy-cert secret was not created by cert-manager') do
+    _out, code = get_target('server').run_local('kubectl get secret proxy-cert -n uyuni', check_errors: false)
+    break if code.zero?
+
+    sleep 5
+  end
+end
+
+When(/^I transfer the proxy certificate from the server to "(.*)"$/) do |target|
+  out, code = get_target('server').run_local(
+    'kubectl get secret proxy-cert -n uyuni -o yaml --show-managed-fields=false'
+  )
+  raise SystemCallError, 'Failed to extract proxy-cert secret from server' unless code.zero?
+
+  secret = YAML.safe_load(out)
+  secret['metadata'].delete_if { |k, _| %w[uid resourceVersion creationTimestamp annotations].include?(k) }
+  clean_yaml = YAML.dump(secret)
+
+  secret_file = '/tmp/proxy-cert-secret.yaml'
+  file = generate_temp_file('proxy-cert-secret', clean_yaml)
+  success = file_inject(get_target(target), file.path, secret_file)
+  file.close
+  file.unlink
+  raise ScriptError, 'Failed to inject proxy-cert secret into proxy' unless success
+
+  _out, code = get_target(target).run_local(
+    "kubectl apply -f #{secret_file}"
+  )
+  raise SystemCallError, 'Failed to apply proxy-cert secret on proxy cluster' unless code.zero?
+end
+
+When(/^I update the uyuni-ca configmap on "(.*)" with the external CA$/) do |target|
+  ca_dir = get_context(:external_ca_dir)
+
+  # Copy the external CA cert to the proxy node
+  success = file_extract(get_target('server'), "#{ca_dir}/ca.crt", '/tmp/external-ca.crt')
+  raise ScriptError, 'Failed to extract external CA cert from server' unless success
+
+  success = file_inject(get_target(target), '/tmp/external-ca.crt', '/tmp/external-ca.crt')
+  raise ScriptError, 'Failed to inject external CA cert into proxy' unless success
+
+  # Replace the uyuni-ca configmap on the proxy cluster
+  _out, code = get_target(target).run_local(
+    'kubectl delete configmap uyuni-ca -n uyuni --ignore-not-found && ' \
+    'kubectl create configmap uyuni-ca -n uyuni --from-file=ca.crt=/tmp/external-ca.crt'
+  )
+  raise SystemCallError, 'Failed to update uyuni-ca configmap on proxy' unless code.zero?
 end

--- a/testsuite/features/support/kubernetes.rb
+++ b/testsuite/features/support/kubernetes.rb
@@ -1,33 +1,34 @@
 # Copyright (c) 2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
+require 'erb'
+
+# Render a cert-manager Certificate YAML from the shared ERB template.
+#
+# @param opts [Hash] Template variables: name, secret_name, fqdn, namespace, issuer_name, issuer_kind, issuer_group, subject, is_ca (nil=omit, false=emit isCA:false with leaf key settings).
+# @return [String] The rendered YAML string.
+def render_certificate_yaml(opts)
+  defaults = { namespace: nil, issuer_group: nil, subject: nil, is_ca: nil }
+  opts = defaults.merge(opts)
+  template_path = File.join(File.dirname(__FILE__), '..', 'upload_files', 'certificate.yaml.erb')
+  ERB.new(File.read(template_path), trim_mode: '-').result_with_hash(opts)
+end
+
 # Create an SSL certificate using cert-manager and return the path on the server where the files have been copied
 #
 # @param name [String] The name of the certificate.
 # @param fqdn [String] The fully qualified domain name (FQDN) for the certificate.
 # @return [Array<String>] An array containing the paths to the generated certificate files: [crt_path, key_path, ca_path].
 def generate_certificate(name, fqdn)
-  certificate = 'apiVersion: cert-manager.io/v1\\n'\
-                'kind: Certificate\\n'\
-                'metadata:\\n'\
-                "  name: uyuni-#{name}\\n"\
-                'spec:\\n'\
-                "  secretName: uyuni-#{name}-cert\\n"\
-                '  subject:\\n'\
-                "    countries: ['DE']\\n"\
-                "    provinces: ['Bayern']\\n"\
-                "    localities: ['Nuernberg']\\n"\
-                "    organizations: ['SUSE']\\n"\
-                "    organizationalUnits: ['SUSE']\\n"\
-                '  emailAddresses:\\n'\
-                '    - galaxy-noise@suse.de\\n'\
-                "  commonName: #{fqdn}\\n"\
-                '  dnsNames:\\n'\
-                "    - #{fqdn}\\n"\
-                '  issuerRef:\\n'\
-                '    name: uyuni-ca-issuer\\n'\
-                '    kind: Issuer'
-  _out, return_code = get_target('server').run_local("echo -e \"#{certificate}\" | kubectl apply -f -")
+  certificate = render_certificate_yaml(
+    name: "uyuni-#{name}",
+    secret_name: "uyuni-#{name}-cert",
+    fqdn: fqdn,
+    issuer_name: 'uyuni-ca-issuer',
+    issuer_kind: 'Issuer',
+    subject: { country: 'DE', province: 'Bayern', locality: 'Nuernberg', org: 'SUSE', ou: 'SUSE', email: 'galaxy-noise@suse.de' }
+  )
+  _out, return_code = get_target('server').run_local("cat <<'CERT_EOF' | kubectl apply -f -\n#{certificate}\nCERT_EOF")
   raise SystemCallError, "Failed to define #{name} Certificate resource" unless return_code.zero?
 
   # cert-manager takes some time to generate the secret, wait for it before continuing

--- a/testsuite/features/upload_files/certificate.yaml.erb
+++ b/testsuite/features/upload_files/certificate.yaml.erb
@@ -1,0 +1,38 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: <%= name %>
+<% if namespace -%>
+  namespace: <%= namespace %>
+<% end -%>
+spec:
+  secretName: <%= secret_name %>
+<% if is_ca == false -%>
+  isCA: false
+  usages:
+    - server auth
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+    rotationPolicy: Always
+<% end -%>
+<% if subject -%>
+  subject:
+    countries: ['<%= subject[:country] %>']
+    provinces: ['<%= subject[:province] %>']
+    localities: ['<%= subject[:locality] %>']
+    organizations: ['<%= subject[:org] %>']
+    organizationalUnits: ['<%= subject[:ou] %>']
+  emailAddresses:
+    - <%= subject[:email] %>
+<% end -%>
+  commonName: <%= fqdn %>
+  dnsNames:
+    - <%= fqdn %>
+  issuerRef:
+    name: <%= issuer_name %>
+    kind: <%= issuer_kind %>
+<% if issuer_group -%>
+    group: <%= issuer_group %>
+<% end -%>


### PR DESCRIPTION

## What does this PR change?

reference card: https://github.com/SUSE/spacewalk/issues/29464

Add end-to-end Cucumber tests that verify replacing the cert-manager
  self-signed CA with an externally provided one on both the server and
  proxy RKE2 clusters, and that deployments recover afterwards.

The test scenario is hard to recreate because we'd need to have infrastructure with a CA already in place, and deploy MLM-RKE2 on that.

To simulate a realistic scenario, we use the regular deployment and then switch to an external CA after the install.

This also create an issue when the controller needs to communicate with the machines, as previous SSL trust is being broken. So we need to reconfigure the controller trust as well.

  New files:
  - srv_rke2_external_ca.feature: 4 scenarios covering CA replacement on server, leaf cert re-issuance verification, proxy CA injection via configmap, and deployment recovery on both clusters.
  - rke2_steps.rb: step definitions for generating an EC CA, replacing the uyuni-ca secret (deleting the Certificate CR first to prevent cert-manager from overwriting it), deleting and waiting for leaf secrets, verifying issuer chains, re-generating proxy certificates, and transferring secrets between clusters.
  - certificate.yaml.erb: shared ERB template for cert-manager Certificate resources, replacing the inline YAML string in kubernetes.rb.




## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

