### PR TITLE
New consolidated cucumber report

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -280,6 +280,24 @@ namespace :utils do
     sh 'rm -rf ./cucumber_report && mkdir cucumber_report', verbose: false
     sh "timeout 180 bash -c -- \"while find #{result_folder}/output*.json -type f -size 0 | grep json; do sleep 10;done\" ; exit 0", verbose: false
     sh 'find . -size 0 -delete', verbose: false
+
+    # Strip before/after hooks from all JSON files before generating reports.
+    Dir.glob("#{result_folder}/output_*.json").each do |json_file|
+      begin
+        features = JSON.parse(File.read(json_file))
+        features.each do |feature|
+          (feature['elements'] || []).each do |scenario|
+            scenario.delete('before')
+            scenario.delete('after')
+            (scenario['steps'] || []).each { |step| step.delete('after') }
+          end
+        end
+        File.write(json_file, JSON.generate(features))
+      rescue => e
+        warn "WARNING: Could not strip hooks from #{json_file}: #{e.message}"
+      end
+    end
+
     sh "node index.cjs #{result_folder} &> cucumber_reporter.log", verbose: false
     sh "cp -r cucumber_report/. #{result_folder}/cucumber_report/"
   end

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -50,6 +50,21 @@ namespace :cucumber do
     # This block executes when the task runs and uses the exact same `html_results` path.
     # This file is used to expose the cucumber html report in Jenkins
     Rake::Task[task_name].enhance do
+      # Patch the HTML report to preserve execution order instead of alphabetical sorting.
+      # cucumber-html-formatter 21.x hardcodes a localeCompare sort by URI in its bundled JS,
+      # which overrides the execution order regardless of the --order flag.
+      # We neutralise that sort call so features render in the order they were executed.
+      if File.exist?(html_results)
+        html_content = File.read(html_results)
+        sort_call = 'i.sort(((e,t)=>(e.uri||"").localeCompare(t.uri||"")))'
+        if html_content.include?(sort_call)
+          patched = html_content.gsub(sort_call, 'i' + (' ' * (sort_call.length - 1)))
+          File.write(html_results, patched)
+        else
+          warn "WARNING: Could not find sort patch target in #{html_results} — " \
+                 'cucumber-html-formatter may have changed; verify execution order in the HTML report.'
+        end
+      end
       # Write the final HTML path (without the option flag) to the file
       # This uses the CONSISTENT, PRE-CALCULATED 'html_results' variable
       sh "echo '#{html_results}' > #{path_export_file}", verbose: false

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -272,18 +272,27 @@ namespace :utils do
     sh "timeout 180 bash -c -- \"while find #{result_folder}/output*.json -type f -size 0 | grep json; do sleep 10;done\" ; exit 0", verbose: false
     sh 'find . -size 0 -delete', verbose: false
 
-    # Strip before/after hooks from all JSON files before generating reports.
+    # Strip before/after hooks into a separate folder for the Jenkins Cucumber
+    # plugin — originals are preserved intact so index.cjs can rescue
+    # screenshot embeddings from hooks before stripping them for the report.
+    # Only passed/skipped hooks are stripped — failed hooks are kept so they
+    # remain visible in both reports (a missing result status is also kept).
+    stripped_folder = "#{result_folder}/stripped"
+    sh "rm -rf #{stripped_folder} && mkdir -p #{stripped_folder}", verbose: false
+    safe_statuses = %w[passed skipped]
     Dir.glob("#{result_folder}/output_*.json").each do |json_file|
       begin
         features = JSON.parse(File.read(json_file))
         features.each do |feature|
           (feature['elements'] || []).each do |scenario|
-            scenario.delete('before')
-            scenario.delete('after')
-            (scenario['steps'] || []).each { |step| step.delete('after') }
+            scenario['before'] = (scenario['before'] || []).reject { |h| safe_statuses.include?(h.dig('result', 'status')) }
+            scenario['after']  = (scenario['after']  || []).reject { |h| safe_statuses.include?(h.dig('result', 'status')) }
+            (scenario['steps'] || []).each do |step|
+              step['after'] = (step['after'] || []).reject { |h| safe_statuses.include?(h.dig('result', 'status')) }
+            end
           end
         end
-        File.write(json_file, JSON.generate(features))
+        File.write("#{stripped_folder}/#{File.basename(json_file)}", JSON.generate(features))
       rescue => e
         warn "WARNING: Could not strip hooks from #{json_file}: #{e.message}"
       end

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -53,7 +53,7 @@ namespace :cucumber do
       # Patch the HTML report to preserve execution order instead of alphabetical sorting.
       # cucumber-html-formatter 21.x hardcodes a localeCompare sort by URI in its bundled JS,
       # which overrides the execution order regardless of the --order flag.
