### PR TITLE
Use API to delete minions

### DIFF
--- a/testsuite/features/secondary/min_bootstrap_activation_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_activation_key.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2025 SUSE LLC
+# Copyright (c) 2018-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
@@ -13,11 +13,8 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     Given I am authorized
 
   Scenario: Delete SLES minion system profile
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
+    When I delete "sle_minion" system using the api
+    And I perform a full salt minion cleanup on "sle_minion"
     And I wait until Salt client is inactive on "sle_minion"
     Then "sle_minion" should not be registered
 

--- a/testsuite/features/secondary/min_bootstrap_api.feature
+++ b/testsuite/features/secondary/min_bootstrap_api.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 SUSE LLC
+# Copyright (c) 2017-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features when running in sequential:
@@ -13,11 +13,8 @@ Feature: Register a Salt minion via API
     Given I am authorized
 
   Scenario: Delete SLES minion system profile before API bootstrap test
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
+    When I delete "sle_minion" system using the api
+    And I perform a full salt minion cleanup on "sle_minion"
     And I wait until Salt client is inactive on "sle_minion"
     Then "sle_minion" should not be registered
 

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2025 SUSE LLC
+# Copyright (c) 2019-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
@@ -22,11 +22,8 @@ Feature: Register a Salt minion with a bootstrap script
     Given I am authorized
 
   Scenario: Delete SLES minion system profile before script bootstrap test
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
+    When I delete "sle_minion" system using the api
+    And I perform a full salt minion cleanup on "sle_minion"
     And I wait until Salt client is inactive on "sle_minion"
     Then "sle_minion" should not be registered
 

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 SUSE LLC
+# Copyright (c) 2021-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #
@@ -14,11 +14,8 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
     Given I am authorized
 
   Scenario: Delete SLES minion system profile before bootstrap with SSH key test
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
+    When I delete "sle_minion" system using the api
+    And I perform a full salt minion cleanup on "sle_minion"
     And I wait until Salt client is inactive on "sle_minion"
     Then "sle_minion" should not be registered
 

--- a/testsuite/features/secondary/min_deblike_ssh.feature
+++ b/testsuite/features/secondary/min_deblike_ssh.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 SUSE LLC
+# Copyright (c) 2017-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # 1) delete Debian-like minion and register as SSH minion
@@ -92,11 +92,9 @@ Feature: Bootstrap a SSH-managed Debian-like minion and do some basic operations
     Then I check for failed events on history event page
 
   Scenario: Cleanup: delete the SSH-managed Debian-like minion
-    When I am on the Systems overview page of this "deblike_minion"
-    And I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
+    When I delete "deblike_minion" system using the api
+    And I perform a full salt minion cleanup on "deblike_minion"
+    And I wait until Salt client is inactive on "deblike_minion"
     Then "deblike_minion" should not be registered
 
   Scenario: Cleanup: bootstrap a Debian-like minion

--- a/testsuite/features/secondary/min_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/min_move_from_and_to_proxy.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 SUSE LLC
+# Copyright (c) 2021-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle_minion
@@ -9,11 +9,8 @@ Feature: Move a minion from a proxy to direct connection
     Given I am authorized
 
   Scenario: Delete minion system profile before bootstrap
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
+    When I delete "sle_minion" system using the api
+    And I perform a full salt minion cleanup on "sle_minion"
     And I wait until Salt client is inactive on "sle_minion"
     Then "sle_minion" should not be registered
 

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2024 SUSE LLC
+# Copyright (c) 2017-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # 1) delete Red Hat-like minion and register as SSH minion
@@ -92,11 +92,9 @@ Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operation
     Then I check for failed events on history event page
 
   Scenario: Cleanup: delete the SSH-managed Red Hat-like minion
-    When I am on the Systems overview page of this "rhlike_minion"
-    And I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
+    When I delete "rhlike_minion" system using the api
+    And I perform a full salt minion cleanup on "rhlike_minion"
+    And I wait until Salt client is inactive on "rhlike_minion"
     Then "rhlike_minion" should not be registered
 
   Scenario: Cleanup: bootstrap a Red Hat-like minion after SSH minion tests

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -43,11 +43,8 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     And I wait until there is no Salt job calling the module "hardware.profileupdate" on "sle_minion"
 
   Scenario: Delete SLES minion system profile before mgrcompat test
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
+    When I delete "sle_minion" system using the api
+    And I perform a full salt minion cleanup on "sle_minion"
     And I wait until Salt client is inactive on "sle_minion"
     Then "sle_minion" should not be registered
 
@@ -84,13 +81,10 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     And I wait until there is no Salt job calling the module "hardware.profileupdate" on "sle_minion"
 
   Scenario: Cleanup: Delete profile of the minion and disable new module.run syntax
-    Given I am on the Systems overview page of this "sle_minion"
-    And I remove "custom_modulerun.conf" from salt minion config directory on "sle_minion"
+    When I remove "custom_modulerun.conf" from salt minion config directory on "sle_minion"
     And I remove "custom_grains.conf" from salt minion config directory on "sle_minion"
-    When I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
+    And I delete "sle_minion" system using the api
+    And I perform a full salt minion cleanup on "sle_minion"
     And I wait until Salt client is inactive on "sle_minion"
     Then "sle_minion" should not be registered
 

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -17,11 +17,8 @@ Feature: Management of minion keys
     Given I am authorized
 
   Scenario: Delete SLES minion system profile before exploring the onboarding page
