### PR TITLE
Prevent failures when building for openSUSE Leap 16.0

### DIFF
--- a/projects/ssl-cert-check/spacewalk-ssl-cert-check-rpmlintrc
+++ b/projects/ssl-cert-check/spacewalk-ssl-cert-check-rpmlintrc
@@ -1,1 +1,2 @@
 addFilter("suse-filelist-forbidden-sysconfig .*/sysconfig")
+addFilter("filelist-forbidden-sysconfig .*/sysconfig")

--- a/projects/ssl-cert-check/spacewalk-ssl-cert-check.changes.meaksh.master-fix-spacewalk-ssl-cert-check-on-leap16
+++ b/projects/ssl-cert-check/spacewalk-ssl-cert-check.changes.meaksh.master-fix-spacewalk-ssl-cert-check-on-leap16
@@ -1,0 +1,1 @@
+- Prevent failures when building for openSUSE Leap 16.0


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue when building `spacewalk-ssl-certs-check` package on openSUSE Leap 16.0 due rpmlint constraints.

```
[   23s] spacewalk-ssl-cert-check.noarch: E: filelist-forbidden-sysconfig (Badness: 10000) /etc/sysconfig/rhn
[   23s] spacewalk-ssl-cert-check.noarch: E: filelist-forbidden-sysconfig (Badness: 10000) /etc/sysconfig/rhn/ssl-cert-check
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28911

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
