### PR TITLE
Testsuite: SW channels and repos management new test added + Internal Server Error check

### DIFF
--- a/testsuite/config/cucumber.yml
+++ b/testsuite/config/cucumber.yml
@@ -13,6 +13,7 @@ content_staging: --tags @scope_content_staging
 cve_audit: --tags @scope_cve_audit
 deblike: --tags @scope_deblike
 formulas: --tags @scope_formulas
+hibernate: --tags @scope_hibernate
 hub: --tags @scope_hub
 kubernetes_integration: --tags @scope_kubernetes_integration
 maintenance_windows: --tags @scope_maintenance_windows
@@ -31,6 +32,7 @@ retracted_patches: --tags @scope_retracted_patches
 rhlike: --tags @rhlike_minion
 salt_ssh: --tags @scope_salt_ssh
 salt: --tags @scope_salt
+software_channels_and_repositories: --tags @scope_software_channels_and_repositories
 spacecmd: --tags @scope_spacecmd
 spacewalk_utils: --tags @scope_spacewalk_utils
 sp_migration: --tags @scope_sp_migration

--- a/testsuite/features/secondary/srv_software_channels_and_repositories_management.feature
+++ b/testsuite/features/secondary/srv_software_channels_and_repositories_management.feature
@@ -96,6 +96,8 @@ Feature: Software channels and repositories management
     And I click on "Delete Channel"
     Then I wait until I see "Channel Hibernate test channel has been deleted." text
 
+@skip_if_github_validation
+  # server log contains hibernate excepcions, please remove the skip when it's fixed
   Scenario: Check the cleanup succeeded and the errors in logs
     When I follow the left menu "Software > Manage > Repositories"
     And I should not see a "hibernate-repository" text

--- a/testsuite/features/secondary/srv_software_channels_and_repositories_management.feature
+++ b/testsuite/features/secondary/srv_software_channels_and_repositories_management.feature
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@scope_software_channels_and_repositories
+@scope_hibernate
+Feature: Software channels and repositories management
+  To check and test operability of software channels and repositories,
+  and related CRUD operations encapsulated with hibernate.
+
+  Scenario: Log in as org admin user
+    Given I am authorized
+
+  Scenario: Create a custom channel with a repository
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Create Channel"
+    And I enter "Hibernate channel" as "Channel Name"
+    And I enter "hibernate-test-channel" as "Channel Label"
+    And I enter "hibernate-test-channel" as "Channel Summary"
+    Then I click on "Create Channel"
+    And I wait until I see "Hibernate channel created." text
+    When I follow "Repositories" in the content area
+    And I follow "Add / Remove"
+    And I follow "Create Repository"
+    And I enter "hibernate-test-repository" as "label"
+    And I enter "https://localhost" as "url"
+    And I select "yum" from "contenttype"
+    Then I click on "Create Repository"
+    And I wait until I see "Repository created successfully" text
+    And I should see a "hibernate-test-channel repository information was successfully updated" text
+
+  Scenario: Create a repository from channel management
+    When I follow the left menu "Software > Manage > Channels"
+    Then I should see a "Hibernate channel" text
+    When I follow "Hibernate channel"
+    And I follow "Repositories" in the content area
+    And I follow "Add / Remove"
+    And I follow "Create Repository"
+    And I enter "hibernate-test-repository-2" as "label"
+    And I enter "https://localhost.localdomain" as "url"
+    And I select "yum" from "contenttype"
+    Then I click on "Create Repository"
+    And I wait until I see "Repository created successfully" text
+    And I should see a "hibernate-test-channel repository information was successfully updated" text
+
+  Scenario: Modify the channel Hibernate
+    When I follow the left menu "Software > Manage > Channels"
+    Then I should see a "Hibernate channel" text
+    When I follow "Hibernate channel"
+    And I should not see a "hibernate-channel" text
+    And I enter "Hibernate test channel" as "Channel Name"
+    Then I click on "Update Channel"
+    And I wait until I see "Channel Hibernate test channel updated." text
+
+  Scenario: Modify the repository of the channel Hibernate
+    When I follow the left menu "Software > Manage > Repositories"
+    And I follow "hibernate-test-repository-2"
+    And I enter "hibernate-repository" as "label"
+    And I select "deb" from "contenttype"
+    Then I click on "Update Repository"
+    And I wait until I see "Repository updated successfully" text
+
+  Scenario: Check the Hibernate channel and repositories
+    When I follow the left menu "Software > Manage > Channels"
+    Then I should see a "Hibernate test channel" text
+    When I follow "Hibernate test channel"
+    And I follow "Repositories" in the content area
+    And I follow "Sync"
+    Then I should see a "hibernate-repository" text
+    And I should see a "hibernate-test-repository" text
+    When I follow "hibernate-repository"
+    Then I should see a "deb" text
+
+  Scenario: Cleanup: Delete Hibernate repository from Repositories
+    When I follow the left menu "Software > Manage > Repositories"
+    And I follow "hibernate-repository"
+    And I follow "Delete Repository"
+    And I should see a "Confirm Repository Delete" text
+    And I click on "Delete Repository"
+    Then I wait until I see "Repository deleted successfully" text
+
+  Scenario: Cleanup: Delete Hibernate repository from Channels
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Hibernate test channel"
+    And I follow "Repositories" in the content area
+    And I follow "hibernate-test-repository"
+    And I follow "Delete Repository"
+    And I should see a "Confirm Repository Delete" text
+    Then I click on "Delete Repository"
+    And I wait until I see "Repository deleted successfully" text
+
+  Scenario: Cleanup: Delete Hibernate channel
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Hibernate test channel"
+    And I follow "Delete Channel"
+    And I should see a "Delete Channel" text
+    Then I click on "Delete Channel"
+    And I wait until I see "Channel Hibernate test channel has been deleted." text
+
+  Scenario: Check the cleanup succeeded and the errors in logs
+    When I follow the left menu "Software > Manage > Repositories"
+    Then I should not see a "hibernate-repository" text
+    And I should not see a "hibernate-test-repository" text
+    And I should not see a "hibernate-test-repository-2" text
+    When I follow the left menu "Software > Manage > Channels"
+    Then I should not see a "Hibernate test channel" text
+    And I should not see a "Hibernate channel" text
+    And the server log does not contain "hibernate" errors

