### PR TITLE
server-helm: use HTTPS to connect to peripheral servers

### DIFF
--- a/containers/server-helm/server-helm.changes.cbosdo.hub-https
+++ b/containers/server-helm/server-helm.changes.cbosdo.hub-https
@@ -1,0 +1,1 @@
+- Use HTTPS to connect to peripheral servers (bsc#1265931)

--- a/containers/server-helm/templates/hub.yaml
+++ b/containers/server-helm/templates/hub.yaml
@@ -26,6 +26,8 @@ spec:
       - env:
         - name: HUB_API_URL
           value: http://web/rpc/api
+        - name: HUB_CONNECT_USING_SSL
+          value: "true"
         image: {{ include "uyuni.image" (dict "name" "server-hub-xmlrpc-api" "global" . "local" .Values.hubAPI) }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         name: hub-xmlrpc

--- a/containers/server-helm/tests/gateway_test.yaml
+++ b/containers/server-helm/tests/gateway_test.yaml
@@ -290,3 +290,54 @@ tests:
         documentSelector:
           path: metadata.name
           value: uyuni-nossl-routes
+  
+  - it: should not create the paths for the hub API by default
+    set:
+      global.fqdn: uyuni.example.com
+      gateway:
+        enable: true
+    release:
+      namespace: myns
+    asserts:
+      - notContains:
+          path: spec.rules
+          content:
+            matches:
+              - path:
+                  type: PathPrefix
+                  value: /hub/rpc/api
+            backendRefs:
+              - name: hub-xmlrpc
+                port: 2830
+          any: true
+        template: routes.yaml
+        documentSelector:
+          path: metadata.name
+          value: uyuni-https-routes
+
+
+  - it: should create the paths for the hub API if enabled
+    set:
+      global.fqdn: uyuni.example.com
+      gateway:
+        enable: true
+      hubAPI:
+        enable: true
+    release:
+      namespace: myns
+    asserts:
+      - contains:
+          path: spec.rules
+          content:
+            matches:
+              - path:
+                  type: PathPrefix
+                  value: /hub/rpc/api
+            backendRefs:
+              - name: hub-xmlrpc
+                port: 2830
+          any: true
+        template: routes.yaml
+        documentSelector:
+          path: metadata.name
+          value: uyuni-https-routes

--- a/containers/server-helm/tests/services_test.yaml
+++ b/containers/server-helm/tests/services_test.yaml
@@ -55,7 +55,31 @@ tests:
         documentSelector:
           path: metadata.name
           value: tftp
-
+      - hasDocuments:
+          count: 0
+        documentSelector:
+          path: metadata.name
+          value: hub-xmlrpc
+          skipEmptyTemplates: true
+  
+  - it: should render hub service when hub is enabled
+    set:
+      global.fqdn: uyuni.example.com
+      hubAPI:
+        enable: true
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+        documentSelector:
+          path: metadata.name
+          value: hub-xmlrpc
+      - equal:
+          path: spec.ports[?(@.name=="hub")].port
+          value: 2830
+        documentSelector:
+          path: metadata.name
+          value: hub-xmlrpc
 
   - it: should not render db services when db is disabled
     set:


### PR DESCRIPTION
## What does this PR change?

The Hub API containers deployed on Kubernetes need to use HTTPS to query the peripheral servers API (bsc#1265931).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30767

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
