### PR TITLE
susemanager: fix issues building package for openSUSE Leap 16.0

### DIFF
--- a/susemanager/Makefile.defs
+++ b/susemanager/Makefile.defs
@@ -9,7 +9,7 @@ TOP		?= .
 ROOT		?= /usr/share/rhn
 export ROOT
 
-SPACEWALK_ROOT	?= $(shell $(PYTHON_BIN) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/spacewalk
+SPACEWALK_ROOT	?= $(shell $(PYTHON_BIN) -c "import sysconfig; print(sysconfig.get_path('purelib'))")/spacewalk
 export SPACEWALK_ROOT
 
 PREFIX		?=

--- a/susemanager/susemanager.changes.meaksh.master-fix-for-leap16
+++ b/susemanager/susemanager.changes.meaksh.master-fix-for-leap16
@@ -1,0 +1,1 @@
+- Fix issues building package for openSUSE Leap 16.0

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -68,12 +68,12 @@ BuildRequires:  spacewalk-backend >= 1.7.38.20
 BuildRequires:  spacewalk-backend-server
 BuildRequires:  spacewalk-backend-sql-postgresql
 
-BuildRequires:  %fillup_prereq
-BuildRequires:  %insserv_prereq
+BuildRequires:  systemd-rpm-macros
 BuildRequires:  fdupes
 BuildRequires:  tftp
-Requires(pre):  %fillup_prereq %insserv_prereq tftp
-Requires(preun): %fillup_prereq %insserv_prereq tftp
+%{?systemd_ordering}
+Requires(pre):  tftp
+Requires(post): %fillup_prereq
 Requires(post): user(%{apache_user})
 Requires(pre):  salt
 Requires:       cobbler
@@ -203,7 +203,6 @@ rm -rf %{_localstatedir}/tmp/fakepython
 %posttrans
 
 %postun
-%insserv_cleanup
 # Cleanup
 sed -i '/You can access .* via https:\/\//d' /tmp/motd 2> /dev/null ||:
 

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -70,6 +70,7 @@ BuildRequires:  spacewalk-backend-sql-postgresql
 
 BuildRequires:  %fillup_prereq
 BuildRequires:  %insserv_prereq
+BuildRequires:  fdupes
 BuildRequires:  tftp
 Requires(pre):  %fillup_prereq %insserv_prereq tftp
 Requires(preun): %fillup_prereq %insserv_prereq tftp
@@ -94,8 +95,8 @@ Requires(pre):  uyuni-base-server
 # yast module dependency
 Requires:       postfix
 Requires:       reprepro >= 5.4
-%define python_sitelib %(%{pythonX} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
-%global pythonsmroot %{python_sitelib}/spacewalk
+%{!?python3_sitelib: %global python3_sitelib %(%{__python3} -c "import sysconfig; print(sysconfig.get_path('purelib'))")}
+%global pythonsmroot %{python3_sitelib}/spacewalk
 
 %description
 A collection of scripts for managing %{productprettyname}'s initial
@@ -183,12 +184,15 @@ make -C po install PREFIX=%{buildroot}
 # Bash completion
 %make_install -C bash-completion
 
+%fdupes %{buildroot}%{python3_sitelib}
+%fdupes %{buildroot}/usr/share
+
 %check
 # we need to build a fake python dir. python did not work with
 # two site-package/spacewalk dirs having different content
 mkdir -p %{_localstatedir}/tmp/fakepython/spacewalk
-cp -a %{python_sitelib}/spacewalk/* %{_localstatedir}/tmp/fakepython/spacewalk/
-cp -a %{buildroot}%{python_sitelib}/spacewalk/* %{_localstatedir}/tmp/fakepython/spacewalk/
+cp -a %{python3_sitelib}/spacewalk/* %{_localstatedir}/tmp/fakepython/spacewalk/
+cp -a %{buildroot}%{python3_sitelib}/spacewalk/* %{_localstatedir}/tmp/fakepython/spacewalk/
 export PYTHONPATH=%{_localstatedir}/tmp/fakepython/:%{_datadir}/rhn
 make -f Makefile.susemanager PYTHON_BIN=%{pythonX} unittest
 unset PYTHONPATH

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -67,13 +67,11 @@ BuildRequires:  python3-pycurl
 BuildRequires:  spacewalk-backend >= 1.7.38.20
 BuildRequires:  spacewalk-backend-server
 BuildRequires:  spacewalk-backend-sql-postgresql
-
-BuildRequires:  systemd-rpm-macros
 BuildRequires:  fdupes
-BuildRequires:  tftp
-%{?systemd_ordering}
+BuildRequires:  sed
+
+Requires(postun): sed
 Requires(pre):  tftp
-Requires(post): %fillup_prereq
 Requires(post): user(%{apache_user})
 Requires(pre):  salt
 Requires:       cobbler


### PR DESCRIPTION
## What does this PR change?

This PR fixes some issues in order to allow the `susemanager` package to be able to build for openSUSE Leap 16.0:

- Moving away from insserv dependency and macros
- Fix issue around `python_sitelib` variable

See the package building for both openSUSE Leap 16.0 and 15.6 here: https://build.opensuse.org/package/show/home:PSuarezHernandez:uyuniexperiments/susemanager

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28911

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
