### PR TITLE
Allow "server-saline-image" to build based on Leap 16.0

### DIFF
--- a/containers/server-saline-image/Dockerfile
+++ b/containers/server-saline-image/Dockerfile
@@ -8,23 +8,27 @@ ARG PRODUCT=Uyuni
 ARG VENDOR="Uyuni project"
 ARG URL="https://www.uyuni-project.org/"
 ARG REFERENCE_PREFIX="registry.opensuse.org/uyuni"
+ARG USEPYTHON="python311"
 
 RUN groupadd -r --gid 10554 salt && \
     useradd -r -s /usr/sbin/nologin -g salt -d /var/lib/salt --uid 10554 salt
 
 COPY run_saline.sh /run_saline.sh
 
+# We need to install find before we can run the installation of saline packages
+RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses --force-resolution findutils
+
 # Main packages
-RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses --force-resolution --download-only saline python311-saline && \
+RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses --force-resolution --download-only saline ${USEPYTHON}-saline && \
     rpm -ivh --nodeps $(find /var/cache/zypp/packages/ -type f \
       -name update-alternatives.rpm -o \
-      -name python311-base.rpm -o -name 'libpython3_11*.rpm' -o -name 'libopenssl*.rpm' -o -name libexpat1.rpm -o \
-      -name salt.rpm -o -name python311-salt.rpm -o -name python311-tornado.rpm -o \
-      -name python311-contextvars.rpm -o -name python311-immutables.rpm -o -name python311-looseversion.rpm -o \
-      -name python311-packaging.rpm -o -name python311-distro.rpm -o \
-      -name python311-PyYAML.rpm -o -name 'libyaml*.rpm' -o -name python311-Jinja2.rpm -o -name python311-MarkupSafe.rpm -o \
-      -name python311-msgpack.rpm -o -name python311-more-itertools.rpm -o \
-      -name saline.rpm -o -name python311-saline.rpm -o -name python311-python-dateutil.rpm -o -name python311-six.rpm) && \
+      -name ${USEPYTHON}-base.rpm -o -name 'lib${USEPYTHON/python3/python3_/}*.rpm' -o -name 'libopenssl*.rpm' -o -name libexpat1.rpm -o \
+      -name salt.rpm -o -name ${USEPYTHON}-salt.rpm -o -name ${USEPYTHON}-tornado.rpm -o \
+      -name ${USEPYTHON}-contextvars.rpm -o -name ${USEPYTHON}-immutables.rpm -o -name ${USEPYTHON}-looseversion.rpm -o \
+      -name ${USEPYTHON}-packaging.rpm -o -name ${USEPYTHON}-distro.rpm -o \
+      -name ${USEPYTHON}-PyYAML.rpm -o -name 'libyaml*.rpm' -o -name ${USEPYTHON}-Jinja2.rpm -o -name ${USEPYTHON}-MarkupSafe.rpm -o \
+      -name ${USEPYTHON}-msgpack.rpm -o -name ${USEPYTHON}-more-itertools.rpm -o \
+      -name saline.rpm -o -name ${USEPYTHON}-saline.rpm -o -name ${USEPYTHON}-python-dateutil.rpm -o -name ${USEPYTHON}-six.rpm) && \
     mkdir /etc/saline.defaults && cp -r /etc/salt/saline* /etc/saline.defaults/ && \
     chown -R salt:salt /etc/saline.defaults && \
     zypper --non-interactive clean --all && \

--- a/containers/server-saline-image/server-saline-image.changes.meaksh.uyuni-main-fixes-for-saline-image
+++ b/containers/server-saline-image/server-saline-image.changes.meaksh.uyuni-main-fixes-for-saline-image
@@ -1,0 +1,1 @@
+- Allow building container based on Leap 16.0


### PR DESCRIPTION
## What does this PR change?

This PR fixes `server-saline-image` to be able to build on openSUSE Leap 16.0, but keeping the ability to also build on 15.6 and SLE15SP7.

The `USEPYTHON` argument (default to `python311`) can be set to `python313` (via projconfig) to allow building on Leap 16.0 and SLE 16.

See this building in this TEST PR: https://src.opensuse.org/uyuni/Uyuni/pulls/44

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
