### PR TITLE
Fix Refishdata feature

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -607,19 +607,22 @@ When(/^the controller starts mocking a Redfish host$/) do
   file_extract(get_target('server'), key_path.strip, '/root/controller.key')
   file_extract(get_target('server'), crt_path.strip, '/root/controller.crt')
 
-  `curl --output /root/DSP2043_2019.1.zip https://www.dmtf.org/sites/default/files/standards/documents/DSP2043_2019.1.zip`
-  `unzip /root/DSP2043_2019.1.zip -d /root/`
+  data_dir = "#{File.dirname(__FILE__)}/../upload_files/Redfish-Mockup-Server/data/public-catfish"
   cmd = "/usr/bin/python3 #{File.dirname(__FILE__)}/../upload_files/Redfish-Mockup-Server/redfishMockupServer.py " \
         "-H #{hostname} -p 8443 " \
-        '-S -D /root/DSP2043_2019.1/public-catfish/ ' \
+        "-S -D #{data_dir} " \
         '--ssl --cert /root/controller.crt --key /root/controller.key ' \
         '< /dev/null > /dev/null 2>&1 &'
   `#{cmd}`
+  repeat_until_timeout(timeout: 30, message: 'Redfish mock server did not start on port 8443') do
+    result = `curl -sk --connect-timeout 2 --max-time 3 https://#{hostname}:8443/redfish/v1 2>/dev/null`
+    break unless result.empty?
+    sleep 1
+  end
 end
 
 When(/^the controller stops mocking a Redfish host$/) do
   `pkill -e -f #{File.dirname(__FILE__)}/../upload_files/Redfish-Mockup-Server/redfishMockupServer.py`
