### PR TITLE
Only run tests for multiple Python versions on Uyuni

### DIFF
--- a/susemanager-utils/testing/automation/backend-unittest-pgsql.sh
+++ b/susemanager-utils/testing/automation/backend-unittest-pgsql.sh
@@ -63,6 +63,7 @@ if [ $? -ne 0 ]; then
     EXIT=4
 fi
 
+if [ "${VPRODUCT}" = "VERSION.Uyuni" ]; then
 echo
 echo "##################### RUNNING TESTS ON PYTHON 3.6 ###########################"
 $EXECUTOR pull $REGISTRY/$PGSQL_CONTAINER_PYTHON36
@@ -85,6 +86,7 @@ CMD="/manager/python/test/docker-backend-server-tests.sh"
 $EXECUTOR run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER_PYTHON36 /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"
 if [ $? -ne 0 ]; then
     EXIT=8
+fi
 fi
 
 rm -f $GITROOT/python/spacewalk/common/usix.py*

--- a/susemanager-utils/testing/automation/spacecmd-unittest.sh
+++ b/susemanager-utils/testing/automation/spacecmd-unittest.sh
@@ -48,12 +48,14 @@ if [ $? -ne 0 ]; then
     EXIT=1
 fi
 
+if [ "${VPRODUCT}" = "VERSION.Uyuni" ]; then
 echo
 echo "##################### RUNNING TESTS ON PYTHON 3.6 ###########################"
 $EXECUTOR run --rm -e $DOCKER_RUN_EXPORT $DOCKER_RUN_VOLUMES ${REGISTRY}/${PGSQL_CONTAINER_PYTHON36} \
 	/bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; popd; ${CHOWN_CMD} && exit \${RET}"
 if [ $? -ne 0 ]; then
     EXIT=2
+fi
 fi
 
 exit $EXIT

--- a/susemanager-utils/testing/automation/susemanager-sls-tests.sh
+++ b/susemanager-utils/testing/automation/susemanager-sls-tests.sh
@@ -41,6 +41,7 @@ if [ $? -ne 0 ]; then
     EXIT=1
 fi
 
+if [ "${VPRODUCT}" = "VERSION.Uyuni" ]; then
 echo
 echo "##################### RUNNING TESTS ON PYTHON 3.6 ###########################"
 $EXECUTOR pull $REGISTRY/$PGSQL_CONTAINER_PYTHON36
@@ -48,6 +49,7 @@ echo "$EXECUTOR run --rm=true -v \"$GITROOT:/manager\" $REGISTRY/$PGSQL_CONTAINE
 $EXECUTOR run --rm=true -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER_PYTHON36 /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"
 if [ $? -ne 0 ]; then
     EXIT=2
+fi
 fi
 
 exit $EXIT

--- a/susemanager-utils/testing/automation/susemanager-unittest.sh
+++ b/susemanager-utils/testing/automation/susemanager-unittest.sh
@@ -43,6 +43,7 @@ if [ $? -ne 0 ]; then
     EXIT=1
 fi
 
+if [ "${VPRODUCT}" = "VERSION.Uyuni" ]; then
 echo
 echo "##################### RUNNING TESTS WITH PYTHON 3.6 ###########################"
 $EXECUTOR pull $REGISTRY/$PGSQL_CONTAINER_PYTHON36
@@ -51,4 +52,6 @@ $EXECUTOR run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$
 if [ $? -ne 0 ]; then
     EXIT=2
 fi
+fi
+
 exit $EXIT


### PR DESCRIPTION
## What does this PR change?

This PR makes Python tests executors to only run tests for multiple Python versions when running tests for Uyuni (and not for MLM).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
