### PR TITLE
Fix /html error when looking for text

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -945,6 +945,7 @@ Then(/^I click on the filter button until page does not contain "([^"]*)" text$/
            Selenium::WebDriver::Error::StaleElementReferenceError,
            Selenium::WebDriver::Error::NoSuchElementError,
            NoMethodError
+
       # page mid-navigation, retry
     end
   end
@@ -961,6 +962,7 @@ Then(/^I click on the filter button until page does contain "([^"]*)" text$/) do
            Selenium::WebDriver::Error::StaleElementReferenceError,
            Selenium::WebDriver::Error::NoSuchElementError,
            NoMethodError
+
       # page mid-navigation, retry
     end
   end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -714,27 +714,23 @@ end
 # Test for text in a snippet textarea
 #
 Then(/^I should see "([^"]*)" in the textarea$/) do |text|
-  within('textarea') do
-    raise ScriptError, "Text '#{text}' not found" unless check_text?(text)
-  end
+  content = find('textarea').value.to_s
+  raise ScriptError, "Text '#{text}' not found" unless content.include?(text)
 end
 
 Then(/^I should see "([^"]*)" or "([^"]*)" in the textarea$/) do |text1, text2|
-  within('textarea') do
-    raise ScriptError, "Text '#{text1}' and '#{text2}' not found" unless check_text?(text1, text2: text2)
-  end
+  content = find('textarea').value.to_s
+  raise ScriptError, "Text '#{text1}' and '#{text2}' not found" unless content.include?(text1) || content.include?(text2)
 end
 
 Then(/^I should see "([^"]*)" in the ([^ ]+) textarea$/) do |text, id|
-  within(:xpath, ".//textarea[@data-testid='#{id}']") do
-    raise ScriptError, "Text '#{text}' not found" unless check_text?(text)
-  end
+  content = find(:xpath, ".//textarea[@data-testid='#{id}']").value.to_s
+  raise ScriptError, "Text '#{text}' not found" unless content.include?(text)
 end
 
 Then(/^I should see "([^"]*)" or "([^"]*)" in the ([^ ]+) textarea$/) do |text1, text2, id|
-  within(:xpath, ".//textarea[@data-testid='#{id}']") do
-    raise ScriptError, "Text '#{text1}' and '#{text2}' not found" unless check_text?(text1, text2: text2)
-  end
+  content = find(:xpath, ".//textarea[@data-testid='#{id}']").value.to_s
+  raise ScriptError, "Text '#{text1}' and '#{text2}' not found" unless content.include?(text1) || content.include?(text2)
 end
 
 #
@@ -942,8 +938,15 @@ Then(/^I click on the filter button until page does not contain "([^"]*)" text$/
   repeat_until_timeout(message: "'#{text}' still found") do
     break unless check_text?(text)
 
-    find('button.spacewalk-button-filter').click
-    has_text?('is filtered', wait: 10)
+    begin
+      find('button.spacewalk-button-filter').click
+      check_text?('is filtered')
+    rescue Capybara::ElementNotFound,
+           Selenium::WebDriver::Error::StaleElementReferenceError,
+           Selenium::WebDriver::Error::NoSuchElementError,
+           NoMethodError
+      # page mid-navigation, retry
+    end
   end
 end
 
@@ -951,8 +954,15 @@ Then(/^I click on the filter button until page does contain "([^"]*)" text$/) do
   repeat_until_timeout(message: "'#{text}' was not found") do
     break if check_text?(text)
 
-    find('button.spacewalk-button-filter').click
-    has_text?('is filtered', wait: 10)
+    begin
+      find('button.spacewalk-button-filter').click
+      check_text?('is filtered')
+    rescue Capybara::ElementNotFound,
+           Selenium::WebDriver::Error::StaleElementReferenceError,
+           Selenium::WebDriver::Error::NoSuchElementError,
+           NoMethodError
+      # page mid-navigation, retry
+    end
   end
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -122,9 +122,28 @@ end
 # @param timeout [Integer] The maximum time to wait for the text to become visible (default: Capybara.default_max_wait_time).
 # @return [Boolean] Returns true if the text is visible, false otherwise.
 def check_text?(text1, text2: nil, timeout: Capybara.default_max_wait_time)
