### PR TITLE
Fix depedencies java

### DIFF
--- a/java/spacewalk-java.changes.mcalmer.fix-depedencies-java
+++ b/java/spacewalk-java.changes.mcalmer.fix-depedencies-java
@@ -1,0 +1,1 @@
+- Update java dependencies

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -107,7 +107,7 @@ BuildRequires:  jakarta-persistence-api
 BuildRequires:  httpcomponents-asyncclient
 BuildRequires:  httpcomponents-client
 BuildRequires:  ical4j
-BuildRequires:  istack-commons-runtime
+BuildRequires:  mvn(com.sun.istack:istack-commons-runtime) >= 4.2.0
 BuildRequires:  jade4j
 BuildRequires:  java-%{java_version}-openjdk-devel
 BuildRequires:  java-saml
@@ -195,7 +195,7 @@ Requires:       jakarta-jstl
 Requires:       hibernate-models
 Requires:       httpcomponents-client
 Requires:       ical4j
-Requires:       istack-commons-runtime
+Requires:       mvn(com.sun.istack:istack-commons-runtime) >= 4.2.0
 Requires:       jade4j
 Requires:       java-%{java_version}-openjdk
 Requires:       java-saml

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -120,7 +120,6 @@ BuildRequires:  jdom
 BuildRequires:  joda-time
 BuildRequires:  jose4j
 BuildRequires:  jsch
-BuildRequires:  jta
 BuildRequires:  libxml2
 BuildRequires:  log4j
 BuildRequires:  log4j-jcl
@@ -209,7 +208,6 @@ Requires:       jdom
 Requires:       joda-time
 Requires:       jose4j
 Requires:       jakarta-persistence-api
-Requires:       jta
 Requires:       libsolv-tools
 Requires:       log4j
 Requires:       log4j-jcl

--- a/microservices/uyuni-java-parent/pom-16.xml
+++ b/microservices/uyuni-java-parent/pom-16.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026 SUSE LLC and contributors
+  ~
+  ~ This software is licensed to you under the GNU General Public License,
+  ~ version 2 (GPLv2). There is NO WARRANTY for this software, express or
+  ~ implied, including the implied warranties of MERCHANTABILITY or FITNESS
+  ~ FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+  ~ along with this software; if not, see
+  ~ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.uyuni-project</groupId>
+    <artifactId>uyuni-java-parent</artifactId>
+    <version>5.2.5</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <modules>
+        <module>../uyuni-java-common</module>
+        <module>../coco-attestation</module>
+        <module>../../branding</module>
+        <module>../../java</module>
+    </modules>
+
+    <!-- Global dependencies based on the package version in OBS -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>2.20.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mybatis</groupId>
+                <artifactId>mybatis</artifactId>
+                <version>3.5.19</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>2.20.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>42.7.7</version>
+                <exclusions>
+                    <!-- Not used at runtime -->
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-qual</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.ongres.scram</groupId>
+                <artifactId>client</artifactId>
+                <version>3.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.ongres.scram</groupId>
+                <artifactId>common</artifactId>
+                <version>3.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.ongres.stringprep</groupId>
+                <artifactId>stringprep</artifactId>
+                <version>2.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.ongres.stringprep</groupId>
+                <artifactId>saslprep</artifactId>
+                <version>2.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.mchange</groupId>
+                <artifactId>c3p0</artifactId>
+                <version>0.12.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.mchange</groupId>
+                <artifactId>mchange-commons-java</artifactId>
+                <version>0.4.0</version>
+            </dependency>
+
+            <!-- Test dependencies -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>5.8.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>5.10.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>5.10.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>4.2.1</version>
+                <scope>test</scope>
+            </dependency>
+         </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <!-- Basic plugin version and common configuration -->
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.11.0</version>
+                    <configuration>
+                        <release>17</release>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.2.2</version>
+                    <configuration>
+                        <!-- enable assertions and disable sharing of classes for tests -->
+                        <argLine>-ea -Xshare:off</argLine>
+                        <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+                            <usePhrasedFileName>false</usePhrasedFileName>
+                            <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+                            <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+                            <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+                        </statelessTestsetReporter>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>3.3.1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>10.12.7</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <includeResources>false</includeResources>
+                        <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                        <includeTestResources>false</includeTestResources>
+                        <headerLocation>../../java/buildconf/LICENSE.txt</headerLocation>
+                        <configLocation>../../java/buildconf/checkstyle.xml</configLocation>
+                        <suppressionsLocation>../../java/buildconf/checkstyle-suppressions.xml</suppressionsLocation>
+                        <propertyExpansion>
+                            javadoc.method.scope=public
+                            javadoc.var.scope=package
+                            javadoc.type.scope=package
+                            javadoc.lazy=false
+                        </propertyExpansion>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/microservices/uyuni-java-parent/uyuni-java-parent.changes.mcalmer.fix-depedencies-java
+++ b/microservices/uyuni-java-parent/uyuni-java-parent.changes.mcalmer.fix-depedencies-java
@@ -1,0 +1,1 @@
+- Provide pom file with updated dependencies for SLES/Leap 16 usage

--- a/microservices/uyuni-java-parent/uyuni-java-parent.spec
+++ b/microservices/uyuni-java-parent/uyuni-java-parent.spec
@@ -38,6 +38,11 @@ Package that contains the parent POM used by all %{productprettyname} Maven comp
 
 %prep
 %setup -q
+%if 0%{?suse_version} >= 1600
+mv pom-16.xml pom.xml
+%else
+rm -f pom-16.xml
+%endif
 
 %build
 %{mvn_build} -j -- --non-recursive


### PR DESCRIPTION
## What does this PR change?

Update requirements for java packages to build easier with SLES/Leap 16.

- istack-commons-runtime exists only for 15.6. We should use already jaxb-istack-commons-runtime. Solve this by require the maven provided name with the newer version. This version is also available in 15 SP7 
- remove `jta` dependency. We should use already `jakarta-transaction` package. `jta` is provided by geronimo-jta-1_1 in Leap 15.6, but not in 16.0. The geronimo package is also available in Leap 16, but it seems this old interface is not needed anymore.
- With Leap 16, we use newer versions of some packages. Update the versions in the uyuni-java-parent package to solve build errors. We use a new pom file as it is easier to use instead of replacements in the spec file.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
