### PR TITLE
Stop forcing password-based SAML auth by default

### DIFF
--- a/java/conf/rhn_java_sso.conf
+++ b/java/conf/rhn_java_sso.conf
@@ -144,12 +144,18 @@ onelogin.saml2.security.want_assertions_encrypted = false
 onelogin.saml2.security.want_nameid_encrypted = false
 
 # Authentication context.
-# Set Empty and no AuthContext will be sent in the AuthNRequest
-# You can set multiple values (comma separated them)
-onelogin.saml2.security.requested_authncontext = urn:oasis:names:tc:SAML:2.0:ac:classes:Password
+# Optional. If set, the IdP is asked to authenticate the user with one of
+# the listed contexts (e.g. urn:oasis:names:tc:SAML:2.0:ac:classes:Password).
+# When unset, no AuthnContext is sent and the IdP is free to pick the most
+# appropriate authentication method, so passwordless options such as
+# Yubikey, FIDO2 or Windows Hello keep working with strict SAML clients
+# (e.g. Microsoft Edge). Multiple contexts can be comma separated.
+# onelogin.saml2.security.requested_authncontext = urn:oasis:names:tc:SAML:2.0:ac:classes:Password
 
-# Allows the authn comparison parameter to be set, defaults to 'exact'
-onelogin.saml2.security.requested_authncontextcomparison = exact
+# Comparison parameter for the requested AuthnContext. Defaults to 'exact'
+# (so the IdP must use the requested context). Only meaningful when
+# requested_authncontext above is set.
+# onelogin.saml2.security.requested_authncontextcomparison = exact
 
 # Indicates if the SP will validate all received xmls.
 # (In order to validate the xml, 'strict' and 'wantXMLValidation' must be true).

--- a/java/spacewalk-java.changes.officialasishkumar.remove-sso-authncontext-defaults
+++ b/java/spacewalk-java.changes.officialasishkumar.remove-sso-authncontext-defaults
@@ -1,0 +1,5 @@
+- Stop forcing password-based SAML authentication by default; the
+  requested AuthnContext defaults shipped in the SSO config are now
+  commented out so the IdP can pick the appropriate authentication
+  method (FIDO2, Yubikey, Windows Hello) with strict SAML clients
+  such as Microsoft Edge


### PR DESCRIPTION
## What does this PR change?

The shipped SSO defaults at `/usr/share/rhn/config-defaults/rhn_java_sso.conf` force the SAML SP to request the `Password` AuthnContext with comparison `exact`. Strict SAML clients such as Microsoft Edge honor the request literally, so the IdP is required to authenticate the user with a password, breaking modern flows the IdP would otherwise allow (Yubikey, FIDO2, Windows Hello). Trying to disable the behavior by setting the option to an empty string in `/etc/rhn/rhn.conf` is reported in #11705 not to work because the empty value is dropped during config merging and the default keeps applying.

The OneLogin SAML toolkit only emits an `AuthnContextClassRef` in the `AuthnRequest` when `requested_authncontext` is configured. This PR comments the two `requested_authncontext` / `requested_authncontextcomparison` entries out so the default behaves as "let the IdP choose" — which is the documented intent of the surrounding comment ("Set Empty and no AuthContext will be sent in the AuthNRequest").

Administrators who need the previous strict behavior can still uncomment the lines or set the properties in `/etc/rhn/rhn.conf` under the `java.sso.*` namespace, which is the supported override mechanism for `SSOConfig`.

The accompanying inline comments in the config file are rewritten to spell out the new default behavior and the override mechanism.

## End-User Impact & Release Notes

Change in config defaults, see changelog entry.

- [x] **DONE**

## Codespace

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)

## GUI diff

No difference.

The change is in the default SAML SP configuration only; the Uyuni Web UI is unchanged. Users will simply find that passwordless SSO logins through stricter SAML clients (notably Microsoft Edge) now succeed without manually editing the defaults.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

The defaults are documented inline in the same config file with the rewritten comments.

- [x] **DONE**

## Test coverage
- No tests: already covered

`SSOControllerTest` exercises `Saml2Settings` assembly through `SettingsBuilder`; that path is unchanged by this PR (it only commentes out two optional defaults). There is no behavior to add a unit test against — the test would be checking that a property the toolkit no longer sees is no longer set.

- [x] **DONE**

## Links

Issue(s): #11705

- [x] **DONE**

## Changelogs

- [ ] No changelog needed

A delta entry under `java/spacewalk-java.changes.officialasishkumar.remove-sso-authncontext-defaults` describes the user-visible change.