### PR TITLE
Uyuni: Fix delete of a reportdb user with uyuni-setup-reportdb-user (bsc#1261841)

### DIFF
--- a/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
+++ b/spacewalk/uyuni-setup-reportdb/bin/uyuni-setup-reportdb-user
@@ -235,7 +235,11 @@ case "$ACTION" in
       TEMP_PASSWORD=$(dd status=none bs=18 count=1 < /dev/random | base64)
       echo "ALTER USER ${DBUSER} PASSWORD '${TEMP_PASSWORD}';" | spacewalk-sql --reportdb --select-mode -
       echo "DROP OWNED BY current_user;" | (PGPASSWORD=${TEMP_PASSWORD} psql -U ${DBUSER} -h ${DBHOST} -p ${DBPORT} -d ${DBNAME})
-      QUERY="REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM ${DBUSER}; DROP ROLE ${DBUSER};"
+      QUERY="REVOKE SELECT ON ALL SEQUENCES IN SCHEMA public FROM ${DBUSER};
+        REVOKE ALL ON ALL TABLES IN SCHEMA public FROM ${DBUSER};
+        REVOKE ALL ON SCHEMA public FROM ${DBUSER};
+        REVOKE CONNECT ON DATABASE ${DBNAME} FROM ${DBUSER};
+        DROP ROLE ${DBUSER};"
     fi
   ;;
 esac

--- a/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes.carlo.1261841-reportdb-user-delete
+++ b/spacewalk/uyuni-setup-reportdb/uyuni-setup-reportdb.changes.carlo.1261841-reportdb-user-delete
@@ -1,0 +1,2 @@
+- Fix delete of a reportdb user with uyuni-setup-reportdb-user
+  (bsc#1261841)


### PR DESCRIPTION
## What does this PR change?

Bugfix of [uyuni-setup-reportdb-user --delete fails with "role cannot be dropped because some objects depend on it"](https://bugzilla.suse.com/show_bug.cgi?id=1261841) 

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links
Issue(s): # https://github.com/SUSE/spacewalk/issues/30565
Port(s): 
5.1: https://github.com/SUSE/spacewalk/pull/30760
5.0: not backported
4.3: not backported
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [x] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
