### PR TITLE
Fix issues for "spacewalk-certs-tools" running on Python 3.13

### DIFF
--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.meaksh.master-fixes-for-python313
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.meaksh.master-fixes-for-python313
@@ -1,0 +1,1 @@
+- Fix error running with Python 3.13

--- a/spacewalk/certs-tools/sslToolConfig.py
+++ b/spacewalk/certs-tools/sslToolConfig.py
@@ -548,7 +548,7 @@ def figureSerial(caCertFilename, serialFilename, indexFilename):
         random.seed()
         # pylint: disable-next=eval-used
         max_serial = eval("0x" + "F" * 40)
-        serial = random.randrange(1, max_serial - caSerial / 2)
+        serial = random.randrange(1, int(max_serial - caSerial / 2))
     serial = fixSerial(hex(serial))
 
     # create the serial file if it doesn't exist

--- a/spacewalk/certs-tools/sslToolConfig.py
+++ b/spacewalk/certs-tools/sslToolConfig.py
@@ -692,8 +692,7 @@ class ConfigFile:
 dir                     = %s
 database                = $dir/index.txt
 serial                  = $dir/serial
-"""
-                                % newdir
+""" % newdir
                             )
                             # pylint: disable-next=invalid-name
                             dirSetYN = 1


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue on `spacewalk-certs-tools` when running with Python 3.13:

```
Traceback (most recent call last):
File "/usr/bin/rhn-ssl-tool", line 56, in <module>
    sys.exit(mod.main() or 0)
             ~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/certs/rhn_ssl_tool.py", line 1398, in main
    ret = _main() or 0
          ~~~~~^^
  File "/usr/lib/python3.13/site-packages/certs/rhn_ssl_tool.py", line 1364, in _main
    genServerCert(getCAPassword(options, confirmYN=0), DEFS, options.verbose)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/certs/rhn_ssl_tool.py", line 740, in genServerCert
    ser = figureSerial(ca_cert, serial, index_txt)
  File "/usr/lib/python3.13/site-packages/certs/sslToolConfig.py", line 551, in figureSerial
    serial = random.randrange(1, max_serial - caSerial / 2)
  File "/usr/lib64/python3.13/random.py", line 316, in randrange
    istop = _index(stop)
TypeError: 'float' object cannot be interpreted as an integer
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
