### PR TITLE
parse and ignore inventory class for in ubuntu oval data (bsc#1265319)

### DIFF
--- a/java/core/src/main/java/com/suse/oval/OVALCachingFactory.java
+++ b/java/core/src/main/java/com/suse/oval/OVALCachingFactory.java
@@ -83,10 +83,11 @@ public class OVALCachingFactory extends HibernateFactory {
 
         List<ProductVulnerablePackages> productVulnerablePackages = new ArrayList<>();
         for (DefinitionType definition : rootType.getDefinitions()) {
-            VulnerablePackagesExtractor vulnerablePackagesExtractor =
+            Optional<VulnerablePackagesExtractor> vulnerablePackagesExtractor =
                     VulnerablePackagesExtractors.create(definition, rootType.getOsFamily(), ovalResourcesCache);
 
-            productVulnerablePackages.addAll(vulnerablePackagesExtractor.extract());
+            vulnerablePackagesExtractor.ifPresent(vPackage ->
+                productVulnerablePackages.addAll(vPackage.extract()));
         }
 
         // Write OVAL metadata in batches

--- a/java/core/src/main/java/com/suse/oval/ovaltypes/DefinitionClassEnum.java
+++ b/java/core/src/main/java/com/suse/oval/ovaltypes/DefinitionClassEnum.java
@@ -45,7 +45,18 @@ public enum DefinitionClassEnum {
      * "the system is vulnerable if ...".
      */
     @XmlEnumValue("vulnerability")
-    VULNERABILITY("vulnerability");
+    VULNERABILITY("vulnerability"),
+
+    /**
+     * An inventory definition describes whether a specific piece of software is installed on the system.
+     * <p>
+     * A definition of this class will evaluate to true when the specified software is found on the system.
+     * Another way of thinking about this is that an inventory definition
+     * is stating "the software is installed if ...".
+     */
+    @XmlEnumValue("inventory")
+    INVENTORY("inventory");
+
     private final String value;
 
     DefinitionClassEnum(String v) {

--- a/java/core/src/main/java/com/suse/oval/vulnerablepkgextractor/VulnerablePackagesExtractors.java
+++ b/java/core/src/main/java/com/suse/oval/vulnerablepkgextractor/VulnerablePackagesExtractors.java
@@ -22,6 +22,8 @@ import com.suse.oval.ovaltypes.DefinitionType;
 import com.suse.oval.vulnerablepkgextractor.redhat.RedHatVulnerablePackageExtractorFromPatchDefinition;
 import com.suse.oval.vulnerablepkgextractor.redhat.RedHatVulnerablePackageExtractorFromVulnerabilityDefinition;
 
+import java.util.Optional;
+
 /**
  * A factory for {@link VulnerablePackagesExtractor}
  * */
@@ -37,27 +39,39 @@ public class VulnerablePackagesExtractors {
      * @param ovalResourcesCache a helper class to lookup OVAL resources efficiently
      * @return a vulnerable package extractor instance
      * */
-    public static VulnerablePackagesExtractor create(DefinitionType definition, OsFamily osFamily,
-                                                     OVALResourcesCache ovalResourcesCache) {
+    public static Optional<VulnerablePackagesExtractor> create(DefinitionType definition, OsFamily osFamily,
+                                                                 OVALResourcesCache ovalResourcesCache) {
         switch (osFamily) {
             case LEAP, LEAP_MICRO,
                  SUSE_LINUX_ENTERPRISE_SERVER, SUSE_LINUX_ENTERPRISE_DESKTOP, SUSE_LINUX_ENTERPRISE_MICRO:
-                return new SUSEVulnerablePackageExtractor(definition, ovalResourcesCache);
+                return Optional.of(new SUSEVulnerablePackageExtractor(definition, ovalResourcesCache));
             case DEBIAN:
-                return new DebianVulnerablePackagesExtractor(definition);
+                return Optional.of(new DebianVulnerablePackagesExtractor(definition));
             case REDHAT_ENTERPRISE_LINUX:
                 if (definition.getDefinitionClass() == DefinitionClassEnum.VULNERABILITY) {
-                    return new RedHatVulnerablePackageExtractorFromVulnerabilityDefinition(definition);
+                    return Optional.of(new RedHatVulnerablePackageExtractorFromVulnerabilityDefinition(definition));
                 }
                 else if (definition.getDefinitionClass() == DefinitionClassEnum.PATCH) {
-                    return new RedHatVulnerablePackageExtractorFromPatchDefinition(definition);
+                    return Optional.of(new RedHatVulnerablePackageExtractorFromPatchDefinition(definition));
                 }
                 else {
                     throw new IllegalArgumentException(
                             "Only VULNERABILITY and PATCH definitions are allowed for RedHat OVALs");
                 }
             case UBUNTU:
-                return new UbuntuVulnerablePackageExtractor(definition);
+                if (definition.getDefinitionClass() == DefinitionClassEnum.VULNERABILITY) {
+                    return Optional.of(new UbuntuVulnerablePackageExtractor(definition));
+                }
+                else if (definition.getDefinitionClass() == DefinitionClassEnum.INVENTORY) {
+                    // Inventory is a valid definition class for Ubuntu OVALs,
+                    // but it doesn't contain any vulnerable package information,
+                    // so we return an empty Optional here.
+                    return Optional.empty();
+                }
+                else {
+                    throw new IllegalArgumentException(
+                            "Only VULNERABILITY and INVENTORY definitions are allowed for Ubuntu OVALs");
+                }
             default:
                 throw new IllegalArgumentException(
                         "Cannot find any vulnerable packages extractor implementation for " + osFamily);

--- a/java/spacewalk-java.changes.rmateus.uyuni_oval_ubuntu_inventory_ignore
+++ b/java/spacewalk-java.changes.rmateus.uyuni_oval_ubuntu_inventory_ignore
@@ -1,0 +1,1 @@
+- Fix Oval data sync for ubuntu 26.04(bsc#1265319)


### PR DESCRIPTION
## What does this PR change?

fixes issue: https://bugzilla.suse.com/show_bug.cgi?id=1265319
https://github.com/SUSE/spacewalk/issues/30715

On Ubuntu 26.04 oval data a new class was added. We don't need to save any data from there but we need to parse and ignore it's values.
This implementation parses that data, but when it runs the code to get the package or errata processor it returns an empty optional to not process anything, since we know that that class doesn't contain any packages and CVE information.

That class is related to the OS flavor, but that check is done by UYUNI itself, and we don't need to save data from there.


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference. Internal code only

- [x] **DONE**

## Documentation
- No documentation needed: Internal change only

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: It's an adjustment of the previous code, no new tests are needed at this stage.

- [x] **DONE**

## Links

Issue(s): https://bugzilla.suse.com/show_bug.cgi?id=1265319
Port(s):
- Need to check if ubuntu 26.06 and oval data processing needs to be ported to MLM 5.1

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
