### PR TITLE
Show playbook name in Action Chain entries

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/action/ansible/PlaybookActionFormatter.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/ansible/PlaybookActionFormatter.java
@@ -27,6 +27,9 @@ import com.redhat.rhn.manager.system.SystemManager;
 
 import com.suse.manager.webui.utils.YamlHelper;
 
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.yaml.snakeyaml.error.YAMLException;
 
 import java.util.Comparator;
@@ -49,6 +52,29 @@ public class PlaybookActionFormatter extends ActionFormatter {
      */
     public PlaybookActionFormatter(Action actionIn) {
         super(actionIn);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Returns the playbook file name so the Action Chain UI can show what each
+     * "Execute Ansible playbook" step actually runs. The path is reduced to its
+     * basename and HTML-escaped because the value is interpolated into the
+     * already-localized message via {@code <bean:message ... arg0=...>} and is
+     * rendered as raw HTML by the JSP, like the other action formatters
+     * (errata, package).
+     */
+    @Override
+    public String getRelatedObjectDescription() {
+        PlaybookActionDetails actionDetails = ((PlaybookAction) this.getAction()).getDetails();
+        if (actionDetails == null) {
+            return "";
+        }
+        String playbookPath = actionDetails.getPlaybookPath();
+        if (StringUtils.isBlank(playbookPath)) {
+            return "";
+        }
+        return StringEscapeUtils.escapeHtml4(FilenameUtils.getName(playbookPath));
     }
 
     /**

--- a/java/core/src/main/resources/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -2802,7 +2802,7 @@ button below, and &lt;b&gt;will be unable to log back in&lt;/b&gt;.</source>
         </context-group>
       </trans-unit>
       <trans-unit id="actionchain.jsp.ansible.playbook" xml:space="preserve">
-        <source>Execute Ansible playbook</source>
+        <source>Execute Ansible playbook {0} on</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/schedule/ActionChain</context>
         </context-group>

--- a/java/core/src/test/java/com/redhat/rhn/domain/action/ansible/PlaybookActionFormatterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/action/ansible/PlaybookActionFormatterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.action.ansible;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link PlaybookActionFormatter#getRelatedObjectDescription()}.
+ *
+ * The Action Chain UI shows the formatter output as the {0} placeholder of
+ * the {@code actionchain.jsp.ansible.playbook} message, so distinct playbook
+ * names need to make it through the formatter unambiguously.
+ */
+public class PlaybookActionFormatterTest {
+
+    @Test
+    public void testReturnsBasenameOfPlaybookPath() {
+        String result = formatter("/etc/ansible/playbooks/deploy.yml").getRelatedObjectDescription();
+        assertEquals("deploy.yml", result);
+    }
+
+    @Test
+    public void testHandlesPathWithoutDirectory() {
+        String result = formatter("update.yml").getRelatedObjectDescription();
+        assertEquals("update.yml", result);
+    }
+
+    @Test
+    public void testEscapesHtmlSpecialCharacters() {
+        // The Action Chain JSP renders relatedObjectDescription as raw HTML
+        // through <bean:message arg0="..."/>, so any HTML metacharacters in
+        // the file name must be escaped (matching ErrataActionFormatter /
+        // PackageActionFormatter behavior).
+        String result = formatter("/playbooks/<evil>.yml").getRelatedObjectDescription();
+        assertEquals("&lt;evil&gt;.yml", result);
+    }
+
+    @Test
+    public void testReturnsEmptyStringWhenDetailsMissing() {
+        PlaybookAction action = new PlaybookAction();
+        PlaybookActionFormatter formatter = new PlaybookActionFormatter(action);
+        assertEquals("", formatter.getRelatedObjectDescription());
+    }
+
+    @Test
+    public void testReturnsEmptyStringWhenPathBlank() {
+        assertEquals("", formatter("").getRelatedObjectDescription());
+        assertEquals("", formatter("   ").getRelatedObjectDescription());
+        assertEquals("", formatter(null).getRelatedObjectDescription());
+    }
+
+    private static PlaybookActionFormatter formatter(String playbookPath) {
+        PlaybookActionDetails details = new PlaybookActionDetails();
+        details.setPlaybookPath(playbookPath);
+        PlaybookAction action = new PlaybookAction();
+        action.setDetails(details);
+        return new PlaybookActionFormatter(action);
+    }
+}

--- a/java/spacewalk-java.changes.officialasishkumar.show-playbook-name-in-action-chain
+++ b/java/spacewalk-java.changes.officialasishkumar.show-playbook-name-in-action-chain
@@ -1,0 +1,3 @@
+- Show the playbook file name on "Execute Ansible playbook" Action
+  Chain entries so multiple playbook actions can be distinguished
+  and reordered


### PR DESCRIPTION
## What does this PR change?

The Action Chain edit view rendered every "Execute Ansible playbook" entry with the same identical text, making it impossible to tell multiple playbook actions apart or to confidently reorder them (the user-reported screenshot in #11470 shows three identical rows).

The chain JSP renders each entry via:

```jsp
<bean:message key="actionchain.jsp.${group.actionTypeLabel}" arg0="${group.relatedObjectDescription}"/>
```

so two things needed to change together so the playbook step displays its file name:

1. **Formatter** — `PlaybookActionFormatter` overrides `getRelatedObjectDescription()` to return the playbook file name. The full path is reduced to its basename via Apache Commons `FilenameUtils.getName` (no filesystem access) and HTML-escaped, matching the pattern used by `ErrataActionFormatter` and `PackageActionFormatter` (the JSP renders the value as raw HTML). When the action has no `PlaybookActionDetails` or a blank path, the formatter returns the empty string so the message degrades to `Execute Ansible playbook  on` rather than `Execute Ansible playbook null on`.
2. **Localization** — the `actionchain.jsp.ansible.playbook` source gains a `{0}` placeholder and the trailing `on`, lining up with the existing patterns (`Apply patch(es) {0} on`, `Deploy {0} to`, etc.). The chain JSP follows the message with the system counter, so the rendered line becomes:

   ```
   Execute Ansible playbook deploy.yml on 1 system
   ```

## Codespace

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)

## GUI diff

Each "Execute Ansible playbook" entry on `/rhn/schedule/ActionChain.do?id=…` now carries the playbook file name.

Before:

```
1. Execute Ansible playbook 1 system
2. Execute Ansible playbook 1 system
3. Execute Ansible playbook 1 system
```

After:

```
1. Execute Ansible playbook deploy.yml on 1 system
2. Execute Ansible playbook restart-services.yml on 1 system
3. Execute Ansible playbook smoke-test.yml on 1 system
```

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

The change is a clarifying label inside the existing Action Chain edit view; no new feature or workflow is introduced.

- [x] **DONE**

## Test coverage
- Unit tests were added

`PlaybookActionFormatterTest` covers the basename extraction, HTML escaping of metacharacters, the no-details fallback, and the blank / null path branches.

- [x] **DONE**

## Links

Issue(s): #11470

- [x] **DONE**

## Changelogs

- [ ] No changelog needed

A delta entry under `java/spacewalk-java.changes.officialasishkumar.show-playbook-name-in-action-chain` describes the user-visible change.