### PR TITLE
Fix issues building pacakges for openSUSE Leap 16.0

### DIFF
--- a/projects/ssl-cert-check/spacewalk-ssl-cert-check.spec
+++ b/projects/ssl-cert-check/spacewalk-ssl-cert-check.spec
@@ -98,6 +98,8 @@ install -m644 ssl-cert-check.8 %{buildroot}%{_mandir}/man8/
 
 %files
 %defattr(-,root,root,-)
+%dir /srv/www
+%dir /srv/www/htdocs
 %dir %{_sysconfdir}/sysconfig/rhn
 %{_unitdir}/%{name}.service
 %{_unitdir}/%{name}.timer

--- a/python/spacewalk/Makefile.defs
+++ b/python/spacewalk/Makefile.defs
@@ -12,7 +12,7 @@ ifeq ("$(PYTHON_BIN)", "")
     PYTHON_BIN = "python"
 endif
 
-SPACEWALK_ROOT	?= $(shell $(PYTHON_BIN) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/spacewalk
+SPACEWALK_ROOT	?= $(shell $(PYTHON_BIN) -c "import sysconfig; print(sysconfig.get_path('purelib'))")/spacewalk
 export SPACEWALK_ROOT
 
 PREFIX		?=

--- a/python/spacewalk/spacewalk-backend.changes.meaksh.master-fix-for-leap16
+++ b/python/spacewalk/spacewalk-backend.changes.meaksh.master-fix-for-leap16
@@ -1,0 +1,1 @@
+- Fix issues building package on Leap 16.0

--- a/python/spacewalk/spacewalk-backend.spec
+++ b/python/spacewalk/spacewalk-backend.spec
@@ -21,7 +21,7 @@
 
 %{!?_unitdir: %global _unitdir /lib/systemd/system}
 
-%{!?python3_sitelib: %global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%{!?python3_sitelib: %global python3_sitelib %(%{__python3} -c "import sysconfig; print(sysconfig.get_path('purelib'))")}
 %global rhnroot %{_datadir}/rhn
 %global rhnconfigdefaults %{rhnroot}/config-defaults
 %global rhnconf %{_sysconfdir}/rhn


### PR DESCRIPTION
## What does this PR change?

This PR fixes issues for `spacewalk-ssl-cert-check` and `spacewalk-backend` packages to build them on openSUSE Leap 16.0.

NOTE: I'm not adding changelog entry for `spacewalk-ssl-cert-check` as I've already added one entry that also applies for this (and not yet released).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28911

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
