### PR TITLE
Fix flaky "Schedule another package lock" scenario

### DIFF
--- a/testsuite/features/secondary/min_salt_lock_packages.feature
+++ b/testsuite/features/secondary/min_salt_lock_packages.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 SUSE LLC
+# Copyright (c) 2021-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
@@ -88,11 +88,12 @@ Feature: Lock packages on SLES salt minion
     And I follow "Lock / Unlock"
     And I enter "milkyway-dummy-2.0-1.1" as the filtered package name
     And I click on the filter button
+    And I save the ID of the last event for "sle_minion"
     When I check row with "milkyway-dummy-2.0-1.1" and arch of "sle_minion"
     And I click on "Lock"
     Then I should see a "Packages has been requested for being locked." text
     And package "milkyway-dummy-2.0-1.1" is reported as pending to be locked
-    When I wait until event "Lock packages scheduled" is completed
+    When I wait until the new "Lock packages scheduled" event is completed for "sle_minion"
     Then "hoag-dummy-1.1-1.1" is locked on "sle_minion"
     And "milkyway-dummy-2.0-1.1" is locked on "sle_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/secondary/min_salt_lock_packages.feature
+++ b/testsuite/features/secondary/min_salt_lock_packages.feature
@@ -29,7 +29,7 @@ Feature: Lock packages on SLES salt minion
     And I click on "Lock"
     Then I should see a "Packages has been requested for being locked." text
     When I wait until event "Lock packages scheduled" is completed
-    Then "hoag-dummy-1.1-1.1" is locked on "sle_minion"
+    Then "hoag-dummy-1.1-1.1" should be locked on "sle_minion"
     When I follow "Software" in the content area
     And I follow "Lock / Unlock"
     Then package "hoag-dummy-1.1-1.1" is reported as locked
@@ -64,7 +64,7 @@ Feature: Lock packages on SLES salt minion
     And I click on "Unlock"
     Then I should see a "Packages has been requested for being unlocked." text
     When I wait until event "Lock packages scheduled" is completed
-    Then "hoag-dummy-1.1-1.1" is unlocked on "sle_minion"
+    Then "hoag-dummy-1.1-1.1" should be unlocked on "sle_minion"
     When I follow "Software" in the content area
     And I follow "Lock / Unlock"
     And I enter "hoag-dummy-1.1-1.1" as the filtered package name
@@ -94,8 +94,8 @@ Feature: Lock packages on SLES salt minion
     Then I should see a "Packages has been requested for being locked." text
     And package "milkyway-dummy-2.0-1.1" is reported as pending to be locked
     When I wait until the new "Lock packages scheduled" event is completed for "sle_minion"
-    Then "hoag-dummy-1.1-1.1" is locked on "sle_minion"
-    And "milkyway-dummy-2.0-1.1" is locked on "sle_minion"
+    Then "hoag-dummy-1.1-1.1" should be locked on "sle_minion"
+    And "milkyway-dummy-2.0-1.1" should be locked on "sle_minion"
     When I follow "Software" in the content area
     And I follow "Lock / Unlock"
     Then package "hoag-dummy-1.1-1.1" is reported as locked
@@ -124,9 +124,9 @@ Feature: Lock packages on SLES salt minion
     Then I should see a "Packages has been requested for being unlocked." text
     And package "milkyway-dummy-2.0-1.1" is reported as pending to be unlocked
     When I wait until event "Lock packages scheduled" is completed
-    Then "hoag-dummy-1.1-1.1" is locked on "sle_minion"
-    And "milkyway-dummy-2.0-1.1" is unlocked on "sle_minion"
-    And "orion-dummy-1.1-1.1" is locked on "sle_minion"
+    Then "hoag-dummy-1.1-1.1" should be locked on "sle_minion"
+    And "milkyway-dummy-2.0-1.1" should be unlocked on "sle_minion"
+    And "orion-dummy-1.1-1.1" should be locked on "sle_minion"
     When I follow "Software" in the content area
     And I follow "Lock / Unlock"
     Then package "hoag-dummy-1.1-1.1" is reported as locked
@@ -144,8 +144,8 @@ Feature: Lock packages on SLES salt minion
     Then I should see a "Packages has been requested for being unlocked." text
     And only packages "hoag-dummy-1.1-1.1, orion-dummy-1.1-1.1" are reported as pending to be unlocked
     When I wait until event "Lock packages scheduled" is completed
-    Then "hoag-dummy-1.1-1.1" is unlocked on "sle_minion"
-    And "orion-dummy-1.1-1.1" is unlocked on "sle_minion"
+    Then "hoag-dummy-1.1-1.1" should be unlocked on "sle_minion"
+    And "orion-dummy-1.1-1.1" should be unlocked on "sle_minion"
     When I follow "Software" in the content area
     And I follow "Lock / Unlock"
     And I enter "hoag-dummy-1.1-1.1" as the filtered package name

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -174,6 +174,27 @@ When(/^I wait at most (\d+) seconds until event "([^"]*)" is completed$/) do |fi
   step %(I wait 180 seconds until the event is picked up and #{final_timeout} seconds until the event "#{event}" is completed)
 end
 
+When(/^I save the ID of the last event for "(.*?)"$/) do |host|
+  add_context('last_event_before_action', get_last_event(host)['id'])
+end
+
+When(/^I wait until the new "([^"]*)" event is completed for "(.*?)"$/) do |event_text, host|
+  checkpoint_id = get_context('last_event_before_action')
+  raise ScriptError, "Checkpoint event ID not found — run 'I save the ID of the last event for \"#{host}\"' before this step" if checkpoint_id.nil?
+
+  node = get_target(host)
+  system_id = get_system_id(node)
+  new_event = nil
+  repeat_until_timeout(message: "New '#{event_text}' event not found for #{host}") do
+    events = $api_test.system.get_event_history(system_id, 0, 10)
+    new_event = events.find { |e| e['id'] > checkpoint_id && e['summary'].include?(event_text) }
+    break if new_event
+
+    sleep 2
+  end
+  wait_action_complete(new_event['id'])
+end
+
 When(/^I wait until I see the event "([^"]*)" completed during last minute, refreshing the page$/) do |event|
   repeat_until_timeout(message: "Couldn't find the event #{event}") do
     now = Time.now

