### PR TITLE
Numeric branch names should not be stored in double type (bsc#1258382)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/saltboot/PXEEvent.java
+++ b/java/core/src/main/java/com/suse/manager/saltboot/PXEEvent.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -58,8 +59,24 @@ public class PXEEvent {
         return (String)data.get("action");
     }
 
-    public String getSaltbootGroup() {
-        return String.valueOf(data.get("minion_id_prefix"));
+    /**
+     * Return the expected saltboot group name
+     * @return the saltboot group name
+     * @throws SaltbootException SaltbootException if data validation failed
+     */
+    public String getSaltbootGroup() throws SaltbootException {
+        Object val = data.get("minion_id_prefix");
+        if (val == null) {
+            throw new SaltbootException("Missing branch prefix in the incoming data");
+        }
+
+        if (val instanceof Number num) {
+            return new BigDecimal(num.toString())
+                    .stripTrailingZeros()
+                    .toPlainString();
+        }
+
+        return String.valueOf(val);
     }
 
     public String getRoot() {

--- a/java/core/src/test/java/com/suse/manager/saltboot/PXEEventTest.java
+++ b/java/core/src/test/java/com/suse/manager/saltboot/PXEEventTest.java
@@ -325,11 +325,12 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
     }
 
     /**
-     * Tests parsing {@link PXEEvent} when branch id is numeric
+     * Tests parsing {@link PXEEvent} when branch id is integer
      */
     @Test
-    public void testParseBranchIdIsNumeric() {
+    public void testParseBranchIdIsInteger() {
         Event event = mock(Event.class);
+        // see also assert for getSaltbootGroup below
         Integer branchId = 12345;
         Map<String, Object> data = createTestData(MINION_ID, branchId, "root=/dev/sda1",
                 "/dev/sda1", BOOT_IMAGE, "custom=option", true);
@@ -345,7 +346,73 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
         assertTrue(parsed.isPresent());
         parsed.ifPresent(e -> {
             assertEquals(MINION_ID, e.getMinionId());
-            assertEquals(String.valueOf(branchId), e.getSaltbootGroup());
+            assertEquals("12345", e.getSaltbootGroup());
+            assertEquals("root=/dev/sda1", e.getRoot());
+            assertEquals(Optional.of("/dev/sda1"), e.getSaltDevice());
+            assertEquals(Optional.of("custom=option"), e.getKernelParameters());
+            assertEquals(BOOT_IMAGE, e.getBootImage());
+            // Localhost device should be parsed out
+            assertEquals(1, e.getHwAddresses().size());
+            assertEquals(MAC_ADDRESS, e.getHwAddresses().get(0));
+        });
+    }
+
+    /**
+     * Tests parsing {@link PXEEvent} when branch id is double
+     */
+    @Test
+    public void testParseBranchIdIsDouble() {
+        Event event = mock(Event.class);
+        // see also assert for getSaltbootGroup below
+        Double branchId = 12345.0;
+        Map<String, Object> data = createTestData(MINION_ID, branchId, "root=/dev/sda1",
+                "/dev/sda1", BOOT_IMAGE, "custom=option", true);
+        context().checking(new Expectations() {{
+            allowing(event).getTag();
+            will(returnValue("suse/manager/pxe_update"));
+            allowing(event).getData();
+            will(returnValue(data));
+        }});
+
+        Optional<PXEEvent> parsed = PXEEvent.parse(event);
+
+        assertTrue(parsed.isPresent());
+        parsed.ifPresent(e -> {
+            assertEquals(MINION_ID, e.getMinionId());
+            assertEquals("12345", e.getSaltbootGroup());
+            assertEquals("root=/dev/sda1", e.getRoot());
+            assertEquals(Optional.of("/dev/sda1"), e.getSaltDevice());
+            assertEquals(Optional.of("custom=option"), e.getKernelParameters());
+            assertEquals(BOOT_IMAGE, e.getBootImage());
+            // Localhost device should be parsed out
+            assertEquals(1, e.getHwAddresses().size());
+            assertEquals(MAC_ADDRESS, e.getHwAddresses().get(0));
+        });
+    }
+
+    /**
+     * Tests parsing {@link PXEEvent} when branch id is numeric and we cannot lose precision
+     */
+    @Test
+    public void testParseBranchIdIsExplicitDouble() {
+        Event event = mock(Event.class);
+        // see also assert for getSaltbootGroup below
+        Double branchId = 12345.67;
+        Map<String, Object> data = createTestData(MINION_ID, branchId, "root=/dev/sda1",
+                "/dev/sda1", BOOT_IMAGE, "custom=option", true);
+        context().checking(new Expectations() {{
+            allowing(event).getTag();
+            will(returnValue("suse/manager/pxe_update"));
+            allowing(event).getData();
+            will(returnValue(data));
+        }});
+
+        Optional<PXEEvent> parsed = PXEEvent.parse(event);
+
+        assertTrue(parsed.isPresent());
+        parsed.ifPresent(e -> {
+            assertEquals(MINION_ID, e.getMinionId());
+            assertEquals("12345.67", e.getSaltbootGroup());
             assertEquals("root=/dev/sda1", e.getRoot());
             assertEquals(Optional.of("/dev/sda1"), e.getSaltDevice());
             assertEquals(Optional.of("custom=option"), e.getKernelParameters());

--- a/java/spacewalk-java.changes.oholecek.fix_numeric_branchIds
+++ b/java/spacewalk-java.changes.oholecek.fix_numeric_branchIds
@@ -1,0 +1,2 @@
+- Numeric branch names should not be stored in double format
+  (bsc#1258382)


### PR DESCRIPTION
## What does this PR change?

Numeric branch names should not be converted to string from double type as that appends .0

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29810
Port(s): https://github.com/SUSE/spacewalk/pull/29899

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
