### PR TITLE
Use db_ssl_enabled value consistently

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -1004,6 +1004,9 @@ public class ConfigDefaults {
         if (!"localhost".equals(host) && useSsl) {
             connectionUrl.append("?ssl=true&sslrootcert=" + sslrootcert + "&sslmode=" + sslmode);
         }
+        else {
+            connectionUrl.append("?ssl=false&sslmode=disable");
+        }
 
         return connectionUrl.toString();
     }

--- a/java/spacewalk-java.changes.nadvornik.sslmode
+++ b/java/spacewalk-java.changes.nadvornik.sslmode
@@ -1,0 +1,1 @@
+- Use db_ssl_enabled value consistently

--- a/python/spacewalk/common/rhnConfig.py
+++ b/python/spacewalk/common/rhnConfig.py
@@ -36,6 +36,13 @@ _CONFIG_DEFAULTS_ROOT = os.environ.get(
 )
 
 
+def is_true(val):
+    """
+    Returns True if the value is a string that represents a truthy value.
+    """
+    return str(val).lower() in ("1", "y", "true", "yes", "on")
+
+
 def warn(*args):
     """
     Function used for debugging purposes
@@ -416,7 +423,7 @@ def parse_line(line):
 
     # now split it into keys and values. We allow for max one
     # split/cut (the first one)
-    (keys, vals) = [c.strip() for c in line.split("=", 1)]
+    keys, vals = [c.strip() for c in line.split("=", 1)]
 
     # extract the keys, convert to lowercase
     keys = keys.lower()
@@ -456,7 +463,7 @@ def parse_file(filename, single_key=0):
         # lineno is 1-based
         lineno = lineno + 1
         try:
-            (keys, values) = parse_line(line)
+            keys, values = parse_line(line)
         except:
             raise_with_tb(
                 ConfigParserError(

--- a/python/spacewalk/server/rhnSQL/__init__.py
+++ b/python/spacewalk/server/rhnSQL/__init__.py
@@ -20,7 +20,7 @@ import sys
 
 from uyuni.common.usix import raise_with_tb
 from spacewalk.common.rhnLog import log_debug
-from spacewalk.common.rhnConfig import CFG, initCFG
+from spacewalk.common.rhnConfig import CFG, initCFG, is_true
 from spacewalk.common.rhnException import rhnException
 from spacewalk.common.rhnTB import add_to_seclist
 
@@ -32,6 +32,7 @@ from . import dbi
 from . import sql_types
 
 types = sql_types
+
 
 # pylint: disable-next=wrong-import-position
 from .const import POSTGRESQL, SUPPORTED_BACKENDS
@@ -130,11 +131,11 @@ def initDB(
             database = CFG.DB_NAME
             username = CFG.DB_USER
             password = CFG.DB_PASSWORD
-            if CFG.DB_SSL_ENABLED:
-                sslmode = "verify-full"
+            if is_true(CFG.DB_SSL_ENABLED) and CFG.DB_HOST != "localhost":
+                sslmode = CFG.DB_SSLMODE or "verify-full"
                 sslrootcert = CFG.DB_SSLROOTCERT
             else:
-                sslmode = None
+                sslmode = "disable"
                 sslrootcert = None
 
     if backend not in SUPPORTED_BACKENDS:

--- a/python/spacewalk/server/rhnSQL/driver_postgresql.py
+++ b/python/spacewalk/server/rhnSQL/driver_postgresql.py
@@ -212,11 +212,17 @@ class Database(sql_base.Database):
             ):
                 dsndata["sslmode"] = self.sslmode
                 dsndata["sslrootcert"] = self.sslrootcert
+            elif self.sslmode == "disable":
+                dsndata["sslmode"] = self.sslmode
             elif self.sslmode is not None:
                 raise AttributeError(
-                    'Only sslmode="verify-full" (or None) is supported.'
+                    'Only sslmode="verify-full" or "disable" (or None) is supported.'
                 )
-            if self.sslmode is not None and self.sslrootcert is None:
+            if (
+                self.sslmode is not None
+                and self.sslmode != "disable"
+                and self.sslrootcert is None
+            ):
                 raise AttributeError(
                     "Attribute sslrootcert needs to be set if sslmode is set."
                 )

--- a/python/spacewalk/spacewalk-backend.changes.nadvornik.sslmode
+++ b/python/spacewalk/spacewalk-backend.changes.nadvornik.sslmode
@@ -1,0 +1,1 @@
+- Use db_ssl_enabled value consistently

--- a/python/uyuni-cobbler-helper/uyuni-cobbler-helper.changes.nadvornik.sslmode
+++ b/python/uyuni-cobbler-helper/uyuni-cobbler-helper.changes.nadvornik.sslmode
@@ -1,0 +1,1 @@
+- Use db_ssl_enabled value consistently

--- a/python/uyuni-cobbler-helper/uyuni_cobbler_helper.py
+++ b/python/uyuni-cobbler-helper/uyuni_cobbler_helper.py
@@ -28,11 +28,18 @@ WHERE T.channel_id = CT.parent_or_self_id
     return result
 
 
+def is_true(val):
+    return str(val).lower() in ("1", "y", "true", "yes", "on")
+
+
 def _connect_db():
     config = configparser.ConfigParser()
     with open("/etc/rhn/rhn.conf", "r", encoding="utf-8") as fd:
         content = "[default]\n" + fd.read()
         config.read_string(content)
+
+    db_ssl_enabled = is_true(config.get("default", "db_ssl_enabled", fallback="0"))
+    sslmode = "verify-full" if db_ssl_enabled else "disable"
 
     # pylint: disable-next=undefined-variable
     return psycopg2.connect(
@@ -41,6 +48,7 @@ def _connect_db():
         password=config.get("default", "db_password"),
         dbname=config.get("default", "db_name"),
         port=int(config.get("default", "db_port")),
+        sslmode=sslmode,
     )
 
 

--- a/schema/spacewalk/spacewalk-sql
+++ b/schema/spacewalk/spacewalk-sql
@@ -8,6 +8,11 @@ use IPC::Open3 ();
 use Getopt::Long ();
 use Cwd 'abs_path';
 
+sub is_true {
+        my $val = shift;
+        return (defined $val and $val =~ /^(1|y|true|yes|on)$/i);
+}
+
 sub usage {
         die "Usage: $0 [-i | [ OPTIONS ] [sql-file-to-use.sql | - ]]\n    where possible OPTIONS are\n        --verbose\n        --reportdb\n        --select-mode or --select-mode-direct\n";
 }
@@ -51,7 +56,7 @@ my %options;
 Spacewalk::Setup::read_config($config_file, \%options);
 
 if ($reportdb) {
-    for my $n (qw( db_backend db_name db_user db_password db_host db_port db_ssl_enabled)) {
+    for my $n (qw( db_backend db_name db_user db_password db_host db_port db_ssl_enabled db_sslmode db_sslrootcert )) {
         $options{$n} = $options{'report_'.$n} if (defined $options{'report_'.$n});
     }
 }
@@ -85,6 +90,14 @@ if ($options{db_backend} eq 'postgresql') {
               push @command, ( '-v', 'ON_ERROR_STOP=ON', '-f', $filename );
       }
       $ENV{PGPASSWORD} = $options{db_password};
+      if (defined $options{db_host} and $options{db_host} eq 'localhost') {
+              $ENV{PGSSLMODE} = 'disable';
+      } elsif (is_true($options{db_ssl_enabled})) {
+              $ENV{PGSSLMODE} = $options{db_sslmode} || 'verify-full';
+              $ENV{PGSSLROOTCERT} = $options{db_sslrootcert} if $options{db_sslrootcert};
+      } else {
+              $ENV{PGSSLMODE} = 'disable';
+      }
       if ($verbose) {
               print STDERR "Running: @command\n";
       }

--- a/schema/spacewalk/susemanager-schema.changes.nadvornik.sslmode
+++ b/schema/spacewalk/susemanager-schema.changes.nadvornik.sslmode
@@ -1,0 +1,1 @@
+- Use db_ssl_enabled value consistently

--- a/search-server/spacewalk-search/spacewalk-search.changes.nadvornik.sslmode
+++ b/search-server/spacewalk-search/spacewalk-search.changes.nadvornik.sslmode
@@ -1,0 +1,1 @@
+- Use db_ssl_enabled value consistently

--- a/search-server/spacewalk-search/src/java/com/redhat/satellite/search/db/DatabaseManager.java
+++ b/search-server/spacewalk-search/src/java/com/redhat/satellite/search/db/DatabaseManager.java
@@ -93,6 +93,8 @@ public class DatabaseManager {
                             trustStore + ". Path can be changed with java.ssl_truststore option.");
                     }
                     System.setProperty("javax.net.ssl.trustStore", trustStore);
+                } else {
+                    connectionUrl += "?ssl=false&sslmode=disable";
                 }
                 overrides.setProperty("db_name", connectionUrl);
             }

--- a/spacewalk/admin/salt-secrets-config.py
+++ b/spacewalk/admin/salt-secrets-config.py
@@ -12,8 +12,7 @@ import yaml
 import hashlib
 
 from contextlib import redirect_stderr
-from spacewalk.common.rhnConfig import cfg_component
-
+from spacewalk.common.rhnConfig import cfg_component, is_true
 
 uyuni_roster_config = {}
 
@@ -34,6 +33,9 @@ if not os.path.isdir(cert_location):
     cert_location = "/etc/pki/ca-trust/source/anchors"
 
 with cfg_component(component=None) as CFG:
+    db_ssl_enabled = is_true(getattr(CFG, "db_ssl_enabled", "0"))
+    sslmode = "verify-full" if db_ssl_enabled else "disable"
+
     mgr_events_config = {
         "engines": [
             {
@@ -44,6 +46,7 @@ with cfg_component(component=None) as CFG:
                         "dbname": CFG.db_name,
                         "user": CFG.db_user,
                         "password": CFG.db_password,
+                        "sslmode": sslmode,
                     },
                     "events": {"thread_pool_size": thread_pool_size},
                 }
@@ -58,6 +61,7 @@ with cfg_component(component=None) as CFG:
             "db": CFG.db_name,
             "user": CFG.db_user,
             "pass": CFG.db_password,
+            "sslmode": sslmode,
         }
     }
 

--- a/spacewalk/admin/spacewalk-admin.changes.nadvornik.sslmode
+++ b/spacewalk/admin/spacewalk-admin.changes.nadvornik.sslmode
@@ -1,0 +1,1 @@
+- Use db_ssl_enabled value consistently

--- a/susemanager-utils/performance/copy-system.py
+++ b/susemanager-utils/performance/copy-system.py
@@ -87,15 +87,13 @@ def do_clone_using_id(cursor, table, columns, key, old, new, converter=None):
         SELECT {}
         FROM {}
         WHERE {} = %s;
-        """.format(
-            columns_str, table, key
-        ),
+        """.format(columns_str, table, key),
         (old,),
     )
     for row in cursor.fetchall():
         # Convert the row values if needed
         if converter:
-            (columns, row) = converter(row)
+            columns, row = converter(row)
 
         cursor.execute(
             # pylint: disable-next=consider-using-f-string
@@ -386,7 +384,7 @@ def clone_rhnvirtualinstance(cursor, name, clone_name, id, new_id):
     )
     columns = ["name", "instance_type", "memory_size", "vcpus", "state"]
     for row in cursor.fetchall():
-        (instance_id, host_id, virtual_id, uuid, confirmed) = row
+        instance_id, host_id, virtual_id, uuid, confirmed = row
         new_instance_id = get_sequence_next_value(cursor, "rhn_vi_id_seq")
         host_id = host_id if host_id != id else new_id
         virtual_id = virtual_id if virtual_id != id else new_id
@@ -506,6 +504,10 @@ def clone(conn, id, name, clone_name, secret_key):
             conn.rollback()
 
 
+def is_true(val):
+    return str(val).lower() in ("1", "y", "true", "yes", "on")
+
+
 @click.command()
 @click.option(
     "-n", "--name", required=True, type=str, help="Name of the system to clone"
@@ -533,8 +535,10 @@ def copy(name, count):
     user = rhn_conf["db_user"]
     password = rhn_conf["db_password"]
     db = rhn_conf["db_name"]
+    db_ssl_enabled = is_true(rhn_conf.get("db_ssl_enabled", "0"))
+    sslmode = "verify-full" if db_ssl_enabled else "disable"
 
-    with connect_db(host, port, user, password, db) as conn:
+    with connect_db(host, port, user, password, db, sslmode=sslmode) as conn:
         with conn:
             cursor = conn.cursor()
             system_id = get_system_id(cursor, name)

--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -117,12 +117,12 @@ class Responder:
         db_config = self.config.get("postgres_db")
         if "port" in db_config:
             # pylint: disable-next=consider-using-f-string
-            conn_string = "dbname='{dbname}' user='{user}' host='{host}' port='{port}' password='{password}'".format(
+            conn_string = "dbname='{dbname}' user='{user}' host='{host}' port='{port}' password='{password}' sslmode='{sslmode}'".format(
                 **db_config
             )
         else:
             # pylint: disable-next=consider-using-f-string
-            conn_string = "dbname='{dbname}' user='{user}' host='{host}' password='{password}'".format(
+            conn_string = "dbname='{dbname}' user='{user}' host='{host}' password='{password}' sslmode='{sslmode}'".format(
                 **db_config
             )
         log.debug("connecting to database")

--- a/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
@@ -92,6 +92,7 @@ def _get_cursor(func):
             "pass": "",
             "db": "susemanager",
             "port": 5432,
+            "sslmode": "disable",
         }
         # pylint: disable-next=undefined-variable
         options.update(__opts__.get("__master_opts__", __opts__).get("postgres", {}))
@@ -101,6 +102,7 @@ def _get_cursor(func):
             password=options["pass"],
             dbname=options["db"],
             port=options["port"],
+            sslmode=options["sslmode"],
         )
 
     # pylint: disable-next=undefined-variable
@@ -217,12 +219,10 @@ def load_global_pillars(cursor, pillar):
     """
     log.debug("Loading global pillars from db")
     # Query for global pillar and extract the formula order