-    Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
+    When I delete "sle_minion" system using the api
+    And I perform a full salt minion cleanup on "sle_minion"
     And I wait until Salt client is inactive on "sle_minion"
     Then "sle_minion" should not be registered
 

--- a/testsuite/features/secondary/minssh_bootstrap_api.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_api.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2024 SUSE LLC
+# Copyright (c) 2017-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
@@ -19,11 +19,9 @@ Feature: Register a salt-ssh system via API
     Given I am authorized
 
   Scenario: Delete SSH minion system profile before API bootstrap test
-    Given I am on the Systems overview page of this "ssh_minion"
-    When I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
+    When I delete "ssh_minion" system using the api
+    And I perform a full salt minion cleanup on "ssh_minion"
+    And I wait until Salt client is inactive on "ssh_minion"
     Then "ssh_minion" should not be registered
 
 @proxy

--- a/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 SUSE LLC
+# Copyright (c) 2021-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
@@ -19,11 +19,9 @@ Feature: Move a SSH minion from a proxy to direct connection
     Given I am authorized
 
   Scenario: Delete minion system profile before bootstrap
-    Given I am on the Systems overview page of this "ssh_minion"
-    When I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
+    When I delete "ssh_minion" system using the api
+    And I perform a full salt minion cleanup on "ssh_minion"
+    And I wait until Salt client is inactive on "ssh_minion"
     Then "ssh_minion" should not be registered
 
   Scenario: Bootstrap a minion

--- a/testsuite/features/secondary/minssh_tunnel.feature
+++ b/testsuite/features/secondary/minssh_tunnel.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024 SUSE LLC
+# Copyright (c) 2020-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
@@ -84,11 +84,9 @@ Feature: Register a Salt system to be managed via SSH tunnel
     Then I should see "My remote command output" in the command output for "ssh_minion"
 
   Scenario: Cleanup: delete the SSH tunnel minion
-    Given I am on the Systems overview page of this "ssh_minion"
-    When I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
+    When I delete "ssh_minion" system using the api
+    And I perform a full salt minion cleanup on "ssh_minion"
+    And I wait until Salt client is inactive on "ssh_minion"
     Then "ssh_minion" should not be registered
 
   Scenario: Cleanup: register a SSH minion after SSH tunnel tests


### PR DESCRIPTION
## What does this PR change?

Delete a system/profile takes  4 minutes each, we are doing this action a lot during the test. Keep at list one system delete using the UI for each minion type and move all the other delete system to API call. It should save around 35 minutes.

### UI deletes remaining — all intentional:
  - min_salt_minions_page.feature:72 → "Delete profile of unreacheable minion" (tests timeout + "Delete Without Cleanup" modal)
  - min_bootstrap_activation_key.feature:152 → activation key deletion message, not a system profile delete (unrelated)
  - min_rhlike_ssh.feature:28 → "Delete the Red Hat-like minion before SSH minion tests" (1 UI kept for rhlike)
  - min_deblike_ssh.feature:29 → "Delete the Debian-like minion" (1 UI kept for deblike)
  - minssh_tunnel.feature:24 → "Delete the Salt minion for SSH tunnel bootstrap" (1 UI kept for ssh_minion)

  
### Summary of what was changes:

13 scenarios across 12 feature files converted from UI delete (~4 min each) to API delete (<5 seconds). Estimated ~35 minutes saved per run.

UI coverage preserved per minion type:

  ```
┌────────────────┬─────────────────────────────────────────────────────────────────┬────────────────────────────────┐
  │     Minion     │                        Kept UI scenario                         │            Feature             │
  ├────────────────┼─────────────────────────────────────────────────────────────────┼────────────────────────────────┤
  │ sle_minion     │ "Delete profile of unreacheable minion" — tests timeout + modal │ min_salt_minions_page          │
  ├────────────────┼─────────────────────────────────────────────────────────────────┼────────────────────────────────┤
  │ rhlike_minion  │ "Delete the Red Hat-like minion before SSH minion tests"        │ min_rhlike_ssh                 │
  ├────────────────┼─────────────────────────────────────────────────────────────────┼────────────────────────────────┤
  │ deblike_minion │ "Delete the Debian-like minion"                                 │ min_deblike_ssh                │
  ├────────────────┼─────────────────────────────────────────────────────────────────┼────────────────────────────────┤
  │ ssh_minion     │ "Delete the Salt minion for SSH tunnel bootstrap"               │ minssh_tunnel                  │
  ├────────────────┼─────────────────────────────────────────────────────────────────┼────────────────────────────────┤
  │ pxeboot_minion │ "Cleanup: delete the new Retail terminal" (untouched)           │ proxy_container_retail_pxeboot │
  ├────────────────┼─────────────────────────────────────────────────────────────────┼────────────────────────────────┤
  │ virtual hosts  │ Both deletions untouched                                        │ srv_virtual_host_manager       │
  ├────────────────┼─────────────────────────────────────────────────────────────────┼────────────────────────────────┤
  │ empty profiles │ Both deletions untouched (feature tests this UI flow)           │ min_empty_system_profiles      │
  └────────────────┴─────────────────────────────────────────────────────────────────┴────────────────────────────────┘
```

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): 
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/30739
 - 5.0: https://github.com/SUSE/spacewalk/pull/30740
 - 4.3: https://github.com/SUSE/spacewalk/pull/30741

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
