### PR TITLE
Fix pg_hba for kubernetes (bsc#1265352)

### DIFF
--- a/containers/server-postgresql-image/root/docker-entrypoint-upgdb.d/01-pg_hba.sh
+++ b/containers/server-postgresql-image/root/docker-entrypoint-upgdb.d/01-pg_hba.sh
@@ -14,10 +14,20 @@ PG_HBA_CHANGED=""
 if [ -f "$NAMESPACE_FILE" ] ; then
     # kubernetes
     NAMESPACE=$(<"$NAMESPACE_FILE")
-    INTERNAL_ACCESS=."$NAMESPACE".svc.cluster.local
+
+    # reverse lookup does nor work during initialization, we must check also IP
+    POD_IP=$(getent hosts $(cat /etc/hostname) 2>/dev/null | sed 's/[[:space:]].*//')
+    POD_NETWORK=$(echo "${POD_IP:-10.42.0.0}" | cut -d. -f1,2).0.0/16
+    INTERNAL_ACCESS="$POD_NETWORK .$NAMESPACE.svc.cluster.local"
+
+    # handle external access via traefik
+    # it matches the IP so it must be rejected explicitly, by domain
+    EXTERNAL_RULES="hostssl reportdb all .kube-system.svc.cluster.local scram-sha-256
+host all all .kube-system.svc.cluster.local reject"
 else
     # podman
     INTERNAL_ACCESS=uyuni-server
+    EXTERNAL_RULES=""
 fi
 
 # Check if we already have the include directive
@@ -42,7 +52,8 @@ include_if_exists pg_hba_custom.conf
 local all all peer
 local replication all peer
 host all all 127.0.0.1/8 scram-sha-256
-host all all ::1/128 scram-sha-256"
+host all all ::1/128 scram-sha-256
+$EXTERNAL_RULES"
 
 for host in $INTERNAL_ACCESS; do
     NEW_CONFIG="$NEW_CONFIG

--- a/containers/server-postgresql-image/server-postgresql-image.changes.nadvornik.pg_hba_fix
+++ b/containers/server-postgresql-image/server-postgresql-image.changes.nadvornik.pg_hba_fix
@@ -1,0 +1,1 @@
+- Fix pg_hba for kubernetes (bsc#1265352)


### PR DESCRIPTION
## What does this PR change?

There was a problem with https://github.com/uyuni-project/uyuni/pull/11940
The reverse lookup does not work during container initialization, so it must be filtered by internal network IP range.
External connections come via traefik from the same IP range, so they must be handled separately, but here the reverse lookup works.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: fix

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30434
https://github.com/uyuni-project/uyuni/pull/11940
https://bugzilla.suse.com/show_bug.cgi?id=1265352

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
