### PR TITLE
Use python3*-tornado6 to make it working with Python 3.11

### DIFF
--- a/containers/server-saline-image/Dockerfile
+++ b/containers/server-saline-image/Dockerfile
@@ -23,7 +23,7 @@ RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-li
     rpm -ivh --nodeps $(find /var/cache/zypp/packages/ -type f \
       -name update-alternatives.rpm -o \
       -name ${USEPYTHON}-base.rpm -o -name 'lib${USEPYTHON/python3/python3_/}*.rpm' -o -name 'libopenssl*.rpm' -o -name libexpat1.rpm -o \
-      -name salt.rpm -o -name ${USEPYTHON}-salt.rpm -o -name ${USEPYTHON}-tornado.rpm -o \
+      -name salt.rpm -o -name ${USEPYTHON}-salt.rpm -o -name ${USEPYTHON}-tornado6.rpm -o \
       -name ${USEPYTHON}-contextvars.rpm -o -name ${USEPYTHON}-immutables.rpm -o -name ${USEPYTHON}-looseversion.rpm -o \
       -name ${USEPYTHON}-packaging.rpm -o -name ${USEPYTHON}-distro.rpm -o \
       -name ${USEPYTHON}-PyYAML.rpm -o -name 'libyaml*.rpm' -o -name ${USEPYTHON}-Jinja2.rpm -o -name ${USEPYTHON}-MarkupSafe.rpm -o \

--- a/containers/server-saline-image/server-saline-image.changes.vzhestkov.fix-saline-container-with-tornado
+++ b/containers/server-saline-image/server-saline-image.changes.vzhestkov.fix-saline-container-with-tornado
@@ -1,0 +1,1 @@
+- Use python3*-tornado6 package to make it working with Python 3.11


### PR DESCRIPTION
## What does this PR change?

With the latest changes on `openSUSE/salt` side we introduced the switch from vendored `tornado` (`salt.ext.tornado`) to non-vendored `tornado` shipped with `python3*-tornado6` package, when `salt` is running with `Python 3.11` and higher (before this change it was 3.12 and higher). (PR with the change introduced to `salt`: https://github.com/openSUSE/salt/pull/755)

With this switch it turns that `saline` container is building with `python3*-tornado` package directly picking it for building the container with smaller size, but `python3*-tornado` doesn't ship the module itself, but requires `python3*-tornado6` which is delivering the module.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: already covered (container will fail to start on deploying with the testsuite)

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
