### PR TITLE
Sync package removal permissions in packages API with the Web UI (bsc#1261327)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandler.java
@@ -355,7 +355,7 @@ public class PackagesHandler extends BaseHandler {
      * @apidoc.returntype #return_int_success()
      */
     public int removePackage(User loggedInUser, Integer pid) throws FaultException {
-        if (!loggedInUser.hasRole(RoleFactory.ORG_ADMIN)) {
+        if (!loggedInUser.hasRole(RoleFactory.CHANNEL_ADMIN)) {
             throw new PermissionCheckFailureException();
         }
         Package pkg = lookupPackage(loggedInUser, pid);
@@ -390,7 +390,7 @@ public class PackagesHandler extends BaseHandler {
      * @apidoc.returntype #return_int_success()
      */
     public int removeSourcePackage(User loggedInUser, Integer psid) throws FaultException {
-        if (!loggedInUser.hasRole(RoleFactory.ORG_ADMIN)) {
+        if (!loggedInUser.hasRole(RoleFactory.CHANNEL_ADMIN)) {
             throw new PermissionCheckFailureException();
         }
         PackageSource pkg = PackageFactory.lookupPackageSourceByIdAndOrg(

--- a/java/core/src/main/java/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -796,12 +796,12 @@ public class PackageManager extends BaseManager {
      * Deletes a package from the system
      * @param user calling user
      * @param pkg package to delete
-     * @throws PermissionCheckFailureException - caller is not an org admin,
+     * @throws PermissionCheckFailureException - caller is not a channel admin,
      * the package is in one of the RH owned channels, or is in different org
      */
     public static void schedulePackageRemoval(User user, Package pkg)
         throws PermissionCheckFailureException {
-        if (!user.hasRole(RoleFactory.ORG_ADMIN)) {
+        if (!user.hasRole(RoleFactory.CHANNEL_ADMIN)) {
             throw new PermissionCheckFailureException();
         }
         DataResult<Row> channels = PackageManager.orgPackageChannels(
@@ -840,12 +840,12 @@ public class PackageManager extends BaseManager {
      * Deletes a source package from the system
      * @param user calling user
      * @param pkg source package to delete
-     * @throws PermissionCheckFailureException - caller is not an org admin,
+     * @throws PermissionCheckFailureException - caller is not a channel admin,
      * the package is in one of the RH owned channels, or is in different org
      */
     public static void schedulePackageSourceRemoval(User user, PackageSource pkg)
         throws PermissionCheckFailureException {
-        if (!user.hasRole(RoleFactory.ORG_ADMIN)) {
+        if (!user.hasRole(RoleFactory.CHANNEL_ADMIN)) {
             throw new PermissionCheckFailureException();
         }
         if (pkg.getOrg() == null || user.getOrg() != pkg.getOrg()) {

--- a/java/spacewalk-java.changes.cbbayburt.bsc1261327
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1261327
@@ -1,0 +1,2 @@
+- Sync package removal permissions in packages API with the Web UI
+  (bsc#1261327)

--- a/schema/spacewalk/common/data/accessGroupNamespace.sql
+++ b/schema/spacewalk/common/data/accessGroupNamespace.sql
@@ -784,7 +784,7 @@ INSERT INTO access.accessGroupNamespace
     )
     ON CONFLICT DO NOTHING;
 
--- Namespace: packages
+-- Namespace: packages (RO)
 -- Namespace: packages.search
 -- Permit to all
 INSERT INTO access.accessGroupNamespace
@@ -801,8 +801,6 @@ INSERT INTO access.accessGroupNamespace
         'api.packages.list_providing_channels',
         'api.packages.list_providing_errata',
         'api.packages.list_source_packages',
-        'api.packages.remove_package',
-        'api.packages.remove_source_package',
         'api.packages.search.advanced',
         'api.packages.search.advanced_with_act_key',
         'api.packages.search.advanced_with_channel',
@@ -810,6 +808,16 @@ INSERT INTO access.accessGroupNamespace
         'api.packages.search.name_and_description',
         'api.packages.search.name_and_summary'
     )
+    ON CONFLICT DO NOTHING;
+
+-- Namespace: packages (W)
+-- Permit to 'channel admin'
+INSERT INTO access.accessGroupNamespace
+    SELECT ag.id, ns.id
+    FROM access.accessGroup ag, access.namespace ns
+    WHERE ag.label = 'channel_admin'
+    AND (ns.namespace = 'api.packages.remove_package' OR
+        ns.namespace = 'api.packages.remove_source_package')
     ON CONFLICT DO NOTHING;
 
 -- Namespace: packages.provider

--- a/schema/spacewalk/susemanager-schema.changes.cbbayburt.bsc1261327
+++ b/schema/spacewalk/susemanager-schema.changes.cbbayburt.bsc1261327
@@ -1,0 +1,2 @@
+- Sync package removal permissions in packages API with the Web UI
+  (bsc#1261327)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.8-to-susemanager-schema-5.2.9/210-rbac-remove-pkg-api.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.8-to-susemanager-schema-5.2.9/210-rbac-remove-pkg-api.sql
@@ -1,0 +1,27 @@
+--
+-- Copyright (c) 2026 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+-- Remove access from all standard roles except 'channel_admin'
+DELETE FROM access.accessGroupNamespace
+WHERE namespace_id IN (
+    SELECT id FROM access.namespace WHERE namespace IN (
+            'api.packages.remove_package',
+            'api.packages.remove_source_package'
+    )
+) AND group_id IN (
+    SELECT id FROM access.accessGroup WHERE label IN (
+        'activation_key_admin',
+        'image_admin',
+        'config_admin',
+        'system_group_admin',
+        'regular_user'
+    )
+);


### PR DESCRIPTION
Removing managed packages requires "Channel Admin" access in the web UI, whereas the same operation requires "Org Admin" access in the API. This PR updates the API to require "Channel Admin" access so that it's the same as in the Web UI. The patch also reflects this change in the RBAC mappings.

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/30225

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
