### PR TITLE
Fix mgr-push installation reliability and add API-based package management step

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 SUSE LLC
+# Copyright (c) 2024-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if:
@@ -44,7 +44,7 @@ Feature: Setup containerized proxy
     When I wait until onboarding is completed for "proxy"
 
   Scenario: Upgrade mgrpxy tool
-    When I upgrade "proxy" with the last "mgrpxy" version
+    When I upgrade "mgrpxy" on "proxy" using the API
 
 @transactional_server
   Scenario: Reboot after mgrpxy upgrade

--- a/testsuite/features/build_validation/migration/migration_sle15sp6_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_sle15sp6_minion.feature
@@ -9,7 +9,7 @@ Feature: Migrate a SLES 15 SP6 Salt minion to 15 SP7
     Given I am authorized for the "Admin" section
 
   Scenario: Prerequisite: update OS zypper to the latest version
-    When I upgrade "sle15sp6_minion" with the last "zypper" version
+    When I upgrade "zypper" on "sle15sp6_minion" using the API
 
   Scenario: Migrate this minion to SLE 15 SP7
     Given I am on the Systems overview page of this "sle15sp6_minion"

--- a/testsuite/features/build_validation/migration/migration_sle15sp6_ssh_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_sle15sp6_ssh_minion.feature
@@ -9,7 +9,7 @@ Feature: Migrate a SLES 15 SP6 Salt SSH minion to 15 SP7
     Given I am authorized for the "Admin" section
 
   Scenario: Prerequisite: update OS zypper to the latest version
-    When I upgrade "sle15sp6_ssh_minion" with the last "zypper" version
+    When I upgrade "zypper" on "sle15sp6_ssh_minion" using the API
 
   Scenario: Migrate this SSH minion to SLE 15 SP7
     Given I am on the Systems overview page of this "sle15sp6_ssh_minion"

--- a/testsuite/features/build_validation/migration/migration_slemicro54_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_slemicro54_minion.feature
@@ -9,7 +9,7 @@ Feature: Migrate a SLE Micro 5.4 Salt minion to SLE Micro 5.5
     Given I am authorized for the "Admin" section
 
   Scenario: Prerequisite: update OS zypper to the latest version
-    When I upgrade "slemicro54_minion" with the last "zypper" version
+    When I upgrade "zypper" on "slemicro54_minion" using the API
 
   Scenario: Prerequisite: Reboot the slemicro 5.4 after updating zypper
     When I reboot the "slemicro54_minion" host through SSH, waiting until it comes back

--- a/testsuite/features/build_validation/migration/migration_slemicro55_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_slemicro55_minion.feature
@@ -9,7 +9,7 @@ Feature: Migrate a SLE Micro 5.5 Salt minion to SL Micro 6.2
     Given I am authorized for the "Admin" section
 
   Scenario: Prerequisite: update OS zypper to the latest version
-    When I upgrade "slemicro55_minion" with the last "zypper" version
+    When I upgrade "zypper" on "slemicro55_minion" using the API
 
   Scenario: Prerequisite: Reboot the slemicro 5.5 after updating zypper
     When I reboot the "slemicro55_minion" host through SSH, waiting until it comes back

--- a/testsuite/features/secondary/srv_push_package.feature
+++ b/testsuite/features/secondary/srv_push_package.feature
@@ -13,7 +13,7 @@ Feature: Push a package with unset vendor
     Given I am authorized
 
   Scenario: Pre-requisite: mgr-push package must be installed on the SLES minion
-    Then I install "mgr-push" on "sle_minion" using the API
+    When I install "mgr-push" on "sle_minion" using the API
 
   Scenario: Push a package with unset vendor through the SLES minion
     When I copy unset package file on "sle_minion"
@@ -29,4 +29,4 @@ Feature: Push a package with unset vendor
     And I should see a "Not defined" text
 
   Scenario: Cleanup: remove mgr-push from the SLES minion
-    Then I remove "mgr-push" on "sle_minion" using the API
+    When I remove "mgr-push" on "sle_minion" using the API

--- a/testsuite/features/secondary/srv_push_package.feature
+++ b/testsuite/features/secondary/srv_push_package.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2024 SUSE LLC
+# Copyright (c) 2015-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle_minion
@@ -13,18 +13,7 @@ Feature: Push a package with unset vendor
     Given I am authorized
 
   Scenario: Pre-requisite: mgr-push package must be installed on the SLES minion
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Software" in the content area
-    And I wait until I see "Upgrade Packages" text
-    And I follow "Install"
-    And I wait until I see "Installable Packages" text
-    And I enter "mgr-push" as the filtered package name
-    And I click on the filter button
-    And I check "mgr-push" in the list
-    And I click on "Install Packages"
-    And I click on "Confirm"
-    Then I should see a "1 package install has been scheduled for" text
-    And I wait until event "Package Install/Upgrade scheduled" is completed
+    Then I install "mgr-push" on "sle_minion" using the API
 
   Scenario: Push a package with unset vendor through the SLES minion
     When I copy unset package file on "sle_minion"
@@ -38,3 +27,6 @@ Feature: Push a package with unset vendor
     And I follow "subscription-tools-1.0-0.noarch"
     Then I should see a "Vendor:" text
     And I should see a "Not defined" text