-    cursor.execute(
-        """
+    cursor.execute("""
             SELECT p.pillar
             FROM susesaltpillar AS p
-            WHERE p.server_id is NULL AND p.group_id is NULL AND p.org_id is NULL;"""
-    )
+            WHERE p.server_id is NULL AND p.group_id is NULL AND p.org_id is NULL;""")
     for row in cursor.fetchall():
         pillar = salt.utils.dictupdate.merge(pillar, row[0], strategy="recurse")
     return pillar

--- a/susemanager-utils/susemanager-sls/modules/roster/uyuni.py
+++ b/susemanager-utils/susemanager-sls/modules/roster/uyuni.py
@@ -28,7 +28,6 @@ except ImportError:
 
 from yaml import dump
 
-
 __virtualname__ = "uyuni"
 
 log = logging.getLogger(__name__)
@@ -89,13 +88,13 @@ class UyuniRoster:
 
         if "port" in db_config:
             # pylint: disable-next=consider-using-f-string
-            self.db_connect_str = "dbname='{db}' user='{user}' host='{host}' port='{port}' password='{pass}'".format(
+            self.db_connect_str = "dbname='{db}' user='{user}' host='{host}' port='{port}' password='{pass}' sslmode='{sslmode}'".format(
                 **db_config
             )
         else:
             self.db_connect_str = (
                 # pylint: disable-next=consider-using-f-string
-                "dbname='{db}' user='{user}' host='{host}' password='{pass}'".format(
+                "dbname='{db}' user='{user}' host='{host}' password='{pass}' sslmode='{sslmode}'".format(
                     **db_config
                 )
             )

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.nadvornik.sslmode
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.nadvornik.sslmode
@@ -1,0 +1,1 @@
+- Use db_ssl_enabled value consistently

--- a/susemanager-utils/susemanager-sls/test/test_pillar_suma_minion.py
+++ b/susemanager-utils/susemanager-sls/test/test_pillar_suma_minion.py
@@ -15,7 +15,6 @@ import os
 # pylint: disable-next=wrong-import-position
 import suma_minion
 
-
 suma_minion.__opts__ = {}
 suma_minion.__context__ = {}
 suma_minion.psycopg2 = MagicMock()
@@ -99,6 +98,7 @@ def test_reading_postgres_opts_in__get_cursor():
             "pass": "test_pass",
             "db": "test_db",
             "port": 1234,
+            "sslmode": "disable",
         }
     }
     with patch.object(suma_minion, "__opts__", test_opts), patch(
@@ -112,6 +112,7 @@ def test_reading_postgres_opts_in__get_cursor():
             "password": "test_pass",
             "dbname": "test_db",
             "port": 1234,
+            "sslmode": "disable",
         }
 
     pg_connect_mock.reset_mock()