-  raise ScriptError, 'BUG DETECTED! Internal Server Error' if has_text?('Internal Server Error', wait: 0)
+  # WORKAROUND: Chrome 134+ raises Capybara::ElementNotFound, StaleElementReferenceError, or
+  # NoMethodError (CDP response type mismatch) during page navigation, bypassing Capybara's
+  # synchronize() retry mechanism. All three are caught and retried. All other exceptions still
+  # propagate. When text is stably absent, return false immediately so the page remains in a
+  # settled state (allowing screenshots on failure).
+  repeat_until_timeout(timeout: timeout) do
+    begin
+      return true if has_text?(text1, wait: timeout)
+      return true if !text2.nil? && has_text?(text2, wait: timeout)
 
-  has_text?(text1, wait: timeout) || (!text2.nil? && has_text?(text2, wait: timeout))
+      return false # text not found, page was stable - exit without looping
+    rescue Capybara::ElementNotFound,
+           Selenium::WebDriver::Error::StaleElementReferenceError,
+           Selenium::WebDriver::Error::NoSuchElementError,
+           NoMethodError
+      # page mid-navigation, let it settle and retry
+      sleep 2
+    end
+  end
+  false
+rescue Timeout::Error
+  false
 end
 
 # Formats the detail message with optional last result and report result.

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -137,6 +137,7 @@ def check_text?(text1, text2: nil, timeout: Capybara.default_max_wait_time)
            Selenium::WebDriver::Error::StaleElementReferenceError,
            Selenium::WebDriver::Error::NoSuchElementError,
            NoMethodError
+
       # page mid-navigation, let it settle and retry
       sleep 2
     end


### PR DESCRIPTION
## What does this PR change?

### Problem

Chrome 134+ introduced a breaking change in its CDP (Chrome DevTools Protocol) implementation: during page navigation, it returns unexpected response types that bypass Capybara's internal synchronize() retry mechanism. This causes has_text? and find() to raise exceptions instead of waiting and retrying:
  - Capybara::ElementNotFound — element lookup during navigation
  - Selenium::WebDriver::Error::StaleElementReferenceError — element became detached mid-navigation
  - Selenium::WebDriver::Error::NoSuchElementError — raw WebDriver-level element not found
  - NoMethodError: undefined method 'map' for String — CDP response type mismatch in find()

These caused intermittent step failures with missing screenshots, as the exceptions propagated before the page had settled.

### Changes

 1. check_text? rewrite (commonlib.rb)

The previous implementation called has_text? directly with no protection against navigation-phase exceptions. The new implementation wraps the check in repeat_until_timeout and catches all four known Chrome 134+ exception forms. Key design decisions:

  - Exits immediately when text is stably absent (return false after has_text? returns false) — avoids spinning the full timeout when the page is settled and the text simply isn't there. This keeps screenshots working: the page state is stable when the ScriptError fires.
  - Retries only on navigation exceptions — all other exceptions still propagate normally.
  - Removed the Internal Server Error check — this side-effect in a boolean helper was masking page state rather than surfacing it cleanly.

 2. Textarea steps (navigation_steps.rb)

Four steps (I should see "X" in the textarea, I should see "X" or "Y" in the textarea, and their data-testid variants) previously used within(element) { check_text? }. This pattern is incompatible with check_text?'s retry loop: when a navigation exception fires inside a within block, the retry re-runs against the same stale scope element and loops until timeout. By that point the modal has often closed, web_session_is_active? returns false, and the screenshot is lost.

Replaced with find(element).value.to_s.include?(text). This is also semantically more correct: has_text? reads DOM text nodes, but textarea content set by JavaScript lives in the .value property — not in text nodes. find().value reads the actual current content. find retains its built-in wait: retry for the element lookup itself.

 3. Filter button steps (navigation_steps.rb)

find('button.spacewalk-button-filter').click was raising NoMethodError (Chrome 134+ CDP type mismatch) during page navigation, which was not caught. Wrapped the click and post-click check in begin/rescue covering all four Chrome 134+ exception types. Also replaced has_text?('is filtered', wait: 10) with check_text?('is filtered') for consistency.

trigger_upgrade / trigger_install / trigger_remove (commonlib.rb)

Removed the spacecmd clear_caches pre-call. It was an unconditional cache flush before every package operation, adding latency without meaningful benefit since spacecmd handles cache state internally.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Port(s):
 - 5.1: https://github.com/SUSE/spacewalk/pull/30830
 - 5.0: https://github.com/SUSE/spacewalk/pull/30831
 - 4.3: https://github.com/SUSE/spacewalk/pull/30832

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
