### PR TITLE
Fix location for tomcat in Leap 16.0

### DIFF
--- a/containers/server-image/root/docker-entrypoint-init.d/00-mgrSetup.sh
+++ b/containers/server-image/root/docker-entrypoint-init.d/00-mgrSetup.sh
@@ -198,9 +198,17 @@ scc-pass = ${SCC_PASS}
 
 setup_admin_user() {
     if [ -n "${ADMIN_PASS}" ]; then
+        if [ -f /usr/libexec/tomcat/server ]; then
+            TOMCAT_INIT=/usr/libexec/tomcat/server
+        elif [ -f /usr/lib/tomcat/server ]; then
+            TOMCAT_INIT=/usr/lib/tomcat/server
+        else
+            echo "Error! Cannot find tomcat init command"
+            exit 1
+        fi
         echo "starting tomcat..."
         # Start in background
-        (su -s /usr/bin/sh -g tomcat -G www -G susemanager tomcat /usr/lib/tomcat/server start) &
+        (su -s /usr/bin/sh -g tomcat -G www -G susemanager tomcat ${TOMCAT_INIT} start) &
 
         echo "starting apache2..."
         /usr/sbin/start_apache2 -k start
@@ -245,7 +253,7 @@ setup_admin_user() {
         echo "Admin creation complete"
 
         /usr/sbin/start_apache2 -k stop
-        su -s /usr/bin/sh -g tomcat -G www -G susemanager tomcat /usr/lib/tomcat/server stop
+        su -s /usr/bin/sh -g tomcat -G www -G susemanager tomcat ${TOMCAT_INIT} stop
     fi
 }
 


### PR DESCRIPTION
## What does this PR change?

This PR adjust the entrypoint for the `server-image` to locate `tomcat` init script in openSUSE Leap 16.0, to avoid getting the following error when starting the `uyuni-server` container based on Leap 16.0:

```
May 21 15:43:31 uyuni-ci-main-podman-server uyuni-server[7619]: Created symlink '/etc/systemd/system/sockets.target.wants/tftp.socket' → '/usr/li>
May 21 15:43:31 uyuni-ci-main-podman-server uyuni-server[7619]: * Deploying configuration files.
May 21 15:43:31 uyuni-ci-main-podman-server uyuni-server[7619]: Installation complete.
May 21 15:43:31 uyuni-ci-main-podman-server uyuni-server[7619]: starting tomcat...
May 21 15:43:31 uyuni-ci-main-podman-server uyuni-server[7619]: starting apache2...
May 21 15:43:31 uyuni-ci-main-podman-server uyuni-server[7619]: sh: /usr/lib/tomcat/server: No such file or directory
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
