### PR TITLE
Improve failing steps speed

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -208,7 +208,7 @@ end
 def web_session_is_active?
   return false unless capybara_session_created?
 
-  page.has_selector?('header') || page.has_selector?('#username-field')
+  page.has_selector?('header', wait: 0) || page.has_selector?('#username-field', wait: 0)
 end
 
 # Take a screenshot and try to log back at suse manager server
@@ -245,7 +245,7 @@ end
 # Relog and visit the previous URL
 def relog_and_visit_previous_url
   begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
+    Timeout.timeout(30) do
       previous_url = current_url
       step %(I am authorized as "#{$current_user}" with password "#{$current_password}")
       visit previous_url
@@ -779,13 +779,13 @@ end
 # have more infos about the errors
 def print_server_logs
   $stdout.puts '=> /var/log/rhn/rhn_web_ui.log'
-  out, _code = get_target('server').run('tail -n20 /var/log/rhn/rhn_web_ui.log | awk -v limit="$(date --date="5 minutes ago" "+%Y-%m-%d %H:%M:%S")" \'substr($0, 1, 19) > limit\'')
+  out, _code = get_target('server').run('tail -n20 /var/log/rhn/rhn_web_ui.log | awk -v limit="$(date --date="5 minutes ago" "+%Y-%m-%d %H:%M:%S")" \'substr($0, 1, 19) > limit\'', timeout: 10)
   out.each_line do |line|
     $stdout.puts line.to_s
   end
   $stdout.puts
   $stdout.puts '=> /var/log/rhn/rhn_web_api.log'
-  out, _code = get_target('server').run('tail -n20 /var/log/rhn/rhn_web_api.log | awk -v limit="$(date --date="5 minutes ago" "+%Y-%m-%d %H:%M:%S")" \'substr($0, 2, 19) > limit\'')
+  out, _code = get_target('server').run('tail -n20 /var/log/rhn/rhn_web_api.log | awk -v limit="$(date --date="5 minutes ago" "+%Y-%m-%d %H:%M:%S")" \'substr($0, 2, 19) > limit\'', timeout: 10)
   out.each_line do |line|
     $stdout.puts line.to_s
   end


### PR DESCRIPTION
## What does this PR change?

When looking at failures, I found that the worst case scenario can take up to 13 minutes without reason. We are using the default 250 s timeout where it's not necessary and have 10 second timeout on simple check. 
Tune those timeout to fail faster

Summary of the full failure-path cost (worst case, before fixes):
| Step | Worst case before | After fix |
|---|---|---|
| `web_session_is_active?` | 20s (2 × 10s Capybara wait) | ~0s (`wait: 0`) |
| `handle_screenshot_and_relog` | fast (browser-local) | unchanged |
| `relog_and_visit_previous_url` | 250s | ~30s |
| `print_server_logs` (×2 SSH) | 500s | 20s (already fixed) |
| **Total worst case** | **~770s (~13 min)** | **~50s** |


Summary of the changes:

| File | Change | Impact |
|---|---|---|
| `env.rb` | `has_selector?` → `wait: 0` | 0s instead of up to 20s |
| `env.rb` | `relog_and_visit_previous_url` timeout 250s → 30s | 30s instead of up to 250s|
| `env.rb` | `print_server_logs` SSH timeout 250s → 10s (×2) | 20s instead of up to 500s |

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): -
Port(s):
 - 5.1: https://github.com/SUSE/spacewalk/pull/30736
 - 5.0: https://github.com/SUSE/spacewalk/pull/30737
 - 4.3: https://github.com/SUSE/spacewalk/pull/30738

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
