### PR TITLE
Set the default ingress class to traefik on proxy

### DIFF
--- a/containers/proxy-helm/proxy-helm.changes.cbosdo.ingress-class
+++ b/containers/proxy-helm/proxy-helm.changes.cbosdo.ingress-class
@@ -1,0 +1,1 @@
+- Align ingress class to traefik default on rke2 (bsc#1264279)

--- a/containers/proxy-helm/tests/traefik_test.yaml
+++ b/containers/proxy-helm/tests/traefik_test.yaml
@@ -3,6 +3,38 @@ templates:
   - templates/ingress.yaml
   - templates/traefik-routes.yaml
 tests:
+  - it: should create traefik resources with default traefik class
+    set:
+      global.config: |
+        max_cache_size_mb: 2048
+        server: parent.example.org
+        proxy_fqdn: proxy.example.org
+        email: foo@example.org
+        log_level: 2
+      global.httpd: "httpd_content: test httpd"
+      global.ssh: "ssh_content: test ssh"
+    release:
+      namespace: proxy1
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            traefik.ingress.kubernetes.io/router.tls: "true"
+            traefik.ingress.kubernetes.io/router.entrypoints: "websecure,web"
+            traefik.ingress.kubernetes.io/router.tls.domains.n.main: "proxy.example.org"
+        template: ingress.yaml
+        documentSelector:
+          path: metadata.name
+          value: uyuni-proxy-ssl
+      
+      - equal:
+          path: spec.ingressClassName
+          value: traefik
+        template: ingress.yaml
+        documentSelector:
+          path: metadata.name
+          value: uyuni-proxy-ssl
+
   - it: should create traefik resources
     set:
       global.config: |

--- a/containers/proxy-helm/values.schema.json
+++ b/containers/proxy-helm/values.schema.json
@@ -57,7 +57,7 @@
         },
         "class": {
           "type": "string",
-          "default": "",
+          "default": "traefik",
           "description": "The ingress class name."
         },
         "annotations": {

--- a/containers/proxy-helm/values.yaml
+++ b/containers/proxy-helm/values.yaml
@@ -43,7 +43,7 @@ ingress:
   # --providers.kubernetescrd.ingressclass parameter's value.
   # On rke2 this is likely to be "traefik". On K3S it is likely to be ""
   #
-  class: ""
+  class: "traefik"
   
   # annotations can be used to set custom annotations on the created ingress rules.
   # This can be used to configure another ingress than the ones already wired with the ingress.type.


### PR DESCRIPTION
## What does this PR change?

RKE2 uses 'traefik' as the traefik ingress class while K3S uses ''. Set the default to fit RKE2 as this is the distro we prefer (bsc#1264279)./billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30616
Port(s): 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
