### PR TITLE
susemanager: fix issue running tests during rpmbuild

### DIFF
--- a/susemanager/Makefile.susemanager
+++ b/susemanager/Makefile.susemanager
@@ -14,6 +14,9 @@ unittest ::
 	$(PYTHON_BIN) -m pytest -v src/ ; \
 	rm ../python/spacewalk/susemanager ; \
 
+__unittest_rpmbuild:
+	$(PYTHON_BIN) -m pytest -v src/ ; \
+
 unittest_inside_docker ::
 	ln -fs /manager/susemanager/src /manager/python/spacewalk/susemanager
 	pytest -v --junitxml src/reports/tests.xml src/test

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -64,6 +64,7 @@ BuildRequires:  python3-devel
 
 # check section
 BuildRequires:  python3-pycurl
+BuildRequires:  python3-pytest
 BuildRequires:  spacewalk-backend >= 1.7.38.20
 BuildRequires:  spacewalk-backend-server
 BuildRequires:  spacewalk-backend-sql-postgresql
@@ -192,7 +193,7 @@ mkdir -p %{_localstatedir}/tmp/fakepython/spacewalk
 cp -a %{python3_sitelib}/spacewalk/* %{_localstatedir}/tmp/fakepython/spacewalk/
 cp -a %{buildroot}%{python3_sitelib}/spacewalk/* %{_localstatedir}/tmp/fakepython/spacewalk/
 export PYTHONPATH=%{_localstatedir}/tmp/fakepython/:%{_datadir}/rhn
-make -f Makefile.susemanager PYTHON_BIN=%{pythonX} unittest
+make -f Makefile.susemanager PYTHON_BIN=%{pythonX} __unittest_rpmbuild
 unset PYTHONPATH
 rm -rf %{_localstatedir}/tmp/fakepython
 


### PR DESCRIPTION
## What does this PR change?

This PR an issue caused after the merge of https://github.com/uyuni-project/uyuni/pull/11988 that is causing a failure to run tests while building the `susemanager` package.

NOTE: No changelog needed for this.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
