### PR TITLE
Run ANALYZE asynchronously after CLM alignment to avoid deadlocks (bsc#1261753)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/common/messaging/MessageQueue.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/messaging/MessageQueue.java
@@ -20,6 +20,8 @@ import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.frontend.events.AlignSoftwareTargetAction;
 import com.redhat.rhn.frontend.events.AlignSoftwareTargetMsg;
+import com.redhat.rhn.frontend.events.AnalyzeAlignTablesAction;
+import com.redhat.rhn.frontend.events.AnalyzeAlignTablesMsg;
 import com.redhat.rhn.frontend.events.CloneErrataAction;
 import com.redhat.rhn.frontend.events.CloneErrataEvent;
 import com.redhat.rhn.frontend.events.NewCloneErrataAction;
@@ -332,6 +334,10 @@ public class MessageQueue {
         // Copy SW source contents to an Environment target
         MessageQueue.registerAction(new AlignSoftwareTargetAction(),
                                     AlignSoftwareTargetMsg.class);
+
+        // Analyze CLM tables after align transaction finishes
+        MessageQueue.registerAction(new AnalyzeAlignTablesAction(),
+                        AnalyzeAlignTablesMsg.class);
 
         // Asynchronously schedule immediate repo sync
         MessageQueue.registerAction(new ScheduleRepoSyncAction(),

--- a/java/core/src/main/java/com/redhat/rhn/frontend/events/AnalyzeAlignTablesAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/events/AnalyzeAlignTablesAction.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.frontend.events;
+
+import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Run ANALYZE on tables heavily modified by CLM alignment.
+ *
+ * This is triggered by CLM alignment completion events, and may be triggered multiple times in a short period if
+ * multiple CLM builds are being run. To avoid excessive load, only one run executes at a time, and if multiple
+ * triggers arrive during a run, only one additional trailing run will be queued to execute immediately after the
+ * active run completes.
+ */
+public class AnalyzeAlignTablesAction implements MessageAction {
+
+    private static final Logger LOG = LogManager.getLogger(AnalyzeAlignTablesAction.class);
+    private static final int IDLE = 0;
+    private static final int RUNNING = 1;
+    private static final int TRAILING_RUN_QUEUED = 2;
+    private static final AtomicInteger STATE = new AtomicInteger(IDLE);
+
+    @Override
+    public void execute(EventMessage msg) {
+        // If a run is active, queue one trailing rerun and return.
+        int previousState = STATE.getAndUpdate(state -> state == IDLE ? RUNNING : TRAILING_RUN_QUEUED);
+        if (previousState != IDLE) {
+            LOG.debug("Post-align ANALYZE run already in progress, trailing rerun requested");
+            return;
+        }
+
+        try {
+            while (!Thread.currentThread().isInterrupted()) {
+                Instant start = Instant.now();
+                LOG.info("Starting post-align ANALYZE run");
+
+                try {
+                    runAnalyzeTables();
+                    LOG.info("Finished post-align ANALYZE run in {}", Duration.between(start, Instant.now()));
+                }
+                catch (Exception e) {
+                    LOG.error("Post-align ANALYZE run failed after {}", Duration.between(start, Instant.now()), e);
+                }
+
+                // Decide rerun/stop
+                if (STATE.compareAndSet(RUNNING, IDLE)) {
+                    return;
+                }
+
+                // It was TRAILING_RUN_QUEUED. Reset to RUNNING and loop
+                STATE.set(RUNNING);
+                LOG.debug("Executing trailing post-align ANALYZE run");
+            }
+        }
+        finally {
+            // Ensure we do not remain stuck in a non-idle state after any unexpected exit path.
+            STATE.set(IDLE);
+        }
+    }
+
+    @Override
+    public boolean canRunConcurrently() {
+        return true;
+    }
+
+    private static void runAnalyzeTables() {
+        ChannelFactory.analyzeChannelPackages();
+        ChannelFactory.analyzeErrataPackages();
+        ChannelFactory.analyzeChannelErrata();
+        ChannelFactory.analyzeErrataCloned();
+        ChannelFactory.analyzeErrata();
+        ChannelFactory.analyzeServerNeededCache();
+    }
+}

--- a/java/core/src/main/java/com/redhat/rhn/frontend/events/AnalyzeAlignTablesMsg.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/events/AnalyzeAlignTablesMsg.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.events;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.messaging.EventDatabaseMessage;
+import com.redhat.rhn.domain.user.User;
+
+import org.hibernate.Transaction;
+
+/**
+ * Post-transaction message to analyze CLM alignment tables.
+ */
+public class AnalyzeAlignTablesMsg implements EventDatabaseMessage {
+
+    private final Transaction txn;
+    private final User user;
+
+    /**
+     * Standard constructor.
+     * @param userIn the user that initiates the message
+     */
+    public AnalyzeAlignTablesMsg(User userIn) {
+        this.user = userIn;
+        this.txn = HibernateFactory.getSession().getTransaction();
+    }
+
+    @Override
+    public Transaction getTransaction() {
+        return txn;
+    }
+
+    @Override
+    public String toText() {
+        return toString();
+    }
+
+    @Override
+    public Long getUserId() {
+        return user.getId();
+    }
+
+    @Override
+    public String toString() {
+        return "AnalyzeAlignTablesMsg";
+    }
+}

--- a/java/core/src/main/java/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -68,6 +68,7 @@ import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.events.AlignSoftwareTargetAction;
 import com.redhat.rhn.frontend.events.AlignSoftwareTargetMsg;
+import com.redhat.rhn.frontend.events.AnalyzeAlignTablesMsg;
 import com.redhat.rhn.manager.EntityExistsException;
 import com.redhat.rhn.manager.EntityNotExistsException;
 import com.redhat.rhn.manager.appstreams.AppStreamsManager;
@@ -1193,9 +1194,6 @@ public class ContentManager {
         // want them in the cache. For this we need the errata to be up-to-date in target
         alignPackageCache(tgt, oldTgtPackages);
 
-        // a lot was inserted into tables at this point. Make sure stats are up-to-date before continuing
-        analyzeAlignTables();
-
         // Also check if content of cloned errata needs alignment (advisory status etc.)
         if (user.getOrg().getOrgConfig().isClmSyncPatches()) {
             ChannelManager.listErrataNeedingResync(tgt, user).forEach(e -> {
@@ -1211,18 +1209,9 @@ public class ContentManager {
         tgt.setLastModified(new Date());
         tgt = HibernateFactory.getSession().merge(tgt);
         ChannelManager.queueChannelChange(tgt.getLabel(), "java::alignChannel", "Channel aligned");
-    }
 
-    /**
-     * Run database analyze in tables more affected by the CLM channel align
-     */
-    private void analyzeAlignTables() {
-        ChannelFactory.analyzeChannelPackages();
-        ChannelFactory.analyzeErrataPackages();
-        ChannelFactory.analyzeChannelErrata();
-        ChannelFactory.analyzeErrataCloned();
-        ChannelFactory.analyzeErrata();
-        ChannelFactory.analyzeServerNeededCache();
+        // Run ANALYZE once this transaction is complete to update stats after alignment.
+        MessageQueue.publish(new AnalyzeAlignTablesMsg(user));
     }
 
     private void alignPackageCache(Channel channel, Set<Package> oldChannelPackages) {

--- a/java/spacewalk-java.changes.cbbayburt.bsc1261753
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1261753
@@ -1,0 +1,2 @@
+- Run ANALYZE asynchronously after CLM alignment to avoid
+  deadlocks (bsc#1261753)


### PR DESCRIPTION
CLM target alignment process includes ANALYZE runs on tables that have been updated during the transaction, once per target channel. This causes deadlocks in some instances.

This PR moves the ANALYZE command to run in an isolated transaction, scheduled to run after the CLM alignment to prevent deadlocks from occurring, while debouncing the scheduling so it runs only as needed.

Port of: https://github.com/SUSE/spacewalk/pull/30579

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
