### PR TITLE
Fix PostgreSQL peer auth failure when POSTGRES_USER != postgres

### DIFF
--- a/containers/server-postgresql-image/root/docker-entrypoint-upgdb.d/01-pg_hba.sh
+++ b/containers/server-postgresql-image/root/docker-entrypoint-upgdb.d/01-pg_hba.sh
@@ -68,6 +68,16 @@ if [[ "$(< "$HBA_FILE")" != "$NEW_CONFIG" ]]; then
     PG_HBA_CHANGED=1
 fi
 
+# Ensure 'postgres' role exists for local socket connections under peer auth.
+# initdb creates the cluster superuser as POSTGRES_USER (not 'postgres'), so peer
+# auth would fail without a matching 'postgres' role for the OS user.
+# If we can connect as 'postgres' the role already exists; otherwise trust auth
+# is still in memory (fresh install) so we can create it via POSTGRES_USER.
+if ! PGHOST= PGHOSTADDR= psql -p "${PGPORT:-5432}" -U postgres --no-password --no-psqlrc -c "" 2>/dev/null; then
+    PGHOST= PGHOSTADDR= psql -p "${PGPORT:-5432}" -U "${POSTGRES_USER}" --no-psqlrc \
+        -c "CREATE ROLE postgres SUPERUSER LOGIN;"
+fi
+
 # restart database to pickup new pg_hba changes
 if [ -n "$PG_HBA_CHANGED" ]; then
     pg_ctl -D "$PGDATA" reload

--- a/containers/server-postgresql-image/root/docker-entrypoint-upgdb.d/02-sys-database-collation.sh
+++ b/containers/server-postgresql-image/root/docker-entrypoint-upgdb.d/02-sys-database-collation.sh
@@ -6,7 +6,7 @@
 function run_sql() {
     PGHOST='' PGHOSTADDR='' psql -v ON_ERROR_STOP=1 \
         -p "${PGPORT:-5432}" \
-        -U "${POSTGRES_USER:-postgres}" \
+        -U postgres \
         --no-password --no-psqlrc --tuples-only --no-align "$@"
 }
 

--- a/containers/server-postgresql-image/root/docker-entrypoint-upgdb.d/get_pgsql_disk_severity.sh
+++ b/containers/server-postgresql-image/root/docker-entrypoint-upgdb.d/get_pgsql_disk_severity.sh
@@ -9,14 +9,14 @@ DB_WARN=${DISKCHECKALERT:-90}
 
 # Determine which database to use (susemanager or uyuni)
 DB_NAME="susemanager"
-if [ -z "$(PGHOST='' PGHOSTADDR='' psql -p "${PGPORT:-5432}" -U "$POSTGRES_USER" --no-password --no-psqlrc -lqt | cut -d \| -f 1 | sed -n "/^\s*$DB_NAME\s*$/p")" ]; then
+if [ -z "$(PGHOST='' PGHOSTADDR='' psql -p "${PGPORT:-5432}" -U postgres --no-password --no-psqlrc -lqt | cut -d \| -f 1 | sed -n "/^\s*$DB_NAME\s*$/p")" ]; then
   DB_NAME="uyuni"
 fi
 
 run_sql() {
     PGHOST='' PGHOSTADDR='' psql -v ON_ERROR_STOP=1 \
         -p "${PGPORT:-5432}" \
-        -U "$POSTGRES_USER" \
+        -U postgres \
         --no-password --no-psqlrc -d "$DB_NAME" "$@"
 }
 

--- a/containers/server-postgresql-image/root/docker-entrypoint-upgdb.d/zz-evr_t.sh
+++ b/containers/server-postgresql-image/root/docker-entrypoint-upgdb.d/zz-evr_t.sh
@@ -16,14 +16,14 @@
 
 # Determine which database to use (susemanager or uyuni)
 DB_NAME="susemanager"
-if [ -z "$(PGHOST= PGHOSTADDR= psql -p "${PGPORT:-5432}" -U "$POSTGRES_USER" --no-password --no-psqlrc -lqt | cut -d \| -f 1 | sed -n "/^\s*$DB_NAME\s*$/p")" ]; then
+if [ -z "$(PGHOST= PGHOSTADDR= psql -p "${PGPORT:-5432}" -U postgres --no-password --no-psqlrc -lqt | cut -d \| -f 1 | sed -n "/^\s*$DB_NAME\s*$/p")" ]; then
   DB_NAME="uyuni"
 fi
 
 run_sql() {
   PGHOST= PGHOSTADDR= psql -v ON_ERROR_STOP=1 \
     -p "${PGPORT:-5432}" \
-    -U "$POSTGRES_USER" \
+    -U postgres \
     --no-password --no-psqlrc -d "$DB_NAME" "$@"
 }
 


### PR DESCRIPTION
## What does this PR change?

When `POSTGRES_USER` is not '`postgres`', initdb creates a superuser with a different name (e.g. dbadmin), leaving no 'postgres' DB role. After` 01-pg_hba.sh` activates peer auth via` pg_ctl reload`, all Unix socket connections are restricted to the DB role matching the OS user, which is always '`postgres`'. Scripts using` -U $POSTGRES_USER` therefore fail
authentication.

Fix by creating the 'postgres' role in 01-pg_hba.sh before the reload. The check connects as 'postgres' first: success means the role already exists (upgrade/restart path); failure means trust auth is still in memory (fresh install), so the role is created via POSTGRES_USER.

Update 02-sys-database-collation.sh, get_pgsql_disk_severity.sh and zz-evr_t.sh to use -U postgres on socket connections, since peer auth is active when these scripts run.


--
When `POSTGRES_USER` is set to any value other than `postgres` (e.g. `dbadmin` in the test suite, or a user-defined value in production), the `uyuni-db` container crashes on every start after the initial database setup.

This was the flow

1. `initdb` is called with `--username=$POSTGRES_USER`, creating that user as the cluster superuser. The `postgres` DB role does **not** exist.
2. `01-pg_hba.sh` (introduced in c2fef597, reloading added in 9d22ee08) rewrites `pg_hba.conf` and calls `pg_ctl reload`,
   activating peer auth on the Unix socket:
                    `local all all peer`

3. Peer auth maps the connecting OS user to the DB role of the same name. The postgres process always runs as OS user `postgres`, so Unix socket connections can only authenticate as DB role `postgres`.

4. All subsequent upgdb scripts (`02-sys-database-collation.sh`, `get_pgsql_disk_severity.sh`, `zz-evr_t.sh`) use
`-U $POSTGRES_USER` on the socket. When `POSTGRES_USER != postgres` this fails peer auth and the container exits.


This PR create the `postgres` DB role before calling `pg_ctl reload`. The approach avoids any dependency on TCP or `PGPASSWORD`:

Try connecting as `postgres` via socket.
- **Success** → role already exists (upgrade/restart path, peer auth active) → skip creation.
- **Failure** → role does not exist; trust auth is still in memory (fresh install path) → create the role via `POSTGRES_USER`, which works under trust.

`02-sys-database-collation.sh`, `get_pgsql_disk_severity.sh`, `zz-evr_t.sh` Change socket connections from `-U $POSTGRES_USER` to `-U postgres`. These scripts run after `01-pg_hba.sh` has already activated peer auth, so `$POSTGRES_USER` can never work on the socket unless it equals `postgres`. Using `-U postgres` is both correct and honest about the peer auth constraint.

I Verified locally using the podman test suite runner (`testsuite/podman_runner/07_server_setup.sh`) with `POSTGRES_USER=dbadmin`, which previously caused the container to crash immediately after the
initdb phase.


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
