### PR TITLE
Add custom id to the saltboot grub entries (bsc#1258382, bsc#1208800)

### DIFF
--- a/.github/workflows/python-checkstyle.yml
+++ b/.github/workflows/python-checkstyle.yml
@@ -1,4 +1,4 @@
-name: Python checkstyle
+name: Python checkstyle and unit tests
 
 on:
   push:
@@ -47,3 +47,65 @@ jobs:
         CHANGED_FILES: ${{ steps.files.outputs.added_modified_renamed }}
       run: pylint --rcfile=/root/.pylintrc ${CHANGED_FILES}
 
+  unit_tests:
+    runs-on: ubuntu-latest
+    needs: checkstyle
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.13']
+
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+    - id: files
+      uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c #v2.3.0
+      with:
+        filter:  |
+          *.py
+          !mgr_bootstrap_data.py
+          !testsuite/**
+
+    - name: Set up Python ${{ matrix.python-version }}
+      if: ${{ steps.files.outputs.added_modified_renamed }}
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #v7.0.0
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      if: ${{ steps.files.outputs.added_modified_renamed }}
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest requests pyyaml
+
+    - name: Run unit tests on related files
+      if: ${{ steps.files.outputs.added_modified_renamed }}
+      env:
+        CHANGED_FILES: ${{ steps.files.outputs.added_modified_renamed }}
+      run: |
+        TEST_TARGETS=""
+        for file in ${CHANGED_FILES}; do
+          DIR=$(dirname "$file")
+          BASE=$(basename "$file")
+
+          # If the changed file is already a test file, target it directly
+          if [[ "$BASE" == test_*.py ]]; then
+            TEST_TARGETS="$TEST_TARGETS $file"
+            continue
+          fi
+
+          # Map source.py -> test/test_source.py
+          POTENTIAL_TEST="$DIR/test/test_$BASE"
+          if [ -f "$POTENTIAL_TEST" ]; then
+            TEST_TARGETS="$TEST_TARGETS $POTENTIAL_TEST"
+          fi
+        done
+
+        # Remove duplicates
+        TEST_TARGETS=$(echo "$TEST_TARGETS" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+        if [ -n "$TEST_TARGETS" ]; then
+          echo "Running pytest on: $TEST_TARGETS"
+          pytest $TEST_TARGETS
+        else
+          echo "No matching unit test files found for modified files."
+        fi

--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes.oholecek.grub-entry-id
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes.oholecek.grub-entry-id
@@ -1,0 +1,2 @@
+- Use custom entry id for grub saltboot entries
+  (bsc#1258382)

--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes.oholecek.grub-entry-id
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes.oholecek.grub-entry-id
@@ -1,2 +1,2 @@
 - Use custom entry id for grub saltboot entries
-  (bsc#1258382)
+  (bsc#1258382, bsc#1208800)

--- a/containers/proxy-tftpd-image/test/grub-example.cfg
+++ b/containers/proxy-tftpd-image/test/grub-example.cfg
@@ -1,0 +1,28 @@
+menuentry '1234:S:1:Organization' --class gnu-linux --class gnu --class os {
+  echo 'Loading kernel ...'
+  clinux /images/kernel panic=60 splash=silent MASTER=proxy1234.example.com MINION_ID_PREFIX=1234
+  echo 'Loading initial ramdisk ...'
+  cinitrd /images/initrd
+  echo '...done'
+}
+menuentry 'ABCD:S:1:Organization' --class gnu-linux --class gnu --class os {
+  echo 'Loading kernel ...'
+  clinux /images/kernel panic=60 splash=silent MASTER=proxyABCD.example.com MINION_ID_PREFIX=ABCD
+  echo 'Loading initial ramdisk ...'
+  cinitrd /images/initrd
+  echo '...done'
+}
+menuentry 'profile:1:MyOrganizationInc' --class gnu-linux --class gnu --class os {
+  echo 'Loading kernel ...'
+  clinux /images/linux  inst.auto=http://server.example.com/cblr/svc/op/autoinstall/profile/profile:1:MyOrganizationInc root=live:http://server.example.com/ks/dist/sle16/LiveOS/squashfs.img ip=dhcp  autoyast=http://server.example.com/cblr/svc/op/autoinstall/profile/profile:1:MyOrganizationInc
+  echo 'Loading initial ramdisk ...'
+  cinitrd /images/initrd
+  echo '...done'
+}
+menuentry 'second_profile:1:MyOrganizationInc' --class gnu-linux --class gnu --class os {
+  echo 'Loading kernel ...'
+  clinux /images/linux  inst.auto=http://server.example.com/cblr/svc/op/autoinstall/profile/second_profile:1:MyOrganizationInc root=live:http://server.example.com/ks/dist/sle16/LiveOS/squashfs.img ip=dhcp  autoyast=http://server.example.com/cblr/svc/op/autoinstall/profile/second_profile:1:MyOrganizationInc
+  echo 'Loading initial ramdisk ...'
+  cinitrd /images/initrd
+  echo '...done'
+}

--- a/containers/proxy-tftpd-image/test/pxe-example.cfg
+++ b/containers/proxy-tftpd-image/test/pxe-example.cfg
@@ -1,0 +1,33 @@
+DEFAULT menu
+PROMPT 0
+MENU TITLE Cobbler | https://cobbler.github.io
+TIMEOUT 200
+TOTALTIMEOUT 6000
+ONTIMEOUT local
+
+LABEL local
+        MENU LABEL (local)
+        MENU DEFAULT
+        LOCALBOOT -1
+
+LABEL 1234:S:1:Organization
+        MENU LABEL 1234:S:1:Organization
+        kernel /images/kernel
+        append initrd=/images/initrd panic=60 splash=silent MASTER=proxy1234.example.com MINION_ID_PREFIX=1234
+        ipappend 2
+LABEL ABCD:S:1:Organization
+        MENU LABEL ABCD:S:1:Organization
+        kernel /images/kernel
+        append initrd=/images/initrd panic=60 splash=silent MASTER=proxyABCD.example.com MINION_ID_PREFIX=ABCD
+        ipappend 2
+LABEL profile:1:MyOrganizationInc
+        MENU LABEL profile:1:MyOrganizationInc
+        kernel /images/sle16:1:MyOrganizationInc/linux
+        append initrd=/images/initrd inst.auto=http://server.example.com/cblr/svc/op/autoinstall/profile/profile:1:MyOrganizationInc root=live:http://server.example.com/ks/dist/sle16/LiveOS/squashfs.img ip=dhcp  autoyast=http://server.example.com/cblr/svc/op/autoinstall/profile/profile:1:MyOrganizationInc
+        ipappend 2
+LABEL second_profile:1:MyOrganizationInc
+        MENU LABEL second_profile:1:MyOrganizationInc
+        kernel /images/sle16:1:MyOrganizationInc/linux
+        append initrd=/images/initrd inst.auto=http://server.example.com/cblr/svc/op/autoinstall/profile/second_profile:1:MyOrganizationInc root=live:http://server.example.com/ks/dist/sle16/LiveOS/squashfs.img ip=dhcp  autoyast=http://server.example.com/cblr/svc/op/autoinstall/profile/second_profile:1:MyOrganizationInc
+        ipappend 2
+MENU end

--- a/containers/proxy-tftpd-image/test/test_tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/test/test_tftp_wrapper.py
@@ -1,22 +1,32 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 SUSE LLC
+#
+# SPDX-License-Identifier: MIT
 
+import re
 import sys
 from unittest.mock import MagicMock
+
 
 # Define fake base classes
 class FakeResponseData:
     pass
+
 
 class FakeBaseHandler:
     def __init__(self, server_addr, peer, path, options, stats):
         self._path = path
         self._stats = MagicMock()
         pass
+
     def run(self):
         pass
+
 
 class FakeBaseServer:
     def __init__(self, *args, **kwargs):
         pass
+
 
 # Mock dependencies
 fbtftp_mock = MagicMock()
@@ -26,19 +36,20 @@ fbtftp_base_handler_mock.BaseHandler = FakeBaseHandler
 fbtftp_base_server_mock = MagicMock()
 fbtftp_base_server_mock.BaseServer = FakeBaseServer
 
-sys.modules['fbtftp'] = fbtftp_mock
-sys.modules['fbtftp.base_handler'] = fbtftp_base_handler_mock
-sys.modules['fbtftp.base_server'] = fbtftp_base_server_mock
-sys.modules['fbtftp.constants'] = MagicMock()
-sys.modules['requests'] = MagicMock()
-sys.modules['yaml'] = MagicMock()
+sys.modules["fbtftp"] = fbtftp_mock
+sys.modules["fbtftp.base_handler"] = fbtftp_base_handler_mock
+sys.modules["fbtftp.base_server"] = fbtftp_base_server_mock
+sys.modules["fbtftp.constants"] = MagicMock()
+sys.modules["requests"] = MagicMock()
+sys.modules["yaml"] = MagicMock()
 
 import unittest
 import os
 
 # Add the directory containing tftp_wrapper.py to sys.path
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import tftp_wrapper
+
 
 class TestTftpWrapper(unittest.TestCase):
 
@@ -47,18 +58,18 @@ class TestTftpWrapper(unittest.TestCase):
         self.proxy_fqdn_abcd = "proxyABCD.example.com"
         self.server_fqdn = "server.example.com"
         self.replace_fqdns = ["other.example.com"]
-        
+
         # Load examples
-        with open('test/pxe-example.cfg', 'r') as f:
+        with open("test/pxe-example.cfg", "r") as f:
             self.pxe_example = f.read()
-        with open('test/grub-example.cfg', 'r') as f:
+        with open("test/grub-example.cfg", "r") as f:
             self.grub_example = f.read()
 
     def test_pxe_filter_saltboot_match(self):
-        with unittest.mock.patch('tftp_wrapper.requests.get') as mock_get:
+        with unittest.mock.patch("tftp_wrapper.requests.get") as mock_get:
             mock_response = MagicMock()
             mock_response.status_code = 200
-            mock_response.content = self.pxe_example.encode('utf-8')
+            mock_response.content = self.pxe_example.encode("utf-8")
             mock_get.return_value = mock_response
 
             pxe_filter = tftp_wrapper.HttpResponseDataFilteredPXE(
@@ -66,10 +77,10 @@ class TestTftpWrapper(unittest.TestCase):
                 None,
                 self.proxy_fqdn_1234,
                 self.server_fqdn,
-                self.replace_fqdns
+                self.replace_fqdns,
             )
-            
-            filtered_content = pxe_filter._content.decode('utf-8')
+
+            filtered_content = pxe_filter._content.decode("utf-8")
             # Should contain the matched saltboot entry
             self.assertIn("LABEL 1234:S:1:Organization", filtered_content)
             self.assertIn("MENU DEFAULT", filtered_content)
@@ -80,10 +91,10 @@ class TestTftpWrapper(unittest.TestCase):
             self.assertNotIn("LABEL profile:1:MyOrganizationInc", filtered_content)
 
     def test_pxe_filter_cobbler_fallback(self):
-        with unittest.mock.patch('tftp_wrapper.requests.get') as mock_get:
+        with unittest.mock.patch("tftp_wrapper.requests.get") as mock_get:
             mock_response = MagicMock()
             mock_response.status_code = 200
-            mock_response.content = self.pxe_example.encode('utf-8')
+            mock_response.content = self.pxe_example.encode("utf-8")
             mock_get.return_value = mock_response
 
             pxe_filter = tftp_wrapper.HttpResponseDataFilteredPXE(
@@ -91,22 +102,25 @@ class TestTftpWrapper(unittest.TestCase):
                 None,
                 "nonexistent-proxy.example.com",
                 self.server_fqdn,
-                self.replace_fqdns
+                self.replace_fqdns,
             )
-            
-            filtered_content = pxe_filter._content.decode('utf-8')
+
+            filtered_content = pxe_filter._content.decode("utf-8")
             # Should contain filtered cobbler entries
             self.assertIn("LABEL profile:1:MyOrganizationInc", filtered_content)
-            self.assertIn("http://nonexistent-proxy.example.com/cblr/svc/op/autoinstall", filtered_content)
+            self.assertIn(
+                "http://nonexistent-proxy.example.com/cblr/svc/op/autoinstall",
+                filtered_content,
+            )
             self.assertNotIn(self.server_fqdn, filtered_content)
             # Should contain other saltboot entries as filtered (but they won't match as saltboot)
             self.assertIn("LABEL 1234:S:1:Organization", filtered_content)
 
     def test_grub_filter_saltboot_match(self):
-        with unittest.mock.patch('tftp_wrapper.requests.get') as mock_get:
+        with unittest.mock.patch("tftp_wrapper.requests.get") as mock_get:
             mock_response = MagicMock()
             mock_response.status_code = 200
-            mock_response.content = self.grub_example.encode('utf-8')
+            mock_response.content = self.grub_example.encode("utf-8")
             mock_get.return_value = mock_response
 
             grub_filter = tftp_wrapper.HttpResponseDataFilteredGrub(
@@ -114,23 +128,30 @@ class TestTftpWrapper(unittest.TestCase):
                 None,
                 self.proxy_fqdn_abcd,
                 self.server_fqdn,
-                self.replace_fqdns
+                self.replace_fqdns,
             )
-            
-            filtered_content = grub_filter._content.decode('utf-8')
-            # Should contain matched saltboot entry
-            self.assertIn("menuentry 'ABCD:S:1:Organization'", filtered_content)
-            self.assertIn("set default='ABCD:S:1:Organization'", filtered_content)
+
+            filtered_content = grub_filter._content.decode("utf-8")
+            entry_name = "'ABCD:S:1:Organization'"
+
+            # Should contain matched saltboot entry with ID
+            self.assertIn(f"menuentry {entry_name}", filtered_content)
+            self.assertIn("--id ", filtered_content)
+            entry_match = re.search(r"--id (.*) {", filtered_content)
+            self.assertIsNotNone(entry_match)
+            self.assertIn(f"set default={entry_match.group(1)}", filtered_content)
             # Should NOT contain other saltboot entries
             self.assertNotIn("menuentry '1234:S:1:Organization'", filtered_content)
             # Should NOT contain cobbler entries
-            self.assertNotIn("menuentry 'profile:1:MyOrganizationInc'", filtered_content)
+            self.assertNotIn(
+                "menuentry 'profile:1:MyOrganizationInc'", filtered_content
+            )
 
     def test_grub_filter_cobbler_fallback(self):
-        with unittest.mock.patch('tftp_wrapper.requests.get') as mock_get:
+        with unittest.mock.patch("tftp_wrapper.requests.get") as mock_get:
             mock_response = MagicMock()
             mock_response.status_code = 200
-            mock_response.content = self.grub_example.encode('utf-8')
+            mock_response.content = self.grub_example.encode("utf-8")
             mock_get.return_value = mock_response
 
             grub_filter = tftp_wrapper.HttpResponseDataFilteredGrub(
@@ -138,49 +159,72 @@ class TestTftpWrapper(unittest.TestCase):
                 None,
                 "nonexistent-proxy.example.com",
                 self.server_fqdn,
-                self.replace_fqdns
+                self.replace_fqdns,
             )
-            
-            filtered_content = grub_filter._content.decode('utf-8')
+
+            filtered_content = grub_filter._content.decode("utf-8")
             # Should contain filtered cobbler entries
             self.assertIn("menuentry 'profile:1:MyOrganizationInc'", filtered_content)
-            self.assertIn("http://nonexistent-proxy.example.com/cblr/svc/op/autoinstall", filtered_content)
+            self.assertIn(
+                "http://nonexistent-proxy.example.com/cblr/svc/op/autoinstall",
+                filtered_content,
+            )
             self.assertNotIn(self.server_fqdn, filtered_content)
 
     def test_handler_routing(self):
         handler = tftp_wrapper.TFTPHandler(
-            "127.0.0.1", "127.0.0.2", "pxelinux.cfg/01-mac", {}, "/root",
-            "http://localhost", self.proxy_fqdn_1234, self.server_fqdn, None, self.replace_fqdns
+            "127.0.0.1",
+            "127.0.0.2",
+            "pxelinux.cfg/01-mac",
+            {},
+            "/root",
+            "http://localhost",
+            self.proxy_fqdn_1234,
+            self.server_fqdn,
+            None,
+            self.replace_fqdns,
         )
-        
-        with unittest.mock.patch('tftp_wrapper.HttpResponseDataFilteredPXE') as mock_pxe:
+
+        with unittest.mock.patch(
+            "tftp_wrapper.HttpResponseDataFilteredPXE"
+        ) as mock_pxe:
             handler.get_response_data_delayed()
             mock_pxe.assert_called_once()
-            self.assertEqual(mock_pxe.call_args[0][0], "http://localhost/tftp/pxelinux.cfg/01-mac")
+            self.assertEqual(
+                mock_pxe.call_args[0][0], "http://localhost/tftp/pxelinux.cfg/01-mac"
+            )
 
         handler._path = "grub/system"
-        with unittest.mock.patch('tftp_wrapper.HttpResponseDataFilteredGrub') as mock_grub:
+        with unittest.mock.patch(
+            "tftp_wrapper.HttpResponseDataFilteredGrub"
+        ) as mock_grub:
             handler.get_response_data_delayed()
             mock_grub.assert_called_once()
-            self.assertEqual(mock_grub.call_args[0][0], "http://localhost/tftp/grub/system")
+            self.assertEqual(
+                mock_grub.call_args[0][0], "http://localhost/tftp/grub/system"
+            )
 
         handler._path = "other/file"
-        with unittest.mock.patch('tftp_wrapper.HttpResponseData') as mock_http:
+        with unittest.mock.patch("tftp_wrapper.HttpResponseData") as mock_http:
             handler.get_response_data_delayed()
             mock_http.assert_called_once()
-            self.assertEqual(mock_http.call_args[0][0], "http://localhost/tftp/other/file")
+            self.assertEqual(
+                mock_http.call_args[0][0], "http://localhost/tftp/other/file"
+            )
 
     def test_http_response_data_read(self):
         url = "http://localhost/tftp/file"
-        with unittest.mock.patch('tftp_wrapper.requests.get') as mock_get:
+        with unittest.mock.patch("tftp_wrapper.requests.get") as mock_get:
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_response.headers = {"content-length": "10"}
-            mock_response.iter_content.return_value = iter([b"abc", b"def", b"ghi", b"j"])
+            mock_response.iter_content.return_value = iter(
+                [b"abc", b"def", b"ghi", b"j"]
+            )
             mock_get.return_value = mock_response
 
             resp = tftp_wrapper.HttpResponseData(url, None)
-            
+
             self.assertEqual(resp.read(2), b"ab")
             self.assertEqual(resp._content, b"c")
             self.assertEqual(resp.read(5), b"cdefg")
@@ -188,5 +232,6 @@ class TestTftpWrapper(unittest.TestCase):
             self.assertEqual(resp.read(10), b"hij")
             self.assertEqual(resp._content, b"")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/containers/proxy-tftpd-image/test/test_tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/test/test_tftp_wrapper.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import re
 import sys
 from unittest.mock import MagicMock
 
@@ -60,9 +59,11 @@ class TestTftpWrapper(unittest.TestCase):
         self.replace_fqdns = ["other.example.com"]
 
         # Load examples
-        with open("test/pxe-example.cfg", "r") as f:
+        with open(os.path.join(os.path.dirname(__file__), "pxe-example.cfg"), "r") as f:
             self.pxe_example = f.read()
-        with open("test/grub-example.cfg", "r") as f:
+        with open(
+            os.path.join(os.path.dirname(__file__), "grub-example.cfg"), "r"
+        ) as f:
             self.grub_example = f.read()
 
     def test_pxe_filter_saltboot_match(self):
@@ -137,9 +138,12 @@ class TestTftpWrapper(unittest.TestCase):
             # Should contain matched saltboot entry with ID
             self.assertIn(f"menuentry {entry_name}", filtered_content)
             self.assertIn("--id ", filtered_content)
-            entry_match = re.search(r"--id (.*) {", filtered_content)
-            self.assertIsNotNone(entry_match)
-            self.assertIn(f"set default={entry_match.group(1)}", filtered_content)
+            self.assertIn(
+                f"--id {tftp_wrapper.DEFAULT_ENTRY_IDENTIFIER}", filtered_content
+            )
+            self.assertIn(
+                f"set default={tftp_wrapper.DEFAULT_ENTRY_IDENTIFIER}", filtered_content
+            )
             # Should NOT contain other saltboot entries
             self.assertNotIn("menuentry '1234:S:1:Organization'", filtered_content)
             # Should NOT contain cobbler entries

--- a/containers/proxy-tftpd-image/test/test_tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/test/test_tftp_wrapper.py
@@ -1,0 +1,192 @@
+
+import sys
+from unittest.mock import MagicMock
+
+# Define fake base classes
+class FakeResponseData:
+    pass
+
+class FakeBaseHandler:
+    def __init__(self, server_addr, peer, path, options, stats):
+        self._path = path
+        self._stats = MagicMock()
+        pass
+    def run(self):
+        pass
+
+class FakeBaseServer:
+    def __init__(self, *args, **kwargs):
+        pass
+
+# Mock dependencies
+fbtftp_mock = MagicMock()
+fbtftp_base_handler_mock = MagicMock()
+fbtftp_base_handler_mock.ResponseData = FakeResponseData
+fbtftp_base_handler_mock.BaseHandler = FakeBaseHandler
+fbtftp_base_server_mock = MagicMock()
+fbtftp_base_server_mock.BaseServer = FakeBaseServer
+
+sys.modules['fbtftp'] = fbtftp_mock
+sys.modules['fbtftp.base_handler'] = fbtftp_base_handler_mock
+sys.modules['fbtftp.base_server'] = fbtftp_base_server_mock
+sys.modules['fbtftp.constants'] = MagicMock()
+sys.modules['requests'] = MagicMock()
+sys.modules['yaml'] = MagicMock()
+
+import unittest
+import os
+
+# Add the directory containing tftp_wrapper.py to sys.path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import tftp_wrapper
+
+class TestTftpWrapper(unittest.TestCase):
+
+    def setUp(self):
+        self.proxy_fqdn_1234 = "proxy1234.example.com"
+        self.proxy_fqdn_abcd = "proxyABCD.example.com"
+        self.server_fqdn = "server.example.com"
+        self.replace_fqdns = ["other.example.com"]
+        
+        # Load examples
+        with open('test/pxe-example.cfg', 'r') as f:
+            self.pxe_example = f.read()
+        with open('test/grub-example.cfg', 'r') as f:
+            self.grub_example = f.read()
+
+    def test_pxe_filter_saltboot_match(self):
+        with unittest.mock.patch('tftp_wrapper.requests.get') as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = self.pxe_example.encode('utf-8')
+            mock_get.return_value = mock_response
+
+            pxe_filter = tftp_wrapper.HttpResponseDataFilteredPXE(
+                "http://localhost/tftp/pxelinux.cfg/01-mac",
+                None,
+                self.proxy_fqdn_1234,
+                self.server_fqdn,
+                self.replace_fqdns
+            )
+            
+            filtered_content = pxe_filter._content.decode('utf-8')
+            # Should contain the matched saltboot entry
+            self.assertIn("LABEL 1234:S:1:Organization", filtered_content)
+            self.assertIn("MENU DEFAULT", filtered_content)
+            self.assertIn("ONTIMEOUT 1234:S:1:Organization", filtered_content)
+            # Should NOT contain other saltboot entries
+            self.assertNotIn("LABEL ABCD:S:1:Organization", filtered_content)
+            # Should NOT contain cobbler entries
+            self.assertNotIn("LABEL profile:1:MyOrganizationInc", filtered_content)
+
+    def test_pxe_filter_cobbler_fallback(self):
+        with unittest.mock.patch('tftp_wrapper.requests.get') as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = self.pxe_example.encode('utf-8')
+            mock_get.return_value = mock_response
+
+            pxe_filter = tftp_wrapper.HttpResponseDataFilteredPXE(
+                "http://localhost/tftp/pxelinux.cfg/01-mac",
+                None,
+                "nonexistent-proxy.example.com",
+                self.server_fqdn,
+                self.replace_fqdns
+            )
+            
+            filtered_content = pxe_filter._content.decode('utf-8')
+            # Should contain filtered cobbler entries
+            self.assertIn("LABEL profile:1:MyOrganizationInc", filtered_content)
+            self.assertIn("http://nonexistent-proxy.example.com/cblr/svc/op/autoinstall", filtered_content)
+            self.assertNotIn(self.server_fqdn, filtered_content)
+            # Should contain other saltboot entries as filtered (but they won't match as saltboot)
+            self.assertIn("LABEL 1234:S:1:Organization", filtered_content)
+
+    def test_grub_filter_saltboot_match(self):
+        with unittest.mock.patch('tftp_wrapper.requests.get') as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = self.grub_example.encode('utf-8')
+            mock_get.return_value = mock_response
+
+            grub_filter = tftp_wrapper.HttpResponseDataFilteredGrub(
+                "http://localhost/tftp/grub/system",
+                None,
+                self.proxy_fqdn_abcd,
+                self.server_fqdn,
+                self.replace_fqdns
+            )
+            
+            filtered_content = grub_filter._content.decode('utf-8')
+            # Should contain matched saltboot entry
+            self.assertIn("menuentry 'ABCD:S:1:Organization'", filtered_content)
+            self.assertIn("set default='ABCD:S:1:Organization'", filtered_content)
+            # Should NOT contain other saltboot entries
+            self.assertNotIn("menuentry '1234:S:1:Organization'", filtered_content)
+            # Should NOT contain cobbler entries
+            self.assertNotIn("menuentry 'profile:1:MyOrganizationInc'", filtered_content)
+
+    def test_grub_filter_cobbler_fallback(self):
+        with unittest.mock.patch('tftp_wrapper.requests.get') as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = self.grub_example.encode('utf-8')
+            mock_get.return_value = mock_response
+
+            grub_filter = tftp_wrapper.HttpResponseDataFilteredGrub(
+                "http://localhost/tftp/grub/system",
+                None,
+                "nonexistent-proxy.example.com",
+                self.server_fqdn,
+                self.replace_fqdns
+            )
+            
+            filtered_content = grub_filter._content.decode('utf-8')
+            # Should contain filtered cobbler entries
+            self.assertIn("menuentry 'profile:1:MyOrganizationInc'", filtered_content)
+            self.assertIn("http://nonexistent-proxy.example.com/cblr/svc/op/autoinstall", filtered_content)
+            self.assertNotIn(self.server_fqdn, filtered_content)
+
+    def test_handler_routing(self):
+        handler = tftp_wrapper.TFTPHandler(
+            "127.0.0.1", "127.0.0.2", "pxelinux.cfg/01-mac", {}, "/root",
+            "http://localhost", self.proxy_fqdn_1234, self.server_fqdn, None, self.replace_fqdns
+        )
+        
+        with unittest.mock.patch('tftp_wrapper.HttpResponseDataFilteredPXE') as mock_pxe:
+            handler.get_response_data_delayed()
+            mock_pxe.assert_called_once()
+            self.assertEqual(mock_pxe.call_args[0][0], "http://localhost/tftp/pxelinux.cfg/01-mac")
+
+        handler._path = "grub/system"
+        with unittest.mock.patch('tftp_wrapper.HttpResponseDataFilteredGrub') as mock_grub:
+            handler.get_response_data_delayed()
+            mock_grub.assert_called_once()
+            self.assertEqual(mock_grub.call_args[0][0], "http://localhost/tftp/grub/system")
+
+        handler._path = "other/file"
+        with unittest.mock.patch('tftp_wrapper.HttpResponseData') as mock_http:
+            handler.get_response_data_delayed()
+            mock_http.assert_called_once()
+            self.assertEqual(mock_http.call_args[0][0], "http://localhost/tftp/other/file")
+
+    def test_http_response_data_read(self):
+        url = "http://localhost/tftp/file"
+        with unittest.mock.patch('tftp_wrapper.requests.get') as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-length": "10"}
+            mock_response.iter_content.return_value = iter([b"abc", b"def", b"ghi", b"j"])
+            mock_get.return_value = mock_response
+
+            resp = tftp_wrapper.HttpResponseData(url, None)
+            
+            self.assertEqual(resp.read(2), b"ab")
+            self.assertEqual(resp._content, b"c")
+            self.assertEqual(resp.read(5), b"cdefg")
+            self.assertEqual(resp._content, b"hi")
+            self.assertEqual(resp.read(10), b"hij")
+            self.assertEqual(resp._content, b"")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/containers/proxy-tftpd-image/test/test_tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/test/test_tftp_wrapper.py
@@ -3,239 +3,252 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Unit tests for the TFTP wrapper script."""
+
+# pylint: disable=redefined-outer-name,protected-access
+
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+# Dynamically mock fbtftp if not installed
+try:
+    import fbtftp  # pylint: disable=unused-import
+except ImportError:
 
-# Define fake base classes
-class FakeResponseData:
-    pass
-
-
-class FakeBaseHandler:
-    def __init__(self, server_addr, peer, path, options, stats):
-        self._path = path
-        self._stats = MagicMock()
+    class FakeResponseData:
         pass
 
-    def run(self):
-        pass
+    class FakeBaseHandler:
+        # pylint: disable=unused-argument
+        def __init__(self, server_addr, peer, path, options, stats):
+            self._path = path
+            self._stats = MagicMock()
 
+        def run(self):
+            pass
 
-class FakeBaseServer:
-    def __init__(self, *args, **kwargs):
-        pass
+    class FakeBaseServer:
+        def __init__(self, *args, **kwargs):
+            pass
 
+    fbtftp_mock = MagicMock()
+    fbtftp_base_handler_mock = MagicMock()
+    fbtftp_base_handler_mock.ResponseData = FakeResponseData
+    fbtftp_base_handler_mock.BaseHandler = FakeBaseHandler
+    fbtftp_base_server_mock = MagicMock()
+    fbtftp_base_server_mock.BaseServer = FakeBaseServer
 
-# Mock dependencies
-fbtftp_mock = MagicMock()
-fbtftp_base_handler_mock = MagicMock()
-fbtftp_base_handler_mock.ResponseData = FakeResponseData
-fbtftp_base_handler_mock.BaseHandler = FakeBaseHandler
-fbtftp_base_server_mock = MagicMock()
-fbtftp_base_server_mock.BaseServer = FakeBaseServer
+    sys.modules["fbtftp"] = fbtftp_mock
+    sys.modules["fbtftp.base_handler"] = fbtftp_base_handler_mock
+    sys.modules["fbtftp.base_server"] = fbtftp_base_server_mock
+    sys.modules["fbtftp.constants"] = MagicMock()
 
-sys.modules["fbtftp"] = fbtftp_mock
-sys.modules["fbtftp.base_handler"] = fbtftp_base_handler_mock
-sys.modules["fbtftp.base_server"] = fbtftp_base_server_mock
-sys.modules["fbtftp.constants"] = MagicMock()
-sys.modules["requests"] = MagicMock()
-sys.modules["yaml"] = MagicMock()
+# Dynamically mock requests if not installed
+try:
+    import requests  # pylint: disable=unused-import
+except ImportError:
+    sys.modules["requests"] = MagicMock()
 
-import unittest
+# Dynamically mock yaml if not installed
+try:
+    import yaml  # pylint: disable=unused-import
+except ImportError:
+    sys.modules["yaml"] = MagicMock()
+
 import os
+import pytest
 
 # Add the directory containing tftp_wrapper.py to sys.path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+# pylint: disable=wrong-import-position
 import tftp_wrapper
 
 
-class TestTftpWrapper(unittest.TestCase):
+@pytest.fixture
+def config_data():
+    return {
+        "proxy_fqdn_1234": "proxy1234.example.com",
+        "proxy_fqdn_abcd": "proxyABCD.example.com",
+        "server_fqdn": "server.example.com",
+        "replace_fqdns": ["other.example.com"],
+    }
 
-    def setUp(self):
-        self.proxy_fqdn_1234 = "proxy1234.example.com"
-        self.proxy_fqdn_abcd = "proxyABCD.example.com"
-        self.server_fqdn = "server.example.com"
-        self.replace_fqdns = ["other.example.com"]
 
-        # Load examples
-        with open(os.path.join(os.path.dirname(__file__), "pxe-example.cfg"), "r") as f:
-            self.pxe_example = f.read()
-        with open(
-            os.path.join(os.path.dirname(__file__), "grub-example.cfg"), "r"
-        ) as f:
-            self.grub_example = f.read()
+@pytest.fixture
+def pxe_example():
+    with open(
+        os.path.join(os.path.dirname(__file__), "pxe-example.cfg"),
+        "r",
+        encoding="utf-8",
+    ) as f:
+        return f.read()
 
-    def test_pxe_filter_saltboot_match(self):
-        with unittest.mock.patch("tftp_wrapper.requests.get") as mock_get:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.content = self.pxe_example.encode("utf-8")
-            mock_get.return_value = mock_response
 
-            pxe_filter = tftp_wrapper.HttpResponseDataFilteredPXE(
-                "http://localhost/tftp/pxelinux.cfg/01-mac",
-                None,
-                self.proxy_fqdn_1234,
-                self.server_fqdn,
-                self.replace_fqdns,
-            )
+@pytest.fixture
+def grub_example():
+    with open(
+        os.path.join(os.path.dirname(__file__), "grub-example.cfg"),
+        "r",
+        encoding="utf-8",
+    ) as f:
+        return f.read()
 
-            filtered_content = pxe_filter._content.decode("utf-8")
-            # Should contain the matched saltboot entry
-            self.assertIn("LABEL 1234:S:1:Organization", filtered_content)
-            self.assertIn("MENU DEFAULT", filtered_content)
-            self.assertIn("ONTIMEOUT 1234:S:1:Organization", filtered_content)
-            # Should NOT contain other saltboot entries
-            self.assertNotIn("LABEL ABCD:S:1:Organization", filtered_content)
-            # Should NOT contain cobbler entries
-            self.assertNotIn("LABEL profile:1:MyOrganizationInc", filtered_content)
 
-    def test_pxe_filter_cobbler_fallback(self):
-        with unittest.mock.patch("tftp_wrapper.requests.get") as mock_get:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.content = self.pxe_example.encode("utf-8")
-            mock_get.return_value = mock_response
+def test_pxe_filter_saltboot_match(config_data, pxe_example):
+    with patch("tftp_wrapper.requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = pxe_example.encode("utf-8")
+        mock_get.return_value = mock_response
 
-            pxe_filter = tftp_wrapper.HttpResponseDataFilteredPXE(
-                "http://localhost/tftp/pxelinux.cfg/01-mac",
-                None,
-                "nonexistent-proxy.example.com",
-                self.server_fqdn,
-                self.replace_fqdns,
-            )
-
-            filtered_content = pxe_filter._content.decode("utf-8")
-            # Should contain filtered cobbler entries
-            self.assertIn("LABEL profile:1:MyOrganizationInc", filtered_content)
-            self.assertIn(
-                "http://nonexistent-proxy.example.com/cblr/svc/op/autoinstall",
-                filtered_content,
-            )
-            self.assertNotIn(self.server_fqdn, filtered_content)
-            # Should contain other saltboot entries as filtered (but they won't match as saltboot)
-            self.assertIn("LABEL 1234:S:1:Organization", filtered_content)
-
-    def test_grub_filter_saltboot_match(self):
-        with unittest.mock.patch("tftp_wrapper.requests.get") as mock_get:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.content = self.grub_example.encode("utf-8")
-            mock_get.return_value = mock_response
-
-            grub_filter = tftp_wrapper.HttpResponseDataFilteredGrub(
-                "http://localhost/tftp/grub/system",
-                None,
-                self.proxy_fqdn_abcd,
-                self.server_fqdn,
-                self.replace_fqdns,
-            )
-
-            filtered_content = grub_filter._content.decode("utf-8")
-            entry_name = "'ABCD:S:1:Organization'"
-
-            # Should contain matched saltboot entry with ID
-            self.assertIn(f"menuentry {entry_name}", filtered_content)
-            self.assertIn("--id ", filtered_content)
-            self.assertIn(
-                f"--id {tftp_wrapper.DEFAULT_ENTRY_IDENTIFIER}", filtered_content
-            )
-            self.assertIn(
-                f"set default={tftp_wrapper.DEFAULT_ENTRY_IDENTIFIER}", filtered_content
-            )
-            # Should NOT contain other saltboot entries
-            self.assertNotIn("menuentry '1234:S:1:Organization'", filtered_content)
-            # Should NOT contain cobbler entries
-            self.assertNotIn(
-                "menuentry 'profile:1:MyOrganizationInc'", filtered_content
-            )
-
-    def test_grub_filter_cobbler_fallback(self):
-        with unittest.mock.patch("tftp_wrapper.requests.get") as mock_get:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.content = self.grub_example.encode("utf-8")
-            mock_get.return_value = mock_response
-
-            grub_filter = tftp_wrapper.HttpResponseDataFilteredGrub(
-                "http://localhost/tftp/grub/system",
-                None,
-                "nonexistent-proxy.example.com",
-                self.server_fqdn,
-                self.replace_fqdns,
-            )
-
-            filtered_content = grub_filter._content.decode("utf-8")
-            # Should contain filtered cobbler entries
-            self.assertIn("menuentry 'profile:1:MyOrganizationInc'", filtered_content)
-            self.assertIn(
-                "http://nonexistent-proxy.example.com/cblr/svc/op/autoinstall",
-                filtered_content,
-            )
-            self.assertNotIn(self.server_fqdn, filtered_content)
-
-    def test_handler_routing(self):
-        handler = tftp_wrapper.TFTPHandler(
-            "127.0.0.1",
-            "127.0.0.2",
-            "pxelinux.cfg/01-mac",
-            {},
-            "/root",
-            "http://localhost",
-            self.proxy_fqdn_1234,
-            self.server_fqdn,
+        pxe_filter = tftp_wrapper.HttpResponseDataFilteredPXE(
+            "http://localhost/tftp/pxelinux.cfg/01-mac",
             None,
-            self.replace_fqdns,
+            config_data["proxy_fqdn_1234"],
+            config_data["server_fqdn"],
+            config_data["replace_fqdns"],
         )
 
-        with unittest.mock.patch(
-            "tftp_wrapper.HttpResponseDataFilteredPXE"
-        ) as mock_pxe:
-            handler.get_response_data_delayed()
-            mock_pxe.assert_called_once()
-            self.assertEqual(
-                mock_pxe.call_args[0][0], "http://localhost/tftp/pxelinux.cfg/01-mac"
-            )
-
-        handler._path = "grub/system"
-        with unittest.mock.patch(
-            "tftp_wrapper.HttpResponseDataFilteredGrub"
-        ) as mock_grub:
-            handler.get_response_data_delayed()
-            mock_grub.assert_called_once()
-            self.assertEqual(
-                mock_grub.call_args[0][0], "http://localhost/tftp/grub/system"
-            )
-
-        handler._path = "other/file"
-        with unittest.mock.patch("tftp_wrapper.HttpResponseData") as mock_http:
-            handler.get_response_data_delayed()
-            mock_http.assert_called_once()
-            self.assertEqual(
-                mock_http.call_args[0][0], "http://localhost/tftp/other/file"
-            )
-
-    def test_http_response_data_read(self):
-        url = "http://localhost/tftp/file"
-        with unittest.mock.patch("tftp_wrapper.requests.get") as mock_get:
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.headers = {"content-length": "10"}
-            mock_response.iter_content.return_value = iter(
-                [b"abc", b"def", b"ghi", b"j"]
-            )
-            mock_get.return_value = mock_response
-
-            resp = tftp_wrapper.HttpResponseData(url, None)
-
-            self.assertEqual(resp.read(2), b"ab")
-            self.assertEqual(resp._content, b"c")
-            self.assertEqual(resp.read(5), b"cdefg")
-            self.assertEqual(resp._content, b"hi")
-            self.assertEqual(resp.read(10), b"hij")
-            self.assertEqual(resp._content, b"")
+        filtered_content = pxe_filter._content.decode("utf-8")
+        # Should contain the matched saltboot entry
+        assert "LABEL 1234:S:1:Organization" in filtered_content
+        assert "MENU DEFAULT" in filtered_content
+        assert "ONTIMEOUT 1234:S:1:Organization" in filtered_content
+        # Should NOT contain other saltboot entries
+        assert "LABEL ABCD:S:1:Organization" not in filtered_content
+        # Should NOT contain cobbler entries
+        assert "LABEL profile:1:MyOrganizationInc" not in filtered_content
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_pxe_filter_cobbler_fallback(config_data, pxe_example):
+    with patch("tftp_wrapper.requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = pxe_example.encode("utf-8")
+        mock_get.return_value = mock_response
+
+        pxe_filter = tftp_wrapper.HttpResponseDataFilteredPXE(
+            "http://localhost/tftp/pxelinux.cfg/01-mac",
+            None,
+            "nonexistent-proxy.example.com",
+            config_data["server_fqdn"],
+            config_data["replace_fqdns"],
+        )
+
+        filtered_content = pxe_filter._content.decode("utf-8")
+        # Should contain filtered cobbler entries
+        assert "LABEL profile:1:MyOrganizationInc" in filtered_content
+        assert (
+            "http://nonexistent-proxy.example.com/cblr/svc/op/autoinstall"
+            in filtered_content
+        )
+        assert config_data["server_fqdn"] not in filtered_content
+        # Should contain other saltboot entries as filtered (but they won't match as saltboot)
+        assert "LABEL 1234:S:1:Organization" in filtered_content
+
+
+def test_grub_filter_saltboot_match(config_data, grub_example):
+    with patch("tftp_wrapper.requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = grub_example.encode("utf-8")
+        mock_get.return_value = mock_response
+
+        grub_filter = tftp_wrapper.HttpResponseDataFilteredGrub(
+            "http://localhost/tftp/grub/system",
+            None,
+            config_data["proxy_fqdn_abcd"],
+            config_data["server_fqdn"],
+            config_data["replace_fqdns"],
+        )
+
+        filtered_content = grub_filter._content.decode("utf-8")
+        entry_name = "'ABCD:S:1:Organization'"
+
+        # Should contain matched saltboot entry with ID
+        assert f"menuentry {entry_name}" in filtered_content
+        assert "--id " in filtered_content
+        assert f"--id {tftp_wrapper.DEFAULT_ENTRY_IDENTIFIER}" in filtered_content
+        assert (
+            f"set default={tftp_wrapper.DEFAULT_ENTRY_IDENTIFIER}" in filtered_content
+        )
+        # Should NOT contain other saltboot entries
+        assert "menuentry '1234:S:1:Organization'" not in filtered_content
+        # Should NOT contain cobbler entries
+        assert "menuentry 'profile:1:MyOrganizationInc'" not in filtered_content
+
+
+def test_grub_filter_cobbler_fallback(config_data, grub_example):
+    with patch("tftp_wrapper.requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = grub_example.encode("utf-8")
+        mock_get.return_value = mock_response
+
+        grub_filter = tftp_wrapper.HttpResponseDataFilteredGrub(
+            "http://localhost/tftp/grub/system",
+            None,
+            "nonexistent-proxy.example.com",
+            config_data["server_fqdn"],
+            config_data["replace_fqdns"],
+        )
+
+        filtered_content = grub_filter._content.decode("utf-8")
+        # Should contain filtered cobbler entries
+        assert "menuentry 'profile:1:MyOrganizationInc'" in filtered_content
+        assert (
+            "http://nonexistent-proxy.example.com/cblr/svc/op/autoinstall"
+            in filtered_content
+        )
+        assert config_data["server_fqdn"] not in filtered_content
+
+
+def test_handler_routing(config_data):
+    handler = tftp_wrapper.TFTPHandler(
+        "127.0.0.1",
+        "127.0.0.2",
+        "pxelinux.cfg/01-mac",
+        {},
+        "/root",
+        "http://localhost",
+        config_data["proxy_fqdn_1234"],
+        config_data["server_fqdn"],
+        None,
+        config_data["replace_fqdns"],
+    )
+
+    with patch("tftp_wrapper.HttpResponseDataFilteredPXE") as mock_pxe:
+        handler.get_response_data_delayed()
+        mock_pxe.assert_called_once()
+        assert mock_pxe.call_args[0][0] == "http://localhost/tftp/pxelinux.cfg/01-mac"
+
+    handler._path = "grub/system"
+    with patch("tftp_wrapper.HttpResponseDataFilteredGrub") as mock_grub:
+        handler.get_response_data_delayed()
+        mock_grub.assert_called_once()
+        assert mock_grub.call_args[0][0] == "http://localhost/tftp/grub/system"
+
+    handler._path = "other/file"
+    with patch("tftp_wrapper.HttpResponseData") as mock_http:
+        handler.get_response_data_delayed()
+        mock_http.assert_called_once()
+        assert mock_http.call_args[0][0] == "http://localhost/tftp/other/file"
+
+
+def test_http_response_data_read():
+    url = "http://localhost/tftp/file"
+    with patch("tftp_wrapper.requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-length": "10"}
+        mock_response.iter_content.return_value = iter([b"abc", b"def", b"ghi", b"j"])
+        mock_get.return_value = mock_response
+
+        resp = tftp_wrapper.HttpResponseData(url, None)
+
+        assert resp.read(2) == b"ab"
+        assert resp._content == b"c"
+        assert resp.read(5) == b"cdefg"
+        assert resp._content == b"hi"
+        assert resp.read(10) == b"hij"
+        assert resp._content == b""

--- a/containers/proxy-tftpd-image/tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/tftp_wrapper.py
@@ -5,7 +5,6 @@
 """Wrapper script for Uyuni proxy tftp container."""
 
 import argparse
-import hashlib
 import logging
 import os
 import errno
@@ -17,6 +16,8 @@ from fbtftp.base_handler import BaseHandler
 from fbtftp.base_handler import ResponseData
 from fbtftp.base_server import BaseServer
 from fbtftp import constants
+
+DEFAULT_ENTRY_IDENTIFIER: str = "id-saltboot-default"
 
 
 def stats(s):
@@ -192,18 +193,22 @@ class HttpResponseDataFilteredGrub(HttpResponseDataFiltered):
                         # When entry starts with a number, grub assumes we are pointing to a menuentry position.
                         # This is incorrect, and so we need to provide custom --id option for the menuentry which will
                         # always start with a character so grub is doing menuentry name match.
-                        entry_id = "id-" + hashlib.md5(entry.encode()).hexdigest()[:8]
                         entry_lines = entry.splitlines()
-                        entry_lines[0] = entry_lines[0].replace(
-                            "{", f"--id {entry_id} {{", 1
+                        entry_lines[0] = re.sub(
+                            r"\{\s*$",
+                            f"--id {DEFAULT_ENTRY_IDENTIFIER} {{",
+                            entry_lines[0],
                         )
                         entry = "\n".join(entry_lines) + "\n"
                         saltboot_content += entry
                         saltboot_content += (
                             'if [ -z "${default}" -o "${default}" == "local" ]; then\n  set default='
-                            + entry_id
+                            + DEFAULT_ENTRY_IDENTIFIER
                             + "\nfi\n"
                         )
+                        # There can be only one matching saltboot entry
+                        # MINION_ID_PREFIX should be unique across deployment
+                        break
                     else:
                         filtered_entry = re.sub(
                             r"\b" + re.escape(self._server_fqdn) + r"\b",

--- a/containers/proxy-tftpd-image/tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/tftp_wrapper.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: 2024 SUSE LLC
+# SPDX-FileCopyrightText: 2026 SUSE LLC
 #
 # SPDX-License-Identifier: MIT
 """Wrapper script for Uyuni proxy tftp container."""
 
 import argparse
+import hashlib
 import logging
 import os
 import errno
@@ -176,7 +177,6 @@ class HttpResponseDataFilteredGrub(HttpResponseDataFiltered):
         cobbler_content = ""
         have_entry = False
         entry = ""
-        entry_name = ""
         in_entry = False
         for line in self._content.decode("utf-8").splitlines():
             if in_entry:
@@ -189,10 +189,19 @@ class HttpResponseDataFilteredGrub(HttpResponseDataFiltered):
                         and "MINION_ID_PREFIX" in entry
                     ):
                         have_entry = True
+                        # When entry starts with a number, grub assumes we are pointing to a menuentry position.
+                        # This is incorrect, and so we need to provide custom --id option for the menuentry which will
+                        # always start with a character so grub is doing menuentry name match.
+                        entry_id = "id-" + hashlib.md5(entry.encode()).hexdigest()[:8]
+                        entry_lines = entry.splitlines()
+                        entry_lines[0] = entry_lines[0].replace(
+                            "{", f"--id {entry_id} {{", 1
+                        )
+                        entry = "\n".join(entry_lines) + "\n"
                         saltboot_content += entry
                         saltboot_content += (
                             'if [ -z "${default}" -o "${default}" == "local" ]; then\n  set default='
-                            + entry_name
+                            + entry_id
                             + "\nfi\n"
                         )
                     else:
@@ -211,7 +220,6 @@ class HttpResponseDataFilteredGrub(HttpResponseDataFiltered):
                     entry = ""
             else:
                 if line.startswith("menuentry"):
-                    entry_name = line.split(" ", 3)[1]
                     entry = line + "\n"
                     in_entry = True
                 else:

--- a/containers/proxy-tftpd-image/tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/tftp_wrapper.py
@@ -7,6 +7,7 @@
 import argparse
 import logging
 import os
+import sys
 import errno
 import re
 import requests
@@ -55,17 +56,19 @@ class HttpResponseData(ResponseData):
         self._size = int(self._request.headers["content-length"])
 
     def read(self, requested):
-        data = self._content
+        chunks = [self._content]
         read = len(self._content)
         while read < requested:
             if self._stream is None:
                 break
             try:
                 d = next(self._stream)
-                data += d
+                chunks.append(d)
                 read += len(d)
             except StopIteration:
+                self._stream = None
                 break
+        data = b"".join(chunks)
         if read > requested:
             self._content = data[requested:]
             data = data[:requested]
@@ -130,7 +133,7 @@ class HttpResponseDataFilteredPXE(HttpResponseDataFiltered):
                     in_entry = False
                     # detect Saltboot entries
                     if (
-                        " MASTER=" + self._proxy_fqdn in entry
+                        f" MASTER={self._proxy_fqdn}" in entry
                         and "MINION_ID_PREFIX" in entry
                     ):
                         have_entry = True
@@ -186,7 +189,7 @@ class HttpResponseDataFilteredGrub(HttpResponseDataFiltered):
                     in_entry = False
                     # detect Saltboot entries
                     if (
-                        " MASTER=" + self._proxy_fqdn in entry
+                        f" MASTER={self._proxy_fqdn}" in entry
                         and "MINION_ID_PREFIX" in entry
                     ):
                         have_entry = True
@@ -477,11 +480,11 @@ def main():
         logging.warning("Configuration file reading error %s, ignoring", str(err))
     except KeyError as err:
         logging.error("Invalid configuration file passed, missing %s", str(err))
-        exit(1)
+        sys.exit(1)
 
     if not isinstance(args.replace_fqdns, list):
         logging.error("Invalid configuration file passed, replace_fqdns is not a list")
-        exit(1)
+        sys.exit(1)
 
     logging.info("Starting TFTP proxy:")
     logging.info("HTTP endpoint: %s", args.http_host)


### PR DESCRIPTION
## What does this PR change?

This PR adds a custom --id entry to the menuitem grub entry for saltboot entries. This is to ensure grub is doing text matching for default entries and not counting menuitem entries in case branch is starting with a number.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29810 https://github.com/SUSE/spacewalk/issues/20987
Port(s): https://github.com/SUSE/spacewalk/pull/30072

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
