### PR TITLE
Fix  FIPS compatibility by using platform-default SecureRandom (bsc#1247707)

### DIFF
--- a/containers/server-image/Dockerfile.leap160
+++ b/containers/server-image/Dockerfile.leap160
@@ -81,6 +81,7 @@ RUN zypper ref && zypper --non-interactive up && \
         virtual-host-gatherer-VMware \
         virtual-host-gatherer-libcloud \
         virtualization-formulas \
+        mozilla-nss-sysinit \
         zchunk && \
     zypper --non-interactive clean --all && \
     rpm -e container-suseconnect && \

--- a/containers/server-image/Dockerfile.sles15sp7
+++ b/containers/server-image/Dockerfile.sles15sp7
@@ -81,6 +81,7 @@ RUN zypper ref && zypper --non-interactive up && \
         virtual-host-gatherer-VMware \
         virtual-host-gatherer-libcloud \
         virtualization-formulas \
+        mozilla-nss-sysinit \
         zchunk && \
     zypper --non-interactive clean --all && \
     rpm -e container-suseconnect && \

--- a/containers/server-image/server-image.changes.abid.fips-enablement
+++ b/containers/server-image/server-image.changes.abid.fips-enablement
@@ -1,0 +1,2 @@
+- Add mozilla-nss-sysinit to Dockerfile required for FIPS
+  (bsc#1247707)

--- a/java/core/src/main/java/com/redhat/rhn/common/security/CSRFTokenValidator.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/security/CSRFTokenValidator.java
@@ -14,7 +14,9 @@
  */
 package com.redhat.rhn.common.security;
 
-import java.security.NoSuchAlgorithmException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.security.SecureRandom;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,30 +28,26 @@ import jakarta.servlet.http.HttpSession;
  */
 public final class CSRFTokenValidator {
 
+    private static final Logger LOG = LogManager.getLogger(CSRFTokenValidator.class);
     private static String tokenKey = "csrf_token";
-    private static String defaultAlgorithm = "SHA1PRNG";
+    private static final SecureRandom SECURE_RANDOM;
+
+    static {
+        SECURE_RANDOM = new SecureRandom();
+        LOG.warn("CSRF token SecureRandom algorithm: {}", SECURE_RANDOM.getAlgorithm());
+    }
 
     /* utility class, no public constructor  */
     private CSRFTokenValidator() {
     }
 
     /**
-     * Create a new CSRF token using the given algorithm, throws a runtime
-     * exception in case of an algorithm is used that is not available.
+     * Create a new CSRF token using the platform default SecureRandom.
      *
-     * @param alg
      * @return token as a String
-     * @throws CSRFTokenException
      */
-    private static String createNewToken(String alg) throws CSRFTokenException {
-        String tokenValue = null;
-        try {
-            tokenValue = String.valueOf(SecureRandom.getInstance(alg).nextLong());
-        }
-        catch (NoSuchAlgorithmException e) {
-            throw new CSRFTokenException(e.getMessage(), e);
-        }
-        return tokenValue;
+    private static String createNewToken() {
+        return String.valueOf(SECURE_RANDOM.nextLong());
     }
 
     /**
@@ -63,7 +61,7 @@ public final class CSRFTokenValidator {
         String tokenValue = (String) session.getAttribute(tokenKey);
         if (tokenValue == null) {
             // Create new token if necessary
-            tokenValue = createNewToken(defaultAlgorithm);
+            tokenValue = createNewToken();
             session.setAttribute(tokenKey, tokenValue);
         }
         return tokenValue;

--- a/java/core/src/main/java/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
+++ b/java/core/src/main/java/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
@@ -106,6 +106,7 @@ public class SchedulerKernel {
             PrometheusExporter.INSTANCE.registerScheduler(SchedulerKernel.scheduler, "taskomatic");
         }
         catch (SchedulerException e) {
+            log.error("Failed to initialize Quartz scheduler", e);
             throw new InstantiationException("this.scheduler failed");
         }
     }

--- a/java/core/src/test/java/com/redhat/rhn/common/security/CSRFTokenValidatorTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/security/CSRFTokenValidatorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ */
+package com.redhat.rhn.common.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.redhat.rhn.testing.RhnMockHttpServletRequest;
+import com.redhat.rhn.testing.RhnMockHttpSession;
+
+import org.junit.jupiter.api.Test;
+
+public class CSRFTokenValidatorTest {
+
+    @Test
+    public void testGetTokenCreatesToken() {
+        RhnMockHttpSession session = new RhnMockHttpSession();
+        String token = CSRFTokenValidator.getToken(session);
+        assertNotNull(token, "Token should not be null");
+        assertNotEquals("", token, "Token should not be empty");
+    }
+
+    @Test
+    public void testGetTokenReturnsSameTokenForSession() {
+        RhnMockHttpSession session = new RhnMockHttpSession();
+        String token1 = CSRFTokenValidator.getToken(session);
+        String token2 = CSRFTokenValidator.getToken(session);
+        assertEquals(token1, token2, "Same session should return the same token");
+    }
+
+    @Test
+    public void testGetTokenReturnsDifferentTokensForDifferentSessions() {
+        String token1 = CSRFTokenValidator.getToken(new RhnMockHttpSession());
+        String token2 = CSRFTokenValidator.getToken(new RhnMockHttpSession());
+        assertNotEquals(token1, token2, "Different sessions should get different tokens");
+    }
+
+    @Test
+    public void testValidateSucceedsWithHeader() throws CSRFTokenException {
+        RhnMockHttpSession session = new RhnMockHttpSession();
+        String token = CSRFTokenValidator.getToken(session);
+
+        RhnMockHttpServletRequest request = new RhnMockHttpServletRequest();
+        request.setSession(session);
+        request.setHeader("X-CSRF-Token", token);
+
+        CSRFTokenValidator.validate(request);
+    }
+
+    @Test
+    public void testValidateSucceedsWithParameter() throws CSRFTokenException {
+        RhnMockHttpSession session = new RhnMockHttpSession();
+        String token = CSRFTokenValidator.getToken(session);
+
+        RhnMockHttpServletRequest request = new RhnMockHttpServletRequest();
+        request.setSession(session);
+        request.addParameter("csrf_token", token);
+
+        CSRFTokenValidator.validate(request);
+    }
+
+    @Test
+    public void testValidateFailsWithNoToken() {
+        RhnMockHttpSession session = new RhnMockHttpSession();
+        CSRFTokenValidator.getToken(session);
+
+        RhnMockHttpServletRequest request = new RhnMockHttpServletRequest();
+        request.setSession(session);
+
+        assertThrows(CSRFTokenException.class, () -> CSRFTokenValidator.validate(request));
+    }
+
+    @Test
+    public void testValidateFailsWithWrongToken() {
+        RhnMockHttpSession session = new RhnMockHttpSession();
+        CSRFTokenValidator.getToken(session);
+
+        RhnMockHttpServletRequest request = new RhnMockHttpServletRequest();
+        request.setSession(session);
+        request.setHeader("X-CSRF-Token", "wrong-token");
+
+        assertThrows(CSRFTokenException.class, () -> CSRFTokenValidator.validate(request));
+    }
+
+    @Test
+    public void testValidateFailsWithNoSessionToken() {
+        RhnMockHttpServletRequest request = new RhnMockHttpServletRequest();
+        request.setSession(new RhnMockHttpSession());
+        request.setHeader("X-CSRF-Token", "some-token");
+
+        assertThrows(CSRFTokenException.class, () -> CSRFTokenValidator.validate(request));
+    }
+}

--- a/java/spacewalk-java.changes.abid.fips-enablement
+++ b/java/spacewalk-java.changes.abid.fips-enablement
@@ -1,0 +1,2 @@
+- Fix CSRFTokenValidator FIPS compatibility by using
+  platform-default SecureRandom (bsc#1247707)


### PR DESCRIPTION
## What does this PR change?

This PR fixes Uyuni server startup failures when running in FIPS 140-2 mode (fips_enabled=1).


CSRFTokenValidator was using SecureRandom.getInstance("SHA1PRNG"), which is blocked in FIPS mode, causing Tomcat's rhn webapp context to fail on startup and returning 404/500 errors on the Web UI. Moreover, 
`mozilla-nss-sysinit ` was missing from the container, so the NSS database at` /etc/pki/nssdb` was never initialized, causing the JVM's SunPKCS11 security provider to fail and breaking Taskomatic startup

Both FIPS-enabled and non-FIPS deployments should work fine now by the SecureRandom change as the platform default is always available.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- Documentation will be updated to refelct that Uyuni server now works on FIPS enabled host.

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Unit tests were added

- [x] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/28268
Port(s): #  As change is pretty safe, we could backport to 5.1

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [x] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
