### PR TITLE
Improve check text error handling

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -89,6 +89,18 @@ end
 # Fix a problem with minitest and cucumber options passed through rake
 MultiTest.disable_autorun
 
+# WORKAROUND: Chrome 134+ raises UnknownError ("Node with given id does not belong to the document")
+# via CDP when a full page navigation invalidates DOM node references mid-wait.
+# Capybara's synchronize() only retries on errors in invalid_element_errors, which does not include
+# UnknownError, so the error surfaces as a hard crash. Extending the driver makes it retryable.
+module CapybaraUnknownErrorRetry
+  # Adds UnknownError to the list of errors that Capybara retries on during synchronize().
+  # Chrome 134+ raises UnknownError via CDP when a page navigation invalidates DOM node references.
+  def invalid_element_errors
+    super | [Selenium::WebDriver::Error::UnknownError]
+  end
+end
+
 # register chromedriver in headless mode
 def capybara_register_driver
   Capybara.register_driver :selenium_chrome_headless do |app|
@@ -114,7 +126,10 @@ def capybara_register_driver
     chrome_options.add_preference('unhandledPromptBehavior', 'accept')
     chrome_options.add_preference('unexpectedAlertBehaviour', 'accept')
 
-    Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options, http_client: client)
+    # WORKAROUND: Chrome 134+ raises UnknownError ("Node with given id does not belong to the document")
+    driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options, http_client: client)
+    driver.extend(CapybaraUnknownErrorRetry)
+    driver
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

### Problem

Since Chrome 134, a Selenium::WebDriver::Error::UnknownError is raised during text-wait steps when a full page navigation occurs mid-wait:

Selenium::WebDriver::Error::UnknownError unknown error: unhandled inspector error:
{"code":-32000,"message":"Node with given id does not belong to the document"}

This happens because Capybara holds Chrome DevTools Protocol (CDP) node references from the previous page. When the page navigates, Chrome invalidates those node IDs and raises UnknownError via CDP.

Two consequences:

1. The step crashes instead of either finding the text or timing out cleanly
2. The After hook detects a WebDriverError subclass and restarts the driver without taking a screenshot, so the failure has no visual evidence

## Root cause

Capybara's synchronize() loop — which backs has_text?, assert_text, and all text-wait methods — retries only on errors in invalid_element_errors. That list includes
StaleElementReferenceError but not UnknownError, so the CDP stale node error surfaces as a hard crash instead of being retried.

## Solution

Extend the registered Capybara driver with a module that appends UnknownError to invalid_element_errors. This makes synchronize() treat the transient CDP error as retryable, so a text wait that coincides with a page navigation will retry until the new page settles and either finds the text or times out normally.

This is the minimal targeted fix: no changes to step definitions or test logic. The scope is limited to the Chrome driver  registration in env.rb.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): Found with https://github.com/SUSE/spacewalk/issues/30538
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/30546
 - 5.0: https://github.com/SUSE/spacewalk/pull/30544
 - 4.3: https://github.com/SUSE/spacewalk/pull/30547

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
