### PR TITLE
Detect failing metadata generation on the server and log accordingly.

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -452,14 +452,28 @@ When(/^I wait until all synchronized channels have solved their dependencies$/) 
   begin
     start = Time.now
     deadline_elapsed = optimized_timeout
+    # Tracks channels where solv.new was observed - generation is known to have started.
+    # We only check for failure on these channels to avoid false positives on queued
+    # channels that have not yet begun metadata generation.
+    channels_generation_started = Set.new
     repeat_until_timeout(timeout: optimized_timeout, message: 'Product not fully initialized') do
       prev_count = channels_to_wait_solv_file.count
 
-      failed_channels = channels_to_wait_solv_file.select { |channel| channel_metadata_failed?(channel) }
+      # Update which channels have started generation (solv.new present)
+      channels_to_wait_solv_file.each do |channel|
+        cache_path = "/var/cache/rhn/repodata/#{channel}"
+        _, code = get_target('server').run("test -f #{cache_path}/solv.new", check_errors: false)
+        channels_generation_started.add(channel) if code.zero?
+      end
+
+      # Only flag channels where we previously confirmed generation started
+      failed_channels = channels_to_wait_solv_file
+        .select { |channel| channels_generation_started.include?(channel) && channel_metadata_failed?(channel) }
       if failed_channels.any?
-        log "WARN: Channels detected as failed (no published metadata): #{failed_channels.join(', ')}"
+        log "WARN: Channels detected as failed (metadata generation started but produced no output): #{failed_channels.join(', ')}"
         add_context('channels_failed_without_solv_file', get_context('channels_failed_without_solv_file') + failed_channels)
         channels_to_wait_solv_file -= failed_channels
+        channels_generation_started -= failed_channels
       end
 
       channels_to_wait_solv_file.reject! { |channel| channel_is_synced?(channel) }

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -454,6 +454,14 @@ When(/^I wait until all synchronized channels have solved their dependencies$/) 
     deadline_elapsed = optimized_timeout
     repeat_until_timeout(timeout: optimized_timeout, message: 'Product not fully initialized') do
       prev_count = channels_to_wait_solv_file.count
+
+      failed_channels = channels_to_wait_solv_file.select { |channel| channel_metadata_failed?(channel) }
+      if failed_channels.any?
+        log "WARN: Channels detected as failed (no published metadata): #{failed_channels.join(', ')}"
+        add_context('channels_failed_without_solv_file', get_context('channels_failed_without_solv_file') + failed_channels)
+        channels_to_wait_solv_file -= failed_channels
+      end
+
       channels_to_wait_solv_file.reject! { |channel| channel_is_synced?(channel) }
       break if channels_to_wait_solv_file.empty?
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -827,29 +827,28 @@ end
 
 # Determines whether a channel's metadata generation has failed on the server.
 #
-# Checks the published metadata directory (/pub/rhn/repodata/) used by the WebUI
-# to mark a channel as FINISHED. If no metadata generation is in progress (no solv.new)
-# and no published metadata exists, the channel has failed or will never complete.
+# Checks the cache directory (/var/cache/rhn/repodata/) where the server writes
+# metadata during generation. Should only be called for channels where solv.new
+# was previously observed (i.e., generation is known to have started).
 #
 # @param channel [String] The name of the channel to check.
 # @return [Boolean] Returns true if the channel has failed, false if still in progress or finished.
 def channel_metadata_failed?(channel)
   server = get_target('server')
-  pub_path = "/pub/rhn/repodata/#{channel}"
   cache_path = "/var/cache/rhn/repodata/#{channel}"
 
   # Still generating - solv.new present means metadata generation is in progress
   _, new_file_code = server.run("test -f #{cache_path}/solv.new", check_errors: false)
   return false if new_file_code.zero?
 
-  # Published metadata exists - channel is finished (RPM or Debian)
-  _, rpm_pub_code = server.run("test -f #{pub_path}/repomd.xml", check_errors: false)
-  return false if rpm_pub_code.zero?
+  # RPM channel completed successfully - solv file exists in cache
+  _, solv_code = server.run("test -f #{cache_path}/solv", check_errors: false)
+  return false if solv_code.zero?
 
