### PR TITLE
Use correct pg function to get database collation (bsc#1264178)

### DIFF
--- a/containers/server-image/root/docker-entrypoint-init.d/90-pgsqlFinalize.sh
+++ b/containers/server-image/root/docker-entrypoint-init.d/90-pgsqlFinalize.sh
@@ -14,9 +14,12 @@ fi
 
 query="\set QUIET 1
 \pset tuples_only
-SELECT d.datcollversion IS DISTINCT FROM pg_collation_actual_version(c.oid) reindex
-FROM pg_collation as c, pg_database as d
-WHERE c.collname = d.datcollate AND d.datname = '$productdb';"
+SELECT COALESCE(
+  (SELECT d.datcollversion IS DISTINCT FROM pg_database_collation_actual_version(d.oid)
+   FROM pg_database as d
+   WHERE d.datname = '$productdb'
+  ), false
+) reindex;"
 if [ "$(printf '%s' "$query" | spacewalk-sql --select-mode - | xargs)" != "f" ]; then
     # Reindexing may not be needed for every collation change, but better be on the safe side.
     echo "Reindexing database. This may take a while, please do not cancel it!"

--- a/containers/server-image/root/docker-entrypoint-init.d/99-cgroupfs-mount.sh
+++ b/containers/server-image/root/docker-entrypoint-init.d/99-cgroupfs-mount.sh
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-Only
 
 if [ "${container:=unknown}" != "oci" ]; then
-    echo "Skipped"
     exit 0
 fi
 

--- a/containers/server-image/server-image.changes.oholecek.use_correct_collation_function
+++ b/containers/server-image/server-image.changes.oholecek.use_correct_collation_function
@@ -1,0 +1,2 @@
+- Do not depend on collation name when checking collation
+  version (bsc#1264178)


### PR DESCRIPTION
## What does this PR change?

This commit get rids of pg_collation join and dependency on collation name by using pg_database_collation_actual_version.

Commit also adds COALESCE guard if something is missing to prevent endless reindex.

Removed unnecessary "Skipping" note for the k8s cgroup mount.


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30640
Port(s): none needed

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