@@ -127,6 +128,7 @@ def test_reading_postgres_opts_in__get_cursor():
             "password": "test_pass",
             "dbname": "test_db",
             "port": 1234,
+            "sslmode": "disable",
         }
 
 
@@ -142,6 +144,7 @@ def test_using_context_in__get_cursor():
             "pass": "test_pass",
             "db": "test_db",
             "port": 1234,
+            "sslmode": "disable",
         }
     }
     with patch.object(
@@ -159,6 +162,7 @@ def test_using_context_in__get_cursor():
             "password": "test_pass",
             "dbname": "test_db",
             "port": 1234,
+            "sslmode": "disable",
         }
 
         pg_connect_mock.reset_mock()
@@ -173,6 +177,7 @@ def test_using_context_in__get_cursor():
             "password": "test_pass",
             "dbname": "test_db",
             "port": 1234,
+            "sslmode": "disable",
         }
         # pylint: disable-next=unnecessary-negation
         assert not "suma_minion_cnx" in suma_minion.__context__
@@ -191,6 +196,7 @@ def test_using_context_in__get_cursor():
             "password": "test_pass",
             "dbname": "test_db",
             "port": 1234,
+            "sslmode": "disable",
         }
 
         pg_connect_mock.reset_mock()
@@ -231,4 +237,5 @@ def test_using_context_in__get_cursor():
             "password": "test_pass",
             "dbname": "test_db",
             "port": 1234,