--- a/testsuite/features/secondary/srv_software_channels_and_repositories_management.feature
+++ b/testsuite/features/secondary/srv_software_channels_and_repositories_management.feature
@@ -16,59 +16,59 @@ Feature: Software channels and repositories management
     And I enter "Hibernate channel" as "Channel Name"
     And I enter "hibernate-test-channel" as "Channel Label"
     And I enter "hibernate-test-channel" as "Channel Summary"
-    Then I click on "Create Channel"
+    And I click on "Create Channel"
     And I wait until I see "Hibernate channel created." text
-    When I follow "Repositories" in the content area
+    And I follow "Repositories" in the content area
     And I follow "Add / Remove"
     And I follow "Create Repository"
     And I enter "hibernate-test-repository" as "label"
     And I enter "https://localhost" as "url"
     And I select "yum" from "contenttype"
-    Then I click on "Create Repository"
+    And I click on "Create Repository"
     And I wait until I see "Repository created successfully" text
-    And I should see a "hibernate-test-channel repository information was successfully updated" text
+    Then I should see a "hibernate-test-channel repository information was successfully updated" text
 
   Scenario: Create a repository from channel management
     When I follow the left menu "Software > Manage > Channels"
-    Then I should see a "Hibernate channel" text
-    When I follow "Hibernate channel"
+    And I should see a "Hibernate channel" text
+    And I follow "Hibernate channel"
     And I follow "Repositories" in the content area
     And I follow "Add / Remove"
     And I follow "Create Repository"
     And I enter "hibernate-test-repository-2" as "label"
     And I enter "https://localhost.localdomain" as "url"
     And I select "yum" from "contenttype"
-    Then I click on "Create Repository"
+    And I click on "Create Repository"
     And I wait until I see "Repository created successfully" text
-    And I should see a "hibernate-test-channel repository information was successfully updated" text
+    Then I should see a "hibernate-test-channel repository information was successfully updated" text
 
   Scenario: Modify the channel Hibernate
     When I follow the left menu "Software > Manage > Channels"
-    Then I should see a "Hibernate channel" text
-    When I follow "Hibernate channel"
+    And I should see a "Hibernate channel" text
+    And I follow "Hibernate channel"
     And I should not see a "hibernate-channel" text
     And I enter "Hibernate test channel" as "Channel Name"
