### PR TITLE
Drop "golang-github-QubitProducts-exporter_exporter" from "server-image"

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -39,7 +39,6 @@ RUN zypper ref && zypper --non-interactive up && \
         bind-utils \
         drbd-formula \
         ed \
-        golang-github-QubitProducts-exporter_exporter \
         golang-github-prometheus-node_exporter \
         grafana-formula \
         grub2-arm64-efi \

--- a/containers/server-image/server-image.changes.meaksh.master-remove-qubit-exporter-from-server-image
+++ b/containers/server-image/server-image.changes.meaksh.master-remove-qubit-exporter-from-server-image
@@ -1,0 +1,1 @@
+- Drop golang-github-QubitProducts-exporter_exporter


### PR DESCRIPTION
## What does this PR change?

As agreed, this PR removes the `golang-github-QubitProducts-exporter_exporter` from the `server-image`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
