### PR TITLE
testsuite: install exporters from universe for Debian like minion

### DIFF
--- a/testsuite/features/secondary/min_deblike_monitoring.feature
+++ b/testsuite/features/secondary/min_deblike_monitoring.feature
@@ -15,6 +15,9 @@ Feature: Monitor MLM environment with Prometheus on a Debian-like Salt minion
   Scenario: Log in as org admin user
     Given I am authorized
 
+  Scenario: Pre-requisite: Enable all the necessary repositories for Monitoring on Debian-like minion
+    When I enable Debian-like "universe" repository on "deblike_minion"
+
   Scenario: Apply Prometheus exporter formulas on the Debian-like minion
     Given I am on the Systems overview page of this "deblike_minion"
     When I follow "Formulas" in the content area
@@ -34,9 +37,6 @@ Feature: Monitor MLM environment with Prometheus on a Debian-like Salt minion
     And I check "postgres" exporter
     And I click on "Save"
     Then I should see a "Formula saved" text
-
-  Scenario: Enable tools_update_repo tools_pool_repo so the exporters packages are available
-    When I enable the repositories "tools_update_repo tools_pool_repo" on this "deblike_minion" without error control
 
 @skip_if_github_validation
   Scenario: Apply highstate for Prometheus exporters on the Debian-like minion
@@ -69,5 +69,5 @@ Feature: Monitor MLM environment with Prometheus on a Debian-like Salt minion
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled" is completed
 
-  Scenario: Cleanup: Disable tools_update_repo tools_pool_repo because they are no longer needed
-    When I disable the repositories "tools_update_repo tools_pool_repo" on this "deblike_minion" without error control
+  Scenario: Cleanup: Disable all the necessary repositories for Monitoring on Debian-like minion
+    When I disable Debian-like "universe" repository on "deblike_minion"


### PR DESCRIPTION
## What does this PR change?

This PR fixes some failures at "Uyuni:Main" acceptance tests as it was decided the monitoring exporters are NOT shipped anymore as part of the client tools for DEB based distros.

So, this PR makes testsuite to temporary enable the "universe" repository in order to get the exporters.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28911

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
