### PR TITLE
Fix gpgverify check for fileobject (bsc#1263886)

### DIFF
--- a/python/spacewalk/common/gpgverify.py
+++ b/python/spacewalk/common/gpgverify.py
@@ -181,7 +181,7 @@ def verify_file(
       unexpectedly.
     """
     # check for file object
-    if hasattr(signed_file, "name"):
+    if hasattr(signed_file, "name") and not isinstance(signed_file, (os.PathLike, str)):
         signed_fname = typing.cast(str, signed_file.name)
     else:
         signed_fname = signed_file

--- a/python/spacewalk/spacewalk-backend.changes.mczernek.gpg-fix
+++ b/python/spacewalk/spacewalk-backend.changes.mczernek.gpg-fix
@@ -1,0 +1,1 @@
+- Fix gpgverify check for file object (bsc#1263886)


### PR DESCRIPTION
## What does this PR change?

Previously, `gpgverify` assumed that if a parameter has the `name` attribute, it's a file object. However, `Path`-like objects also have the `name` attribute, though with completely different meaning:

```
>>> f = open('/tmp/a')
>>> f.name
'/tmp/a'
>>> from pathlib import Path
>>> p = Path('/tmp/a')
>>> p.name
'a'
```

This caused an error when trying to reposync Debian repositories.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Issue(s):  https://github.com/SUSE/spacewalk/issues/30562
Port(s): Not relevant, code is only on `master`

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
