### PR TITLE
Fix Salt RPC transport error handling

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
@@ -25,6 +25,13 @@ __context__: Dict[str, Any] = {}
 __virtualname__: str = "uyuni"
 
 
+def _get_fault_code(exc: Exception):
+    """
+    Return the XML-RPC fault code for Fault exceptions.
+    """
+    return getattr(exc, "faultCode", None)
+
+
 class UyuniUsersException(Exception):
     """
     Uyuni users Exception
@@ -112,7 +119,7 @@ class RPCClient:
                 return getattr(self.conn, method)(*((self.token,) + args))
             # pylint: disable-next=broad-exception-caught
             except Exception as exc:
-                if exc.faultCode != AUTHENTICATION_ERROR:
+                if _get_fault_code(exc) != AUTHENTICATION_ERROR:
                     log.error("Unable to call RPC function: %s", str(exc))
                     raise exc
                 # pylint: disable-next=pointless-string-statement

--- a/susemanager-utils/susemanager-sls/src/states/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/states/uyuni_config.py
@@ -23,6 +23,13 @@ __opts__: Dict[str, Any] = {}
 __virtualname__ = "uyuni"
 
 
+def _get_fault_code(exc: Exception):
+    """
+    Return the XML-RPC fault code for Fault exceptions.
+    """
+    return getattr(exc, "faultCode", None)
+
+
 class StateResult:
     @staticmethod
     def state_error(name: str, comment: str = None):
@@ -145,7 +152,7 @@ class UyuniUsers:
             # pylint: disable-next=broad-exception-caught
             except Exception as exc:
                 # check if it's an authentication error. If yes, password have changed
-                if exc.faultCode == AUTHENTICATION_ERROR:
+                if _get_fault_code(exc) == AUTHENTICATION_ERROR:
                     changes["password"] = {"new": "(hidden)", "old": "(hidden)"}
                 else:
                     error = exc
@@ -204,9 +211,17 @@ class UyuniUsers:
             ]
         # pylint: disable-next=broad-exception-caught
         except Exception as exc:
-            if exc.faultCode == AUTHENTICATION_ERROR:
+            fault_code = _get_fault_code(exc)
+            if fault_code == AUTHENTICATION_ERROR:
                 # pylint: disable-next=consider-using-f-string
                 error_message = "Error while retrieving user information (admin credentials error) '{}': {}".format(
+                    login, exc
+                )
+                log.warning(error_message)
+                return StateResult.state_error(login, comment=error_message)
+            if fault_code is None:
+                # pylint: disable-next=consider-using-f-string
+                error_message = "Error while retrieving user information '{}': {}".format(
                     login, exc
                 )
                 log.warning(error_message)
@@ -309,14 +324,15 @@ class UyuniUsers:
                 org_admin_password=org_admin_password,
             )
         except Exception as exc:
-            if exc.faultCode == NO_SUCH_USER_ERROR:
+            fault_code = _get_fault_code(exc)
+            if fault_code == NO_SUCH_USER_ERROR:
                 return StateResult.prepare_result(
                     login,
                     True,
                     # pylint: disable-next=consider-using-f-string
                     "{0} is already absent".format(login),
                 )
-            if exc.faultCode == AUTHENTICATION_ERROR:
+            if fault_code == AUTHENTICATION_ERROR:
                 return StateResult.state_error(
                     login,
                     # pylint: disable-next=consider-using-f-string
@@ -600,7 +616,7 @@ class UyuniGroups:
             )
         # pylint: disable-next=broad-exception-caught
         except Exception as exc:
-            if exc.faultCode != SERVER_GROUP_NOT_FOUND_ERROR:
+            if _get_fault_code(exc) != SERVER_GROUP_NOT_FOUND_ERROR:
                 return StateResult.state_error(
                     name,
                     # pylint: disable-next=consider-using-f-string
@@ -713,14 +729,15 @@ class UyuniGroups:
                 org_admin_password=org_admin_password,
             )
         except Exception as exc:
-            if exc.faultCode == SERVER_GROUP_NOT_FOUND_ERROR:
+            fault_code = _get_fault_code(exc)
+            if fault_code == SERVER_GROUP_NOT_FOUND_ERROR:
                 return StateResult.prepare_result(
                     name,
                     True,
                     # pylint: disable-next=consider-using-f-string
                     "{0} is already absent".format(name),
                 )
-            if exc.faultCode == AUTHENTICATION_ERROR:
+            if fault_code == AUTHENTICATION_ERROR:
                 return StateResult.state_error(
                     name,
                     # pylint: disable-next=consider-using-f-string
@@ -816,7 +833,7 @@ class UyuniOrgs:
             )
         # pylint: disable-next=broad-exception-caught
         except Exception as exc:
-            if exc.faultCode != ORG_NOT_FOUND_ERROR:
+            if _get_fault_code(exc) != ORG_NOT_FOUND_ERROR:
                 return StateResult.state_error(
                     name,
                     # pylint: disable-next=consider-using-f-string
@@ -905,14 +922,15 @@ class UyuniOrgs:
                 name, admin_user=admin_user, admin_password=admin_password
             )
         except Exception as exc:
-            if exc.faultCode == ORG_NOT_FOUND_ERROR:
+            fault_code = _get_fault_code(exc)
+            if fault_code == ORG_NOT_FOUND_ERROR:
                 return StateResult.prepare_result(
                     name,
                     True,
                     # pylint: disable-next=consider-using-f-string
                     "{0} is already absent".format(name),
                 )
-            if exc.faultCode == AUTHENTICATION_ERROR:
+            if fault_code == AUTHENTICATION_ERROR:
                 return StateResult.state_error(
                     name,
                     # pylint: disable-next=consider-using-f-string
@@ -1349,7 +1367,7 @@ class UyuniActivationKeys:
 
         # pylint: disable-next=broad-exception-caught
         except Exception as exc:
-            if exc.faultCode != ACTIVATION_KEY_NOT_FOUND_ERROR:
+            if _get_fault_code(exc) != ACTIVATION_KEY_NOT_FOUND_ERROR:
                 return StateResult.state_error(
                     key,
                     # pylint: disable-next=consider-using-f-string
@@ -1537,14 +1555,15 @@ class UyuniActivationKeys:
                 org_admin_password=org_admin_password,
             )
         except Exception as exc:
-            if exc.faultCode == ACTIVATION_KEY_NOT_FOUND_ERROR:
+            fault_code = _get_fault_code(exc)
+            if fault_code == ACTIVATION_KEY_NOT_FOUND_ERROR:
                 return StateResult.prepare_result(
                     name,
                     True,
                     # pylint: disable-next=consider-using-f-string
                     "{0} is already absent".format(key),
                 )
-            if exc.faultCode == AUTHENTICATION_ERROR:
+            if fault_code == AUTHENTICATION_ERROR:
                 return StateResult.state_error(
                     name,
                     # pylint: disable-next=consider-using-f-string

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_uyuni_config.py
@@ -167,6 +167,28 @@ class TestRPCClient:
                 "generic error when processing",
             )
 
+    def test_call_rpc_preserves_transport_errors(self):
+        """
+        Preserve non-Fault RPC transport errors.
+
+        :return:
+        """
+        self.rpc_client.token = "the_token"
+        exc = OSError("connection refused")
+        setattr(self.rpc_client.conn, "uyuni.some_method", MagicMock(side_effect=exc))
+
+        with patch("src.modules.uyuni_config.log") as logger:
+            with pytest.raises(OSError) as err:
+                self.rpc_client("uyuni.some_method")
+            assert err.value is exc
+            mo = getattr(self.rpc_client.conn, "uyuni.some_method")
+            assert mo.called
+            mo.assert_called_with("the_token")
+            assert logger.error.call_args[0] == (
+                "Unable to call RPC function: %s",
+                "connection refused",
+            )
+
     def test_call_rpc_crash_handle_reauthenticate_error(self):
         """
         Handle XML-RPC method crash whit reauthenticate error

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_uyuni_config.py
@@ -181,6 +181,33 @@ class TestManageUser:
                 org_admin_password="org_admin_password",
             )
 