-      # We neutralise that sort call so features render in the order they were executed.
+      # We neutralize that sort call so features render in the order they were executed.
       if File.exist?(html_results)
         html_content = File.read(html_results)
         sort_call = 'i.sort(((e,t)=>(e.uri||"").localeCompare(t.uri||"")))'

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -50,17 +50,8 @@ namespace :cucumber do
     # This block executes when the task runs and uses the exact same `html_results` path.
     # This file is used to expose the cucumber html report in Jenkins
     Rake::Task[task_name].enhance do
-      if File.exist?(html_results)
-        html_content = File.read(html_results)
-        sort_call = 'i.sort(((e,t)=>(e.uri||"").localeCompare(t.uri||"")))'
-        if html_content.include?(sort_call)
-          patched = html_content.gsub(sort_call, 'i' + (' ' * (sort_call.length - 1)))
-          File.write(html_results, patched)
-        else
-          raise "Could not find sort patch target in #{html_results} — report ordering will be broken. Update sort_call if the formatter was upgraded."
-        end
-      end
-
+      # Write the final HTML path (without the option flag) to the file
+      # This uses the CONSISTENT, PRE-CALCULATED 'html_results' variable
       sh "echo '#{html_results}' > #{path_export_file}", verbose: false
     end
   end

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -289,7 +289,7 @@ namespace :utils do
     sh "timeout 180 bash -c -- \"while find #{result_folder}/output*.json -type f -size 0 | grep json; do sleep 10;done\" ; exit 0", verbose: false
     sh 'find . -size 0 -delete', verbose: false
     sh "node index.cjs #{result_folder} &> cucumber_reporter.log", verbose: false
-    sh "cp cucumber_report/cucumber_report.html #{result_folder}"
+    sh "cp -r cucumber_report/. #{result_folder}/cucumber_report/"
   end
 
   desc 'Collect and tag flaky tests'

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -50,22 +50,14 @@ namespace :cucumber do
     # This block executes when the task runs and uses the exact same `html_results` path.
     # This file is used to expose the cucumber html report in Jenkins
     Rake::Task[task_name].enhance do
-      warn "DEBUG: html_results path = #{html_results}"
-      warn "DEBUG: file exists = #{File.exist?(html_results)}"
-      warn "DEBUG: file size = #{File.size?(html_results) || 'nil/empty'}"
-      warn "DEBUG: file mtime = #{File.mtime(html_results) rescue 'N/A'}"
-      warn "DEBUG: current time = #{Time.now}"
-
       if File.exist?(html_results)
         html_content = File.read(html_results)
         sort_call = 'i.sort(((e,t)=>(e.uri||"").localeCompare(t.uri||"")))'
-        warn "DEBUG: sort_call found = #{html_content.include?(sort_call)}"
         if html_content.include?(sort_call)
           patched = html_content.gsub(sort_call, 'i' + (' ' * (sort_call.length - 1)))
           File.write(html_results, patched)
-          warn "DEBUG: patch applied successfully"
         else
-          warn "WARNING: Could not find sort patch target in #{html_results}"
+          raise "Could not find sort patch target in #{html_results} — report ordering will be broken. Update sort_call if the formatter was upgraded."
         end
       end
 

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -50,23 +50,25 @@ namespace :cucumber do
     # This block executes when the task runs and uses the exact same `html_results` path.
     # This file is used to expose the cucumber html report in Jenkins
     Rake::Task[task_name].enhance do
-      # Patch the HTML report to preserve execution order instead of alphabetical sorting.
-      # cucumber-html-formatter 21.x hardcodes a localeCompare sort by URI in its bundled JS,
-      # which overrides the execution order regardless of the --order flag.
-      # We neutralize that sort call so features render in the order they were executed.
+      warn "DEBUG: html_results path = #{html_results}"
+      warn "DEBUG: file exists = #{File.exist?(html_results)}"
+      warn "DEBUG: file size = #{File.size?(html_results) || 'nil/empty'}"
+      warn "DEBUG: file mtime = #{File.mtime(html_results) rescue 'N/A'}"
+      warn "DEBUG: current time = #{Time.now}"
+
       if File.exist?(html_results)
         html_content = File.read(html_results)
         sort_call = 'i.sort(((e,t)=>(e.uri||"").localeCompare(t.uri||"")))'
+        warn "DEBUG: sort_call found = #{html_content.include?(sort_call)}"
         if html_content.include?(sort_call)
           patched = html_content.gsub(sort_call, 'i' + (' ' * (sort_call.length - 1)))
           File.write(html_results, patched)