-    Then I click on "Update Channel"
-    And I wait until I see "Channel Hibernate test channel updated." text
+    And I click on "Update Channel"
+    Then I wait until I see "Channel Hibernate test channel updated." text
 
   Scenario: Modify the repository of the channel Hibernate
     When I follow the left menu "Software > Manage > Repositories"
     And I follow "hibernate-test-repository-2"
     And I enter "hibernate-repository" as "label"
     And I select "deb" from "contenttype"
-    Then I click on "Update Repository"
-    And I wait until I see "Repository updated successfully" text
+    And I click on "Update Repository"
+    Then I wait until I see "Repository updated successfully" text
 
   Scenario: Check the Hibernate channel and repositories
     When I follow the left menu "Software > Manage > Channels"
-    Then I should see a "Hibernate test channel" text
-    When I follow "Hibernate test channel"
+    And I should see a "Hibernate test channel" text
+    And I follow "Hibernate test channel"
     And I follow "Repositories" in the content area
     And I follow "Sync"
     Then I should see a "hibernate-repository" text
     And I should see a "hibernate-test-repository" text
-    When I follow "hibernate-repository"
-    Then I should see a "deb" text
+    And I follow "hibernate-repository"
+    And I should see a "deb" text
 
   Scenario: Cleanup: Delete Hibernate repository from Repositories
     When I follow the left menu "Software > Manage > Repositories"
@@ -85,23 +85,23 @@ Feature: Software channels and repositories management
     And I follow "hibernate-test-repository"
     And I follow "Delete Repository"
     And I should see a "Confirm Repository Delete" text
-    Then I click on "Delete Repository"
-    And I wait until I see "Repository deleted successfully" text
+    And I click on "Delete Repository"
+    Then I wait until I see "Repository deleted successfully" text
 
   Scenario: Cleanup: Delete Hibernate channel
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Hibernate test channel"
     And I follow "Delete Channel"
     And I should see a "Delete Channel" text
-    Then I click on "Delete Channel"
-    And I wait until I see "Channel Hibernate test channel has been deleted." text
+    And I click on "Delete Channel"
+    Then I wait until I see "Channel Hibernate test channel has been deleted." text
 
   Scenario: Check the cleanup succeeded and the errors in logs
     When I follow the left menu "Software > Manage > Repositories"
-    Then I should not see a "hibernate-repository" text
+    And I should not see a "hibernate-repository" text
     And I should not see a "hibernate-test-repository" text
     And I should not see a "hibernate-test-repository-2" text
-    When I follow the left menu "Software > Manage > Channels"
+    And I follow the left menu "Software > Manage > Channels"
     Then I should not see a "Hibernate test channel" text
     And I should not see a "Hibernate channel" text
     And the server log should not contain "hibernate" errors

--- a/testsuite/features/secondary/srv_software_channels_and_repositories_management.feature
+++ b/testsuite/features/secondary/srv_software_channels_and_repositories_management.feature
@@ -104,4 +104,4 @@ Feature: Software channels and repositories management
     When I follow the left menu "Software > Manage > Channels"
     Then I should not see a "Hibernate test channel" text
     And I should not see a "Hibernate channel" text
-    And the server log does not contain "hibernate" errors
+    And the server log should not contain "hibernate" errors

--- a/testsuite/features/secondary/srv_software_channels_and_repositories_management.feature
+++ b/testsuite/features/secondary/srv_software_channels_and_repositories_management.feature
@@ -4,8 +4,8 @@
 @scope_software_channels_and_repositories
 @scope_hibernate
 Feature: Software channels and repositories management
-  To check and test operability of software channels and repositories,
-  and related CRUD operations encapsulated with hibernate.
+  Software channels and repositories can be operated,
+  related CRUD operation encapsultade with hibernate work.
 
   Scenario: Log in as org admin user
     Given I am authorized

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -537,6 +537,12 @@ Then(/^the log messages should not contain out of memory errors$/) do
   raise ScriptError, "Out of memory errors in /var/log/messages:\n#{output}" if code.zero?
 end
 
+Then(/^the server log does not contain "([^"]*)" errors$/) do |component|
+  cmd = "cat /var/log/rhn/rhn_web_ui.log | grep -i 'Exception' | grep -i '#{component}'"
+  output, code = get_target('server').run(cmd, check_errors: false)
+  raise ScriptError, "Error related to \"#{component}\" found!\n#{output}" if code.zero?
+end
+
 When(/^I restart the spacewalk service$/) do
   get_target('server').run('spacewalk-service restart')
 end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -537,7 +537,7 @@ Then(/^the log messages should not contain out of memory errors$/) do
   raise ScriptError, "Out of memory errors in /var/log/messages:\n#{output}" if code.zero?
 end
 