--- a/testsuite/features/step_definitions/lock_packages_on_client.rb
+++ b/testsuite/features/step_definitions/lock_packages_on_client.rb
@@ -3,7 +3,7 @@
 
 ### This file contains the definitions for all steps used to lock packages on a system.
 
-Then(/^"(.*?)" is (locked|unlocked) on "(.*?)"$/) do |pkg, action, system|
+Then(/^"(.*?)" should be (locked|unlocked) on "(.*?)"$/) do |pkg, action, system|
   node = get_target(system)
   command = "zypper locks --solvables | grep #{pkg}"
   if action == 'locked'

--- a/testsuite/features/step_definitions/lock_packages_on_client.rb
+++ b/testsuite/features/step_definitions/lock_packages_on_client.rb
@@ -1,15 +1,21 @@
-# Copyright (c) 2010-2023 SUSE LLC.
+# Copyright (c) 2010-2026 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 ### This file contains the definitions for all steps used to lock packages on a system.
 
 Then(/^"(.*?)" is (locked|unlocked) on "(.*?)"$/) do |pkg, action, system|
   node = get_target(system)
-  command = "zypper locks  --solvables | grep #{pkg}"
+  command = "zypper locks --solvables | grep #{pkg}"
   if action == 'locked'
-    node.run(command, timeout: 600)
+    repeat_until_timeout(timeout: 30, message: "Package #{pkg} is not locked on #{system}") do
+      _out, code = node.run(command, check_errors: false, timeout: 10)
+      break if code.zero?
+
+      sleep 2
+    end
   else
-    node.run(command, check_errors: false, timeout: 600)
+    _out, code = node.run(command, check_errors: false, timeout: 600)
+    raise ScriptError, "Package #{pkg} is still locked on #{system}" if code.zero?
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

## Problem

The scenario Schedule another package lock in min_salt_lock_packages.feature was failing intermittently with:

```
FAIL: zypper locks --solvables | grep milkyway-dummy-2.0-1.1 returned status code = 1
```

Two compounding issues caused the flakiness:

1. Ambiguous event wait (race condition)

The previous scenario (Schedule a package lock) schedules a lock for hoag-dummy but does not wait for it to complete, it intentionally leaves the event pending to test that UI state. When Schedule another package lock then schedules a second lock for milkyway-dummy and calls wait until event "Lock packages scheduled" is completed, the existing step navigates the Events UI and follows the first link matching that text. If the hoag-dummy event completed first and appeared first in the history DOM, the wait returned immediately, before Salt had finished applying the milkyway-dummy lock on the minion. This limitation is explicitly acknowledged by a comment in common_steps.rb: "The code below is not perfect because there might beother events with the same name in the events history".

2. No retry on the zypper lock verification

The "(pkg)" is locked on "(system)" step ran zypper locks --solvables | grep <pkg> once with no retry. Even when the SUMA event genuinely completed, a brief propagation delay between Salt reporting the job done and zypper registering the lock could cause an immediate false negative.

## Solution

### New API-anchored event wait steps (common_steps.rb)

1. Two reusable steps replace the UI-based wait for this class of problem:

- `When I save the ID of the last event for "host"`: stores the current last event ID as a checkpoint via add_context, immediately before the action that will create a new event.
- `When I wait until the new "event name" event is completed for "host"`: polls system.getEventHistory for an event with id > checkpoint and a matching summary, then calls wait_action_complete on that specific action ID via the schedule API. This is unambiguous regardless of how many same-named events exist in history.

2. Retry on zypper lock check (lock_packages_on_client.rb)

The single-shot node.run for the locked case is replaced with repeat_until_timeout(timeout: 30), polling every 2 seconds. This absorbs any brief lag between event completion and zypper state without masking real failures (30 s is short enough to fail fast).

### Files changed

- features/secondary/min_salt_lock_packages.feature — add checkpoint before Lock click; use new API-based wait step
- features/step_definitions/common_steps.rb — add I save the ID of the last event for and I wait until the new "..." event is completed for steps
- features/step_definitions/lock_packages_on_client.rb — replace single-shot zypper check with repeat_until_timeout; fix double space in zypper command

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/20168
Port(s):
 - 5.1: https://github.com/SUSE/spacewalk/pull/30662
 - 5.0: https://github.com/SUSE/spacewalk/pull/30663
 - 4.3: https://github.com/SUSE/spacewalk/pull/30664

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