+          warn "DEBUG: patch applied successfully"
         else
-          warn "WARNING: Could not find sort patch target in #{html_results} — " \
-                 'cucumber-html-formatter may have changed; verify execution order in the HTML report.'
+          warn "WARNING: Could not find sort patch target in #{html_results}"
         end
       end
-      # Write the final HTML path (without the option flag) to the file
-      # This uses the CONSISTENT, PRE-CALCULATED 'html_results' variable
+
       sh "echo '#{html_results}' > #{path_export_file}", verbose: false
     end
   end

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -271,8 +271,35 @@ namespace :utils do
     sh 'rm -rf ./cucumber_report && mkdir cucumber_report', verbose: false
     sh "timeout 180 bash -c -- \"while find #{result_folder}/output*.json -type f -size 0 | grep json; do sleep 10;done\" ; exit 0", verbose: false
     sh 'find . -size 0 -delete', verbose: false
+
+    # Strip before/after hooks into a separate folder for the Jenkins Cucumber
+    # plugin — originals are preserved intact so index.cjs can rescue
+    # screenshot embeddings from hooks before stripping them for the report.
+    # Only passed/skipped hooks are stripped — failed hooks are kept so they
+    # remain visible in both reports (a missing result status is also kept).
+    stripped_folder = "#{result_folder}/stripped"
+    sh "rm -rf #{stripped_folder} && mkdir -p #{stripped_folder}", verbose: false
+    safe_statuses = %w[passed skipped]
+    Dir.glob("#{result_folder}/output_*.json").each do |json_file|
+      begin
+        features = JSON.parse(File.read(json_file))
+        features.each do |feature|
+          (feature['elements'] || []).each do |scenario|
+            scenario['before'] = (scenario['before'] || []).reject { |h| safe_statuses.include?(h.dig('result', 'status')) }
+            scenario['after']  = (scenario['after']  || []).reject { |h| safe_statuses.include?(h.dig('result', 'status')) }
+            (scenario['steps'] || []).each do |step|
+              step['after'] = (step['after'] || []).reject { |h| safe_statuses.include?(h.dig('result', 'status')) }
+            end
+          end
+        end
+        File.write("#{stripped_folder}/#{File.basename(json_file)}", JSON.generate(features))
+      rescue => e
+        warn "WARNING: Could not strip hooks from #{json_file}: #{e.message}"
+      end
+    end
+
     sh "node index.cjs #{result_folder} &> cucumber_reporter.log", verbose: false
-    sh "cp cucumber_report/cucumber_report.html #{result_folder}"
+    sh "cp -r cucumber_report/. #{result_folder}/cucumber_report/"
   end
 
   desc 'Collect and tag flaky tests'

--- a/testsuite/index.cjs
+++ b/testsuite/index.cjs
@@ -1,42 +1,84 @@
 /**
  * https://github.com/WasiqB/multiple-cucumber-html-reporter
- * Replaces cucumber-html-reporter (abandoned since 2021).
- * Preserves JSON execution order, supports filter by passed/failed/skipped.
+ * Preserves execution order by injecting a sequence number into feature names
+ * before generating the report, since the library always sorts alphabetically.
  */
 
 const report = require('multiple-cucumber-html-reporter');
-const report = require('multiple-cucumber-html-reporter');
+const fs = require('fs');
 const path = require('path');
 
-// Read command-line arguments
 const args = process.argv.slice(2);
-const jsonDir = args[0] || '.'; // Default to current directory if no argument provided
+const jsonDir = args[0] || '.';
 
