### PR TITLE
Add RKE2 TFTP container sanity tests

### DIFF
--- a/testsuite/features/kubernetes/srv_rke2_tftpd_sanity.feature
+++ b/testsuite/features/kubernetes/srv_rke2_tftpd_sanity.feature
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@rke2
+Feature: RKE2 TFTP container sanity checks on the server
+  In order to provision systems via PXE boot
+  As the system administrator
+  I want to ensure the TFTP container is correctly deployed and serving files
+
+  Scenario: TFTP deployment is ready and service has active endpoints
+    Given The Kubernetes cluster is ready on "server"
+    And the "tftp" deployment on "server" should become ready within 5 minutes
+    Then the "tftp" service on "server" should have at least one active endpoint
+
+  Scenario: TFTP serves a file placed in the boot root
+    Given I create a sanity-check file in the TFTP boot root on "server"
+    When I download the sanity-check file via TFTP from "server"
+    Then the downloaded TFTP content should match the expected sanity-check content on "server"
+    And I remove the sanity-check file from the TFTP boot root on "server"

--- a/testsuite/features/step_definitions/rke2_steps.rb
+++ b/testsuite/features/step_definitions/rke2_steps.rb
@@ -233,3 +233,55 @@ When(/^I update the uyuni-ca configmap on "(.*)" with the external CA$/) do |tar
   )
   raise SystemCallError, 'Failed to update uyuni-ca configmap on proxy' unless code.zero?
 end
+
+### TFTP container sanity check steps
+
+Then(/^the "(.*)" service on "(.*)" should have at least one active endpoint$/) do |svc, target|
+  out, code = get_target(target).run_local(
+    "kubectl get endpoints #{svc} -n uyuni -o jsonpath='{.subsets[0].addresses[0].ip}'"
+  )
+  raise "Service '#{svc}' has no active endpoints on '#{target}'" unless code.zero? && !out.strip.empty?
+end
+
+# File placed in /srv/tftpboot on the uyuni (server) pod.
+# The tftp pod fetches it via http://web.uyuni.svc/tftp/<filename> - it never reads local disk.
+Given(/^I create a sanity-check file in the TFTP boot root on "(.*)"$/) do |target|
+  server_pod = get_pod_name(target, 'server')
+  tftp_probe_filename = 'uyuni-tftp-sanity-probe.txt'
+  tftp_probe_content  = 'uyuni-tftp-sanity-ok'
+  add_context(:tftp_probe_filename, tftp_probe_filename)
+  add_context(:tftp_probe_content, tftp_probe_content)
+  get_target(target).run_local(
+    "kubectl exec -n uyuni #{server_pod} -- " \
+    "sh -c 'echo #{tftp_probe_content} > /srv/tftpboot/#{tftp_probe_filename}'"
+  )
+end
+
+# Uses curl with the tftp:// scheme
+# Tests the full path: server node -> NodePort -> tftp pod -> HTTP -> uyuni pod -> /srv/tftpboot.
+When(/^I download the sanity-check file via TFTP from "(.*)"$/) do |target|
+  node_port = get_tftp_node_port(target)
+  filename  = get_context(:tftp_probe_filename)
+  local     = "/tmp/#{filename}"
+  add_context(:tftp_probe_local_path, local)
+  get_target(target).run_local(
+    "curl --silent --show-error tftp://localhost:#{node_port}/#{filename} --output #{local}"
+  )
+end
+
+Then(/^the downloaded TFTP content should match the expected sanity-check content on "(.*)"$/) do |target|
+  local    = get_context(:tftp_probe_local_path)
+  expected = get_context(:tftp_probe_content)
+  out, _code = get_target(target).run_local("cat #{local}", check_errors: false)
+  raise "Content mismatch — expected: '#{expected}', got: '#{out.strip}'" unless out.strip == expected
+end
+
+And(/^I remove the sanity-check file from the TFTP boot root on "(.*)"$/) do |target|
+  server_pod = get_pod_name(target, 'server')
+  filename   = get_context(:tftp_probe_filename)
+  local      = get_context(:tftp_probe_local_path)
+  get_target(target).run_local(
+    "kubectl exec -n uyuni #{server_pod} -- rm -f /srv/tftpboot/#{filename}"
+  )
+  get_target(target).run_local("rm -f #{local}", check_errors: false)
+end

--- a/testsuite/features/support/kubernetes.rb
+++ b/testsuite/features/support/kubernetes.rb
@@ -81,6 +81,23 @@ def get_pod_name(target, component)
   out if code.zero?
 end
 
+# Returns the NodePort assigned to the TFTP service on the given target cluster.
+# Needed because the LoadBalancer EXTERNAL-IP is pending on bare-metal RKE2;
+# the NodePort is the only externally reachable entry point.
+#
+# @param target [String] The target host where kubectl commands will be executed.
+# @return [Integer] The NodePort number for the TFTP UDP service.
+def get_tftp_node_port(target)
+  cmd = "kubectl get svc tftp -n uyuni -o jsonpath='{.spec.ports[0].nodePort}'"
+  out, code = get_target(target).run_local(cmd)
+  raise 'Failed to query TFTP NodePort' unless code.zero?
+
+  port = out.strip.to_i
+  raise 'TFTP service has no NodePort assigned' if port.zero?
+
+  port
+end
+
 # Polls the Kubernetes Deployment status until all replicas are ready or a timeout is reached.
 #
 # @param target [String] The target host where the kubectl command will be run.


### PR DESCRIPTION
## What does this PR change?

The TFTP service now runs as a dedicated Kubernetes pod (proxy-tftpd image) instead of the removed tftpsync packages. Add two scenarios to verify the new container:

- Smoke: tftp deployment readiness + service endpoint presence
- File transfer: end-to-end TFTP get via NodePort using curl tftp://, exercising the full path through the tftp pod's HTTP proxy to the uyuni pod's /srv/tftpboot

Also adds `get_tftp_node_port()` helper to `kubernetes.rb`

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29930

## Changelogs

- [x] No changelog needed

