### PR TITLE
Include CVEs column in relevant patches CSV export

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/errata/ErrataSearchAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/errata/ErrataSearchAction.java
@@ -303,7 +303,7 @@ public class ErrataSearchAction extends BaseSearchAction {
             // small number of Errata to operate on.
             for (ErrataOverview eo : unsorted) {
                 DataResult<CVE> dr = ErrataManager.errataCVEs(eo.getId());
-                eo.setCves(dr);
+                eo.setCves(dr.stream().map(CVE::getName).toList());
             }
         }
         List<ErrataOverview> filtered = new ArrayList<>();

--- a/java/core/src/main/java/com/redhat/rhn/frontend/dto/ErrataOverview.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/dto/ErrataOverview.java
@@ -14,21 +14,26 @@
  */
 package com.redhat.rhn.frontend.dto;
 
+import com.redhat.rhn.common.db.datasource.RowCallback;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.errata.AdvisoryStatus;
 import com.redhat.rhn.frontend.xmlrpc.InvalidParameterException;
 
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * ErrataOverview
  */
-public class ErrataOverview extends BaseDto {
+public class ErrataOverview extends BaseDto implements RowCallback {
     private Long id;
     private String advisory;
     private String advisoryName;
@@ -194,6 +199,18 @@ public class ErrataOverview extends BaseDto {
      */
     public void setCves(List p) {
         this.cves = p;
+    }
+
+    /**
+     * This method is only used for CSV export.
+     * @return the CVE names joined by a single space, or an empty string
+     *         when no CVEs are associated with this erratum.
+     */
+    public String getCveNames() {
+        if (cves == null || cves.isEmpty()) {
+            return "";
+        }
+        return ((List<?>) cves).stream().map(Object::toString).collect(Collectors.joining(" "));
     }
 
     /**
@@ -603,5 +620,55 @@ public class ErrataOverview extends BaseDto {
      */
     public void setRights(String rightsIn) {
         this.rights = rightsIn;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * The {@code cve} column is populated through {@link #addCve(String)} by
+     * {@link #callback(ResultSet)} during elaboration, so the generic
+     * reflection-based mapping must skip it (it would otherwise look for a
+     * {@code setCve} method that does not exist on this DTO).
+     */
+    @Override
+    public List<String> getCallBackColumns() {
+        List<String> list = new ArrayList<>();
+        list.add("cve");
+        return list;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Picks up CVE names yielded by the {@code errata_cves_elab} elaborator
+     * and feeds them into {@link #addCve(String)}. Other elaborators are
+     * left untouched.
+     */
+    @Override
+    public void callback(ResultSet rs) {
+        if (rs == null) {
+            return;
+        }
+        try {
+            ResultSetMetaData meta = rs.getMetaData();
+            int columnCount = meta.getColumnCount();
+            // errata_cves_elab returns only (id, cve); skip other elaborators
+            // to avoid scanning unrelated result sets.
+            if (columnCount >= 3) {
+                return;
+            }
+            for (int i = 1; i <= columnCount; i++) {
+                if ("cve".equalsIgnoreCase(meta.getColumnLabel(i))) {
+                    String cve = rs.getString(i);
+                    if (cve != null) {
+                        addCve(cve);
+                    }
+                }
+            }
+        }
+        catch (SQLException e) {
+            // intentionally ignored: a missing CVE column simply means this
+            // elaborator is not the CVE one.
+        }
     }
 }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/dto/ErrataOverview.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/dto/ErrataOverview.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * ErrataOverview
@@ -47,7 +46,7 @@ public class ErrataOverview extends BaseDto implements RowCallback {
     private Date issueDate;
     private Integer affectedSystemCount;
     private String advisoryLastUpdated;
-    private List cves = new ArrayList<>();
+    private List<String> cves = new ArrayList<>();
     private List<String> packageNames = new ArrayList<>();
     private List<Long> pids = new ArrayList<>();
     private List actionId;
@@ -182,7 +181,7 @@ public class ErrataOverview extends BaseDto implements RowCallback {
     /**
      * @return Returns the cves.
      */
-    public List getCves() {
+    public List<String> getCves() {
         return cves;
     }
     /**
@@ -197,7 +196,7 @@ public class ErrataOverview extends BaseDto implements RowCallback {
     /**
      * @param p The cves to set.
      */
-    public void setCves(List p) {
+    public void setCves(List<String> p) {
         this.cves = p;
     }
 
@@ -210,7 +209,7 @@ public class ErrataOverview extends BaseDto implements RowCallback {
         if (cves == null || cves.isEmpty()) {
             return "";
         }
-        return ((List<?>) cves).stream().map(Object::toString).collect(Collectors.joining(" "));
+        return String.join(" ", cves);
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/frontend/dto/ErrataOverview.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/dto/ErrataOverview.java
@@ -632,9 +632,7 @@ public class ErrataOverview extends BaseDto implements RowCallback {
      */
     @Override
     public List<String> getCallBackColumns() {
-        List<String> list = new ArrayList<>();
-        list.add("cve");
-        return list;
+        return List.of("cve");
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/frontend/dto/SecurityErrataOverview.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/dto/SecurityErrataOverview.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009--2012 Red Hat, Inc.
+ * Copyright (c) 2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -14,57 +15,11 @@
  */
 package com.redhat.rhn.frontend.dto;
 
-import com.redhat.rhn.common.db.datasource.RowCallback;
-
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
- *  * SecurityErrataOverview
- *    */
-public class SecurityErrataOverview extends ErrataOverview
-                                    implements RowCallback {
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public List<String> getCallBackColumns() {
-        List<String> list = new ArrayList<>();
-        list.add("cve");
-        return list;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void callback(ResultSet rs) {
-        if (rs != null) {
-            // need to use try-catch, because of use of two
-            // elaborators (only one of them elaborates "CVE")
-            try {
-                ResultSetMetaData meta = rs.getMetaData();
-                int columnCount = meta.getColumnCount();
-                // make it faster by skipping the non-cve elaborators
-                // expected errata_cves_elab returns 2 columns
-                if (columnCount < 3) {
-                    for (int i = 1; i <= columnCount; i++) {
-                        if (meta.getColumnLabel(i).equalsIgnoreCase("cve")) {
-                            String cve = rs.getString("cve");
-                            if (cve != null) {
-                                addCve(cve);
-                            }
-                        }
-                    }
-                }
-            }
-            catch (SQLException e) {
-                //nothing to do
-            }
-        }
-    }
+ * SecurityErrataOverview is a marker subclass kept for backwards compatibility
+ * with the {@code *_with_cves} datasource modes. The CVE row-callback logic
+ * lives on {@link ErrataOverview} so any consumer of that DTO that runs the
+ * {@code errata_cves_elab} elaborator has its CVE list populated.
+ */
+public class SecurityErrataOverview extends ErrataOverview {
 }

--- a/java/core/src/main/resources/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
@@ -34,6 +34,7 @@ SELECT E.id, E.update_date, E.advisory_name, E.synopsis AS ADVISORY_SYNOPSIS, E.
  WHERE E.id = X.errata_id
 ORDER BY  E.update_date DESC, E.id
   </query>
+  <elaborator name="errata_cves_elab" />
   <elaborator name="errata_overview" />
   <elaborator name="errata_flags" />
 </mode>
@@ -51,6 +52,7 @@ SELECT E.id, E.update_date, E.advisory_name, E.synopsis as advisory_synopsis, E.
  AND E.advisory_type = :type
 ORDER BY  E.update_date DESC, E.id
   </query>
+  <elaborator name="errata_cves_elab" />
   <elaborator name="errata_overview" />
   <elaborator name="errata_flags" />
 </mode>

--- a/java/core/src/main/resources/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -20071,6 +20071,12 @@ The Tree Path, Base Channel, and Installer Generation should always match. This 
           <context context-type="sourcefile">/rhn/systems/details/configuration/ConfigChannelList.do</context>
         </context-group>
         </trans-unit>
+        <trans-unit id="exportcolumn.cveNames">
+          <source>CVEs</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/errata/RelevantErrata</context>
+        </context-group>
+        </trans-unit>
         <trans-unit id="exportcolumn.affectedSystemCount">
           <source>Systems Affected</source>
         <context-group name="ctx">

--- a/java/core/src/test/java/com/redhat/rhn/frontend/dto/ErrataOverviewTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/dto/ErrataOverviewTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.rhn.testing.RhnBaseTestCase;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * Tests for {@link ErrataOverview}.
+ */
+public class ErrataOverviewTest extends RhnBaseTestCase {
+
+    private ErrataOverview overview;
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        overview = new ErrataOverview();
+    }
+
+    @Test
+    public void testGetCveNamesWithMultipleCves() {
+        overview.setCves(Arrays.asList("CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"));
+        assertEquals("CVE-2026-0001 CVE-2026-0002 CVE-2026-0003", overview.getCveNames());
+    }
+
+    @Test
+    public void testGetCveNamesWithSingleCve() {
+        overview.setCves(Collections.singletonList("CVE-2026-0001"));
+        assertEquals("CVE-2026-0001", overview.getCveNames());
+    }
+
+    @Test
+    public void testGetCveNamesWithNoCves() {
+        // freshly constructed instance starts with an empty list
+        assertEquals("", overview.getCveNames());
+    }
+
+    @Test
+    public void testGetCveNamesWithEmptyList() {
+        overview.setCves(Collections.emptyList());
+        assertEquals("", overview.getCveNames());
+    }
+
+    @Test
+    public void testGetCveNamesWithNullList() {
+        overview.setCves(null);
+        assertEquals("", overview.getCveNames());
+    }
+
+    @Test
+    public void testAddCveAccumulates() {
+        overview.addCve("CVE-2026-1111");
+        overview.addCve("CVE-2026-2222");
+        // null entries are silently ignored
+        overview.addCve(null);
+        assertEquals("CVE-2026-1111 CVE-2026-2222", overview.getCveNames());
+    }
+}

--- a/java/core/src/test/java/com/redhat/rhn/frontend/dto/ErrataOverviewTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/dto/ErrataOverviewTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.rhn.testing.BaseTestCase;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * Tests for {@link ErrataOverview}.
+ */
+public class ErrataOverviewTest extends BaseTestCase {
+
+    private ErrataOverview overview;
+
+    @BeforeEach
+    public void setUp() {
+        overview = new ErrataOverview();
+    }
+
+    @Test
+    public void testGetCveNamesWithMultipleCves() {
+        overview.setCves(Arrays.asList("CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"));
+        assertEquals("CVE-2026-0001 CVE-2026-0002 CVE-2026-0003", overview.getCveNames());
+    }
+
+    @Test
+    public void testGetCveNamesWithSingleCve() {
+        overview.setCves(Collections.singletonList("CVE-2026-0001"));
+        assertEquals("CVE-2026-0001", overview.getCveNames());
+    }
+
+    @Test
+    public void testGetCveNamesWithNoCves() {
+        // freshly constructed instance starts with an empty list
+        assertEquals("", overview.getCveNames());
+    }
+
+    @Test
+    public void testGetCveNamesWithEmptyList() {
+        overview.setCves(Collections.emptyList());
+        assertEquals("", overview.getCveNames());
+    }
+
+    @Test
+    public void testGetCveNamesWithNullList() {
+        overview.setCves(null);
+        assertEquals("", overview.getCveNames());
+    }
+
+    @Test
+    public void testAddCveAccumulates() {
+        overview.addCve("CVE-2026-1111");
+        overview.addCve("CVE-2026-2222");
+        // null entries are silently ignored
+        overview.addCve(null);
+        assertEquals("CVE-2026-1111 CVE-2026-2222", overview.getCveNames());
+    }
+}

--- a/java/core/src/test/java/com/redhat/rhn/manager/errata/ErrataManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/errata/ErrataManagerTest.java
@@ -255,6 +255,29 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
     }
 
     @Test
+    public void testRelevantErrataListElaboratesCves() throws Exception {
+        User user = UserTestUtils.createUser(this);
+        Errata errata = createRelevantErrataWithCve(user, ErrataFactory.ERRATA_TYPE_BUG, "CVE-2026-3333");
+
+        DataResult<ErrataOverview> result = ErrataManager.relevantErrata(user);
+        result.elaborate();
+
+        assertEquals("CVE-2026-3333", getOverview(result, errata).getCveNames());
+    }
+
+    @Test
+    public void testRelevantErrataByTypeElaboratesCves() throws Exception {
+        User user = UserTestUtils.createUser(this);
+        Errata errata = createRelevantErrataWithCve(user, ErrataFactory.ERRATA_TYPE_BUG, "CVE-2026-4444");
+
+        DataResult<ErrataOverview> result = ErrataManager.relevantErrataByType(
+                user, null, ErrataFactory.ERRATA_TYPE_BUG);
+        result.elaborate();
+
+        assertEquals("CVE-2026-4444", getOverview(result, errata).getCveNames());
+    }
+
+    @Test
     public void testLookupErrata() throws Exception {
         User user = UserTestUtils.createUser(this);
         Errata errata = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
@@ -1685,5 +1708,19 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         ));
         olderPkg.setPackageName(fromPkg.getPackageName());
         return olderPkg;
+    }
+
+    private Errata createRelevantErrataWithCve(User user, String errataType, String cveName) throws Exception {
+        Map<String, Object> cache = ErrataCacheManagerTest.createServerNeededCache(user, errataType);
+        Errata errata = (Errata) cache.get("errata");
+        errata.setCves(Set.of(ErrataTestUtils.createTestCve(cveName)));
+        return TestUtils.saveAndFlush(errata);
+    }
+
+    private ErrataOverview getOverview(DataResult<ErrataOverview> result, Errata errata) {
+        return result.stream()
+                .filter(overview -> overview.getId().equals(errata.getId()))
+                .findFirst()
+                .orElseThrow();
     }
 }

--- a/java/core/src/test/java/com/redhat/rhn/manager/errata/ErrataManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/errata/ErrataManagerTest.java
@@ -254,6 +254,29 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
     }
 
     @Test
+    public void testRelevantErrataListElaboratesCves() throws Exception {
+        User user = UserTestUtils.createUser(this);
+        Errata errata = createRelevantErrataWithCve(user, ErrataFactory.ERRATA_TYPE_BUG, "CVE-2026-3333");
+
+        DataResult<ErrataOverview> result = ErrataManager.relevantErrata(user);
+        result.elaborate();
+
+        assertEquals("CVE-2026-3333", getOverview(result, errata).getCveNames());
+    }
+
+    @Test
+    public void testRelevantErrataByTypeElaboratesCves() throws Exception {
+        User user = UserTestUtils.createUser(this);
+        Errata errata = createRelevantErrataWithCve(user, ErrataFactory.ERRATA_TYPE_BUG, "CVE-2026-4444");
+
+        DataResult<ErrataOverview> result = ErrataManager.relevantErrataByType(
+                user, null, ErrataFactory.ERRATA_TYPE_BUG);
+        result.elaborate();
+
+        assertEquals("CVE-2026-4444", getOverview(result, errata).getCveNames());
+    }
+
+    @Test
     public void testLookupErrata() throws Exception {
         User user = UserTestUtils.createUser(this);
         Errata errata = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
@@ -1684,5 +1707,19 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         ));
         olderPkg.setPackageName(fromPkg.getPackageName());
         return olderPkg;
+    }
+
+    private Errata createRelevantErrataWithCve(User user, String errataType, String cveName) throws Exception {
+        Map<String, Object> cache = ErrataCacheManagerTest.createServerNeededCache(user, errataType);
+        Errata errata = (Errata) cache.get("errata");
+        errata.setCves(Set.of(ErrataTestUtils.createTestCve(cveName)));
+        return TestUtils.saveAndFlush(errata);
+    }
+
+    private ErrataOverview getOverview(DataResult<ErrataOverview> result, Errata errata) {
+        return result.stream()
+                .filter(overview -> overview.getId().equals(errata.getId()))
+                .findFirst()
+                .orElseThrow();
     }
 }

--- a/java/spacewalk-java.changes.officialasishkumar.csv-export-relevant-patches-cves
+++ b/java/spacewalk-java.changes.officialasishkumar.csv-export-relevant-patches-cves
@@ -1,0 +1,2 @@
+- Include CVEs column in the CSV export of the "Patches Relevant to
+  your Systems" page

--- a/java/spacewalk-java.changes.officialasishkumar.csv-export-relevant-patches-cves
+++ b/java/spacewalk-java.changes.officialasishkumar.csv-export-relevant-patches-cves
@@ -1,2 +1,2 @@
 - Include CVEs column in the CSV export of the "Patches Relevant to
-  your Systems" page
+  Your Systems" page

--- a/java/webapp/src/main/webapp/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf
@@ -4,7 +4,7 @@
         <div class="action-button-wrapper">
             <rl:csv
                 name="errataList"
-                exportColumns="errataAdvisoryType,advisoryName,advisorySynopsis,affectedSystemCount,updateDate"
+                exportColumns="errataAdvisoryType,advisoryName,advisorySynopsis,affectedSystemCount,updateDate,cveNames"
                 header="${system.name}"/>
         </div>
     </div>

--- a/java/webapp/src/main/webapp/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf
@@ -4,7 +4,7 @@
         <div class="action-button-wrapper">
             <rl:csv
                 name="errataList"
-                exportColumns="errataAdvisoryType,advisoryName,advisorySynopsis,affectedSystemCount,updateDate,cveNames"
+                exportColumns="${errataExportColumns}"
                 header="${system.name}"/>
         </div>
     </div>

--- a/java/webapp/src/main/webapp/WEB-INF/pages/errata/all.jsp
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/errata/all.jsp
@@ -19,6 +19,16 @@
 <p><bean:message key="errata.all.jsp.summary"/></p>
 
 <c:set var="emptyListKey" value="erratalist.jsp.noerrata"/>
+<c:choose>
+  <c:when test="${displayCves}">
+    <c:set var="errataExportColumns"
+           value="errataAdvisoryType,advisoryName,advisorySynopsis,affectedSystemCount,updateDate,cveNames"/>
+  </c:when>
+  <c:otherwise>
+    <c:set var="errataExportColumns"
+           value="errataAdvisoryType,advisoryName,advisorySynopsis,affectedSystemCount,updateDate"/>
+  </c:otherwise>
+</c:choose>
 <%@ include file="/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf" %>
 
 </body>

--- a/java/webapp/src/main/webapp/WEB-INF/pages/errata/relevant.jsp
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/errata/relevant.jsp
@@ -19,6 +19,8 @@
 <p><bean:message key="errata.overview.jsp.summary"/></p>
 
 <c:set var="emptyListKey" value="erratalist.jsp.norelevanterrata"/>
+<c:set var="errataExportColumns"
+       value="errataAdvisoryType,advisoryName,advisorySynopsis,affectedSystemCount,updateDate,cveNames"/>
 <%@ include file="/WEB-INF/pages/common/fragments/errata/relevant-errata-list.jspf" %>
 
 </body>


### PR DESCRIPTION
## What does this PR change?

The CSV export of the "Patches Relevant to Your Systems" view did not include any CVE information. The page renders four columns plus an updated date, then the CVEs column appears only on the Security sub-tab; either way the CSV download produced nothing for CVE.

Three coordinated changes make the export carry CVE data and match the existing security view:

1. **Datasource modes** — `relevant_errata` and `relevant_errata_by_type` now run the existing `errata_cves_elab` elaborator (the same one already used by the `*_with_cves` modes that back the Security tab). The elaborator query selects only `id` and `cve`, so there is one extra batch query per page load and no row multiplication.
2. **DTO mapping** — `ErrataOverview` itself now implements `RowCallback` so any datasource mode whose class is plain `ErrataOverview` has its CVE list populated by `errata_cves_elab`. The `columnCount >= 3` guard keeps the callback inert for unrelated elaborators (`errata_overview` and `errata_flags` both return three or more columns). `SecurityErrataOverview` is kept as a marker subclass for backwards compatibility with the `*_with_cves` modes; its CVE-specific code is now inherited.
3. **JSP + getter** — `relevant-errata-list.jspf` adds a `cveNames` column to `exportColumns`. `ErrataOverview.getCveNames()` joins the CVE list into a single space-separated cell, and `exportcolumn.cveNames` localizes the header to "CVEs".

## Codespace

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)

## GUI diff

No difference.

The relevant-patches list page itself looks the same on screen. The change is only visible inside the downloaded CSV file (a new trailing "CVEs" column).

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

The CSV column is self-describing through the localized "CVEs" header; the page UI is unchanged.

- [x] **DONE**

## Test coverage
- Unit tests were added

`ErrataOverviewTest` covers the empty / single / multi-CVE branches of `getCveNames()` and the `addCve` accumulator on a fresh DTO.

- [x] **DONE**

## Links

Issue(s): #11919

- [x] **DONE**

## Changelogs

- [ ] No changelog needed

A delta entry under `java/spacewalk-java.changes.officialasishkumar.csv-export-relevant-patches-cves` describes the user-visible change.