-report.generate({
-  jsonDir: jsonDir,
-  // Output to cucumber_report/ — the reporter creates index.html inside this folder.
-  // The Rakefile copies cucumber_report/index.html as cucumber_report.html into result_folder.
-  reportPath: 'cucumber_report',
-  reportName: 'Uyuni/Head Testsuite',
+// Read all Cucumber JSON files in the directory.
+// Filenames contain timestamps (e.g. output_20260429143645-sanity_check.json)
+// so lexicographic sort == chronological == execution order.
+const jsonFiles = fs.readdirSync(jsonDir)
+  .filter(f => f.match(/^output_.*\.json$/))
+  .sort()
+  .map(f => path.join(jsonDir, f));
 
-  // Preserve the order features appear in the JSON (= execution order).
-  // multiple-cucumber-html-reporter does not sort — it uses the JSON array order.
-  displayDuration: true,
-  // Cucumber Ruby reports durations in nanoseconds (not milliseconds)
-  durationInMS: false,
+if (jsonFiles.length === 0) {
+  console.error(`No output_*.json files found in: ${jsonDir}`);
+  process.exit(1);
+}
 
-  displayReportTime: true,
+// Load and merge all features, injecting a zero-padded sequence number
+// into each feature name so alphabetical sort == execution order.
+let sequenceNumber = 0;
+const allFeatures = [];
 
-  // No browser/device metadata columns — not relevant for this setup
-  hideMetadata: true,
-
-  ignoreBadJsonFile: true,
-
-  customData: {
-    title: 'Run info',
-    data: [
-      { label: 'Product',  value: 'Uyuni/Head' },
-      { label: 'Platform', value: 'x86_64' },
-    ]
+for (const file of jsonFiles) {
+  try {
+    const features = JSON.parse(fs.readFileSync(file, 'utf8'));
+    for (const feature of features) {
+      sequenceNumber++;
+      const pad = String(sequenceNumber).padStart(4, '0');
+      feature.name = `${pad} - ${feature.name}`;
+    }
+    allFeatures.push(...features);
+  } catch (e) {
+    console.warn(`Skipping bad JSON file: ${file} — ${e.message}`);
   }
-});
+}
+
+console.log(`Loaded ${allFeatures.length} features from ${jsonFiles.length} JSON files.`);
+
+// Write a single merged + ordered JSON file for the reporter to consume.
+// Using a distinct name avoids it being picked up as a cucumber report itself.
+const mergedJsonPath = path.join(jsonDir, '_ordered_report.json');
+fs.writeFileSync(mergedJsonPath, JSON.stringify(allFeatures));
+
+try {
+  report.generate({
+    // Point at the single pre-ordered merged file rather than the directory,
+    // so the reporter doesn't re-discover and re-sort the individual files.
+    jsonDir: jsonDir,
+    jsonFile: mergedJsonPath,
+    reportPath: 'cucumber_report',
+    reportName: 'Uyuni/Head Testsuite',
+
+    // Durations are in nanoseconds (Cucumber Ruby default)
+    displayDuration: true,
+    durationInMS: false,
+
+    displayReportTime: true,
+
+    // No browser/device metadata columns — not relevant for this setup
+    hideMetadata: true,
+
+    ignoreBadJsonFile: true,
+
+    customData: {
+      title: 'Run info',
+      data: [
+        { label: 'Product',  value: 'Uyuni/Head' },
+        { label: 'Platform', value: 'x86_64' },
+      ]
+    }
+  });
+} finally {
+  // Always clean up the temp merged file
+  fs.unlinkSync(mergedJsonPath);
+}

--- a/testsuite/index.cjs
+++ b/testsuite/index.cjs
@@ -1,34 +1,41 @@
 /**
- * https://github.com/gkushang/cucumber-html-reporter
+ * Cucumber HTML report generator using multiple-cucumber-html-reporter
+ * Replaces cucumber-html-reporter (abandoned since 2021)
+ * Preserves JSON execution order, supports filter by passed/failed/skipped
  */
 
-var reporter = require('cucumber-html-reporter');
-var path = require('path');
+const report = require('multiple-cucumber-html-reporter');
+const path = require('path');
 
-// Read command-line arguments
-var args = process.argv.slice(2);
-var jsonDir = args[0] || '.'; // Default to current directory if no argument provided
+const args = process.argv.slice(2);
+const jsonDir = args[0] || '.';
 
-var options = {
-  theme: 'bootstrap',
+report.generate({
   jsonDir: jsonDir,
-  output: 'cucumber_report/cucumber_report.html',
-  reportSuiteAsScenarios: true,
-  launchReport: true,
-  columnLayout: 1,
-  scenarioTimestamp: true,
-  screenshotsDirectory: './cucumber_report/screenshots/',
-  storeScreenshots: true,
-  noInlineScreenshots: true,
-  ignoreBadJsonFile: true,
-  name: 'Uyuni/Head Testsuite',
-  brandTitle: ' ',
-  metadata: {
-    "App Version":"Uyuni/Head",
-    "Browser": "Chrome",
-    "Platform": "x86_64",
-    "Parallel": "Disabled"
-  }
-};
+  reportPath: 'cucumber_report',
+  reportName: 'Uyuni/Head Testsuite',
 
-reporter.generate(options);
+  // Preserve the order features appear in the JSON (= execution order)
+  // multiple-cucumber-html-reporter does not sort — it uses array order
+  displayDuration: true,
+  durationInMS: false,  // Cucumber Ruby reports in nanoseconds
+
+  // Show pass/fail/skip filter buttons on the overview
+  displayReportTime: true,
+
+  // Flatten metadata (no browser/device columns — not relevant for your setup)
+  hideMetadata: true,
+
+  customData: {
+    title: 'Run info',
+    data: [
+      { label: 'Product',   value: 'Uyuni/Head' },
+      { label: 'Platform',  value: 'x86_64' },
+    ]
+  },
+
+  // Screenshots embedded in the report
+  // (attach them in your Cucumber hooks with world.attach(screenshot, 'image/png'))
+
+  ignoreBadJsonFile: true,
+});

--- a/testsuite/index.cjs
+++ b/testsuite/index.cjs
@@ -7,6 +7,7 @@
 const report = require('multiple-cucumber-html-reporter');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 
 const args = process.argv.slice(2);
 const jsonDir = args[0] || '.';
@@ -45,31 +46,26 @@ for (const file of jsonFiles) {
 
 console.log(`Loaded ${allFeatures.length} features from ${jsonFiles.length} JSON files.`);
 
-// Write a single merged + ordered JSON file for the reporter to consume.
-// Using a distinct name avoids it being picked up as a cucumber report itself.
-const mergedJsonPath = path.join(jsonDir, '_ordered_report.json');
+// Write the merged file into a dedicated temp directory.
+// This avoids passing both jsonDir (original files) and jsonFile (merged file)
+// to the reporter simultaneously, which caused duplicate un-numbered entries.
+// The library requires jsonDir to be set, so we point it at the temp dir
+// that contains only our single ordered merged file.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cucumber-report-'));
+const mergedJsonPath = path.join(tmpDir, 'ordered_report.json');
 fs.writeFileSync(mergedJsonPath, JSON.stringify(allFeatures));
 
 try {
   report.generate({
-    // Point at the single pre-ordered merged file rather than the directory,
-    // so the reporter doesn't re-discover and re-sort the individual files.
-    jsonDir: jsonDir,
+    jsonDir: tmpDir,        // only our merged file lives here — no duplicates
     jsonFile: mergedJsonPath,
     reportPath: 'cucumber_report',
     reportName: 'Uyuni/Head Testsuite',
-
-    // Durations are in nanoseconds (Cucumber Ruby default)
     displayDuration: true,
     durationInMS: false,
-
     displayReportTime: true,
-
-    // No browser/device metadata columns — not relevant for this setup
     hideMetadata: true,
-
     ignoreBadJsonFile: true,
-
     customData: {
       title: 'Run info',
       data: [
@@ -79,6 +75,6 @@ try {
     }
   });
 } finally {
-  // Always clean up the temp merged file
-  fs.unlinkSync(mergedJsonPath);
+  // Always clean up the temp directory
+  fs.rmSync(tmpDir, { recursive: true, force: true });
 }

--- a/testsuite/index.cjs
+++ b/testsuite/index.cjs
@@ -15,6 +15,10 @@ const jsonDir = args[0] || '.';
 // Read all Cucumber JSON files in the directory.
 // Filenames contain timestamps (e.g. output_20260429143645-sanity_check.json)
 // so lexicographic sort == chronological == execution order.
+if (!fs.existsSync(jsonDir) || !fs.statSync(jsonDir).isDirectory()) {
+  console.error(`Results directory not found or not a directory: ${jsonDir}`);
+  process.exit(1);
+}
 const jsonFiles = fs.readdirSync(jsonDir)
   .filter(f => f.match(/^output_.*\.json$/))
   .sort()

--- a/testsuite/index.cjs
+++ b/testsuite/index.cjs
@@ -42,13 +42,37 @@ for (const file of jsonFiles) {
       const pad = String(sequenceNumber).padStart(4, '0');
       feature.name = `${pad} - ${feature.name}`;
 
-      // Strip before/after hooks to remove visual noise and fix false failures
       for (const scenario of (feature.elements || [])) {
-        delete scenario.before;
-        delete scenario.after;
-        for (const step of (scenario.steps || [])) {
-          delete step.after;
+        // Rescue screenshot embeddings from hooks before stripping them.
+        // Cucumber Ruby attaches screenshots inside after hooks on failure —
+        // we move them onto the failed step so they appear in the report.
+        const hookEmbeddings = [];
+        for (const hook of [...(scenario.before || []), ...(scenario.after || [])]) {
+          for (const embedding of (hook.embeddings || [])) {
+            if (embedding.mime_type === 'image/png' || embedding.media_type === 'image/png') {
+              hookEmbeddings.push(embedding);
+            }
+          }
         }
+        if (hookEmbeddings.length > 0) {
+          const failedStep = (scenario.steps || []).find(s => s.result?.status === 'failed');
+          if (failedStep) {
+            failedStep.embeddings = [...(failedStep.embeddings || []), ...hookEmbeddings];
+          }
+        }
+
+        // Strip passed/skipped hooks to remove visual noise and fix false failures
+        // in the Jenkins Cucumber plugin. Failed hooks (and hooks with no result)
+        // are kept so they remain visible in the report for debugging.
+        const safeStatuses = ['passed', 'skipped'];
+        scenario.before = (scenario.before || []).filter(h => !safeStatuses.includes(h.result?.status));
+        scenario.after  = (scenario.after  || []).filter(h => !safeStatuses.includes(h.result?.status));
+        for (const step of (scenario.steps || [])) {
+          step.after = (step.after || []).filter(h => !safeStatuses.includes(h.result?.status));
+          if (step.after.length === 0) delete step.after;
+        }
+        if (scenario.before.length === 0) delete scenario.before;
+        if (scenario.after.length === 0)  delete scenario.after;
       }
     }
     allFeatures.push(...features);

--- a/testsuite/index.cjs
+++ b/testsuite/index.cjs
@@ -1,34 +1,113 @@
 /**
- * https://github.com/gkushang/cucumber-html-reporter
+ * https://github.com/WasiqB/multiple-cucumber-html-reporter
+ * Preserves execution order by injecting a sequence number into feature names
+ * before generating the report, since the library always sorts alphabetically.
  */
 
-var reporter = require('cucumber-html-reporter');
-var path = require('path');
+const report = require('multiple-cucumber-html-reporter');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 
-// Read command-line arguments
-var args = process.argv.slice(2);
-var jsonDir = args[0] || '.'; // Default to current directory if no argument provided
+const args = process.argv.slice(2);
+const jsonDir = args[0] || '.';
 
-var options = {
-  theme: 'bootstrap',
-  jsonDir: jsonDir,
-  output: 'cucumber_report/cucumber_report.html',
-  reportSuiteAsScenarios: true,
-  launchReport: true,
-  columnLayout: 1,
-  scenarioTimestamp: true,
-  screenshotsDirectory: './cucumber_report/screenshots/',
-  storeScreenshots: true,
-  noInlineScreenshots: true,
-  ignoreBadJsonFile: true,
-  name: 'Uyuni/Head Testsuite',
-  brandTitle: ' ',
-  metadata: {
-    "App Version":"Uyuni/Head",
-    "Browser": "Chrome",
-    "Platform": "x86_64",
-    "Parallel": "Disabled"
+// Read all Cucumber JSON files in the directory.
+// Filenames contain timestamps (e.g. output_20260429143645-sanity_check.json)
+// so lexicographic sort == chronological == execution order.
+if (!fs.existsSync(jsonDir) || !fs.statSync(jsonDir).isDirectory()) {
+  console.error(`Results directory not found or not a directory: ${jsonDir}`);
+  process.exit(1);
+}
+const jsonFiles = fs.readdirSync(jsonDir)
+  .filter(f => f.match(/^output_.*\.json$/))
+  .sort()
+  .map(f => path.join(jsonDir, f));
+
+if (jsonFiles.length === 0) {
+  console.error(`No output_*.json files found in: ${jsonDir}`);
+  process.exit(1);
+}
+
+// Load and merge all features, injecting a zero-padded sequence number
+// into each feature name so alphabetical sort == execution order.
+let sequenceNumber = 0;
+const allFeatures = [];
+
+for (const file of jsonFiles) {
+  try {
+    const features = JSON.parse(fs.readFileSync(file, 'utf8'));
+    for (const feature of features) {
+      sequenceNumber++;
+      const pad = String(sequenceNumber).padStart(4, '0');
+      feature.name = `${pad} - ${feature.name}`;
+
+      for (const scenario of (feature.elements || [])) {
+        // Rescue screenshot embeddings from hooks before stripping them.
+        // Cucumber Ruby attaches screenshots inside after hooks on failure —
+        // we move them onto the failed step so they appear in the report.
+        const hookEmbeddings = [];
+        for (const hook of [...(scenario.before || []), ...(scenario.after || [])]) {
+          for (const embedding of (hook.embeddings || [])) {
+            if (embedding.mime_type === 'image/png' || embedding.media_type === 'image/png') {
+              hookEmbeddings.push(embedding);
+            }
+          }
+        }
+        if (hookEmbeddings.length > 0) {
+          const failedStep = (scenario.steps || []).find(s => s.result?.status === 'failed');
+          if (failedStep) {
+            failedStep.embeddings = [...(failedStep.embeddings || []), ...hookEmbeddings];
+          }
+        }
+
+        // Strip passed/skipped hooks to remove visual noise and fix false failures
+        // in the Jenkins Cucumber plugin. Failed hooks (and hooks with no result)
+        // are kept so they remain visible in the report for debugging.
+        const safeStatuses = ['passed', 'skipped'];
+        scenario.before = (scenario.before || []).filter(h => !safeStatuses.includes(h.result?.status));
+        scenario.after  = (scenario.after  || []).filter(h => !safeStatuses.includes(h.result?.status));
+        for (const step of (scenario.steps || [])) {
+          step.after = (step.after || []).filter(h => !safeStatuses.includes(h.result?.status));
+          if (step.after.length === 0) delete step.after;
+        }
+        if (scenario.before.length === 0) delete scenario.before;
+        if (scenario.after.length === 0)  delete scenario.after;
+      }
+    }
+    allFeatures.push(...features);
+  } catch (e) {
+    console.warn(`Skipping bad JSON file: ${file} — ${e.message}`);
   }
-};
+}
 
-reporter.generate(options);
+console.log(`Loaded ${allFeatures.length} features from ${jsonFiles.length} JSON files.`);
+
+// Write the merged file into a dedicated temp directory.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cucumber-report-'));
+const mergedJsonPath = path.join(tmpDir, 'ordered_report.json');
+fs.writeFileSync(mergedJsonPath, JSON.stringify(allFeatures));
+
+try {
+  report.generate({
+    jsonDir: tmpDir,        // only our merged file lives here — no duplicates
+    jsonFile: mergedJsonPath,
+    reportPath: 'cucumber_report',
+    reportName: 'Uyuni/Head Testsuite',
+    displayDuration: true,
+    durationInMS: false,
+    displayReportTime: true,
+    hideMetadata: true,
+    ignoreBadJsonFile: true,
+    customData: {
+      title: 'Run info',
+      data: [
+        { label: 'Product',  value: 'Uyuni/Head' },
+        { label: 'Platform', value: 'x86_64' },
+      ]
+    }
+  });
+} finally {
+  // Always clean up the temp directory
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}

--- a/testsuite/index.cjs
+++ b/testsuite/index.cjs
@@ -1,41 +1,42 @@
 /**
- * Cucumber HTML report generator using multiple-cucumber-html-reporter
- * Replaces cucumber-html-reporter (abandoned since 2021)
- * Preserves JSON execution order, supports filter by passed/failed/skipped
+ * https://github.com/WasiqB/multiple-cucumber-html-reporter
+ * Replaces cucumber-html-reporter (abandoned since 2021).
+ * Preserves JSON execution order, supports filter by passed/failed/skipped.
  */
 
 const report = require('multiple-cucumber-html-reporter');
+const report = require('multiple-cucumber-html-reporter');
 const path = require('path');
 
+// Read command-line arguments
 const args = process.argv.slice(2);
-const jsonDir = args[0] || '.';
+const jsonDir = args[0] || '.'; // Default to current directory if no argument provided
 
 report.generate({
   jsonDir: jsonDir,
+  // Output to cucumber_report/ — the reporter creates index.html inside this folder.
+  // The Rakefile copies cucumber_report/index.html as cucumber_report.html into result_folder.
   reportPath: 'cucumber_report',
   reportName: 'Uyuni/Head Testsuite',
 
-  // Preserve the order features appear in the JSON (= execution order)
-  // multiple-cucumber-html-reporter does not sort — it uses array order
+  // Preserve the order features appear in the JSON (= execution order).
+  // multiple-cucumber-html-reporter does not sort — it uses the JSON array order.
   displayDuration: true,
-  durationInMS: false,  // Cucumber Ruby reports in nanoseconds
+  // Cucumber Ruby reports durations in nanoseconds (not milliseconds)
+  durationInMS: false,
 
-  // Show pass/fail/skip filter buttons on the overview
   displayReportTime: true,
 
-  // Flatten metadata (no browser/device columns — not relevant for your setup)
+  // No browser/device metadata columns — not relevant for this setup
   hideMetadata: true,
+
+  ignoreBadJsonFile: true,
 
   customData: {
     title: 'Run info',
     data: [
-      { label: 'Product',   value: 'Uyuni/Head' },
-      { label: 'Platform',  value: 'x86_64' },
+      { label: 'Product',  value: 'Uyuni/Head' },
+      { label: 'Platform', value: 'x86_64' },
     ]
-  },
-
-  // Screenshots embedded in the report
-  // (attach them in your Cucumber hooks with world.attach(screenshot, 'image/png'))
-
-  ignoreBadJsonFile: true,
+  }
 });

--- a/testsuite/index.cjs
+++ b/testsuite/index.cjs
@@ -41,6 +41,15 @@ for (const file of jsonFiles) {
       sequenceNumber++;
       const pad = String(sequenceNumber).padStart(4, '0');
       feature.name = `${pad} - ${feature.name}`;
+
+      // Strip before/after hooks to remove visual noise and fix false failures
+      for (const scenario of (feature.elements || [])) {
+        delete scenario.before;
+        delete scenario.after;
+        for (const step of (scenario.steps || [])) {
+          delete step.after;
+        }
+      }
     }
     allFeatures.push(...features);
   } catch (e) {
@@ -51,10 +60,6 @@ for (const file of jsonFiles) {
 console.log(`Loaded ${allFeatures.length} features from ${jsonFiles.length} JSON files.`);
 
 // Write the merged file into a dedicated temp directory.
-// This avoids passing both jsonDir (original files) and jsonFile (merged file)
-// to the reporter simultaneously, which caused duplicate un-numbered entries.
-// The library requires jsonDir to be set, so we point it at the temp dir
-// that contains only our single ordered merged file.
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cucumber-report-'));
 const mergedJsonPath = path.join(tmpDir, 'ordered_report.json');
 fs.writeFileSync(mergedJsonPath, JSON.stringify(allFeatures));


### PR DESCRIPTION
## What does this PR change?

### Problem
 
The Cucumber HTML report generated after each test run was displaying features in **alphabetical order** instead of **execution order**, making it hard to follow the test flow and correlate failures with the correct pipeline stage.
 
Two independent bugs caused this:
 
1. **`cucumber-html-formatter` 21.x** (the built-in Cucumber HTML formatter)   hardcodes a `localeCompare` sort by URI in its bundled JavaScript, overriding  the execution order regardless of the `--order defined` flag.
2. **`cucumber-html-reporter`** (the merged report generator in `index.cjs`)  don't have new release and also sorted features alphabetically with no option to disable it.


### Solution

#### 1. Rakefile — fix the merged report copy (`utils:generate_test_report` task)
 
`multiple-cucumber-html-reporter` outputs `index.html` (not `cucumber_report.html` like the old reporter did). The copy command is updated accordingly:
 
```ruby
# Before
sh "cp cucumber_report/cucumber_report.html #{result_folder}"
 
# After
sh "cp -r cucumber_report/. #{result_folder}/cucumber_report/"
```
 
The entire `cucumber_report/` directory is now copied (not just a single HTML file) so that the feature sub-pages and asset files are available, fixing 404 errors when clicking on individual features in the report.

#### 2. `index.cjs` — replace `cucumber-html-reporter` with `multiple-cucumber-html-reporter`
 https://github.com/WasiqB/multiple-cucumber-html-reporter 
| | Before | After |
|---|---|---|
| Package | `cucumber-html-reporter@7.2.0` | `multiple-cucumber-html-reporter@3.7.0` |
| Last release | 2024 (not active) | Active (2025) |
| Execution order | ❌ Always alphabetical | ✅ Preserved via sequence prefix |
| Filter by status | ❌ No | ✅ Passed / Failed / Skipped |
| Feature sub-pages | ❌ Single file | ✅ Per-feature detail pages |
 
Because `multiple-cucumber-html-reporter` also sorts features alphabetically internally with no configuration option to disable it, the new `index.cjs` pre-processes the JSON before passing it to the reporter:
 
1. Reads all `output_*.json` files from `result_folder`, sorted lexicographically. The timestamp embedded in each filename
   (`output_20260429143645-sanity_check.json`) means lexicographic order equals chronological/execution order.
2. Injects a zero-padded sequence number into each feature name: `0001 - Sanity checks`, `0002 - Very first settings`, etc.
3.   Screenshot rescue, before stripping, index.cjs now rescues image/png embeddings from before/after hooks and moves them onto the failed step, so screenshots appear in the HTML report even though hooks are stripped.
4. Selective stripping, only passed and skipped hooks are stripped; failed hooks (and hooks with no result status) are kept in both the HTML report and the Jenkins plugin data.
5. Writes a single merged JSON file to an isolated `os.tmpdir()` directory so the reporter sees only one file — preventing the double-scan that was causing unnumbered duplicate entries from the parallel test runs.
6. Generates the report, then cleans up the temp directory in a `finally` block.

<img width="1920" height="1824" alt="screencapture-maxime-controller-mgr-suse-de-results-47-cucumber-report-2026-04-30-13_38_39" src="https://github.com/user-attachments/assets/1d5ef01e-6a45-49d0-b774-84d69107a6dd" />


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30600
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/30604
 - 5.0: https://github.com/SUSE/spacewalk/pull/30606
 - 4.3: https://github.com/SUSE/spacewalk/pull/30605
 
 depends on:
  - ci: https://github.com/SUSE/susemanager-ci/pull/2004
  - sumaform: https://github.com/uyuni-project/sumaform/pull/2140

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
