### PR TITLE
Filter out podman interfaces from FQDN resolution

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/action/HardwareRefreshAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/HardwareRefreshAction.java
@@ -154,10 +154,7 @@ public class HardwareRefreshAction extends Action {
         hwMapper.mapNetworkInfo(result.getNetworkInterfaces(), Optional.of(result.getNetworkIPs()),
                 result.getNetworkModules(),
                 Stream.concat(
-                        Stream.concat(
-                                result.getFqdns().stream(),
-                                result.getDnsFqdns().stream()
-                        ),
+                        result.getDnsFqdns().isEmpty() ? result.getFqdns().stream() : result.getDnsFqdns().stream(),
                         result.getCustomFqdns().stream()
                 ).distinct().collect(Collectors.toList())
         );

--- a/java/spacewalk-java.changes.cbosdo.nic-filter
+++ b/java/spacewalk-java.changes.cbosdo.nic-filter
@@ -1,0 +1,2 @@
+- Use salt's network module if host or nslookup are not installed
+  (bsc#1262720)

--- a/susemanager-utils/susemanager-sls/src/modules/mgrnet.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgrnet.py
@@ -10,6 +10,7 @@ import logging
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from salt.exceptions import CommandExecutionError
 
 import salt.utils.network
 
@@ -79,13 +80,22 @@ def dns_fqdns():
 
     start = time.time()
 
+    interfaces = _get_interfaces()
+    if interfaces is not None and _which("podman"):
+        try:
+            # pylint: disable-next=undefined-variable
+            podman_ifaces = __salt__["cmd.run"](
+                ["podman", "network", "ls", "--format", "{{.NetworkInterface}}"]
+            ).splitlines()
+            interfaces = {k: v for k, v in interfaces.items() if k not in podman_ifaces}
+        except CommandExecutionError as e:
+            log.error("Error trying to find the podman interfaces names: %s", e)
+
     addresses = salt.utils.network.ip_addrs(
-        include_loopback=False, interface_data=_get_interfaces()
+        include_loopback=False, interface_data=interfaces
     )
     addresses.extend(
-        salt.utils.network.ip_addrs6(
-            include_loopback=False, interface_data=_get_interfaces()
-        )
+        salt.utils.network.ip_addrs6(include_loopback=False, interface_data=interfaces)
     )
 
     results = []

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_mgrnet.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_mgrnet.py
@@ -9,7 +9,6 @@ mockery.setup_environment()
 # pylint: disable-next=wrong-import-position
 from ..modules import mgrnet
 
-
 mgrnet.__salt__ = {}
 
 
@@ -86,12 +85,17 @@ def test_mgrnet_dns_fqdns():
                 rc = 1
         return {"retcode": rc, "stdout": out}
 
+    # pylint: disable-next=unused-argument
+    def _cmd_run_podman(cmd):
+        return "podman0\npodman1\n"
+
     with patch.dict(
-        mgrnet.__salt__, {"cmd.run_all": _cmd_run_host_nslookup}
+        mgrnet.__salt__,
+        {"cmd.run_all": _cmd_run_host_nslookup, "cmd.run": _cmd_run_podman},
     ), patch.object(
         mgrnet,
         "_which",
-        MagicMock(side_effect=[True, False, True, False, False]),
+        MagicMock(side_effect=[True, True, False, True, True, False, False, True]),
     ), patch.object(
         mgrnet.salt.utils.network,
         "ip_addrs",

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.cbosdo.5.1-nic-filter
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.cbosdo.5.1-nic-filter
@@ -1,0 +1,1 @@
+- Ignore podman interfaces when resolving FQDNs (bsc#1262720)


### PR DESCRIPTION
## What does this PR change?

If by luck a podman internal network IP is used elsewhere, resolution would bring wrong FQDNs. Skipping those network interfaces is better. (bsc#1262720)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Unit tests were changed

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30457
Port(s): https://github.com/SUSE/spacewalk/pull/30593
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
