### PR TITLE
Do not add non-FQDN hostnames to the proxy fqdn list (bsc#1263841)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -161,7 +161,7 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
 
             // Add the FQDNs as some may not be already known
             server.getFqdns().addAll(fqdns.stream()
-                    .filter(fqdn -> !fqdn.contains("*"))
+                    .filter(fqdn -> fqdn != null && !fqdn.contains("*") && fqdn.contains("."))
                     .map(fqdn -> new ServerFQDN(server, fqdn)).collect(Collectors.toList()));
 
             systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.PROXY);
@@ -173,7 +173,7 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
         server.setName(proxyName);
         server.setHostname(proxyName);
         server.getFqdns().addAll(fqdns.stream()
-                .filter(fqdn -> !fqdn.contains("*"))
+                .filter(fqdn -> fqdn != null && !fqdn.contains("*") && fqdn.contains("."))
                 .map(fqdn -> new ServerFQDN(server, fqdn)).collect(Collectors.toList()));
         server.setOrg(creator.getOrg());
         server.setCreator(creator);

--- a/java/core/src/main/java/com/suse/manager/ssl/SSLCertData.java
+++ b/java/core/src/main/java/com/suse/manager/ssl/SSLCertData.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Data contained in an SSL certificate, also used to generate them
@@ -159,7 +160,10 @@ public class SSLCertData {
             allCnames.add(cn);
         }
         if (cnames != null) {
-            allCnames.addAll(cnames);
+            allCnames.addAll(cnames.stream()
+                // Filter out SANs which are definitely not FQDN - without any .
+                .filter(name -> name != null && name.contains("."))
+                .collect(Collectors.toSet()));
         }
         return allCnames;
     }

--- a/java/core/src/main/java/com/suse/manager/ssl/SSLCertManager.java
+++ b/java/core/src/main/java/com/suse/manager/ssl/SSLCertManager.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -145,11 +146,13 @@ public class SSLCertManager {
                         return Arrays.stream(line.split(","))
                                 .filter(dns -> dns.contains("DNS:"))
                                 .map(dns -> dns.split(":")[1].trim())
+                                // Filter out SANs which are definitely not FQDN - without any .
+                                .filter(name -> name.contains("."))
                                 .collect(Collectors.toSet());
                     }
                     return null;
                 })
-                .filter(name -> name != null)
+                .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
                 .collect(Collectors.toSet());
     }

--- a/java/spacewalk-java.changes.oholecek.skip_non_fqdn_proxy_names
+++ b/java/spacewalk-java.changes.oholecek.skip_non_fqdn_proxy_names
@@ -1,0 +1,2 @@
+- Do not add non-FQDN hostnames to the proxy fqdn list
+  (bsc#1263841)


### PR DESCRIPTION
## What does this PR change?

When parsing certificate data, for the robust onboarding we automatically imported DNS names to the proxy fqdn list. However we do this also for plain hostnames without domain part. This then causes duplicate FQDN results for servers if those plain hostnames are used in more proxies.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30563
Port(s): https://github.com/SUSE/spacewalk/pull/30659

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
