### PR TITLE
Increase max DB connections when running pgsql tests

### DIFF
--- a/susemanager-utils/testing/docker/scripts/reset_pgsql_database.sh
+++ b/susemanager-utils/testing/docker/scripts/reset_pgsql_database.sh
@@ -51,3 +51,6 @@ echo "INSERT INTO  rhnChannelFamily (id, name, label, org_id)
       'private-channel-family-1', 1);" | spacewalk-sql --select-mode -
 echo "INSERT INTO  rhnPrivateChannelFamily (channel_family_id, org_id) VALUES  (1000, 1);" | spacewalk-sql --select-mode -
 
+echo "Increasing max_connections"
+su - postgres -c "psql -d postgres -c \"ALTER SYSTEM SET max_connections = 200;\""
+su - postgres -c "/usr/lib/postgresql/bin/pg_ctl -D /var/lib/pgsql/data restart"


### PR DESCRIPTION
## What does this PR change?

This PR increases the max DB connections allowed when running the `java-tests-pgsql` tests, to avoid flaky executions due:

```
org.postgresql.util.PSQLException: FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute
``` 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
