### PR TITLE
Fix flaky left menu navigation by waiting for submenu to open

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -440,6 +440,8 @@ When(/^I follow the left menu "([^"]*)"$/) do |menu_path|
     begin
       unless find(:xpath, target_link_path + parent_wrapper_path + parent_level_path)[:class].include?('open')
         find(:xpath, target_link_path + parent_wrapper_path).click
+        # wait for the 'open' class to be applied before navigating into the submenu
+        find(:xpath, "#{target_link_path}#{parent_wrapper_path}#{parent_level_path}[contains(@class,'open')]")
       end
     rescue NoMethodError
       warn 'The browser session seems broken. See debug details below:'


### PR DESCRIPTION
## What does this PR change?

The I follow the left menu step was not waiting for a submenu to fully open before navigating into the next level. After clicking to expand a menu item, the code immediately built the XPath for the next level, which could fail if the CSS transition hadn't applied the open class yet.

Added a find call with [contains(@class,'open')] after the click, leveraging Capybara's implicit wait to ensure the submenu is open before proceeding. No sleep required.

Fixes flaky failures on any multi-level left menu path (e.g. Users > User List > Active).

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30586
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/30612
 - 5.0: https://github.com/SUSE/spacewalk/pull/30613
 - 4.3: https://github.com/SUSE/spacewalk/pull/30614

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
