### PR TITLE
Allow building "uyuni-common-libs" on SLE16 and Leap16.0

### DIFF
--- a/python/uyuni/uyuni-common-libs.changes.meaksh.master-build-uyuni-common-libs-on-leap16
+++ b/python/uyuni/uyuni-common-libs.changes.meaksh.master-build-uyuni-common-libs-on-leap16
@@ -1,0 +1,1 @@
+- Allow building uyuni-common-libs on SLE16/Leap16

--- a/python/uyuni/uyuni-common-libs.spec
+++ b/python/uyuni/uyuni-common-libs.spec
@@ -58,7 +58,7 @@ Source0:        %{name}-%{version}.tar.gz
 BuildRequires:  fdupes
 BuildRequires:  make
 BuildArch:      noarch
-%if 0%{?debian} || 0%{?ubuntu} || (0%{?suse_version} >= 1600 && 0%{?suse_version} < 1699)
+%if 0%{?debian} || 0%{?ubuntu}
 ExclusiveArch:  do_not_build
 %endif
 


### PR DESCRIPTION
## What does this PR change?

This PR enables the build of `uyuni-common-libs` package on SLE16 and openSUSE Leap 16.0, as we need it to build our server packages based on openSUSE Leap 16.0.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28911

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
