### PR TITLE
Fix issues building Python packages for openSUSE Leap 16.0

### DIFF
--- a/proxy/proxy-html/spacewalk-proxy-html.changes.meaksh.master-fix-issues-leap16
+++ b/proxy/proxy-html/spacewalk-proxy-html.changes.meaksh.master-fix-issues-leap16
@@ -1,0 +1,1 @@
+- Fix issue building package for openSUSE Leap 16.0

--- a/proxy/proxy-html/spacewalk-proxy-html.spec
+++ b/proxy/proxy-html/spacewalk-proxy-html.spec
@@ -18,9 +18,11 @@
 
 
 %if 0%{?suse_version}
-%global htmldir /srv/www/htdocs
+%global htmlroot /srv/www
+%global htmldir %{htmlroot}/htdocs
 %else
-%global htmldir %{_var}/www/html
+%global htmlroot %{_var}/www
+%global htmldir %{htmlroot}/html
 %endif
 
 Name:           spacewalk-proxy-html
@@ -66,6 +68,7 @@ cp -pR %{proxy_dir_name}/sources/img/* %{buildroot}%{htmldir}/sources/img/
 cp -pR %{proxy_dir_name}/*.html %{buildroot}%{htmldir}/
 
 %files
+%dir %{htmlroot}
 %dir %{htmldir}
 %{htmldir}/index.html
 %{htmldir}/sources

--- a/uyuni/base/uyuni-base.changes.meaksh.master-fix-issues-leap16
+++ b/uyuni/base/uyuni-base.changes.meaksh.master-fix-issues-leap16
@@ -1,0 +1,1 @@
+- Fix issue building package on openSUSE Leap 16.0

--- a/uyuni/base/uyuni-base.spec
+++ b/uyuni/base/uyuni-base.spec
@@ -125,7 +125,8 @@ getent passwd %{apache_user} >/dev/null && %{_sbindir}/usermod -a -G susemanager
 %dir %attr(775,%{apache_user}, root) %{_localstatedir}/spacewalk
 %dir %attr(775,%{apache_user}, %{apache_group}) %{_localstatedir}/spacewalk/systems
 %dir %attr(775,%{apache_user}, %{apache_group}) %{_localstatedir}/spacewalk/packages
-%dir %attr(755,root,root) /srv/www/distributions
+%dir %attr(755,root,root) %{www_path}/www
+%dir %attr(755,root,root) %{www_path}/www/distributions
 %endif
 
 %files proxy


### PR DESCRIPTION
## What does this PR change?

This PR fixes the following issues when building these packages on openSUSE Leap 16:

```
[   12s] spacewalk-proxy-html-5.2.1-260400.6.1.uyuni6.noarch.rpm: directories not owned by a package:
[   12s]  - /srv/www
```

And:

```
[   17s] uyuni-base-server-5.2.2-260400.5.1.uyuni6.x86_64.rpm: directories not owned by a package:
[   17s]  - /srv/www
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28911

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