-  _, deb_pub_code = server.run("test -f #{pub_path}/Release", check_errors: false)
-  return false if deb_pub_code.zero?
+  # Debian channel completed successfully - Release and Packages exist in cache
+  _, deb_code = server.run("test -s #{cache_path}/Release && test -e #{cache_path}/Packages", check_errors: false)
+  return false if deb_code.zero?
 
-  log "WARN: Channel #{channel} has no published metadata and no generation in progress - detected as failed."
   true
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -825,6 +825,34 @@ def channel_is_synced?(channel)
   sync_status
 end
 
+# Determines whether a channel's metadata generation has failed on the server.
+#
+# Checks the published metadata directory (/pub/rhn/repodata/) used by the WebUI
+# to mark a channel as FINISHED. If no metadata generation is in progress (no solv.new)
+# and no published metadata exists, the channel has failed or will never complete.
+#
+# @param channel [String] The name of the channel to check.
+# @return [Boolean] Returns true if the channel has failed, false if still in progress or finished.
+def channel_metadata_failed?(channel)
+  server = get_target('server')
+  pub_path = "/pub/rhn/repodata/#{channel}"
+  cache_path = "/var/cache/rhn/repodata/#{channel}"
+
+  # Still generating - solv.new present means metadata generation is in progress
+  _, new_file_code = server.run("test -f #{cache_path}/solv.new", check_errors: false)
+  return false if new_file_code.zero?
+
+  # Published metadata exists - channel is finished (RPM or Debian)
+  _, rpm_pub_code = server.run("test -f #{pub_path}/repomd.xml", check_errors: false)
+  return false if rpm_pub_code.zero?
+
+  _, deb_pub_code = server.run("test -f #{pub_path}/Release", check_errors: false)
+  return false if deb_pub_code.zero?
+
+  log "WARN: Channel #{channel} has no published metadata and no generation in progress - detected as failed."
+  true
+end
+
 # This function initializes the API client
 #
 # The API client is determined based on the `$debug_mode` and `product` variables.


### PR DESCRIPTION
## What does this PR change?

### Problem

The step When I wait until all synchronized channels have solved their dependencies can take many hours when a channel's metadata generation fails silently.

The step polls each channel by checking for its solver cache file (/var/cache/rhn/repodata/<channel>/solv) or, for Debian channels, Release+Packages in the same cache directory. When metadata generation fails (e.g., a ScriptError in the reposync pipeline), those files never appear — the step has no way to distinguish "still running" from "already failed" and simply waits until its timeout expires.

In a recent build validation run with debian-12-pool-amd64 failing during metadata generation, this caused the step to wait an extra 6 hours after all other channels had already resolved, because the per-channel timeout was recalculated from the moment the failing channel became the last one pending.

### Solution

Add a new channel_metadata_failed? helper in commonlib.rb that performs the same check the WebUI uses to display the exclamation-mark failure icon: it looks for published metadata in `/pub/rhn/repodata/<channel>/` (repomd.xml for RPM channels, Release for Debian channels).

The detection logic is:
1. If /var/cache/rhn/repodata/<channel>/solv.new exists → metadata generation is still running → not failed
2. If /pub/rhn/repodata/<channel>/repomd.xml exists → RPM channel published successfully → not failed
3. If /pub/rhn/repodata/<channel>/Release exists → Debian channel published successfully → not failed
4. Otherwise → no generation in progress and no published result → failed

At each polling iteration the step now calls channel_metadata_failed? on all pending channels. Any channel detected as failed is immediately added to `channels_failed_without_solv_file` (the same context used by the timeout path) and removed from the wait list, triggering an early deadline recalculation. The run then continues without waiting for the channel's full timeout budget.

With this change, the 6-hour wait described above would have been cut to a single polling interval (~10 seconds) from the moment the failure was detectable.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29872
Port(s): 
 - 5.1:
 - 5.0:
 - 4.3: 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