-Then(/^the server log does not contain "([^"]*)" errors$/) do |component|
+Then(/^the server log should not contain "([^"]*)" errors$/) do |component|
   cmd = "cat /var/log/rhn/rhn_web_ui.log | grep -i 'Exception' | grep -i '#{component}'"
   output, code = get_target('server').run(cmd, check_errors: false)
   raise ScriptError, "Error related to \"#{component}\" found!\n#{output}" if code.zero?

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -514,7 +514,7 @@ Then(/^the log messages should not contain out of memory errors$/) do
   raise ScriptError, "Out of memory errors in /var/log/messages:\n#{output}" if code.zero?
 end
 
-Then(/^the server log does not contain "([^"]*)" errors$/) do |component|
+Then(/^the server log should not contain "([^"]*)" errors$/) do |component|
   cmd = "cat /var/log/rhn/rhn_web_ui.log | grep -i 'Exception' | grep -i '#{component}'"
   output, code = get_target('server').run(cmd, check_errors: false)
   raise ScriptError, "Error related to \"#{component}\" found!\n#{output}" if code.zero?

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -514,6 +514,12 @@ Then(/^the log messages should not contain out of memory errors$/) do
   raise ScriptError, "Out of memory errors in /var/log/messages:\n#{output}" if code.zero?
 end
 
+Then(/^the server log does not contain "([^"]*)" errors$/) do |component|
+  cmd = "cat /var/log/rhn/rhn_web_ui.log | grep -i 'Exception' | grep -i '#{component}'"
+  output, code = get_target('server').run(cmd, check_errors: false)
+  raise ScriptError, "Error related to \"#{component}\" found!\n#{output}" if code.zero?
+end
+
 When(/^I restart the spacewalk service$/) do
   get_target('server').run('spacewalk-service restart')
 end

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -123,6 +123,7 @@ end
 # @return [Boolean] Returns true if the text is visible, false otherwise.
 def check_text?(text1, text2: nil, timeout: Capybara.default_max_wait_time)
   raise ScriptError, 'BUG DETECTED! Internal Server Error' if has_text?('Internal Server Error', wait: 0)
+
   has_text?(text1, wait: timeout) || (!text2.nil? && has_text?(text2, wait: timeout))
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -122,6 +122,7 @@ end
 # @param timeout [Integer] The maximum time to wait for the text to become visible (default: Capybara.default_max_wait_time).
 # @return [Boolean] Returns true if the text is visible, false otherwise.
 def check_text?(text1, text2: nil, timeout: Capybara.default_max_wait_time)
+  raise ScriptError, 'BUG DETECTED! Internal Server Error' if has_text?('Internal Server Error', wait: 0)
   has_text?(text1, wait: timeout) || (!text2.nil? && has_text?(text2, wait: timeout))
 end
 

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -42,6 +42,7 @@
 - features/secondary/srv_errata_api.feature
 - features/secondary/srv_health_check_supportconfig.feature
 - features/secondary/srv_password_restriction.feature
+- features/secondary/srv_software_channels_and_repositories_management.feature
 
 - features/secondary/buildhost_docker_build_image.feature
 - features/secondary/buildhost_docker_auth_registry.feature


### PR DESCRIPTION
## What does this PR change? 

Adding server software channels and repositories checks - CRUD operations and hibernate encapsulation - tests
Also adding:
- the component error log check - simple server exception log check
- test case for BSC#1259499
- additional change is for the original function "check_text_and_catch_request_timeout_popup?" (removed today) of the "Internal Server Error" moved to the "check_text?" function.


## GUI diff

No difference.

## Documentation
- No documentation needed: the new test added


## Links

Port(s):
- 5.1: https://github.com/SUSE/spacewalk/pull/30855

## Changelogs

- No changelog needed

## Additional info
Tested with Uyuni and 5.1.3

```
uyuni-master:
=============
10 scenarios (10 passed)
79 steps (79 passed)
0m44.449s

5.1.3:
======
10 scenarios (10 passed)
79 steps (79 passed)
0m32.825s
```
