### PR TITLE
Use UI to delete RH and deblike profiles

### DIFF
--- a/testsuite/features/secondary/min_deblike_ssh.feature
+++ b/testsuite/features/secondary/min_deblike_ssh.feature
@@ -92,9 +92,11 @@ Feature: Bootstrap a SSH-managed Debian-like minion and do some basic operations
     Then I check for failed events on history event page
 
   Scenario: Cleanup: delete the SSH-managed Debian-like minion
-    When I delete "deblike_minion" system using the api
-    And I perform a full salt minion cleanup on "deblike_minion"
-    And I wait until Salt client is inactive on "deblike_minion"
+    When I am on the Systems overview page of this "deblike_minion"
+    And I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
     Then "deblike_minion" should not be registered
 
   Scenario: Cleanup: bootstrap a Debian-like minion

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -92,9 +92,11 @@ Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operation
     Then I check for failed events on history event page
 
   Scenario: Cleanup: delete the SSH-managed Red Hat-like minion
-    When I delete "rhlike_minion" system using the api
-    And I perform a full salt minion cleanup on "rhlike_minion"
-    And I wait until Salt client is inactive on "rhlike_minion"
+    When I am on the Systems overview page of this "rhlike_minion"
+    And I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
     Then "rhlike_minion" should not be registered
 
   Scenario: Cleanup: bootstrap a Red Hat-like minion after SSH minion tests


### PR DESCRIPTION
## What does this PR change?

We can't use API cleanup + system cleanup with rhlike and deblike minions because they keep packages and repositories from sumaform. Doing a full cleanup is removing those packages and repositories and so fail the next bootstrap.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/30800
 - 5.0: https://github.com/SUSE/spacewalk/pull/30801
 - 4.3: https://github.com/SUSE/spacewalk/pull/30802

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
