### PR TITLE
Fix empty custom channel for monitoring server

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -715,8 +715,16 @@ end
 def channel_packages_are_downloaded?(channel_name)
   if channel_name.include?('custom_channel')
     client = channel_name.delete_prefix('custom_channel_')
-    # Monitoring server doesn't have an entry in the custom repository JSON file.
-    return true if $custom_repositories[client].nil? && client != 'monitoring_server'
+    if client == 'monitoring_server'
+      # Monitoring server doesn't have an entry in the custom repository JSON file.
+      # Its custom channel uses MU repositories from minions sharing the same base channel.
+      # Skip the sync wait only when none of those minions have custom repos configured.
+      monitoring_base_channel = BASE_CHANNEL_BY_CLIENT[product][client]
+      matching_minions = BASE_CHANNEL_BY_CLIENT[product].select { |k, v| k.end_with?('_minion') && v == monitoring_base_channel }.keys
+      return true if matching_minions.none? { |c| $custom_repositories[c] }
+    elsif $custom_repositories[client].nil?
+      return true
+    end
   end
   log_tmp_file = '/tmp/reposync.log'
   # Copy reposync logs to /tmp/ to prevent race condition and error when calling .extract()


### PR DESCRIPTION
## What does this PR change?

Fix an issue for monitoring add MU when no custom repository is declare for the minion.
Monitoring server doesn't have his own entry and share it with an other client (sles15sp7).

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Port(s):
 - 5.1: https://github.com/SUSE/spacewalk/pull/30667
 - 5.0: https://github.com/SUSE/spacewalk/pull/30668
 - 4.3: https://github.com/SUSE/spacewalk/pull/30669

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
