### PR TITLE
Show console output for passed steps in the consolidated cucumber report

### DIFF
--- a/testsuite/index.cjs
+++ b/testsuite/index.cjs
@@ -61,6 +61,22 @@ for (const file of jsonFiles) {
           }
         }
 
+        // Convert step.output (array of strings from Ruby `puts`) to embeddings
+        // so the library renders them for all step statuses (including passed).
+        // The library ignores step.output but renders step.embeddings with
+        // mime_type "text/plain" as "Log" attachments.
+        for (const step of (scenario.steps || [])) {
+          if (Array.isArray(step.output) && step.output.length > 0) {
+            const text = step.output.join('\n');
+            step.embeddings = step.embeddings || [];
+            step.embeddings.push({
+              data: Buffer.from(text).toString('base64'),
+              mime_type: 'text/plain',
+            });
+            delete step.output;
+          }
+        }
+
         // Strip passed/skipped hooks to remove visual noise and fix false failures
         // in the Jenkins Cucumber plugin. Failed hooks (and hooks with no result)
         // are kept so they remain visible in the report for debugging.


### PR DESCRIPTION
## What does this PR change?

The multiple-cucumber-html-reporter library ignores the step.output field entirely (it is not part of its type system), so log output from puts calls in Ruby step definitions was silently dropped from cucumber_report/index.html — even though the same output was visible in the individual per-suite HTML files generated by the Cucumber Messages formatter.

This change converts step.output (an array of strings) into a step.embeddings entry with mime_type: "text/plain" before passing data to the library. The library decodes base64 text embeddings and renders them as "Log" attachments in the scenario card — for all step statuses, including passed.

Effect: any step that calls puts (e.g. the products list dump in the SLE15 SP7 product should be added, or the channel sync DEBUG lines in I wait until all synchronized channels have finished) will now display its output in the consolidated report, making it easier to verify what the test actually observed without having to open the individual suite HTML.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s):
 - 5.1: https://github.com/SUSE/spacewalk/pull/30733
 - 5.0: https://github.com/SUSE/spacewalk/pull/30734
 - 4.3: https://github.com/SUSE/spacewalk/pull/30735

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
