### PR TITLE
Re-apply PBKDF2-SHA256 password hashing with build fix

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/common/util/CryptHelper.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/util/CryptHelper.java
@@ -21,17 +21,17 @@ import com.redhat.rhn.domain.common.RhnConfigurationFactory;
 import org.apache.commons.lang3.RandomStringUtils;
 
 import java.security.SecureRandom;
-import java.util.Random;
 
 /**
  * CryptHelper - utility class for crypto routines
  */
 public class CryptHelper {
-    private static String b64t = // a string containing acceptable salt chars
+    public static final String MD5_PREFIX = "$1$";
+    public static final String SHA256_PREFIX = "$5$";
+
+    private static final String B64T = // a string containing acceptable salt chars
         "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-    private static String md5prefix = "$1$";
-    private static String sha256prefix = "$5$";
-    private static Random secureRandom = new SecureRandom();
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     /**
      * CryptHelper
@@ -40,19 +40,11 @@ public class CryptHelper {
     }
 
     /**
-     * getMD5Prefix
-     * @return MD5 prefix string
-     */
-    public static String getMD5Prefix() {
-        return md5prefix;
-    }
-
-    /**
      * getSHA256Prefix
      * @return SHA-256 prefix string
      */
     public static String getSHA256Prefix() {
-        return sha256prefix;
+        return SHA256_PREFIX;
     }
 
     /**
@@ -91,7 +83,7 @@ public class CryptHelper {
         StringBuilder out = new StringBuilder();
 
         while (length > 0) {
-            out.append(b64t.substring((value & 0x3f), (value & 0x3f) + 1));
+            out.append(B64T.substring((value & 0x3f), (value & 0x3f) + 1));
             --length;
             value >>= 6;
         }
@@ -107,8 +99,8 @@ public class CryptHelper {
         StringBuilder salt = new StringBuilder();
 
         for (int i = 0; i < saltLength; i++) {
-            int rand = secureRandom.nextInt(b64t.length());
-            salt.append(b64t.charAt(rand));
+            int rand = SECURE_RANDOM.nextInt(B64T.length());
+            salt.append(B64T.charAt(rand));
         }
 
         return salt.toString();

--- a/java/core/src/main/java/com/redhat/rhn/common/util/Pbkdf2Sha256Crypt.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/util/Pbkdf2Sha256Crypt.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.common.util;
+
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.security.spec.KeySpec;
+import java.util.Base64;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+/**
+ * Pbkdf2Sha256Crypt
+ * Utility class to create/check PBKDF2-SHA256 passwords.
+ * Passwords are in the format of $pbkdf2-sha256$iterations$b64salt$b64hash
+ * with base64 padding stripped.
+ */
+public class Pbkdf2Sha256Crypt {
+
+    public static final String PREFIX = "$pbkdf2-sha256$";
+
+    // PBKDF2 iteration bounds - must match python/spacewalk/server/rhnUser.py.
+    private static final int MIN_ITERATIONS = 600_000;
+    private static final int MAX_ITERATIONS = 2_000_000;
+    private static final int KEY_LENGTH_BITS = 256;
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private Pbkdf2Sha256Crypt() {
+    }
+
+    /**
+     * Verify a candidate password against a stored PBKDF2-SHA256 hash produced by
+     * the Python encrypt_password() helper. Stored format is
+     * {@code $pbkdf2-sha256$<iterations>$<b64salt>$<b64hash>} with base64 padding stripped.
+     *
+     * @param candidate the plaintext password to verify
+     * @param storedHash the stored hash with the {@link #PREFIX} prefix
+     * @return true iff the candidate matches the stored hash
+     */
+    public static boolean verify(String candidate, String storedHash) {
+        if (candidate == null || storedHash == null || !storedHash.startsWith(PREFIX)) {
+            return false;
+        }
+        String[] parts = storedHash.split("\\$");
+        // parts: ["", "pbkdf2-sha256", "<iter>", "<b64salt>", "<b64hash>"]
+        if (parts.length != 5) {
+            return false;
+        }
+        try {
+            int iterations = Integer.parseInt(parts[2]);
+            if (iterations < MIN_ITERATIONS || iterations > MAX_ITERATIONS) {
+                return false;
+            }
+            byte[] salt = Base64.getDecoder().decode(padBase64(parts[3]));
+            byte[] expected = Base64.getDecoder().decode(padBase64(parts[4]));
+            KeySpec spec = new PBEKeySpec(candidate.toCharArray(), salt, iterations, KEY_LENGTH_BITS);
+            byte[] actual = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256").generateSecret(spec).getEncoded();
+            return MessageDigest.isEqual(actual, expected);
+        }
+        catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Hash a plaintext password with PBKDF2-SHA256 in the same stored format the Python
+     * encrypt_password() helper produces:
+     * {@code $pbkdf2-sha256$<iterations>$<b64salt>$<b64hash>} with base64 padding stripped.
+     * Returns {@code null} if the JCE provider does not support PBKDF2WithHmacSHA256, so the
+     * caller can fall back to a legacy hash rather than failing the user-facing operation.
+     *
+     * @param plaintext the password to hash
+     * @return the encoded hash, or {@code null} if PBKDF2 is unavailable
+     */
+    public static String crypt(String plaintext) {
+        byte[] salt = new byte[32];
+        SECURE_RANDOM.nextBytes(salt);
+        try {
+            KeySpec spec = new PBEKeySpec(plaintext.toCharArray(), salt,
+                    MIN_ITERATIONS, KEY_LENGTH_BITS);
+            byte[] dk = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256").generateSecret(spec).getEncoded();
+            String b64salt = Base64.getEncoder().encodeToString(salt).replace("=", "");
+            String b64hash = Base64.getEncoder().encodeToString(dk).replace("=", "");
+            return PREFIX + MIN_ITERATIONS + "$" + b64salt + "$" + b64hash;
+        }
+        catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String padBase64(String s) {
+        int pad = (4 - s.length() % 4) % 4;
+        return pad == 0 ? s : s + "====".substring(0, pad);
+    }
+}

--- a/java/core/src/main/java/com/redhat/rhn/domain/user/legacy/UserImpl.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/user/legacy/UserImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025--2026 SUSE LLC
+ * Copyright (c) 2026 SUSE LLC
  * Copyright (c) 2009--2015 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -20,6 +20,7 @@ import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.util.CryptHelper;
+import com.redhat.rhn.common.util.Pbkdf2Sha256Crypt;
 import com.redhat.rhn.common.util.SHA256Crypt;
 import com.redhat.rhn.domain.BaseDomainHelper;
 import com.redhat.rhn.domain.access.AccessGroup;
@@ -267,7 +268,8 @@ public class UserImpl extends BaseDomainHelper implements User {
          * set it.
          */
         if (Config.get().getBoolean(ConfigDefaults.WEB_ENCRYPTED_PASSWORDS)) {
-            this.password = SHA256Crypt.crypt(passwordIn);
+            String hashed = Pbkdf2Sha256Crypt.crypt(passwordIn);
+            this.password = (hashed != null ? hashed : SHA256Crypt.crypt(passwordIn));
         }
         else {
             this.password = passwordIn;
@@ -469,7 +471,7 @@ public class UserImpl extends BaseDomainHelper implements User {
          * authenticate via pam, otherwise, use the db.
          */
         if (!StringUtils.isBlank(pamAuthService) && this.getUsePamAuthentication()) {
-            if (password.startsWith(CryptHelper.getMD5Prefix())) {
+            if (password.startsWith(CryptHelper.MD5_PREFIX)) {
                 // password field in DB is NOT NULL, so we set a random password
                 // when using PAM authentication. Here the password is still MD5
                 // based. Just set a new one with SHA256crypt
@@ -491,8 +493,12 @@ public class UserImpl extends BaseDomainHelper implements User {
              */
             boolean useEncrPasswds = Config.get().getBoolean(ConfigDefaults.WEB_ENCRYPTED_PASSWORDS);
             if (useEncrPasswds) {
-                // user uses SHA-256 encrypted password
-                if (password.startsWith(CryptHelper.getSHA256Prefix())) {
+                if (password.startsWith(Pbkdf2Sha256Crypt.PREFIX)) {
+                    // user has been migrated to PBKDF2-SHA256 by the Python auth path
+                    result = Pbkdf2Sha256Crypt.verify(thePassword, password);
+                }
+                else if (password.startsWith(CryptHelper.getSHA256Prefix())) {
+                    // legacy SHA-256 crypt(3) password
                     result = SHA256Crypt.crypt(thePassword, password).equals(password);
                 }
             }
@@ -1183,7 +1189,8 @@ public class UserImpl extends BaseDomainHelper implements User {
             * set it.
             */
             if (Config.get().getBoolean(ConfigDefaults.WEB_ENCRYPTED_PASSWORDS)) {
-                password = SHA256Crypt.crypt(passwordIn);
+                String hashed = Pbkdf2Sha256Crypt.crypt(passwordIn);
+                password = (hashed != null ? hashed : SHA256Crypt.crypt(passwordIn));
             }
             else {
                 password = passwordIn;

--- a/java/core/src/test/java/com/redhat/rhn/domain/user/UserTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/user/UserTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
-import com.redhat.rhn.common.util.SHA256Crypt;
+import com.redhat.rhn.common.util.Pbkdf2Sha256Crypt;
 import com.redhat.rhn.domain.role.Role;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.testing.RhnJmockBaseTestCase;
@@ -141,7 +141,8 @@ public class UserTest extends RhnJmockBaseTestCase {
         usr.setPassword(foo);
         boolean encrypt = Config.get().getBoolean(ConfigDefaults.WEB_ENCRYPTED_PASSWORDS);
         if (encrypt) {
-            assertEquals(SHA256Crypt.crypt("foo", usr.getPassword()), usr.getPassword());
+            assertTrue(usr.getPassword().startsWith(Pbkdf2Sha256Crypt.PREFIX));
+            assertTrue(Pbkdf2Sha256Crypt.verify(foo, usr.getPassword()));
         }
         else {
             assertEquals(foo, usr.getPassword());

--- a/java/spacewalk-java.changes.szachovy.password-hashing-pbkdf2
+++ b/java/spacewalk-java.changes.szachovy.password-hashing-pbkdf2
@@ -1,0 +1,2 @@
+- Recognize PBKDF2-SHA256 hashes alongside legacy
+  SHA-256 crypt(3) in the Java password check helpers

--- a/python/spacewalk/server/rhnUser.py
+++ b/python/spacewalk/server/rhnUser.py
@@ -19,9 +19,10 @@
 #
 
 import re
-
-# pylint: disable-next=deprecated-module
-import crypt
+import hmac
+import hashlib
+import os as _os
+import base64 as _base64
 
 # Global Modules
 from rhn.UserDictCase import UserDictCase
@@ -100,13 +101,11 @@ class User:
             # so I'll use a query for now
             # - misa
             #
-            h = rhnSQL.prepare(
-                """
+            h = rhnSQL.prepare("""
                 select ui.use_pam_authentication
                 from web_contact w, rhnUserInfo ui
                 where w.login_uc = UPPER(:login)
-                and w.id = ui.user_id"""
-            )
+                and w.id = ui.user_id""")
             h.execute(login=self.contact["login"])
             data = h.fetchone_dict()
             if not data:
@@ -126,10 +125,10 @@ class User:
         if (
             ret
             and CFG.encrypted_passwords
-            and self.contact["password"].find("$1$") == 0
+            and not self.contact["password"].startswith(_PBKDF2_PREFIX)
         ):
-            # If successfully authenticated and the current password is
-            # MD5 encoded, convert the password to SHA-256 and save it in the DB.
+            # If successfully authenticated and the stored password is not yet
+            # using PBKDF2-SHA256, upgrade it transparently on next login.
             self.contact["password"] = encrypt_password(password)
             self.contact.save()
             rhnSQL.commit()
@@ -268,8 +267,7 @@ class User:
     def get_roles(self):
         user_id = self.getid()
 
-        h = rhnSQL.prepare(
-            """
+        h = rhnSQL.prepare("""
             select ugt.label as role
               from rhnUserGroup ug,
                    rhnUserGroupType ugt,
@@ -277,8 +275,7 @@ class User:
              where ugm.user_id = :user_id
                and ugm.user_group_id = ug.id
                and ug.group_type = ugt.id
-        """
-        )
+        """)
         h.execute(user_id=user_id)
         return [x["role"] for x in h.fetchall_dict() or []]
 
@@ -350,12 +347,10 @@ def session_reload(session_string):
 def get_user_id(username):
     """search for an userid"""
     username = str(username)
-    h = rhnSQL.prepare(
-        """
+    h = rhnSQL.prepare("""
     select w.id from web_contact w
     where w.login_uc = upper(:username)
-    """
-    )
+    """)
     h.execute(username=username)
     data = h.fetchone_dict()
     if data:
@@ -381,12 +376,10 @@ def search(user):
 def is_user_disabled(user):
     log_debug(3, user)
     username = str(user)
-    h = rhnSQL.prepare(
-        """
+    h = rhnSQL.prepare("""
     select 1 from rhnWebContactDisabled
     where login_uc = upper(:username)
-    """
-    )
+    """)
     h.execute(username=username)
     row = h.fetchone_dict()
     if row:
@@ -397,13 +390,11 @@ def is_user_disabled(user):
 def is_user_read_only(user):
     log_debug(3, user)
     username = str(user)
-    h = rhnSQL.prepare(
-        """
+    h = rhnSQL.prepare("""
     select 1 from web_contact
     where login_uc = upper(:username)
     and read_only = 'Y'
-    """
-    )
+    """)
     h.execute(username=username)
     row = h.fetchone_dict()
     if row:
@@ -422,14 +413,12 @@ def __reserve_user_db(user, password):
         3, user, CFG.disallow_user_creation, encrypted_password, CFG.pam_auth_service
     )
     user = str(user)
-    h = rhnSQL.prepare(
-        """
+    h = rhnSQL.prepare("""
     select w.id, w.password, w.org_id, ui.use_pam_authentication
     from web_contact w, rhnUserInfo ui
     where w.login_uc = upper(:p1)
     and w.id = ui.user_id
-    """
-    )
+    """)
     h.execute(p1=user)
     data = h.fetchone_dict()
     if data and data["id"]:
@@ -453,12 +442,10 @@ def __reserve_user_db(user, password):
     user, password = check_user_password(user, password)
 
     # now check the reserved table
-    h = rhnSQL.prepare(
-        """
+    h = rhnSQL.prepare("""
     select r.login, r.password from rhnUserReserved r
     where r.login_uc = upper(:p1)
-    """
-    )
+    """)
     h.execute(p1=user)
     data = h.fetchone_dict()
     if data and data["login"]:
@@ -476,12 +463,10 @@ def __reserve_user_db(user, password):
         # Encrypt the password, let the function pick the salt
         password = encrypt_password(password)
 
-    h = rhnSQL.prepare(
-        """
+    h = rhnSQL.prepare("""
     insert into rhnUserReserved (login, password)
     values (:username, :password)
-    """
-    )
+    """)
     h.execute(username=user, password=password)
     rhnSQL.commit()
 
@@ -500,14 +485,12 @@ def __new_user_db(username, password, email, org_id, org_password):
     log_debug(3, username, email, encrypted_password)
 
     # now search it in the database
-    h = rhnSQL.prepare(
-        """
+    h = rhnSQL.prepare("""
     select w.id, w.password, ui.use_pam_authentication
     from web_contact w, rhnUserInfo ui
     where w.login_uc = upper(:username)
     and w.id = ui.user_id
-    """
-    )
+    """)
     h.execute(username=username)
     data = h.fetchone_dict()
 
@@ -515,12 +498,10 @@ def __new_user_db(username, password, email, org_id, org_password):
 
     if not data:
         # the username is not there, check the reserved user table
-        h = rhnSQL.prepare(
-            """
+        h = rhnSQL.prepare("""
         select login, password from rhnUserReserved
         where login_uc = upper(:username)
-        """
-        )
+        """)
         h.execute(username=username)
         data = h.fetchone_dict()
         if not data:  # nope, not reserved either
@@ -617,6 +598,16 @@ def check_email(email):
     return email
 
 
+_PBKDF2_ITERATIONS = 600000
+_PBKDF2_MIN_ITERATIONS = _PBKDF2_ITERATIONS
+_PBKDF2_MAX_ITERATIONS = 2_000_000
+_PBKDF2_PREFIX = "$pbkdf2-sha256$"
+
+
+def _b64_pad(s):
+    return s + "=" * (-len(s) % 4)
+
+
 def check_password(key, pwd1):
     """Validates the given key against the current or old password
     If encrypted_password is false, it compares key with pwd1.
@@ -642,47 +633,45 @@ def check_password(key, pwd1):
         return 0  # Invalid
 
     # Crypted passwords in the database
-    if pwd1.find("$5") == 0:  # SHA-256 encrypted password
-        if pwd1 == encrypt_password(key, pwd1, "SHA-256"):
-            return 1
-    elif pwd1.find("$1$") == 0:  # MD5 encrypted password
-        if pwd1 == encrypt_password(key, pwd1, "MD5"):
+    if pwd1.startswith(_PBKDF2_PREFIX):  # PBKDF2-SHA256 password
+        # format: $pbkdf2-sha256$<iterations>$<b64salt>$<b64hash>
+        try:
+            _, _, iter_s, b64salt, b64hash = pwd1.split("$")
+            iterations = int(iter_s)
+            if not _PBKDF2_MIN_ITERATIONS <= iterations <= _PBKDF2_MAX_ITERATIONS:
+                raise ValueError("iteration count out of range")
+            raw_salt = _base64.b64decode(_b64_pad(b64salt))
+            dk = hashlib.pbkdf2_hmac("sha256", key.encode(), raw_salt, iterations)
+            stored = _base64.b64decode(_b64_pad(b64hash))
+            if hmac.compare_digest(dk, stored):
+                return 1
+        except (ValueError, TypeError):
+            log_debug(4, "PBKDF2 password verification failed")
+            return 0
+    elif pwd1.find("$5") == 0:  # legacy SHA-256 crypt(3) password
+        if pwd1 == encrypt_password(key, pwd1):
             return 1
 
     log_debug(4, "Encrypted password doesn't match")
     return 0  # invalid
 
 
-def encrypt_password(key, salt=None, method="SHA-256"):
-    """Encrypt the key
-    If no salt is supplied, generates one (md5-crypt salt)
-    """
+def encrypt_password(key, salt=None):
+    """Hash key with PBKDF2-SHA256. The salt param is kept only for legacy crypt(3) verification."""
+    if salt and str(salt).find("$5$") == 0:
+        # Legacy read-side path for existing SHA-256 crypt(3) hashes ($5$…).
+        import crypt as _crypt  # pylint: disable=import-outside-toplevel,deprecated-module
 
-    pw_params = {
-        "MD5": [8, "$1$"],  # method: [salt length, prefix]
-        "SHA-256": [16, "$5$"],
-    }
+        return _crypt.crypt(key, str(salt))
 
-    if not salt:
-        # No salt supplied, generate it ourselves
-        # pylint: disable-next=import-outside-toplevel
-        import base64
-
-        # pylint: disable-next=import-outside-toplevel
-        import time
-
-        # pylint: disable-next=import-outside-toplevel
-        import os
-
-        # Get the first 15 digits after the decimal point from time.time(), and
-        # add the pid too
-        salt = (time.time() % 1) * 1e15 + os.getpid()
-        # base64 it and keep only the first n chars
-        salt = base64.encodestring(str(salt).encode()).decode()[: pw_params[method][0]]
-        # slap the magic in front of the salt
-        salt = pw_params[method][1] + salt + "$"
-    salt = str(salt)
-    return crypt.crypt(key, salt)
+    # Stored format: $pbkdf2-sha256$<iterations>$<b64salt>$<b64hash>
+    # 32-byte salt + 32-byte key → 43 base64 chars each (padding stripped).
+    # Total length ≤ 109 chars, fits in the 110-char web_contact.password column.
+    raw_salt = _os.urandom(32)
+    dk = hashlib.pbkdf2_hmac("sha256", key.encode(), raw_salt, _PBKDF2_ITERATIONS)
+    b64salt = _base64.b64encode(raw_salt).decode().rstrip("=")
+    b64hash = _base64.b64encode(dk).decode().rstrip("=")
+    return f"{_PBKDF2_PREFIX}{_PBKDF2_ITERATIONS}${b64salt}${b64hash}"
 
 
 def validate_new_password(password):

--- a/python/spacewalk/spacewalk-backend.changes.szachovy.password-hashing-pbkdf2
+++ b/python/spacewalk/spacewalk-backend.changes.szachovy.password-hashing-pbkdf2
@@ -1,0 +1,3 @@
+- Use PBKDF2-SHA256 (600000 iterations) for new
+  password hashes; verify legacy SHA-256 crypt(3)
+  hashes transparently


### PR DESCRIPTION
## Summary
- Re-applies the PBKDF2-SHA256 password hashing feature (reverted in fbc8d517f86) with fixes for CI failures
- Fixes non-ASCII em dash (U+2014) in `Pbkdf2Sha256Crypt.java` that broke javadoc build under US-ASCII encoding
- Incorporates all review feedback from #11805: dedicated `Pbkdf2Sha256Crypt` class, license header cleanup, ternary readability

## What changed vs #11805
- PBKDF2 logic extracted from `CryptHelper` into its own `Pbkdf2Sha256Crypt` class (matching `SHA256Crypt` pattern)
- Unicode em dash replaced with ASCII hyphen in comment (root cause of the javadoc build failure)
- Red Hat trademark paragraph removed from new SUSE-authored class
- Copyright year set to 2026
- Parentheses added around ternary in `setPassword` for readability

## Root cause of CI failures
- **Javadoc build error**: non-ASCII character `—` (U+2014) in a comment, incompatible with US-ASCII javadoc encoding
- **Login auth failure**: deployment mismatch — Python package (spacewalk-backend) was rebuilt with PBKDF2 and stored `$pbkdf2-sha256$` hashes, but Java package (spacewalk-java) was not rebuilt, so old `authenticate()` did not recognize the prefix. Not a code bug — both packages must be deployed together.

## Test plan
- [ ] Verify javadoc builds successfully (no unmappable character errors)
- [ ] Verify admin login works after both Java and Python packages are deployed
- [ ] Verify password set via `satpasswd` (Python) can be authenticated via Java UI
- [ ] Verify legacy SHA-256 passwords still authenticate correctly