### PR TITLE
Fix INIT_BASE default argument for Dockerfile.leap160

### DIFF
--- a/containers/server-image/Dockerfile.leap160
+++ b/containers/server-image/Dockerfile.leap160
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 #!BuildTag: uyuni/server:latest
 
-ARG INIT_BASE=registry.suse.com/bci/bci-init:15.7
+ARG INIT_BASE=registry.suse.com/bci/bci-init:16.0
 FROM $INIT_BASE
 
 ARG PRODUCT_PATTERN_PREFIX="patterns-uyuni"


### PR DESCRIPTION
## What does this PR change?

This PR fixes a small inconsistency in the `Dockerfile.leap160` file that we use for building the `server-image` based on openSUSE Leap 16.0.

We do override this `INIT_BASE` value via projectconfig, but the current Dockerfile for Leap 16.0 has an inconsistent default value for `INIT_BASE`, which is misleading.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30581

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