+            "sslmode": "disable",
         }

--- a/web/modules/rhn/RHN/DBI.pm
+++ b/web/modules/rhn/RHN/DBI.pm
@@ -34,6 +34,11 @@ my %DEFAULT_ATTRIBUTES = (
 # /etc/rhn/rhn.conf. It will get the configuration values once
 # and use them for subsequent calls.
 my ($DSN, $LOGIN, $PASSWORD);
+sub is_true {
+        my $val = shift;
+        return (defined $val and $val =~ /^(1|y|true|yes|on)$/i);
+}
+
 sub _get_dbi_connect_parameters {
         if (not defined $DSN) {
                 my $backend = PXT::Config->get("db_backend");
@@ -54,9 +59,12 @@ sub _get_dbi_connect_parameters {
                                 if (defined $port and $port ne '' and $port ne '5432') {
                                         $DSN .= ";port=$port";
                                 }
-                                if (PXT::Config->get("db_ssl_enabled")) {
+                                if (is_true(PXT::Config->get("db_ssl_enabled"))) {
                                         $DSN .= ";sslmode=verify-full";
                                         $DSN .= ";sslrootcert=" . PXT::Config->get("db_sslrootcert");
+                                }
+                                else {
+                                        $DSN .= ";sslmode=disable";
                                 }
                         }
                 }

--- a/web/spacewalk-web.changes.nadvornik.sslmode
+++ b/web/spacewalk-web.changes.nadvornik.sslmode
@@ -1,0 +1,1 @@
+- Use db_ssl_enabled value consistently


### PR DESCRIPTION
## What does this PR change?

Use db_ssl_enabled consistently across java, python and perl.
`true` means ssl mode `verify-full` and `false` means ssl mode `disabled`

Without this PR, `db_ssl_enabled = false` did a fallback to the postgres default, which tried first ssl and then non-ssl connection. This caused confusing ssl-related warnings in the logs.

It fixes this warning from salt master log
```
2026-05-25 19:10:07,973 [salt.loaded.ext.engines.mgr_events:300 ][ERROR   ][5541] Error while inserting data to the table: SSL connection has been closed unexpectedly

2026-05-25 19:10:07,973 [salt.loaded.ext.engines.mgr_events:300 ][ERROR   ][5541] Error commiting: connection already closed
2026-05-25 19:10:08,974 [salt.loaded.ext.engines.mgr_events:300 ][ERROR   ][5541] Diconnected from database. Trying to reconnect...
```
And this from postgres log
```
May 25 13:13:19 server uyuni-db[5313]: 2026-05-25 11:13:19.392 UTC susemanager spacewalk [292]LOG:  SSL error: unexpected eof while reading
May 25 13:13:19 server uyuni-db[5313]: 2026-05-25 11:13:19.392 UTC susemanager spacewalk [292]LOG:  could not receive data from client: Connection reset by peer
```

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: fix

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): related to https://github.com/SUSE/spacewalk/issues/30434
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"  
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