-  `rm -rf /root/DSP2043_2019.1*`
 end
 
 When(/^I install a user-defined state for "([^"]*)" on the server$/) do |host|

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/$metadata/index.xml
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/$metadata/index.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright.-->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ServiceRoot_v1.xml">
+    <edmx:Include Namespace="ServiceRoot"/>
+    <edmx:Include Namespace="ServiceRoot.v1_6_0"/>
+  </edmx:Reference>
+
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/AccountService_v1.xml">
+    <edmx:Include Namespace="AccountService"/>
+    <edmx:Include Namespace="AccountService.v1_7_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Chassis_v1.xml">
+    <edmx:Include Namespace="Chassis"/>
+    <edmx:Include Namespace="Chassis.v1_11_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ChassisCollection_v1.xml">
+    <edmx:Include Namespace="ChassisCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComputerSystem_v1.xml">
+    <edmx:Include Namespace="ComputerSystem"/>
+    <edmx:Include Namespace="ComputerSystem.v1_10_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ComputerSystemCollection_v1.xml">
+    <edmx:Include Namespace="ComputerSystemCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EthernetInterface_v1.xml">
+    <edmx:Include Namespace="EthernetInterface"/>
+    <edmx:Include Namespace="EthernetInterface.v1_5_1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/EthernetInterfaceCollection_v1.xml">
+    <edmx:Include Namespace="EthernetInterfaceCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/LogEntry_v1.xml">
+    <edmx:Include Namespace="LogEntry"/>
+    <edmx:Include Namespace="LogEntry.v1_5_1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/LogEntryCollection_v1.xml">
+    <edmx:Include Namespace="LogEntryCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/LogService_v1.xml">
+    <edmx:Include Namespace="LogService"/>
+    <edmx:Include Namespace="LogService.v1_1_3"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/LogServiceCollection_v1.xml">
+    <edmx:Include Namespace="LogServiceCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Manager_v1.xml">
+    <edmx:Include Namespace="Manager"/>
+    <edmx:Include Namespace="Manager.v1_7_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ManagerCollection_v1.xml">
+    <edmx:Include Namespace="ManagerCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ManagerAccount_v1.xml">
+    <edmx:Include Namespace="ManagerAccount"/>
+    <edmx:Include Namespace="ManagerAccount.v1_5_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ManagerAccountCollection_v1.xml">
+    <edmx:Include Namespace="ManagerAccountCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/ManagerNetworkProtocol_v1.xml">
+    <edmx:Include Namespace="ManagerNetworkProtocol"/>
+    <edmx:Include Namespace="ManagerNetworkProtocol.v1_5_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Message_v1.xml">
+    <edmx:Include Namespace="Message"/>
+    <edmx:Include Namespace="Message.v1_0_8"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Power_v1.xml">
+    <edmx:Include Namespace="Power"/>
+    <edmx:Include Namespace="Power.v1_6_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Role_v1.xml">
+    <edmx:Include Namespace="Role"/>
+    <edmx:Include Namespace="Role.v1_2_4"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RoleCollection_v1.xml">
+    <edmx:Include Namespace="RoleCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Session_v1.xml">
+    <edmx:Include Namespace="Session"/>
+    <edmx:Include Namespace="Session.v1_2_1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SessionCollection_v1.xml">
+    <edmx:Include Namespace="SessionCollection"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/SessionService_v1.xml">
+    <edmx:Include Namespace="SessionService"/>
+    <edmx:Include Namespace="SessionService.v1_1_6"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Thermal_v1.xml">
+    <edmx:Include Namespace="Thermal"/>
+    <edmx:Include Namespace="Thermal.v1_6_0"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/VLanNetworkInterface_v1.xml">
+    <edmx:Include Namespace="VLanNetworkInterface.v1_1_4"/>
+  </edmx:Reference>
+
+  <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+    <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish"/>
+  </edmx:Reference>
+
+  <edmx:DataServices>
+
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Service">
+      <EntityContainer Name="Service" Extends="ServiceRoot.v1_6_0.ServiceContainer"/>
+    </Schema>
+
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Accounts/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Accounts/index.json
@@ -1,0 +1,18 @@
+{
+    "@odata.type": "#ManagerAccountCollection.ManagerAccountCollection",
+    "Name": "Accounts Collection",
+    "Members@odata.count": 3,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/AccountService/Accounts/root"
+        },
+        {
+            "@odata.id": "/redfish/v1/AccountService/Accounts/jane"
+        },
+        {
+            "@odata.id": "/redfish/v1/AccountService/Accounts/john"
+        }
+    ],
+    "@odata.id": "/redfish/v1/AccountService/Accounts",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Accounts/jane/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Accounts/jane/index.json
@@ -1,0 +1,18 @@
+{
+    "@odata.type": "#ManagerAccount.v1_5_0.ManagerAccount",
+    "Id": "jane",
+    "Name": "UserAccount",
+    "Description": "User Account",
+    "Enabled": true,
+    "Password": null,
+    "UserName": "jane",
+    "RoleId": "Operator",
+    "Locked": false,
+    "Links": {
+        "Role": {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Operator"
+        }
+    },
+    "@odata.id": "/redfish/v1/AccountService/Accounts/jane",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Accounts/john/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Accounts/john/index.json
@@ -1,0 +1,18 @@
+{
+    "@odata.type": "#ManagerAccount.v1_5_0.ManagerAccount",
+    "Id": "john",
+    "Name": "UserAccount",
+    "Description": "User Account",
+    "Enabled": true,
+    "Password": null,
+    "UserName": "john",
+    "RoleId": "ReadOnly",
+    "Locked": false,
+    "Links": {
+        "Role": {
+            "@odata.id": "/redfish/v1/AccountService/Roles/ReadOnly"
+        }
+    },
+    "@odata.id": "/redfish/v1/AccountService/Accounts/john",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Accounts/root/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Accounts/root/index.json
@@ -1,0 +1,18 @@
+{
+    "@odata.type": "#ManagerAccount.v1_5_0.ManagerAccount",
+    "Id": "root",
+    "Name": "UserAccount",
+    "Description": "User Account",
+    "Enabled": true,
+    "Password": null,
+    "UserName": "root",
+    "RoleId": "Administrator",
+    "Locked": false,
+    "Links": {
+        "Role": {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Administrator"
+        }
+    },
+    "@odata.id": "/redfish/v1/AccountService/Accounts/root",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Roles/Administrator/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Roles/Administrator/index.json
@@ -1,0 +1,16 @@
+{
+    "@odata.type": "#Role.v1_2_4.Role",
+    "Id": "Administrator",
+    "Name": "User Role",
+    "Description": "Admin User Role",
+    "IsPredefined": true,
+    "AssignedPrivileges": [
+        "Login",
+        "ConfigureManager",
+        "ConfigureUsers",
+        "ConfigureSelf",
+        "ConfigureComponents"
+    ],
+    "@odata.id": "/redfish/v1/AccountService/Roles/Administrator",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Roles/Operator/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Roles/Operator/index.json
@@ -1,0 +1,14 @@
+{
+    "@odata.type": "#Role.v1_2_4.Role",
+    "Id": "Operator",
+    "Name": "User Role",
+    "Description": "Operator User Role",
+    "IsPredefined": true,
+    "AssignedPrivileges": [
+        "Login",
+        "ConfigureSelf",
+        "ConfigureComponents"
+    ],
+    "@odata.id": "/redfish/v1/AccountService/Roles/Operator",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Roles/ReadOnly/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Roles/ReadOnly/index.json
@@ -1,0 +1,13 @@
+{
+    "@odata.type": "#Role.v1_2_4.Role",
+    "Id": "ReadOnly",
+    "Name": "User Role",
+    "Description": "ReadOnly User Role",
+    "IsPredefined": true,
+    "AssignedPrivileges": [
+        "Login",
+        "ConfigureSelf"
+    ],
+    "@odata.id": "/redfish/v1/AccountService/Roles/ReadOnly",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Roles/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/Roles/index.json
@@ -1,0 +1,18 @@
+{
+    "@odata.type": "#RoleCollection.RoleCollection",
+    "Name": "Roles Collection",
+    "Members@odata.count": 3,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Administrator"
+        },
+        {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Operator"
+        },
+        {
+            "@odata.id": "/redfish/v1/AccountService/Roles/ReadOnly"
+        }
+    ],
+    "@odata.id": "/redfish/v1/AccountService/Roles",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/AccountService/index.json
@@ -1,0 +1,25 @@
+{
+    "@odata.type": "#AccountService.v1_7_0.AccountService",
+    "Id": "AccountService",
+    "Name": "Account Service",
+    "Description": "Account Service",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ServiceEnabled": true,
+    "AuthFailureLoggingThreshold": 3,
+    "MinPasswordLength": 8,
+    "AccountLockoutThreshold": 5,
+    "AccountLockoutDuration": 30,
+    "AccountLockoutCounterResetAfter": 30,
+    "AccountLockoutCounterResetEnabled": true,
+    "Accounts": {
+        "@odata.id": "/redfish/v1/AccountService/Accounts"
+    },
+    "Roles": {
+        "@odata.id": "/redfish/v1/AccountService/Roles"
+    },
+    "@odata.id": "/redfish/v1/AccountService",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Chassis/1/Power/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Chassis/1/Power/index.json
@@ -1,0 +1,27 @@
+{
+    "@odata.type": "#Power.v1_6_0.Power",
+    "Id": "Power",
+    "Name": "Power",
+    "PowerControl": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/PowerControl/0",
+            "MemberId": "0",
+            "Name": "System Power Control",
+            "PowerConsumedWatts": 224,
+            "PowerCapacityWatts": 600,
+            "PowerLimit": {
+                "LimitInWatts": 450,
+                "LimitException": "LogEventOnly",
+                "CorrectionInMs": 1000
+            },
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {}
+        }
+    ],
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1/Power",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Chassis/1/Thermal/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Chassis/1/Thermal/index.json
@@ -1,0 +1,149 @@
+{
+    "@odata.type": "#Thermal.v1_6_0.Thermal",
+    "Id": "Thermal",
+    "Name": "Thermal",
+    "Temperatures": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/0",
+            "MemberId": "0",
+            "Name": "Inlet Temp",
+            "SensorNumber": 42,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 25,
+            "UpperThresholdNonCritical": 35,
+            "UpperThresholdCritical": 40,
+            "UpperThresholdFatal": 50,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 200,
+            "PhysicalContext": "Intake"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/1",
+            "MemberId": "1",
+            "Name": "Board Temp",
+            "SensorNumber": 43,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 35,
+            "UpperThresholdNonCritical": 30,
+            "UpperThresholdCritical": 40,
+            "UpperThresholdFatal": 50,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 200,
+            "PhysicalContext": "SystemBoard"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/2",
+            "MemberId": "2",
+            "Name": "CPU1 Temp",
+            "SensorNumber": 44,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 45,
+            "UpperThresholdNonCritical": 60,
+            "UpperThresholdCritical": 82,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 200,
+            "PhysicalContext": "CPU"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/3",
+            "MemberId": "3",
+            "Name": "CPU2 Temp",
+            "SensorNumber": 45,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 46,
+            "UpperThresholdNonCritical": 60,
+            "UpperThresholdCritical": 82,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 200,
+            "PhysicalContext": "CPU"
+        }
+    ],
+    "Fans": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fan 1",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2100,
+            "ReadingUnits": "RPM",
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 4200,
+            "UpperThresholdFatal": 42,
+            "LowerThresholdNonCritical": 42,
+            "LowerThresholdCritical": 5,
+            "LowerThresholdFatal": 42,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Redundancy/0"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/1",
+            "MemberId": "1",
+            "Name": "BaseBoard System Fan 2",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2100,
+            "ReadingUnits": "RPM",
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 4200,
+            "UpperThresholdFatal": 42,
+            "LowerThresholdNonCritical": 42,
+            "LowerThresholdCritical": 5,
+            "LowerThresholdFatal": 42,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Redundancy/0"
+                }
+            ]
+        }
+    ],
+    "Redundancy": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Redundancy/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fans",
+            "RedundancySet": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/0"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/1"
+                }
+            ],
+            "Mode": "N+m",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "MinNumNeeded": 1,
+            "MaxNumSupported": 2
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1/Thermal",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Chassis/1/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Chassis/1/index.json
@@ -1,0 +1,45 @@
+{
+    "@odata.type": "#Chassis.v1_11_0.Chassis",
+    "Id": "1",
+    "Name": "Catfish System Chassis",
+    "ChassisType": "RackMount",
+    "Manufacturer": "CatfishManufacturer",
+    "Model": "YellowCat1000",
+    "SerialNumber": "2M220100SL",
+    "SKU": "",
+    "PartNumber": "",
+    "AssetTag": "CATFISHASSETTAG",
+    "IndicatorLED": "Lit",
+    "PowerState": "On",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Thermal": {
+        "@odata.id": "/redfish/v1/Chassis/1/Thermal"
+    },
+    "Power": {
+        "@odata.id": "/redfish/v1/Chassis/1/Power"
+    },
+    "Links": {
+        "ComputerSystems": [
+            {
+                "@odata.id": "/redfish/v1/Systems/1"
+            }
+        ],
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/bmc"
+            }
+        ],
+        "ManagersInChassis": [
+            {
+                "@odata.id": "/redfish/v1/Managers/bmc"
+            }
+        ],
+        "Oem": {}
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Chassis/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Chassis/index.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#ChassisCollection.ChassisCollection",
+    "Name": "Chassis Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1"
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Managers/bmc/EthernetInterfaces/eth0/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Managers/bmc/EthernetInterfaces/eth0/index.json
@@ -1,0 +1,59 @@
+{
+    "@odata.type": "#EthernetInterface.v1_5_1.EthernetInterface",
+    "Id": "eth0",
+    "Name": "Manager Ethernet Interface",
+    "Description": "Management Network Interface",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "InterfaceEnabled": true,
+    "PermanentMACAddress": "AA:BB:CC:DD:EE:FF",
+    "MACAddress": "AA:BB:CC:DD:EE:FF",
+    "SpeedMbps": 100,
+    "AutoNeg": true,
+    "FullDuplex": true,
+    "MTUSize": 1500,
+    "HostName": "MyHostName",
+    "FQDN": "MyHostName.MyDomainName.com",
+    "MaxIPv6StaticAddresses": 1,
+    "VLAN": {
+        "VLANEnable": true,
+        "VLANId": 101
+    },
+    "IPv4Addresses": [
+        {
+            "Address": "192.168.0.10",
+            "SubnetMask": "255.255.252.0",
+            "AddressOrigin": "DHCP",
+            "Gateway": "192.168.0.1",
+            "Oem": {}
+        }
+    ],
+    "IPv6AddressPolicyTable": [
+        {
+            "Prefix": "::1/128",
+            "Precedence": 50,
+            "Label": 0
+        }
+    ],
+    "IPv6StaticAddresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e24",
+            "PrefixLength": 16
+        }
+    ],
+    "IPv6DefaultGateway": "fe80::1ec1:deff:fe6f:1e24",
+    "IPv6Addresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e24",
+            "PrefixLength": 64,
+            "AddressOrigin": "SLAAC",
+            "AddressState": "Preferred",
+            "Oem": {}
+        }
+    ],
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Managers/bmc/EthernetInterfaces/eth0",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Managers/bmc/EthernetInterfaces/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Managers/bmc/EthernetInterfaces/index.json
@@ -1,0 +1,14 @@
+{
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "Name": "Ethernet Network Interface Collection",
+    "Description": "Collection of EthernetInterfaces for this Manager",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/bmc/EthernetInterfaces/eth0"
+        }
+    ],
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Managers/bmc/EthernetInterfaces",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Managers/bmc/NetworkProtocol/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Managers/bmc/NetworkProtocol/index.json
@@ -1,0 +1,46 @@
+{
+    "@odata.type": "#ManagerNetworkProtocol.v1_5_0.ManagerNetworkProtocol",
+    "Id": "NetworkProtocol",
+    "Name": "Manager Network Protocol",
+    "Description": "Manager Network Service Status",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "HostName": "myBmcHostname",
+    "FQDN": "mymanager.mydomain.com",
+    "HTTP": {
+        "ProtocolEnabled": true,
+        "Port": 80
+    },
+    "HTTPS": {
+        "ProtocolEnabled": true,
+        "Port": 443
+    },
+    "IPMI": {
+        "ProtocolEnabled": true,
+        "Port": 623
+    },
+    "SSH": {
+        "ProtocolEnabled": true,
+        "Port": 22
+    },
+    "SNMP": {
+        "ProtocolEnabled": true,
+        "Port": 161
+    },
+    "SSDP": {
+        "ProtocolEnabled": true,
+        "Port": 1900,
+        "NotifyMulticastIntervalSeconds": 600,
+        "NotifyTTL": 5,
+        "NotifyIPv6Scope": "Site"
+    },
+    "Telnet": {
+        "ProtocolEnabled": true,
+        "Port": 23
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Managers/bmc/NetworkProtocol",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Managers/bmc/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Managers/bmc/index.json
@@ -1,0 +1,52 @@
+{
+    "@odata.type": "#Manager.v1_7_0.Manager",
+    "Id": "bmc",
+    "Name": "Manager",
+    "ManagerType": "BMC",
+    "Description": "BMC",
+    "ServiceEntryPointUUID": "92384634-2938-2342-8820-489239905423",
+    "UUID": "00000000-0000-0000-0000-000000000000",
+    "Model": "CatfishBMC",
+    "DateTime": "2015-03-13T04:14:33+06:00",
+    "DateTimeLocalOffset": "+06:00",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "FirmwareVersion": "1.00",
+    "NetworkProtocol": {
+        "@odata.id": "/redfish/v1/Managers/bmc/NetworkProtocol"
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Managers/bmc/EthernetInterfaces"
+    },
+    "Links": {
+        "ManagerForServers": [
+            {
+                "@odata.id": "/redfish/v1/Systems/1"
+            }
+        ],
+        "ManagerForChassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1"
+            }
+        ],
+        "ManagerInChassis": {
+            "@odata.id": "/redfish/v1/Chassis/1"
+        },
+        "Oem": {}
+    },
+    "Actions": {
+        "#Manager.Reset": {
+            "target": "/redfish/v1/Managers/bmc/Actions/Manager.Reset",
+            "ResetType@Redfish.AllowableValues": [
+                "ForceRestart",
+                "GracefulRestart"
+            ]
+        },
+        "Oem": {}
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Managers/bmc",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Managers/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Managers/index.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#ManagerCollection.ManagerCollection",
+    "Name": "Manager Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/bmc"
+        }
+    ],
+    "@odata.id": "/redfish/v1/Managers",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/README.md
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/README.md
@@ -1,0 +1,39 @@
+---
+DocTitle:  Catfish Mockup
+---
+# Catfish Mockup:
+  *  A simple, minimal Redfish Service
+  *  For a monolithic Server
+  *  Aligned with: OCP Remote Machine Management Spec feature set
+
+
+# Top Level Description:
+  * A Monolithic server:
+      * One ComputerSystem
+      * One Chassis
+      * One Manager
+  --Provides basic management features aligned with OCP Remote Machine Management Spec 1.01:
+      * Power-on/off/reset
+      * Boot to PXE, HDD, BIOS setup (boot override)
+      * 4 temp sensors per DCMI (CPU1, CPU2, Board, Inlet)
+      * Simple Power Reading, and  DCMI Power Limiting
+      * Fan Monitoring w/ redundancy
+      * Set asset tag and Indicator LED
+      * Basic inventory (serial#, model, SKU, Vendor, BIOS ver…)
+      * User Management
+      * BMC management: get/set IP, version, enable/disable protocol
+
+# What it does NOT have -- that the Redfish 1.0 model supports
+   * No PSUs in model  (RMM spec did not include PSUs) 
+   * No ProcessorInfo, MemoryInfo, StorageInfo, System-EthernetInterfaceInfo
+   * No Tasks
+   * JsonSchema and Registries collections left out (since that is optional)
+   * No EventService
+   * Remote Machine Management spec used basic PET alerts
+
+
+# Discussion
+   * Opportunity to define some Redfish ‘Integration Recipe’ that specify
+      * What APIs and properties are supported / required
+      * How to capture
+

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/README.txt
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/README.txt
@@ -1,0 +1,38 @@
+
+Catfish Mockup:
+  -- A simple, minimal Redfish Service
+  -- For a monolythic Server
+  -- Aligned with: OCP Remote Machine Management Spec feature set
+
+
+Top Level Description:
+  --A Monolythic server:
+        --One ComputerSystem
+        --One Chassis
+        --One Manager
+  --Provides basic management features aligned with OCP Remote Machine Management Spec 1.01:
+        --Power-on/off/reset
+        --Boot to PXE, HDD, BIOS setup (boot override)
+        --4 temp sensors per DCMI (CPU1, CPU2, Board, Inlet)
+        --Simple Power Reading, and  DCMI Power Limiting
+        --Fan Monitoring w/ redundancy
+        --Set asset tag and Indicator LED
+        --Basic inventory (serial#, model, SKU, Vendor, BIOS ver…)
+        --User Management
+        --BMC management: get/set IP, version, enable/disable protocol
+
+What it does NOT have -- that the Redfish 1.0 model supports
+   --No PSUs in model  (RMM spec did not include PSUs) 
+   --No ProcessorInfo, MemoryInfo, StorageInfo, System-EthernetInterfaceInfo
+   --No Tasks
+   --JsonSchema and Registries collections left out (since that is optional)
+   --No EventService
+   --Remote Machine Management spec used basic PET alerts
+
+
+Discussion
+   --Opportunity to define some Redfish ‘API Profiles’ that specify
+       --What APIs and properties are supported / required
+       --Min and Max issue
+       --How to capture
+

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/SessionService/Sessions/1234567890ABCDEF/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/SessionService/Sessions/1234567890ABCDEF/index.json
@@ -1,0 +1,10 @@
+{
+    "@odata.type": "#Session.v1_2_1.Session",
+    "Id": "1234567890ABCDEF",
+    "Name": "User Session",
+    "Description": "Manager User Session",
+    "UserName": "root",
+    "Oem": {},
+    "@odata.id": "/redfish/v1/SessionService/Sessions/1234567890ABCDEF",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/SessionService/Sessions/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/SessionService/Sessions/index.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#SessionCollection.SessionCollection",
+    "Name": "Session Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/SessionService/Sessions/1234567890ABCDEF"
+        }
+    ],
+    "@odata.id": "/redfish/v1/SessionService/Sessions",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/SessionService/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/SessionService/index.json
@@ -1,0 +1,17 @@
+{
+    "@odata.type": "#SessionService.v1_1_6.SessionService",
+    "Id": "SessionService",
+    "Name": "Session Service",
+    "Description": "Session Service",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ServiceEnabled": true,
+    "SessionTimeout": 30,
+    "Sessions": {
+        "@odata.id": "/redfish/v1/SessionService/Sessions"
+    },
+    "@odata.id": "/redfish/v1/SessionService",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Systems/1/LogServices/SEL/Entries/1/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Systems/1/LogServices/SEL/Entries/1/index.json
@@ -1,0 +1,22 @@
+{
+    "@odata.type": "#LogEntry.v1_5_1.LogEntry",
+    "Id": "1",
+    "Name": "Log Entry 1",
+    "EntryType": "SEL",
+    "Severity": "Critical",
+    "Created": "2012-03-07T14:44:00Z",
+    "EntryCode": "Upper Critical - going high",
+    "SensorType": "Temperature",
+    "SensorNumber": 1,
+    "Message": "Temperature threshold exceeded",
+    "MessageId": "0x592A28",
+    "Links": {
+        "OriginOfCondition": {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal"
+        },
+        "Oem": {}
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/SEL/Entries/1",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Systems/1/LogServices/SEL/Entries/2/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Systems/1/LogServices/SEL/Entries/2/index.json
@@ -1,0 +1,22 @@
+{
+    "@odata.type": "#LogEntry.v1_5_1.LogEntry",
+    "Id": "2",
+    "Name": "Log Entry 2",
+    "EntryType": "SEL",
+    "Severity": "Critical",
+    "Created": "2012-03-07T14:45:00Z",
+    "EntryCode": "Upper Critical - going high",
+    "SensorType": "Temperature",
+    "SensorNumber": 2,
+    "Message": "Temperature threshold exceeded",
+    "MessageId": "0x592E28",
+    "Links": {
+        "OriginOfCondition": {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal"
+        },
+        "Oem": {}
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/SEL/Entries/2",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Systems/1/LogServices/SEL/Entries/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Systems/1/LogServices/SEL/Entries/index.json
@@ -1,0 +1,53 @@
+{
+    "@odata.type": "#LogEntryCollection.LogEntryCollection",
+    "Name": "Log Service Collection",
+    "Description": "Collection of Logs for this System",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/SEL/Entries/1",
+            "@odata.type": "#LogEntry.v1_5_1.LogEntry",
+            "Id": "1",
+            "Name": "Log Entry 1",
+            "EntryType": "SEL",
+            "Severity": "Critical",
+            "Created": "2012-03-07T14:44:00Z",
+            "EntryCode": "Upper Critical - going high",
+            "SensorType": "Temperature",
+            "SensorNumber": 1,
+            "Message": "Temperature threshold exceeded",
+            "MessageId": "0x592A28",
+            "Links": {
+                "OriginOfCondition": {
+                    "@odata.id": "/redfish/v1/Chassis/1/Thermal"
+                },
+                "Oem": {}
+            },
+            "Oem": {}
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/SEL/Entries/2",
+            "@odata.type": "#LogEntry.v1_5_1.LogEntry",
+            "Id": "2",
+            "Name": "Log Entry 2",
+            "EntryType": "SEL",
+            "Severity": "Critical",
+            "Created": "2012-03-07T14:45:00Z",
+            "EntryCode": "Upper Critical - going high",
+            "SensorType": "Temperature",
+            "SensorNumber": 2,
+            "Message": "Temperature threshold exceeded",
+            "MessageId": "0x592E28",
+            "Links": {
+                "OriginOfCondition": {
+                    "@odata.id": "/redfish/v1/Chassis/1/Thermal"
+                },
+                "Oem": {}
+            },
+            "Oem": {}
+        }
+    ],
+    "@odata.nextLink": "/redfish/v1/Systems/1/LogServices/SEL/Entries?$skiptoken=2",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/SEL/Entries",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Systems/1/LogServices/SEL/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Systems/1/LogServices/SEL/index.json
@@ -1,0 +1,26 @@
+{
+    "@odata.type": "#LogService.v1_1_3.LogService",
+    "Id": "SEL",
+    "Name": "System Log Service",
+    "MaxNumberOfRecords": 1000,
+    "OverWritePolicy": "WrapsWhenFull",
+    "DateTime": "2015-03-13T04:14:33+06:00",
+    "DateTimeLocalOffset": "+06:00",
+    "ServiceEnabled": true,
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Oem": {},
+    "Actions": {
+        "#LogService.ClearLog": {
+            "target": "/redfish/v1/Systems/1/LogServices/SEL/Actions/LogService.ClearLog"
+        },
+        "Oem": {}
+    },
+    "Entries": {
+        "@odata.id": "/redfish/v1/Systems/1/LogServices/SEL/Entries"
+    },
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/SEL",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Systems/1/LogServices/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Systems/1/LogServices/index.json
@@ -1,0 +1,14 @@
+{
+    "@odata.type": "#LogServiceCollection.LogServiceCollection",
+    "Name": "Log Service Collection",
+    "Description": "Collection of Logs for this System",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/SEL"
+        }
+    ],
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Systems/1/LogServices",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Systems/1/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Systems/1/index.json
@@ -1,0 +1,69 @@
+{
+    "@odata.type": "#ComputerSystem.v1_10_0.ComputerSystem",
+    "Id": "1",
+    "Name": "Catfish System",
+    "SystemType": "Physical",
+    "AssetTag": "CATFISHASSETTAG",
+    "Manufacturer": "CatfishManufacturer",
+    "Model": "YellowCat1000",
+    "SerialNumber": "2M220100SL",
+    "SKU": "",
+    "PartNumber": "",
+    "Description": "Catfish Implementation Recipe of simple scale-out monolithic server",
+    "UUID": "00000000-0000-0000-0000-000000000000",
+    "HostName": "catfishHostname",
+    "PowerState": "On",
+    "BiosVersion": "X00.1.2.3.4(build-23)",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "IndicatorLED": "Off",
+    "Boot": {
+        "BootSourceOverrideEnabled": "Once",
+        "BootSourceOverrideMode": "UEFI",
+        "UefiTargetBootSourceOverride": "uefiDevicePath",
+        "BootSourceOverrideTarget": "Pxe",
+        "BootSourceOverrideTarget@Redfish.AllowableValues": [
+            "None",
+            "Pxe",
+            "Usb",
+            "Hdd",
+            "BiosSetup",
+            "UefiTarget",
+            "UefiHttp"
+        ]
+    },
+    "LogServices": {
+        "@odata.id": "/redfish/v1/Systems/1/LogServices"
+    },
+    "Links": {
+        "Chassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1"
+            }
+        ],
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/bmc"
+            }
+        ],
+        "Oem": {}
+    },
+    "Actions": {
+        "#ComputerSystem.Reset": {
+            "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+            "ResetType@Redfish.AllowableValues": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "ForceRestart",
+                "Nmi",
+                "GracefulRestart",
+                "ForceOn"
+            ]
+        }
+    },
+    "@odata.id": "/redfish/v1/Systems/1",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Systems/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/Systems/index.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+    "Name": "Computer System Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1"
+        }
+    ],
+    "@odata.id": "/redfish/v1/Systems",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/explorer_config.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/explorer_config.json
@@ -1,0 +1,48 @@
+{
+    "name": "Proposed OCP Redfish Profile",
+    "description": "This draft example, for ongoing development, represents a proposed minimal Redfish data model \"profile\" that meets the needs of the Open Compute Project's Hardware Management requirements. This draft profile is intended to help define a list of required properties so that essential management-related tasks, as defined by OCP, can be performed on any Redfish implementation.",
+    "navlinks": [
+        {
+            "text": "Main",
+            "target": "main"
+        },
+        {
+            "text": "Systems",
+            "target": "Systems",
+            "navlinks": [
+                {
+                    "text": "1",
+                    "target": "1"
+                }
+            ]
+        },
+        {
+            "text": "Chassis",
+            "target": "Chassis",
+            "navlinks": [
+                {
+                    "text": "1",
+                    "target": "1"
+                }
+            ]
+        },
+        {
+            "text": "Managers",
+            "target": "Managers",
+            "navlinks": [
+                {
+                    "text": "BMC",
+                    "target": "bmc"
+                }
+            ]
+        },
+        {
+            "text": "Session Service",
+            "target": "SessionService"
+        },
+        {
+            "target": "AccountService",
+            "text": "Account Service"
+        }
+    ]
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/index.json
@@ -1,0 +1,30 @@
+{
+    "@odata.type": "#ServiceRoot.v1_6_0.ServiceRoot",
+    "Id": "RootService",
+    "Name": "Root Service",
+    "RedfishVersion": "1.0.2",
+    "UUID": "92384634-2938-2342-8820-489239905423",
+    "Systems": {
+        "@odata.id": "/redfish/v1/Systems"
+    },
+    "Chassis": {
+        "@odata.id": "/redfish/v1/Chassis"
+    },
+    "Managers": {
+        "@odata.id": "/redfish/v1/Managers"
+    },
+    "SessionService": {
+        "@odata.id": "/redfish/v1/SessionService"
+    },
+    "AccountService": {
+        "@odata.id": "/redfish/v1/AccountService"
+    },
+    "Links": {
+        "Sessions": {
+            "@odata.id": "/redfish/v1/SessionService/Sessions"
+        }
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/odata/index.json
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/data/public-catfish/odata/index.json
@@ -1,0 +1,41 @@
+{
+    "value": [
+        {
+            "name": "Service",
+            "kind": "Singleton",
+            "url": "/redfish/v1/"
+        },
+        {
+            "name": "Systems",
+            "kind": "Singleton",
+            "url": "/redfish/v1/Systems"
+        },
+        {
+            "name": "Chassis",
+            "kind": "Singleton",
+            "url": "/redfish/v1/Chassis"
+        },
+        {
+            "name": "Managers",
+            "kind": "Singleton",
+            "url": "/redfish/v1/Managers"
+        },
+        {
+            "name": "AccountService",
+            "kind": "Singleton",
+            "url": "/redfish/v1/AccountService"
+        },
+        {
+            "name": "SessionService",
+            "kind": "Singleton",
+            "url": "/redfish/v1/SessionService"
+        },
+        {
+            "name": "Sessions",
+            "kind": "Singleton",
+            "url": "/redfish/v1/SessionService/Sessions"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata",
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}


### PR DESCRIPTION
## What does this PR change?

### Problem

The Test Redfish functions scenario was failing consistently across all versions with a timeout waiting for the power status to show "On".

Root cause: the setup step downloaded the Redfish mockup dataset from an external DMTF URL (dmtf.org) at test time, with no error checking and all output discarded. When the download failed silently, redfishMockupServer.py had no data to serve and refused connections. The SUMA server's fence_redfish then got [Errno 111] Connection refused on every power action,
Cobbler kept retrying the fence pipeline indefinitely, and the UI never updated the power status.

### Changes

features/upload_files/Redfish-Mockup-Server/data/public-catfish/ — Bundle the public-catfish  mockup dataset directly in the testsuite (34 files / 144KB). Only this profile is used by the test; the other profiles from the DSP2043 zip (public-bladed, public-rackmount1, etc.) are not included.

features/step_definitions/command_steps.rb — Update the controller starts mocking a Redfish host to:

- Use the bundled data path instead of downloading and unzipping from dmtf.org at runtime
- Add a health check after starting the mock server — polls
https://{controller}:8443/redfish/v1 for up to 30 seconds and fails the setup scenario loudly if the server doesn't respond, rather than silently proceeding with a non-functional mock

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30532
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/30559
 - 5.0: https://github.com/SUSE/spacewalk/pull/30560
 
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
