### PR TITLE
SonarCloud error reduction fix step 17, refactoring to reduce cognitive complexity (BaseSubscribeAction)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/ssm/BaseSubscribeAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/ssm/BaseSubscribeAction.java
@@ -143,37 +143,33 @@ public class BaseSubscribeAction extends RhnLookupDispatchAction {
     /**
      * Confirm the base channel changes.
      *
-     * @param mapping ActionMapping
-     * @param formIn ActionForm
-     * @param request ServletRequest
+     * @param mapping  ActionMapping
+     * @param formIn   ActionForm
+     * @param request  ServletRequest
      * @param response ServletResponse
      * @return The ActionForward to go to next.
      */
-    public ActionForward confirmUpdateBaseChannels(ActionMapping mapping,
-            ActionForm formIn, HttpServletRequest request, HttpServletResponse response) {
+    public ActionForward confirmUpdateBaseChannels(ActionMapping mapping, ActionForm formIn,
+                                                   HttpServletRequest request, HttpServletResponse response) {
 
         log.debug("confirmUpdateBaseChannels()");
-        RequestContext rctx = new RequestContext(request);
-        User user = rctx.getCurrentUser();
+        RequestContext requestContext = new RequestContext(request);
+        User user = requestContext.getCurrentUser();
 
-        List<ChildChannelPreservationDto> unmatched =
-                new LinkedList<>();
-        List<ChildChannelPreservationDto> matched =
-                new LinkedList<>();
+        List<ChildChannelPreservationDto> incompatibles = new LinkedList<>();
+        List<ChildChannelPreservationDto> compatibles = new LinkedList<>();
 
         Map<Long, Long> changedChannels = copyChangedChannels(request);
 
-        // Technically speaking an inattentive user could submit this screen with all
-        // channels set to "No Change":
-        if (changedChannels.entrySet().isEmpty()) {
+        // Technically speaking an inattentive user could submit this screen with all channels set to "No Change"
+        if (changedChannels.isEmpty()) {
             return handleNoChanges(mapping, request);
         }
 
-        // As base channel assignments are made asynchnously and UI redirects to base
-        // channels page after changing assignments, it might happen that the user
-        // is using a non refreshed UI page which contains the old base assignments.
-        // That would produce an ISE error due those old base channels are not assigned
-        // to any system on the SSM. (bsc#1040420)
+        // As base channel assignments are made asynchronously and UI redirects to base channels page after changing
+        // assignments, it might happen that the user is using a non-refreshed UI page which contains the old base
+        // assignments. That would produce an ISE error due those old base channels are not assigned to any system
+        // on the SSM. (bsc#1040420)
         for (Long oldBaseChannelId : changedChannels.keySet()) {
             List<Long> servers = serversInSSMWithBase(user, oldBaseChannelId);
             if (servers.isEmpty()) {
@@ -184,113 +180,53 @@ public class BaseSubscribeAction extends RhnLookupDispatchAction {
         // for each old to new base channel value in the form
         for (Map.Entry<Long, Long> entry : changedChannels.entrySet()) {
             Long oldBaseChannelId = entry.getKey();
+            Channel newBase = null;
+
             Channel oldBase = null;
             // if old channel was present, get it
             if (oldBaseChannelId.intValue() != -1) {
                 oldBase = ChannelFactory.lookupByIdAndUser(oldBaseChannelId, user);
             }
-            Channel newBase = null;
 
             // get new base channel from the key-value map from the form
             Long newBaseChannelId = entry.getValue();
             log.debug("newBaseChannelId = {}", newBaseChannelId);
 
-            // First add an entry for the default base channel:
-            // "Default system base channel" option was selected
+            // First add an entry for the default base channel: "Default system base channel" option was selected
             if (newBaseChannelId.intValue() == -1) {
                 log.debug("Default system base channel was selected.");
 
                 List<Long> servers = serversInSSMWithBase(user, oldBaseChannelId);
-                List<Server> skippedServers = new LinkedList<>();
 
-                // Check if for all servers in the set we can guess base channel
-                // if not add them to the skipped list
-                for (Long sId : servers) {
-                    Server server = SystemManager.lookupByIdAndUser(sId, user);
-                    if (!ChannelManager.guessServerBaseChannel(user, server).isPresent()) {
-                        skippedServers.add(server);
-                    }
-                }
+                // Check if for all servers in the set we can guess base channel. If not add them to the skipped list
+                List<Server> skippedServers = getSkippedServers(servers, user);
 
                 if (!skippedServers.isEmpty()) {
-                    // Display the name list of not manageable to the user
-                    // and return empty handed.
-                    StrutsDelegate strutsDelegate = getStrutsDelegate();
-                    ActionMessages msgs = new ActionMessages();
-                    String oldBaseChannelMessage = oldBaseChannelId.intValue() == -1 ?
-                            localizationInstance.getMessage("basesub.jsp.noBaseChannel") :
-                                ChannelFactory.lookupByIdAndUser(oldBaseChannelId, user)
-                                    .getLabel();
-                    ActionMessage actionMessage = new ActionMessage(
-                            "basesub.jsp.unableToLookupSystemDefaultChannelWithParams",
-                            String.join(", ", skippedServers.stream()
-                                    .map(s -> "'" + s.getName() + "'")
-                                    .collect(Collectors.toList())), oldBaseChannelMessage);
-                    msgs.add(ActionMessages.GLOBAL_MESSAGE, actionMessage);
-                    strutsDelegate.saveMessages(request, msgs);
-
-                    return strutsDelegate.forwardParams(mapping.findForward("success"),
-                            new HashMap<>());
+                    // Display the name list of not manageable to the user and return empty-handed.
+                    return forwardWithUnmanageableServersMessage(oldBaseChannelId, skippedServers, user, mapping,
+                            request);
                 }
 
-                List<DistChannelMap> dcms = ChannelFactory.listDistChannelMaps(oldBase);
-                if (!dcms.isEmpty() && oldBase != null) {
-                    for (DistChannelMap dcm : dcms) {
-                        String version = dcm.getRelease();
-                        DistChannelMap defaultDcm =
-                            ChannelManager.lookupDistChannelMapByPnReleaseArch(
-                                user.getOrg(),
-                                ChannelManager.RHEL_PRODUCT_NAME, version,
-                                oldBase.getChannelArch());
-                        // Default base channel FOUND
-                        if (defaultDcm != null) {
-                            newBase = defaultDcm.getChannel();
-                            log.debug("Determined default base channel will be: {}", newBase.getLabel());
-                                break;
-                        }
-                    }
-                }
+                newBase = findDefaultBaseChannel(oldBase, user).orElse(newBase);
+
                 // no "default base channel" found so far
                 if (newBase == null) {
                     // Looks like an EUS or custom channel, need to get a little crazy :(
-                    // Should be safe to assume there's at least one result returned here,
-                    // we need a server object to call the stored procedure and guess a
-                    // default base channel:
+                    // Should be safe to assume there's at least one result returned here, we need a server object
+                    // to call the stored procedure and guess a default base channel:
 
-                    // take the first system of the list, guess its base channel and use it
-                    Server s = SystemManager.lookupByIdAndUser(servers.get(0), user);
-                    newBase = ChannelManager.guessServerBaseChannel(user, s).orElse(null);
-
-                    // no "default base channel" found so far
-                    if (newBase == null) {
-                        // lets search for suse channels
-                        List<EssentialChannelDto> dr = ChannelManager.
-                                listPossibleSuseBaseChannelsForServer(s).orElse(null);
-                        if (dr != null && dr.get(0) != null) {
-                            newBase = ChannelFactory.lookupByIdAndUser(
-                                    dr.get(0).getId(), user);
-                        }
-                    }
+                    newBase = findOtherBaseChannel(servers, user).orElse(newBase);
                 }
             }
 
             // we are here because:
-            // 1- system default base channel selected but we couldn't guess a channel
+            // 1- system default base channel has been selected, but we couldn't guess a channel
             // 2- option selected is a specific base channel not yet evaluated
             if (newBase == null) {
-                // case 1 --> see comments above
-                // (can happen in the case of solaris systems)
+                // case 1 --> see comments above (can happen in the case of Solaris systems)
                 if (newBaseChannelId.intValue() == -1) {
-                    // Display a warning to the user and return empty handed.
-                    StrutsDelegate strutsDelegate = getStrutsDelegate();
-                    ActionMessages msgs = new ActionMessages();
-                    msgs.add(ActionMessages.GLOBAL_MESSAGE,
-                            new ActionMessage(
-                                    "basesub.jsp.unableToLookupSystemDefaultChannel"));
-                    strutsDelegate.saveMessages(request, msgs);
-
-                    return strutsDelegate.forwardParams(mapping.findForward("success"),
-                            new HashMap<>());
+                    // Display a warning to the user and return empty-handed.
+                    return forwardWithMissingDefaultChannelMessage(mapping, request);
                 }
                 //case 2 --> evaluate the new base channel selected and use it
                 newBase = ChannelManager.lookupByIdAndUser(newBaseChannelId, user);
@@ -299,56 +235,165 @@ public class BaseSubscribeAction extends RhnLookupDispatchAction {
             // an old base channel was present
             if (oldBase != null) {
                 log.debug("{} -> {}", oldBase.getName(), newBase.getName());
-                Map<Channel, Channel> preservations = ChannelManager.findCompatibleChildren(
-                        oldBase, newBase, user);
+                Map<Channel, Channel> preservations = ChannelManager.findCompatibleChildren(oldBase, newBase, user);
 
-                for (Map.Entry<Channel, Channel> preservationsEntry : preservations.entrySet()) {
-                    Channel c = preservationsEntry.getKey();
-                    Channel match = preservationsEntry.getValue();
-                    List<Map<String, Object>> serversAffected =
-                            SystemManager.
-                        getSsmSystemsSubscribedToChannel(user, c.getId());
-                    log.debug("found {} servers in set with channel: {}", serversAffected.size(), c.getId());
-                    if (!serversAffected.isEmpty()) {
-                        matched.add(new ChildChannelPreservationDto(c.getId(), c.getName(),
-                                match.getId(), match.getName(), serversAffected));
-                    }
-                }
-
-                for (Channel c : oldBase.getAccessibleChildrenFor(user)) {
-                    if (!preservations.containsKey(c)) {
-                        List<Map<String, Object>> serversAffected =
-                            SystemManager.getSsmSystemsSubscribedToChannel(user, c.getId());
-                        log.debug("found {} servers in set with channel: {}", serversAffected.size(), c.getId());
-                        if (!serversAffected.isEmpty()) {
-                            unmatched.add(new ChildChannelPreservationDto(c.getId(),
-                                    c.getName(), c.getParentChannel().getId(),
-                                    c.getParentChannel().getName(), serversAffected));
-                        }
-                    }
-                }
+                compatibles.addAll(collectCompatiblePreservations(preservations, user));
+                incompatibles.addAll(collectIncompatiblePreservations(oldBase, preservations, user));
             }
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Matches:");
-            for (ChildChannelPreservationDto dto : matched) {
-                log.debug("   {} {} {}", dto.getOldChannelName(), dto.getOtherChannelName(), dto.getSystemsAffected());
-            }
-
-            log.debug("Unmatches:");
-            for (ChildChannelPreservationDto dto : unmatched) {
-                log.debug("   {} {} {}", dto.getOldChannelName(), dto.getOtherChannelName(), dto.getSystemsAffected());
-            }
-        }
+        logChannelCompatibilityResults(compatibles, incompatibles);
 
         request.setAttribute(ListTagHelper.PARENT_URL, request.getRequestURI());
-        request.setAttribute(MATCHED_CHILD_CHANNELS, matched);
-        request.setAttribute(FOUND_UNMATCHED_CHANNELS, !unmatched.isEmpty());
-        request.setAttribute(UNMATCHED_CHILD_CHANNELS, unmatched);
+        request.setAttribute(MATCHED_CHILD_CHANNELS, compatibles);
+        request.setAttribute(FOUND_UNMATCHED_CHANNELS, !incompatibles.isEmpty());
+        request.setAttribute(UNMATCHED_CHILD_CHANNELS, incompatibles);
 
         log.debug("end confirmUpdateBaseChannels()");
         return mapping.findForward(RhnHelper.CONFIRM_FORWARD);
+    }
+
+    private List<Server> getSkippedServers(List<Long> servers, User user) {
+        // Check if for all servers in the set we can guess base channel. If not add them to the skipped list
+        List<Server> skippedServers = new LinkedList<>();
+
+        for (Long sId : servers) {
+            Server server = SystemManager.lookupByIdAndUser(sId, user);
+            if (ChannelManager.guessServerBaseChannel(user, server).isEmpty()) {
+                skippedServers.add(server);
+            }
+        }
+
+        return skippedServers;
+    }
+
+    private ActionForward forwardWithUnmanageableServersMessage(Long oldBaseChannelId, List<Server> skippedServers,
+                                                                User user, ActionMapping mapping,
+                                                                HttpServletRequest request) {
+        // Display the name list of not manageable to the user and return empty-handed.
+        StrutsDelegate strutsDelegate = getStrutsDelegate();
+        ActionMessages actionMessages = new ActionMessages();
+        String oldBaseChannelMessage = oldBaseChannelId.intValue() == -1 ?
+                localizationInstance.getMessage("basesub.jsp.noBaseChannel") :
+                ChannelFactory.lookupByIdAndUser(oldBaseChannelId, user).getLabel();
+
+        ActionMessage actionMessage = new ActionMessage(
+                "basesub.jsp.unableToLookupSystemDefaultChannelWithParams",
+                String.join(", ", skippedServers.stream()
+                        .map(s -> "'" + s.getName() + "'")
+                        .collect(Collectors.toList())), oldBaseChannelMessage);
+        actionMessages.add(ActionMessages.GLOBAL_MESSAGE, actionMessage);
+        strutsDelegate.saveMessages(request, actionMessages);
+
+        return strutsDelegate.forwardParams(mapping.findForward("success"), new HashMap<>());
+    }
+
+    private Optional<Channel> findDefaultBaseChannel(Channel oldBase, User user) {
+        if (oldBase == null) {
+            return Optional.empty();
+        }
+
+        List<DistChannelMap> distChannelMapList = ChannelFactory.listDistChannelMaps(oldBase);
+        for (DistChannelMap dcm : distChannelMapList) {
+            String version = dcm.getRelease();
+            DistChannelMap defaultDcm = ChannelManager.lookupDistChannelMapByPnReleaseArch(user.getOrg(),
+                    ChannelManager.RHEL_PRODUCT_NAME, version, oldBase.getChannelArch());
+
+            // Default base channel FOUND
+            if (defaultDcm != null) {
+                Channel newBase = defaultDcm.getChannel();
+                log.debug("Determined default base channel will be: {}", newBase.getLabel());
+                return Optional.of(newBase);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<Channel> findOtherBaseChannel(List<Long> servers, User user) {
+        // Looks like an EUS or custom channel, need to get a little crazy :(
+        // Should be safe to assume there's at least one result returned here, we need a server object to call the
+        // stored procedure and guess a default base channel:
+
+        // take the first system of the list, guess its base channel and use it
+        Server s = SystemManager.lookupByIdAndUser(servers.get(0), user);
+        Channel newBase = ChannelManager.guessServerBaseChannel(user, s).orElse(null);
+
+        // no "default base channel" found so far
+        if (newBase == null) {
+            // let's search for Suse channels
+            List<EssentialChannelDto> dr = ChannelManager.listPossibleSuseBaseChannelsForServer(s).orElse(null);
+            if (dr != null && dr.get(0) != null) {
+                newBase = ChannelFactory.lookupByIdAndUser(dr.get(0).getId(), user);
+            }
+        }
+
+        return Optional.ofNullable(newBase);
+    }
+
+    private ActionForward forwardWithMissingDefaultChannelMessage(ActionMapping mapping, HttpServletRequest request) {
+        // Display a warning to the user and return empty-handed.
+        StrutsDelegate strutsDelegate = getStrutsDelegate();
+        ActionMessages actionMessages = new ActionMessages();
+        actionMessages.add(ActionMessages.GLOBAL_MESSAGE,
+                new ActionMessage("basesub.jsp.unableToLookupSystemDefaultChannel"));
+        strutsDelegate.saveMessages(request, actionMessages);
+
+        return strutsDelegate.forwardParams(mapping.findForward("success"), new HashMap<>());
+    }
+
+    private List<ChildChannelPreservationDto> collectCompatiblePreservations(Map<Channel, Channel> preservations,
+                                                                             User user) {
+        List<ChildChannelPreservationDto> matched = new LinkedList<>();
+
+        for (Map.Entry<Channel, Channel> preservationsEntry : preservations.entrySet()) {
+            Channel c = preservationsEntry.getKey();
+            Channel match = preservationsEntry.getValue();
+            List<Map<String, Object>> serversAffected = SystemManager.getSsmSystemsSubscribedToChannel(user, c.getId());
+            log.debug("found {} servers in set with channel: {}", serversAffected.size(), c.getId());
+            if (!serversAffected.isEmpty()) {
+                matched.add(new ChildChannelPreservationDto(c.getId(), c.getName(), match.getId(), match.getName(),
+                        serversAffected));
+            }
+        }
+
+        return matched;
+    }
+
+    private List<ChildChannelPreservationDto> collectIncompatiblePreservations(
+            Channel oldBase, Map<Channel, Channel> preservations, User user) {
+        List<ChildChannelPreservationDto> unmatched = new LinkedList<>();
+
+        for (Channel c : oldBase.getAccessibleChildrenFor(user)) {
+            if (!preservations.containsKey(c)) {
+                List<Map<String, Object>> serversAffected =
+                        SystemManager.getSsmSystemsSubscribedToChannel(user, c.getId());
+                log.debug("found {} servers in set with channel: {}", serversAffected.size(), c.getId());
+                if (!serversAffected.isEmpty()) {
+                    unmatched.add(new ChildChannelPreservationDto(c.getId(), c.getName(), c.getParentChannel().getId(),
+                            c.getParentChannel().getName(), serversAffected));
+                }
+            }
+        }
+
+        return unmatched;
+    }
+
+    private void logChannelCompatibilityResults(List<ChildChannelPreservationDto> matched,
+                                                List<ChildChannelPreservationDto> unmatched) {
+        if (!log.isDebugEnabled()) {
+            return;
+        }
+
+        log.debug("Matches:");
+        for (ChildChannelPreservationDto dto : matched) {
+            log.debug("   {} {} {}", dto.getOldChannelName(), dto.getOtherChannelName(), dto.getSystemsAffected());
+        }
+
+        log.debug("Unmatches:");
+        for (ChildChannelPreservationDto dto : unmatched) {
+            log.debug("   {} {} {}", dto.getOldChannelName(), dto.getOtherChannelName(), dto.getSystemsAffected());
+        }
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

SonarCloud fix: java:S3776 Cognitive Complexity of methods should not be too high

- BaseSubscribeAction


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s): 
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
