### PR TITLE
Have the cucumber html report in execution order

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -50,8 +50,17 @@ namespace :cucumber do
     # This block executes when the task runs and uses the exact same `html_results` path.
     # This file is used to expose the cucumber html report in Jenkins
     Rake::Task[task_name].enhance do
-      # Write the final HTML path (without the option flag) to the file
-      # This uses the CONSISTENT, PRE-CALCULATED 'html_results' variable
+      if File.exist?(html_results)
+        html_content = File.read(html_results)
+        sort_call = 'i.sort(((e,t)=>(e.uri||"").localeCompare(t.uri||"")))'
+        if html_content.include?(sort_call)
+          patched = html_content.gsub(sort_call, 'i' + (' ' * (sort_call.length - 1)))
+          File.write(html_results, patched)
+        else
+          raise "Could not find sort patch target in #{html_results} — report ordering will be broken. Update sort_call if the formatter was upgraded."
+        end
+      end
+
       sh "echo '#{html_results}' > #{path_export_file}", verbose: false
     end
   end


### PR DESCRIPTION
## What does this PR change?

### Problem
 
The Cucumber HTML report generated after each test run was displaying features in **alphabetical order** instead of **execution order**, making it hard to follow the test flow and correlate failures with the correct pipeline stage.

### Rakefile — patch the per-run HTML report (`cucumber` namespace, `enhance` block)
 
After Cucumber writes each HTML report, a post-processing step neutralises the hardcoded sort call in the `cucumber-html-formatter` 21.x JavaScript bundle:
  
The sort call is replaced with whitespace of identical length so the JavaScript bundle byte offsets are preserved. If the patch target is not found (e.g. after a cucumber-html-formatter upgrade), the task  fails with a clear error message so the ordering guarantee is never silently lost.

New report:
<img width="1301" height="483" alt="image" src="https://github.com/user-attachments/assets/d258418f-b4a3-4e1d-bc67-b4de73d53551" />

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): related PR: https://github.com/uyuni-project/uyuni/pull/11852
Ports:
 - 5.1: https://github.com/SUSE/spacewalk/pull/30528
 - 5.0: https://github.com/SUSE/spacewalk/pull/30529
 - 4.3: https://github.com/SUSE/spacewalk/pull/30530

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
