### PR TITLE
Allow "uyuni-config-files" to handle lua scriptlets

### DIFF
--- a/containers/server-image/root/usr/bin/uyuni-configfiles-sync
+++ b/containers/server-image/root/usr/bin/uyuni-configfiles-sync
@@ -219,32 +219,55 @@ sync() {
     cp $DEFAULTS_STORAGE/.buildhash $SYSCONFIG_FILE
 }
 
+execute_scriptslet_stage() {
+    PKG=$1
+    STAGE=$2
+    ARG=$3
+
+    # Query the script content and the requested interpreter
+    SCRIPT=$(rpm -q --qf "%{${STAGE}}" "$PKG")
+    PROG=$(rpm -q --qf "%{${STAGE}PROG}" "$PKG")
+
+    if [ "$SCRIPT" = "(none)" ] || [ -z "$SCRIPT" ]; then
+        # If there is no script, do nothing
+        return
+    fi
+
+    if [ "$PROG" = "(none)" ] || [ -z "$PROG" ]; then
+        # Fallback to /bin/sh if PROG is missing
+        PROG="/bin/sh"
+    fi
+
+    echo "    -> Executing $STAGE using $PROG"
+
+    # Write script to a temporary file to mimic native RPM behavior
+    TMPFILE=$(mktemp)
+    echo "$SCRIPT" > "$TMPFILE"
+    chmod +x "$TMPFILE"
+
+    if [ "$PROG" = "<lua>" ]; then
+        # For <lua> use the rpm %{lua: dofile() }
+        DISABLE_RESTART_ON_UPDATE=1 rpm --eval "%{lua: arg={'$ARG'}; dofile('$TMPFILE') }"
+    else
+        # Execute on standard interpreters (/bin/sh, bash, python, etc.)
+        DISABLE_RESTART_ON_UPDATE=1 $PROG "$TMPFILE" "$ARG"
+    fi
+
+    rm -f "$TMPFILE"
+}
+
 run_scripts() {
     PACKAGE_NAMES=$1
     for PKG in $PACKAGE_NAMES; do
         echo "  * Running scripts for $PKG ..."
+
         # RPM scriptlets ordering:
         # https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#ordering
-        PREIN_SCRIPT=$(rpm -q --qf "%{PREIN}" $PKG)
-        if [ ! "$PREIN_SCRIPT" = "(none)" ]; then
-            echo "$PREIN_SCRIPT" | DISABLE_RESTART_ON_UPDATE=1 sh -s -- 2
-        fi
-        POSTIN_SCRIPT=$(rpm -q --qf "%{POSTIN}" $PKG)
-        if [ ! "$POSTIN_SCRIPT" = "(none)" ]; then
-            echo "$POSTIN_SCRIPT" | DISABLE_RESTART_ON_UPDATE=1 sh -s -- 2
-        fi
-        PREUN_SCRIPT=$(rpm -q --qf "%{PREUN}" $PKG)
-        if [ ! "$PREUN_SCRIPT" = "(none)" ]; then
-            echo "$PREUN_SCRIPT" | DISABLE_RESTART_ON_UPDATE=1 sh -s -- 1
-        fi
-        POSTUN_SCRIPT=$(rpm -q --qf "%{POSTUN}" $PKG)
-        if [ ! "$POSTUN_SCRIPT" = "(none)" ]; then
-            echo "$POSTUN_SCRIPT" | DISABLE_RESTART_ON_UPDATE=1 sh -s -- 1
-        fi
-        POSTTRANS_SCRIPT=$(rpm -q --qf "%{POSTTRANS}" $PKG)
-        if [ ! "$POSTTRANS_SCRIPT" = "(none)" ]; then
-            echo "$POSTTRANS_SCRIPT" | DISABLE_RESTART_ON_UPDATE=1 sh -s -- 2
-        fi
+        execute_scriptslet_stage "$PKG" PREIN 2
+        execute_scriptslet_stage "$PKG" POSTIN 2
+        execute_scriptslet_stage "$PKG" PREUN 1
+        execute_scriptslet_stage "$PKG" POSTUN 1
+        execute_scriptslet_stage "$PKG" POSTTRANS 2
     done
 }
 

--- a/containers/server-image/server-image.changes.meaksh.master-fix-uyuni-config-files-with-lua
+++ b/containers/server-image/server-image.changes.meaksh.master-fix-uyuni-config-files-with-lua
@@ -1,0 +1,1 @@
+- Allow uyuni-config-files to handle lua scriptlets


### PR DESCRIPTION
## What does this PR change?

This PR makes `uyuni-config-files` tool to support running scriptlets with other interpreters than `/bin/sh`, which solves an issue we see currently on the `server-image` when running on top of openSUSE Leap 16.0:

```
uyuni-update-config[687]: Updating /etc/sysconfig/billing-data-service ...
uyuni-update-config[687]:   * Running scripts for cobbler-3.3.3-260400.17.1.uyuni6.noarch ...
uyuni-update-config[687]:   * Running scripts for filesystem-84.87-160000.2.2.x86_64 ...
uyuni-update-config[687]: sh: line 1: needmigrate: command not found
uyuni-update-config[687]: sh: line 2: local: can only be used in a function
uyuni-update-config[687]: sh: line 3: /sbin,: No such file or directory 
uyuni-update-config[687]: sh: line 4: /lib64,: No such file or directory
uyuni-update-config[687]: sh: line 5: /lib: Is a directory
uyuni-update-config[687]: sh: line 6: syntax error near unexpected token `(' 
uyuni-update-config[687]: sh: line 6: `for i in pairs(dirs) do'
uyuni-update-config[687]: Failed to synchronize files to persistent volumes. Aborting!
``` 

This issue is caused as `filesystem` package provides scriptlets to be executed by `<lua>` , which refers to `rpmlua` interpreter (in modern RPM versions) or alternatively the `%{lua: dofile() }` macro.

With the proposed fix, the `uyuni-config-files` tool will check first which `PROG` to use for running a particular scriptlet. Then use it to run the scripts.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
