### PR TITLE
testsuite: include stderr in run_local error messages

### DIFF
--- a/testsuite/features/support/network_utils.rb
+++ b/testsuite/features/support/network_utils.rb
@@ -28,8 +28,8 @@ def ssh_command(command, host, port: 22, timeout: DEFAULT_TIMEOUT, buffer_size: 
     puts "SSH operation timed out after #{timeout} seconds."
   rescue Net::SSH::ConnectionTimeout, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ECONNRESET
     puts "Unable to reach the SSH server at #{host}:#{port}"
-  rescue Net::SSH::AuthenticationFailed
-    puts "Authentication failed for user #{user} on #{host}"
+  rescue Net::SSH::AuthenticationFailed => e
+    puts "Authentication failed on #{host}: #{e.message}"
   end
 
   [stdout, stderr, exit_code]
@@ -48,8 +48,8 @@ def scp_upload_command(local_path, remote_path, host, port: 22, timeout: DEFAULT
     Net::SSH.start(host, nil, port: port, verify_host_key: :never, keepalive: true, timeout: timeout, max_pkt_size: buffer_size, config: true) do |ssh|
       ssh.scp.upload! local_path, remote_path
     end
-  rescue Net::SSH::ConnectionTimeout, Errno::ECONNREFUSED
-    # The connection times out or is refused
+  rescue Net::SSH::ConnectionTimeout, Errno::ECONNREFUSED => e
+    puts "SCP upload failed (#{local_path} -> #{host}:#{remote_path}): #{e.message}"
   end
 end
 
@@ -66,8 +66,8 @@ def scp_download_command(remote_path, local_path, host, port: 22, timeout: DEFAU
     Net::SSH.start(host, nil, port: port, verify_host_key: :never, keepalive: true, timeout: timeout, max_pkt_size: buffer_size, config: true) do |ssh|
       ssh.scp.download! remote_path, local_path
     end
-  rescue Net::SSH::ConnectionTimeout, Errno::ECONNREFUSED
-    # The connection times out or is refused
+  rescue Net::SSH::ConnectionTimeout, Errno::ECONNREFUSED => e
+    puts "SCP download failed (#{host}:#{remote_path} -> #{local_path}): #{e.message}"
   end
 end
 
@@ -85,7 +85,7 @@ def ssh_exec!(ssh, command, timeout: 10)
 
   ssh.open_channel do |channel|
     channel.exec(command) do |_ch, success|
-      raise SystemCallError, 'FAILED: could not execute command (ssh.channel.exec)' unless success
+      raise SystemCallError, "FAILED: could not execute command '#{command}' (ssh.channel.exec)" unless success
 
       channel.on_data do |_ch, data|
         stdout += data

--- a/testsuite/features/support/remote_node.rb
+++ b/testsuite/features/support/remote_node.rb
@@ -169,9 +169,10 @@ class RemoteNode
   def run_local(cmd, separated_results: false, check_errors: true, timeout: DEFAULT_TIMEOUT, successcodes: [0], buffer_size: 65_536, verbose: false)
     out, err, code = ssh_command(cmd, @target, timeout: timeout, buffer_size: buffer_size)
     out_nocolor = out.gsub(/\e\[([;\d]+)?m/, '')
-    raise ScriptError, "FAIL: #{cmd} returned status code = #{code}.\nOutput:\n#{out_nocolor}" if check_errors && !successcodes.include?(code)
+    err_nocolor = err.gsub(/\e\[([;\d]+)?m/, '')
+    raise ScriptError, "FAIL: #{cmd} returned status code = #{code}.\nOutput:\n#{out_nocolor}\nStderr:\n#{err_nocolor}" if check_errors && !successcodes.include?(code)
 
-    $stdout.puts "#{cmd} returned status code = #{code}.\nOutput:\n'#{out_nocolor}'" if verbose
+    $stdout.puts "#{cmd} returned status code = #{code}.\nOutput:\n'#{out_nocolor}'\nStderr:\n'#{err_nocolor}'" if verbose
     if separated_results
       [out, err, code]
     else
@@ -235,8 +236,7 @@ class RemoteNode
       tmp_file = File.join('/tmp/', File.basename(test_runner_file))
       success = get_target('localhost').scp_upload(test_runner_file, tmp_file, host: @full_hostname)
       if success
-        _out, code = run_local("mgrctl cp #{tmp_file} server:#{remote_node_file}")
-        raise ScriptError, "Failed to copy #{tmp_file} to container" unless code.zero?
+        run_local("mgrctl cp #{tmp_file} server:#{remote_node_file}")
       end
     else
       success = get_target('localhost').scp_upload(test_runner_file, remote_node_file, host: @full_hostname)
@@ -252,8 +252,7 @@ class RemoteNode
   def extract(remote_node_file, test_runner_file)
     if @has_mgrctl
       tmp_file = File.join('/tmp/', File.basename(remote_node_file))
-      _out, code = run_local("mgrctl cp server:#{remote_node_file} #{tmp_file}", verbose: false)
-      raise ScriptError, "Failed to extract #{remote_node_file} from container" unless code.zero?
+      run_local("mgrctl cp server:#{remote_node_file} #{tmp_file}", verbose: false)
 
       success = get_target('localhost').scp_download(tmp_file, test_runner_file, host: @full_hostname)
       raise ScriptError, "Failed to extract #{tmp_file} from host" unless success


### PR DESCRIPTION
## What does this PR change?

### Problem

When a remote command fails, run_local raises a ScriptError that includes only stdout in the error message. Stderr is captured by ssh_exec! but silently discarded.

This caused a real diagnostic blind spot: the mgrpush tool (used in srv_push_package.feature) exits with code 1 and writes its error exclusively to stderr (e.g. an ImportError from a missing Python dependency). The Cucumber failure report showed
an empty Output: with no indication of the actual error, making the root cause impossible to determine from CI logs alone.

Apply this logic to other bash command. Get the output in the report to improve the debugging with logs.

### Change

Include err (stderr) in the ScriptError message raised by run_local:

FAIL: <cmd> returned status code = 1.
Output:
<stdout>
Stderr:
<stderr>   ← new

### Impact
Overall improve the debug capacity.
- Applies to all remote commands that fail — broader visibility for any future failures where tools write to stderr
- No functional change when commands succeed
- No change to the separated_results return value or any other behavior

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): Found with https://github.com/SUSE/spacewalk/issues/30500
Port(s): 
 - 5.1:
 - 5.0:
 - 4.3:

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
