### PR TITLE
Fix issue in tests with pg_ctl on Leap 16.0

### DIFF
--- a/susemanager-utils/testing/docker/scripts/init-pgsql-reportdb4eclipse.sh
+++ b/susemanager-utils/testing/docker/scripts/init-pgsql-reportdb4eclipse.sh
@@ -26,7 +26,7 @@ echo $PATH
 echo $PERLLIB
 
 export SYSTEMD_NO_WRAP=1
-su - postgres -c "/usr/lib/postgresql/bin/pg_ctl restart" ||:
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data restart" ||:
 
 # this copy the latest schema from the git into the system
 ./build-reportdb-schema.sh

--- a/susemanager-utils/testing/docker/scripts/reportdb_schema_idempotency_test_pgsql.py
+++ b/susemanager-utils/testing/docker/scripts/reportdb_schema_idempotency_test_pgsql.py
@@ -194,7 +194,7 @@ def manage_postgresql(action):
         raise "Invalid action for the PostgreSQL service"
     if run_command(
         # pylint: disable-next=consider-using-f-string
-        "/usr/bin/su - postgres -c '/usr/lib/postgresql/bin/pg_ctl %s'"
+        "/usr/bin/su - postgres -c '/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data %s'"
         % action
     ):
         # pylint: disable-next=consider-using-f-string

--- a/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
+++ b/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
@@ -193,7 +193,7 @@ def manage_postgresql(action):
         raise "Invalid action for the PostgreSQL service"
     if run_command(
         # pylint: disable-next=consider-using-f-string
-        "/usr/bin/su - postgres -c '/usr/lib/postgresql/bin/pg_ctl %s'"
+        "/usr/bin/su - postgres -c '/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data %s'"
         % action
     ):
         # pylint: disable-next=consider-using-f-string


### PR DESCRIPTION
## What does this PR change?

This PR fixes some issues in our CI tests on openSUSE Leap 16.0 around `pg_ctl` not being able to start/restart/stop. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
