### PR TITLE
Add hub tests for server helm

### DIFF
--- a/containers/server-helm/tests/hub_test.yaml
+++ b/containers/server-helm/tests/hub_test.yaml
@@ -1,0 +1,49 @@
+suite: test hub API deployment
+templates:
+  - hub.yaml
+tests:
+  - it: should not render hub api resources by default
+    set:
+      global.fqdn: uyuni.example.com
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: hub.yaml
+
+  - it: should render hub api deployment when set
+    set:
+      global.fqdn: uyuni.example.com
+      hubAPI:
+        enable: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: hub-xmlrpc
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="hub-xmlrpc")].image
+          value: registry.opensuse.org/uyuni/server-hub-xmlrpc-api:latest
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="hub-xmlrpc")].env
+          content:
+            name: HUB_API_URL
+            value: "http://web/rpc/api"
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="hub-xmlrpc")].env
+          content:
+            name: HUB_CONNECT_USING_SSL
+            value: "true"
+
+  - it: should override image when values.images is provided
+    set:
+      global.fqdn: uyuni.example.com
+      hubAPI:
+        enable: true
+        image: my-custom-registry/uyuni-server-api
+        tag: 1.2.3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="hub-xmlrpc")].image
+          value: my-custom-registry/uyuni-server-api:1.2.3
+


### PR DESCRIPTION
## What does this PR change?

Adds unit tests for the hub API on the server helm charts. This is a follow up of PR https://github.com/uyuni-project/uyuni/pull/11991

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30767

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