+    def test_user_present_retrieval_error_without_fault_code(self):
+        exc = OSError("connection refused")
+
+        with patch.dict(
+            uyuni_config.__salt__,
+            {
+                "uyuni.user_get_details": MagicMock(side_effect=exc),
+                "uyuni.user_create": MagicMock(return_value=True),
+            },
+        ):
+            result = uyuni_config.user_present(
+                "username", "password", "mail@mail.com", "first_name", "last_name"
+            )
+            assert result is not None
+            assert result["name"] == "username"
+            assert result["result"] is False
+            assert (
+                result["comment"]
+                == "Error while retrieving user information 'username': connection refused"
+            )
+            assert result["changes"] == {}
+
+            uyuni_config.__salt__["uyuni.user_get_details"].assert_called_once_with(
+                "username", org_admin_user=None, org_admin_password=None
+            )
+            uyuni_config.__salt__["uyuni.user_create"].assert_not_called()
+
     def test_user_present_update_user(self):
         exc = Exception("user not found")
         exc.faultCode = 2950


### PR DESCRIPTION
## What does this PR change?

The Uyuni Salt XML-RPC client assumed every RPC failure exposes a `faultCode` attribute. That is true for XML-RPC Faults, but transport failures such as connection errors do not have that attribute, so exception handling raised `AttributeError` and hid the original failure.

This PR guards `faultCode` access in the execution module and related state handlers. Authentication Fault 2950 still uses the existing token refresh retry path, while non-Fault exceptions are logged, returned as state errors where appropriate, or re-raised unchanged.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal error handling and unit-test changes

- [x] **DONE**

## Test coverage

- Unit tests were added
- Unit tests were changed

Validation performed:
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q test_module_uyuni_config.py test_state_uyuni_config.py` from `susemanager-utils/susemanager-sls/src/tests`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q` from `susemanager-utils/susemanager-sls/src/tests`
- `git diff --check`

`black` and `pylint` were not available in the local host Python environment, so formatting/linting was checked with the local diff whitespace check and the Salt unit test suite.

- [x] **DONE**

## Links

Issue(s): Fixes #11946
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