+
+  Scenario: Cleanup: remove mgr-push from the SLES minion
+    Then I remove "mgr-push" on "sle_minion" using the API

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1846,14 +1846,24 @@ Then(/^the word "([^']*)" does not occur more than (\d+) times in "(.*)" on "([^
   raise "The word #{word} occured #{occurences} times, which is more more than #{threshold} times in file #{path}" if occurences > threshold
 end
 
-Then(/^I upgrade "([^"]*)" with the last "([^"]*)" version$/) do |host, package|
+Then(/^I (upgrade|install|remove) "([^"]*)" on "([^"]*)" using the API$/) do |action, package, host|
   system_name = get_system_name(host)
-  last_event_before_upgrade = get_last_event(host)
-  last_event = last_event_before_upgrade
-  trigger_upgrade(system_name, package)
+  last_event_before_action = get_last_event(host)
+  last_event = last_event_before_action
+  case action
+  when 'upgrade'
+    trigger_upgrade(system_name, package)
+    event_summary = 'Package Install/Upgrade'
+  when 'install'
+    trigger_install(system_name, package)
+    event_summary = 'Package Install/Upgrade'
+  when 'remove'
+    trigger_remove(system_name, package)
+    event_summary = 'Package Removal'
+  end
   repeat_until_timeout(timeout: DEFAULT_TIMEOUT, message: 'Waiting for the new event to be created') do
     last_event = get_last_event(host)
-    break if last_event['id'] > last_event_before_upgrade['id'] && (last_event['summary'].include? 'Package Install/Upgrade')
+    break if last_event['id'] > last_event_before_action['id'] && (last_event['summary'].include? event_summary)
   end
   wait_action_complete(last_event['id'])
 end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1846,24 +1846,31 @@ Then(/^the word "([^']*)" does not occur more than (\d+) times in "(.*)" on "([^
   raise "The word #{word} occured #{occurences} times, which is more more than #{threshold} times in file #{path}" if occurences > threshold
 end
 
-Then(/^I (upgrade|install|remove) "([^"]*)" on "([^"]*)" using the API$/) do |action, package, host|
+When(/^I (upgrade|install) "([^"]*)" on "([^"]*)" using the API$/) do |action, package, host|
   system_name = get_system_name(host)
   last_event_before_action = get_last_event(host)
   last_event = last_event_before_action
   case action
   when 'upgrade'
     trigger_upgrade(system_name, package)
-    event_summary = 'Package Install/Upgrade'
   when 'install'
     trigger_install(system_name, package)
-    event_summary = 'Package Install/Upgrade'
-  when 'remove'
-    trigger_remove(system_name, package)
-    event_summary = 'Package Removal'
   end
   repeat_until_timeout(timeout: DEFAULT_TIMEOUT, message: 'Waiting for the new event to be created') do
     last_event = get_last_event(host)
-    break if last_event['id'] > last_event_before_action['id'] && (last_event['summary'].include? event_summary)
+    break if last_event['id'] > last_event_before_action['id'] && (last_event['summary'].include? 'Package Install/Upgrade')
+  end
+  wait_action_complete(last_event['id'])
+end
+
+When(/^I remove "([^"]*)" on "([^"]*)" using the API$/) do |package, host|
+  system_name = get_system_name(host)
+  last_event_before_action = get_last_event(host)
+  last_event = last_event_before_action
+  trigger_remove(system_name, package)
+  repeat_until_timeout(timeout: DEFAULT_TIMEOUT, message: 'Waiting for the new event to be created') do
+    last_event = get_last_event(host)
+    break if last_event['id'] > last_event_before_action['id'] && (last_event['summary'].include? 'Package Removal')
   end
   wait_action_complete(last_event['id'])
 end

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -956,7 +956,7 @@ end
 
 # Function to get the highest event ID (latest event)
 #
-# @param host String The hostname of the system from requested
+# @param host String The hostname of the requested system
 def get_last_event(host)
   node = get_target(host)
   system_id = get_system_id(node)
@@ -965,10 +965,26 @@ end
 
 # Function to trigger the upgrade command
 #
-# @param hostname String The hostname of the system from requested
+# @param hostname String The hostname of the requested system
 # @param package String The package name where it will trigger an upgrade
 def trigger_upgrade(hostname, package)
   get_target('server').run("spacecmd -u admin -p admin system_upgradepackage #{hostname} #{package} -y", check_errors: true)
+end
+
+# Function to trigger the install command
+#
+# @param hostname String The hostname of the requested system
+# @param package String The package name to install
+def trigger_install(hostname, package)
+  get_target('server').run("spacecmd -u admin -p admin system_installpackage #{hostname} #{package} -y", check_errors: true)
+end
+
+# Function to trigger the remove command
+#
+# @param hostname String The hostname of the requested system
+# @param package String The package name to remove
+def trigger_remove(hostname, package)
+  get_target('server').run("spacecmd -u admin -p admin system_removepackage #{hostname} #{package} -y", check_errors: true)
 end
 
 # Function to select the latest package from a list based on version and release


### PR DESCRIPTION
## What does this PR change?

### Problem

The prerequisite scenario in srv_push_package.feature was installing mgr-push through the web UI and then waiting for a Package Install/Upgrade event to complete. This was unreliable: if another package action had been scheduled on the minion around the same time, the step could catch an unrelated event and proceed before mgr-push was actually installed, causing the subsequent mgrpush call to fail with exit code 127.

### Changes

- Add trigger_install and trigger_remove helpers in commonlib.rb, using spacecmd system_installpackage and spacecmd system_removepackage respectively
- Replace the step I (upgrade) "host" with the last "package" version with a cleaner I (upgrade|install|remove) "package" on "host" using the API, which explicitly targets the scheduled action by action type (Package Install/Upgrade vs Package Removal) and waits only for the event it created
- Simplify the srv_push_package.feature prerequisite to a single step using the new API-based install
- Add a cleanup scenario to remove mgr-push after the test completes
- Update all existing callers of the old step across migration and proxy feature files

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30500
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/30610
 - 5.0: https://github.com/SUSE/spacewalk/pull/30611

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
