### PR TITLE
Allow building "mgr-push" on Leap 16.0 and SLE 16

### DIFF
--- a/client/tools/mgr-push/mgr-push.changes.meaksh.master-fix-for-leap16
+++ b/client/tools/mgr-push/mgr-push.changes.meaksh.master-fix-for-leap16
@@ -1,0 +1,1 @@
+- Allow building mgr-push on Leap 16.0 and SLE 16

--- a/client/tools/mgr-push/mgr-push.spec
+++ b/client/tools/mgr-push/mgr-push.spec
@@ -54,7 +54,7 @@ Obsoletes:      %{oldname} < %{oldversion}
 %if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version} >= 1210
 BuildArch:      noarch
 %endif
-%if 0%{?debian} || 0%{?ubuntu} || 0%{?rhel} >= 8 || (0%{?suse_version} >= 1600 && 0%{?suse_version} < 1699)
+%if 0%{?debian} || 0%{?ubuntu} || 0%{?rhel} >= 8
 ExclusiveArch:  do_not_build
 %endif
 


### PR DESCRIPTION
## What does this PR change?

This PR enables the build of `mgr-push` on openSUSE Leap 16.0 and SLE 16.0, as we need this as a requirement for `saltboot-formula` package (to be installed on the server container):

```
nothing provides mgr-push needed by spacewalk-common
``` 

Since we don't want this package in the client tools for Leap 16 or SLE16, we explicitely disable the builds for the client tools here:

https://src.opensuse.org/uyuni/UyuniTools/pulls/17
https://src.suse.de/Galaxy/MLMTools/pulls/83

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
