### PR TITLE
Fix mainframe foreign systems showing wrong OS (bsc#1260342)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/core/src/main/java/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -456,13 +456,8 @@ public class HardwareMapper {
         return true;
     }
 
-    /**
-     * Map mainframe sysinfo to the database.
-     *
-     * @param readValuesOutput mainframe sysinfo as returned by mainframesysinfo.read_values
-     */
-    public void mapSysinfo(String readValuesOutput) {
-        String cpuarch = getCpuArch();
+    //package-protected
+    Map<String, String> getSysValuesMap(String readValuesOutput) {
         Map<String, String> sysvalues = new HashMap<>();
         for (String line : readValuesOutput.split("\\r?\\n")) {
             if (!line.contains(":")) {
@@ -473,6 +468,27 @@ public class HardwareMapper {
                 sysvalues.put(StringUtils.trim(split[0]), StringUtils.trim(split[1]));
             }
         }
+        return sysvalues;
+    }
+
+    //package-protected
+    String computeOsStringForS390Arch(Map<String, String> sysvalues) {
+        String osString = sysvalues.entrySet().stream()
+                .filter(e -> e.getKey().toLowerCase().contains("control program"))
+                .map(Map.Entry::getValue)
+                .findFirst().orElse("z/VM");
+        int index = osString.indexOf(" ");
+        return index > 0 ? osString.substring(0, index) : osString;
+    }
+
+    /**
+     * Map mainframe sysinfo to the database.
+     *
+     * @param readValuesOutput mainframe sysinfo as returned by mainframesysinfo.read_values
+     */
+    public void mapSysinfo(String readValuesOutput) {
+        String cpuarch = getCpuArch();
+        Map<String, String> sysvalues = getSysValuesMap(readValuesOutput);
 
         // original code: hardware.py get_sysinfo()
         if (StringUtils.isNotBlank(sysvalues.get("Sequence Code")) &&
@@ -483,7 +499,8 @@ public class HardwareMapper {
             // where this system is running on
 
             String identifier = String.format("Z-%s", sysvalues.get("Sequence Code"));
-            String os = "z/OS";
+            String os = computeOsStringForS390Arch(sysvalues);
+
             String name = String.format("IBM Mainframe %s %s", sysvalues.get("Type"),
                     sysvalues.get("Sequence Code"));
             long totalIfls = 0L;

--- a/java/core/src/main/java/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/core/src/main/java/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -481,6 +481,25 @@ public class HardwareMapper {
         return index > 0 ? osString.substring(0, index) : osString;
     }
 
+    //package-protected
+    String getS390ServerFamily(String type) {
+        // z17, z16, z15: https://www.ibm.com/docs/en/zos/3.1.0?topic=system-identifying-server-requirements
+        // other codes: https://www.ibm.com/support/pages/processor-version-codes-and-srm-constants
+
+        return switch (type) {
+            case "9175" -> "z17";
+            case "3931", "3932" -> "z16";
+            case "8561", "8562" -> "z15";
+            case "3906", "3907" -> "z14";
+            case "2964", "2965" -> "z13";
+            case "2827", "2828" -> "z12";
+            case "2817", "2818" -> "zEnterprise 114";
+            case "2097", "2098" -> "z10";
+            case "2094", "2096" -> "z9";
+            default -> "";
+        };
+    }
+
     /**
      * Map mainframe sysinfo to the database.
      *
@@ -500,8 +519,11 @@ public class HardwareMapper {
 
             String identifier = String.format("Z-%s", sysvalues.get("Sequence Code"));
             String os = computeOsStringForS390Arch(sysvalues);
+            String type = sysvalues.get("Type");
 
-            String name = String.format("IBM Mainframe %s %s", sysvalues.get("Type"),
+            String name = String.format("IBM Mainframe %s %s %s",
+                    getS390ServerFamily(type),
+                    type,
                     sysvalues.get("Sequence Code"));
             long totalIfls = 0L;
             try {
@@ -510,7 +532,6 @@ public class HardwareMapper {
             catch (NumberFormatException e) {
                 LOG.warn("Invalid 'CPUs Total' value: {}", e.getMessage());
             }
-            String type = sysvalues.get("Type");
 
             // register the info about the S390 host in the db
 
@@ -533,7 +554,7 @@ public class HardwareMapper {
                         String.format("Initial Registration Parameters:\n" +
                                 "OS: %s\n" +
                                 "Release: %s\n" +
-                                "CPU Arch: %s", os, sysvalues.get("Type"), cpuarch));
+                                "CPU Arch: %s", os, type, cpuarch));
 
                 zhost.setDigitalServerId(identifier);
                 zhost.setOrg(OrgFactory.getSatelliteOrg()); // OLDTODO clarify this

--- a/java/core/src/test/java/com/suse/manager/reactor/hardware/HardwareMapperTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/hardware/HardwareMapperTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.reactor.hardware;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.MinionServerFactoryTest;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+
+import com.suse.manager.reactor.utils.ValueMap;
+import com.suse.manager.webui.services.SaltGrains;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+
+public class HardwareMapperTest extends BaseTestCaseWithUser {
+
+    // the salt state hardware/profileupdate.sls runs the module mainframesysinfo.read_values whose implementation,
+    // in turn, gets the results of "/usr/bin/read_values -s" or, alternatively of "cat /proc/sysinfo"
+    // the following simulated strings come from the salt state response:
+    //
+    //"module_|-mainframe-sysinfo_|-mainframesysinfo.read_values_|-run": {
+    //    "changes": {
+    //        "ret": [SIMULATED STRING]
+
+    private static final String SERVER_1_DIGITAL_SERVER_ID = "Z-0000000000061A23";
+
+    // usr/bin/read_values -s
+    private static final String SERVER_1_STATE_CHANGES_RET_READ_VALUES =
+            """
+            Version: 1.0.0\n
+            Type: 2827\n
+            Sequence Code: 0000000000061A23\n
+            CPUs Total: 45\n
+            CPUs IFL: 45\n
+            LPAR Number: 10\n
+            LPAR Name: LPA\n
+            LPAR Characteristics: Shared\n
+            LPAR CPUs Total: 6\n
+            LPAR CPUs IFL: 6\n
+            VM00 Name: LINUX123\n
+            VM00 Control Program: z/VM    6.3.0   \n
+            VM00 CPUs Total: 1\n
+            VM00 IFLs: 1
+            """;
+
+
+    private static final String SERVER_2_DIGITAL_SERVER_ID = "Z-00000000000612A3";
+
+    // cat /proc/sysinfo
+    private static final String SERVER_2_STATE_CHANGES_RET_PROC_SYSINFO =
+            """
+            Manufacturer:         IBM\n
+            Type:                 8561\n
+            LIC Identifier:       012345ab6789012c\n
+            Model:                400              LT1\n
+            Sequence Code:        00000000000612A3\n
+            Plant:                02\n
+            Model Capacity:       400              00000000\n
+            Capacity Adj. Ind.:   100\n
+            Capacity Ch. Reason:  0\n
+            Capacity Transient:   0\n
+            Type 1 Percentage:    0\n
+            Type 2 Percentage:    0\n
+            Type 3 Percentage:    0\n
+            Type 4 Percentage:    0\n
+            Type 5 Percentage:    0\n
+            \n
+            CPUs Total:           71\n
+            CPUs Configured:      0\n
+            CPUs Standby:         0\n
+            CPUs Reserved:        71\n
+            CPUs G-MTID:          0\n
+            CPUs S-MTID:          1\n
+            Capability:           3085\n
+            Nominal Capability:   3085\n
+            Secondary Capability: 416\n
+            Adjustment 02-way:    62750\n
+            Adjustment 70-way:    46037\n
+            Adjustment 71-way:    46037\n
+            \n
+            LPAR Number:          65\n
+            LPAR Characteristics: Shared\n
+            LPAR Name:            ZL41\n
+            LPAR Adjustment:      28\n
+            LPAR CPUs Total:      2\n
+            LPAR CPUs Configured: 2\n
+            LPAR CPUs Standby:    0\n
+            LPAR CPUs Reserved:   0\n
+            LPAR CPUs Dedicated:  0\n
+            LPAR CPUs Shared:     2\n
+            LPAR CPUs G-MTID:     0\n
+            LPAR CPUs S-MTID:     1\n
+            LPAR CPUs PS-MTID:    0\n
+            \n
+            VM00 Name:            DUMMYSRV\n
+            VM00 Control Program: z/VM    7.4.0\n
+            VM00 Adjustment:      500\n
+            VM00 CPUs Total:      1\n
+            VM00 CPUs Configured: 1\n
+            VM00 CPUs Standby:    0\n
+            VM00 CPUs Reserved:   0\n
+            """;
+
+    private static final String SERVER_3_DIGITAL_SERVER_ID = "Z-00000000000987F6";
+
+    // usr/bin/read_values -s
+    private static final String SERVER_3_STATE_CHANGES_RET_READ_VALUES =
+            """
+            Version: 1.0.6\n
+            Type : 3932\n
+            Type Name : IBM z16 AGZ\n
+            Sequence Code : 00000000000987F6\n
+            LPAR Number : 21\n
+            LPAR Name : GHI1LM23\n
+            LPAR Characteristics : Shared\n
+            LPAR CPUs Total : 16\n
+            LPAR CPUs IFL : 16\n
+            VM00 Name : k8s_9ab8\n
+            VM00 Control Program : KVM/Linux\n
+            VM00 CPUs Total : 1\n
+            VM00 IFLs : 1\n
+            """;
+
+    // cat /proc/sysinfo
+    private static final String SERVER_3_STATE_CHANGES_RET_PROC_SYSINFO =
+            """
+            Manufacturer:         IBM            \n
+            Type:                 3932\n
+            LIC Identifier:       012345ab678c90d1\n
+            Model:                A00              AGZ            \n
+            Sequence Code:        00000000000987F6\n
+            Plant:                02 \n
+            Model Capacity:       A00              00000000\n
+            Capacity Adj. Ind.:   100\n
+            Capacity Ch. Reason:  0\n
+            Capacity Transient:   0\n
+            Type 1 Percentage:    0\n
+            Type 2 Percentage:    0\n
+            Type 3 Percentage:    0\n
+            Type 4 Percentage:    0\n
+            Type 5 Percentage:    0\n
+            \n
+            CPUs Total:           68\n
+            CPUs Configured:      0\n
+            CPUs Standby:         0\n
+            CPUs Reserved:        68\n
+            CPUs G-MTID:          0\n
+            CPUs S-MTID:          1\n
+            Capability:           7992\n
+            Nominal Capability:   7992\n
+            Secondary Capability: 425\n
+            Adjustment 02-way:    62422\n
+            Adjustment 67-way:    57815\n
+            Adjustment 68-way:    57815\n
+            \n
+            LPAR Number:          21\n
+            LPAR Characteristics: Shared\s\n
+            LPAR Name:            XYZ1AB23\n
+            LPAR Adjustment:      235\n
+            LPAR CPUs Total:      16\n
+            LPAR CPUs Configured: 16\n
+            LPAR CPUs Standby:    0\n
+            LPAR CPUs Reserved:   0\n
+            LPAR CPUs Dedicated:  0\n
+            LPAR CPUs Shared:     16\n
+            LPAR CPUs G-MTID:     0\n
+            LPAR CPUs S-MTID:     1\n
+            LPAR CPUs PS-MTID:    1\n
+            LPAR Extended Name:  \s\n
+            LPAR UUID:            01a2b345-67cd-89e0-1f23-456789012345\n
+            \n
+            VM00 Name:            k8s_9ab8\n
+            VM00 Control Program: KVM/Linux      \s\n
+            VM00 Adjustment:      1000\n
+            VM00 CPUs Total:      1\n
+            VM00 CPUs Configured: 1\n
+            VM00 CPUs Standby:    0\n
+            VM00 CPUs Reserved:   0\n
+            VM00 Extended Name:   k8s_101a2b345101a2b345101a2b345101a2_67cd_89e01f23-4567-8901-2345-89e01f23dc4f\n
+            VM00 UUID:            01a2b345-67cd-89e0-1f23-456789012345\n
+            """;
+
+    private HardwareMapper createTestS390HwMapper() {
+        MinionServer testMinionServer = MinionServerFactoryTest.createTestMinionServer(user);
+        Map<String, String> grains = new HashMap<>() {{
+            put(SaltGrains.CPUARCH.getValue(), "s390x");
+        }};
+        return new HardwareMapper(testMinionServer, new ValueMap(grains));
+    }
+
+    private void assertHostOsString(String expectedOsString, String digitalServerId) {
+        Server zHost = ServerFactory.lookupForeignSystemByDigitalServerId(digitalServerId);
+        assertEquals(expectedOsString, zHost.getOs());
+    }
+
+    private void assertComputeOsString(String expectedOsString, HardwareMapper hwMapper, String readValuesOutput) {
+        Map<String, String> sysValues = hwMapper.getSysValuesMap(readValuesOutput);
+        String os = hwMapper.computeOsStringForS390Arch(sysValues);
+        assertEquals(expectedOsString, os);
+    }
+
+
+    private static Stream<Arguments> allServersInfo() {
+        return Stream.of(
+                Arguments.of("z/VM", SERVER_1_DIGITAL_SERVER_ID, SERVER_1_STATE_CHANGES_RET_READ_VALUES),
+                Arguments.of("z/VM", SERVER_2_DIGITAL_SERVER_ID, SERVER_2_STATE_CHANGES_RET_PROC_SYSINFO),
+                Arguments.of("KVM/Linux", SERVER_3_DIGITAL_SERVER_ID, SERVER_3_STATE_CHANGES_RET_READ_VALUES),
+                Arguments.of("KVM/Linux", SERVER_3_DIGITAL_SERVER_ID, SERVER_3_STATE_CHANGES_RET_PROC_SYSINFO)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("allServersInfo")
+    @DisplayName("mapSysinfo correctly showing OS value on s390 hypervisors")
+    public void mapSysinfoShowingCorrectValues(String expectedOsString, String digitalServerId,
+                                                           String readValuesOutput) {
+        HardwareMapper hwMapper = createTestS390HwMapper();
+        assertNull(ServerFactory.lookupForeignSystemByDigitalServerId(digitalServerId));
+
+        hwMapper.mapSysinfo(readValuesOutput);
+
+        assertNotNull(ServerFactory.lookupForeignSystemByDigitalServerId(digitalServerId));
+        assertComputeOsString(expectedOsString, hwMapper, readValuesOutput);
+        assertHostOsString(expectedOsString, digitalServerId);
+    }
+
+}

--- a/java/core/src/test/java/com/suse/manager/reactor/hardware/HardwareMapperTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/hardware/HardwareMapperTest.java
@@ -220,29 +220,48 @@ public class HardwareMapperTest extends BaseTestCaseWithUser {
         assertEquals(expectedOsString, os);
     }
 
+    private void assertHostS390ServerFamily(String expectedS390ServerFamily, HardwareMapper hwMapper,
+                                            String readValuesOutput, String digitalServerId) {
+        hwMapper.mapSysinfo(readValuesOutput);
+        Server zHost = ServerFactory.lookupForeignSystemByDigitalServerId(digitalServerId);
+        assertEquals(expectedS390ServerFamily, zHost.getName());
+    }
+
+    private void assertComputeS390ServerFamily(String expectedS390ServerFamily, HardwareMapper hwMapper,
+                                               String readValuesOutput) {
+        Map<String, String> sysValues = hwMapper.getSysValuesMap(readValuesOutput);
+        assertEquals(expectedS390ServerFamily, hwMapper.getS390ServerFamily(sysValues.get("Type")));
+    }
 
     private static Stream<Arguments> allServersInfo() {
         return Stream.of(
-                Arguments.of("z/VM", SERVER_1_DIGITAL_SERVER_ID, SERVER_1_STATE_CHANGES_RET_READ_VALUES),
-                Arguments.of("z/VM", SERVER_2_DIGITAL_SERVER_ID, SERVER_2_STATE_CHANGES_RET_PROC_SYSINFO),
-                Arguments.of("KVM/Linux", SERVER_3_DIGITAL_SERVER_ID, SERVER_3_STATE_CHANGES_RET_READ_VALUES),
-                Arguments.of("KVM/Linux", SERVER_3_DIGITAL_SERVER_ID, SERVER_3_STATE_CHANGES_RET_PROC_SYSINFO)
+                Arguments.of("z/VM", "z12", "IBM Mainframe z12 2827 0000000000061A23",
+                        SERVER_1_DIGITAL_SERVER_ID, SERVER_1_STATE_CHANGES_RET_READ_VALUES),
+                Arguments.of("z/VM", "z15", "IBM Mainframe z15 8561 00000000000612A3",
+                        SERVER_2_DIGITAL_SERVER_ID, SERVER_2_STATE_CHANGES_RET_PROC_SYSINFO),
+                Arguments.of("KVM/Linux", "z16", "IBM Mainframe z16 3932 00000000000987F6",
+                        SERVER_3_DIGITAL_SERVER_ID, SERVER_3_STATE_CHANGES_RET_READ_VALUES),
+                Arguments.of("KVM/Linux", "z16", "IBM Mainframe z16 3932 00000000000987F6",
+                        SERVER_3_DIGITAL_SERVER_ID, SERVER_3_STATE_CHANGES_RET_PROC_SYSINFO)
         );
     }
 
     @ParameterizedTest
     @MethodSource("allServersInfo")
     @DisplayName("mapSysinfo correctly showing OS value on s390 hypervisors")
-    public void mapSysinfoShowingCorrectValues(String expectedOsString, String digitalServerId,
-                                                           String readValuesOutput) {
+    public void mapSysinfoShowingCorrectValues(String expectedOs, String expectedFamily, String expectedName,
+                                               String digitalServerId, String readValuesOutput) {
         HardwareMapper hwMapper = createTestS390HwMapper();
         assertNull(ServerFactory.lookupForeignSystemByDigitalServerId(digitalServerId));
 
         hwMapper.mapSysinfo(readValuesOutput);
 
         assertNotNull(ServerFactory.lookupForeignSystemByDigitalServerId(digitalServerId));
-        assertComputeOsString(expectedOsString, hwMapper, readValuesOutput);
-        assertHostOsString(expectedOsString, digitalServerId);
+        assertComputeOsString(expectedOs, hwMapper, readValuesOutput);
+        assertHostOsString(expectedOs, digitalServerId);
+
+        assertComputeS390ServerFamily(expectedFamily, hwMapper, readValuesOutput);
+        assertHostS390ServerFamily(expectedName, hwMapper, readValuesOutput, digitalServerId);
     }
 
 }

--- a/java/core/src/test/java/com/suse/manager/reactor/messaging/JobReturnEventMessageActionTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/messaging/JobReturnEventMessageActionTest.java
@@ -1133,7 +1133,10 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
             assertNotNull(server.getVirtualInstance());
             assertNotNull(server.getVirtualInstance().getHostSystem());
             assertEquals("z/VM", server.getVirtualInstance().getHostSystem().getOs());
-            assertEquals("IBM Mainframe 2827 0000000000069A27", server.getVirtualInstance().getHostSystem().getName());
+
+            assertEquals("IBM Mainframe z12 2827 0000000000069A27",
+                    server.getVirtualInstance().getHostSystem().getName());
+
             assertEquals(Long.valueOf(45), server.getVirtualInstance().getHostSystem().getCpu().getNrCPU());
             assertEquals(Long.valueOf(45), server.getVirtualInstance().getHostSystem().getCpu().getNrsocket());
 

--- a/java/core/src/test/java/com/suse/manager/reactor/messaging/JobReturnEventMessageActionTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/messaging/JobReturnEventMessageActionTest.java
@@ -1132,7 +1132,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
             assertNotNull(server.getVirtualInstance());
             assertNotNull(server.getVirtualInstance().getHostSystem());
-            assertEquals("z/OS", server.getVirtualInstance().getHostSystem().getOs());
+            assertEquals("z/VM", server.getVirtualInstance().getHostSystem().getOs());
             assertEquals("IBM Mainframe 2827 0000000000069A27", server.getVirtualInstance().getHostSystem().getName());
             assertEquals(Long.valueOf(45), server.getVirtualInstance().getHostSystem().getCpu().getNrCPU());
             assertEquals(Long.valueOf(45), server.getVirtualInstance().getHostSystem().getCpu().getNrsocket());

--- a/java/spacewalk-java.changes.carlo.uyuni-1260342-mainframe-foreign-wrong-os
+++ b/java/spacewalk-java.changes.carlo.uyuni-1260342-mainframe-foreign-wrong-os
@@ -1,0 +1,1 @@
+- Fix mainframe foreign systems showing wrong OS (bsc#1260342)


### PR DESCRIPTION
## What does this PR change?

When onboarding a minion that is a VM running on a foreign system, the foreign system itself shows the wrong detail about the OS (z/OS) that should be either z/VM (z/VM case) or Linux (KVM case).


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
Before:
<img width="933" height="44" alt="before" src="https://github.com/user-attachments/assets/1b8c697d-bc48-469e-8571-5b600de7d047" />

After:
<img width="934" height="46" alt="after" src="https://github.com/user-attachments/assets/730c3d76-f8cf-4a11-8cf1-5a03e938cff4" />

- [x] **DONE**

## Documentation
- No documentation needed: OS needs no translation
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30572
Port(s): 5.1: https://github.com/SUSE/spacewalk/pull/31092
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

