### PR TITLE
Fix I follow the left menu step failing with NoMethodError on nil class

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -438,7 +438,7 @@ When(/^I follow the left menu "([^"]*)"$/) do |menu_path|
 
     # open the submenu if needed
     begin
-      unless find(:xpath, target_link_path + parent_wrapper_path + parent_level_path)[:class].include?('open')
+      unless find(:xpath, target_link_path + parent_wrapper_path + parent_level_path)[:class]&.include?('open')
         find(:xpath, target_link_path + parent_wrapper_path).click
         # wait for the 'open' class to be applied before navigating into the submenu
         find(:xpath, "#{target_link_path}#{parent_wrapper_path}#{parent_level_path}[contains(@class,'open')]")


### PR DESCRIPTION
## What does this PR change?

### Problem

When a nav li element has no class attribute (the default collapsed state), [:class] returns nil in Capybara. The call to nil.include?('open') raises NoMethodError, which is caught by the rescue block. That rescue block calls step 'I am authorized for the "Admin" section', navigating the browser to the Overview page mid-loop. The loop continues building the remaining XPath, but the menus are now collapsed. The final find_and_wait_click for the deepest menu link fails with "Unable to find visible xpath".

This explains why I follow the left menu "Users > User List > Active" passed in "Create a new user" (early in the feature, menus had class attributes from prior navigation) but consistently failed in "Add roles for the Malaysian user" (browser in a state where some li elements had no class attribute).

### Fix

Use Ruby's safe navigation operator so nil[:class]&.include?('open') returns nil (falsy) instead of raising NoMethodError. When the class is nil the element is treated as not open and the code correctly proceeds to click and expand the submenu.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30650
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/30670
 - 5.0: https://github.com/SUSE/spacewalk/pull/30665
 - 4.3: https://github.com/SUSE/spacewalk/pull/30666

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
