### PR TITLE
SonarCloud error reduction fix step 16, miscellaneous 8 rules

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/common/util/ServletUtils.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/util/ServletUtils.java
@@ -131,7 +131,7 @@ public class ServletUtils {
      */
     public static String requestParamsToQueryString(ServletRequest request) {
 
-        StringBuffer queryString = new StringBuffer();
+        StringBuilder queryString = new StringBuilder();
 
         String paramName;
         String paramValue;
@@ -164,7 +164,7 @@ public class ServletUtils {
         return URLEncoder.encode(string, StandardCharsets.UTF_8);
     }
 
-    private static boolean endsWith(StringBuffer buffer, char c) {
+    private static boolean endsWith(StringBuilder buffer, char c) {
         if (buffer.length() == 0) {
             return false;
         }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/PackageSearchHelper.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/PackageSearchHelper.java
@@ -159,7 +159,7 @@ public class PackageSearchHelper {
                                           String mode,
                                           List<String> arches) {
 
-        if (!BaseSearchAction.OPT_FREE_FORM.equals(mode) && searchstring.indexOf(':') > 0) {
+        if (!BaseSearchAction.OPT_FREE_FORM.equals(mode) && searchstring.indexOf(':') >= 1) {
             throw new ValidatorException("Can't use free form and field search.");
         }
 

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/groups/AdminListAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/groups/AdminListAction.java
@@ -46,18 +46,25 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class AdminListAction extends BaseListAction<UserOverview> {
 
-    private ManagedServerGroup serverGroup;
-    private User user;
-
-    @Override
-    protected void setup(HttpServletRequest request) {
+    private ManagedServerGroup getServerGroup(HttpServletRequest request) {
         RequestContext requestContext = new RequestContext(request);
-        serverGroup = requestContext.lookupAndBindServerGroup();
-        user = requestContext.getCurrentUser();
+        return requestContext.lookupAndBindServerGroup();
+    }
+
+    private User getUser(HttpServletRequest request) {
+        RequestContext requestContext = new RequestContext(request);
+        return requestContext.getCurrentUser();
     }
 
     @Override
-    protected void processHelper(ListSessionSetHelper helper) {
+    protected void setup(HttpServletRequest request) {
+        // do nothing
+    }
+
+    @Override
+    protected void processHelper(ListSessionSetHelper helper, HttpServletRequest request) {
+        ManagedServerGroup serverGroup = getServerGroup(request);
+
         helper.ignoreEmptySelection();
 
         Set<String> preselected = new HashSet<>();
@@ -74,6 +81,9 @@ public class AdminListAction extends BaseListAction<UserOverview> {
             ActionMapping mapping,
             ActionForm formIn, HttpServletRequest request,
             HttpServletResponse response) {
+
+        ManagedServerGroup serverGroup = getServerGroup(request);
+        User user = getUser(request);
 
         // make sure the user has enough perms
         if (!UserManager.canAdministerSystemGroup(user, serverGroup)) {
@@ -111,6 +121,8 @@ public class AdminListAction extends BaseListAction<UserOverview> {
     /** {@inheritDoc} */
     @Override
     public List<UserOverview> getResult(RequestContext context) {
+        User user = context.getCurrentUser();
+
         List<UserOverview> userList = UserManager.activeInOrg2(user);
         for (UserOverview uo : userList) {
             uo.setSelectable(true);

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/groups/BaseListAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/groups/BaseListAction.java
@@ -70,7 +70,7 @@ public abstract class BaseListAction<T> extends RhnAction implements Listable<T>
         setup(request);
         ListSessionSetHelper helper = new ListSessionSetHelper(this,
                                         request, getParamsMap(request));
-        processHelper(helper);
+        processHelper(helper, request);
         helper.execute();
         if (helper.isDispatched()) {
             ActionForward forward =
@@ -87,7 +87,7 @@ public abstract class BaseListAction<T> extends RhnAction implements Listable<T>
             ActionForm formIn, HttpServletRequest request,
             HttpServletResponse response);
 
-    protected void processHelper(ListSessionSetHelper helper) {
+    protected void processHelper(ListSessionSetHelper helper, HttpServletRequest request) {
         helper.setDataSetName(getDataSetName());
         helper.setListName(getListName());
     }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/kickstart/ScheduleKickstartWizardAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/kickstart/ScheduleKickstartWizardAction.java
@@ -72,6 +72,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -550,22 +551,22 @@ public class ScheduleKickstartWizardAction extends RhnWizardAction {
                 if (rec != null && rec.getProfile() != null && profile.getName().equals(rec.getProfile().getName())) {
                     if (StringUtils.isBlank(form.getString(KERNEL_PARAMS_TYPE))) {
                         form.set(KERNEL_PARAMS_TYPE, KERNEL_PARAMS_CUSTOM);
-                        if (rec.getKernelOptions().isEmpty()) {
-                            form.set(KERNEL_PARAMS, CobblerObject.INHERIT_KEY);
-                        }
-                        else {
-                            form.set(KERNEL_PARAMS, profile.convertOptionsMap(rec.getKernelOptions().get()));
-                        }
+
+                        String kernelOptions = rec.getKernelOptions()
+                                .map(profile::convertOptionsMap)
+                                .orElse(CobblerObject.INHERIT_KEY);
+
+                        form.set(KERNEL_PARAMS, kernelOptions);
                     }
 
                     if (StringUtils.isBlank(form.getString(POST_KERNEL_PARAMS_TYPE))) {
                         form.set(POST_KERNEL_PARAMS_TYPE, KERNEL_PARAMS_CUSTOM);
-                        if (rec.getKernelOptionsPost().isEmpty()) {
-                            form.set(POST_KERNEL_PARAMS, CobblerObject.INHERIT_KEY);
-                        }
-                        else {
-                            form.set(POST_KERNEL_PARAMS, profile.convertOptionsMap(rec.getKernelOptionsPost().get()));
-                        }
+
+                        String kernelOptionsPost = rec.getKernelOptionsPost()
+                                .map(profile::convertOptionsMap)
+                                .orElse(CobblerObject.INHERIT_KEY);
+
+                        form.set(POST_KERNEL_PARAMS, kernelOptionsPost);
                     }
                 }
             }
@@ -575,26 +576,30 @@ public class ScheduleKickstartWizardAction extends RhnWizardAction {
     }
 
     private void addKernelParamsAttribute(RequestContext ctx, CobblerObject cobblerObject, String attrString) {
-        if (cobblerObject.getKernelOptions().isEmpty()) {
+        Optional<Map<String, Object>> optKernelOptions = cobblerObject.getKernelOptions();
+
+        if (optKernelOptions.isEmpty()) {
             ctx.getRequest().setAttribute(attrString, CobblerObject.INHERIT_KEY);
         }
         else {
             ctx.getRequest().setAttribute(attrString,
-                    (cobblerObject.getKernelOptions().get() instanceof Map) ?
-                            cobblerObject.convertOptionsMap(cobblerObject.getKernelOptions().get()) :
-                            cobblerObject.getKernelOptions().get());
+                    (optKernelOptions.get() instanceof Map) ?
+                            cobblerObject.convertOptionsMap(optKernelOptions.get()) :
+                            optKernelOptions.get());
         }
     }
 
     private void addPostKernelParamsAttribute(RequestContext ctx, CobblerObject cobblerObject, String attrString) {
-        if (cobblerObject.getKernelOptionsPost().isEmpty()) {
+        Optional<Map<String, Object>> optKernelOptionsPost = cobblerObject.getKernelOptionsPost();
+
+        if (optKernelOptionsPost.isEmpty()) {
             ctx.getRequest().setAttribute(attrString, CobblerObject.INHERIT_KEY);
         }
         else {
             ctx.getRequest().setAttribute(attrString,
-                    (cobblerObject.getKernelOptionsPost().get() instanceof Map) ?
-                            cobblerObject.convertOptionsMap(cobblerObject.getKernelOptionsPost().get()) :
-                            cobblerObject.getKernelOptionsPost().get());
+                    (optKernelOptionsPost.get() instanceof Map) ?
+                            cobblerObject.convertOptionsMap(optKernelOptionsPost.get()) :
+                            optKernelOptionsPost.get());
         }
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/sdc/ProxyClientsAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/sdc/ProxyClientsAction.java
@@ -44,15 +44,13 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class ProxyClientsAction extends BaseSystemsAction {
 
-    private Server server;
-
     /** {@inheritDoc} */
     @Override
     public ActionForward execute(ActionMapping mapping, ActionForm formIn,
             HttpServletRequest request, HttpServletResponse response) {
         RequestContext requestContext = new RequestContext(request);
         User user = requestContext.getCurrentUser();
-        server = requestContext.lookupAndBindServer();
+        Server server = requestContext.lookupAndBindServer();
 
         if (server.isProxy()) {
             // Try to extract the Proxy InstalledProduct on the client and
@@ -71,7 +69,7 @@ public class ProxyClientsAction extends BaseSystemsAction {
                 request.setAttribute("version", null);
             }
 
-            DataResult<SystemOverview> result = getDataResult(user, null, formIn);
+            DataResult<SystemOverview> result = getDataResultImpl(user, server);
             if (result.isEmpty()) {
                 request.setAttribute(SHOW_NO_SYSTEMS, Boolean.TRUE);
             }
@@ -95,23 +93,26 @@ public class ProxyClientsAction extends BaseSystemsAction {
         return mapping.findForward(RhnHelper.DEFAULT_FORWARD);
     }
 
-    @Override
-    protected DataResult<SystemOverview> getDataResult(User user, PageControl pc,
-            ActionForm formIn) {
-        DataResult<SystemOverview> clients = SystemManager.listClientsThroughProxy(
-                server.getId());
+    protected DataResult<SystemOverview> getDataResultImpl(User user, Server server) {
+        DataResult<SystemOverview> clients = SystemManager.listClientsThroughProxy(server.getId());
         if (clients != null && !clients.isEmpty()) {
             HashSet<Long> clientIdSet = new HashSet<>();
             for (SystemOverview client: clients) {
                 clientIdSet.add(client.getId());
             }
             clients.clear();
-            for (SystemOverview client: SystemManager.systemList(user, pc)) {
+            for (SystemOverview client: SystemManager.systemList(user, null)) {
                 if (clientIdSet.contains(client.getId())) {
                     clients.add(client);
                 }
             }
         }
         return clients;
+    }
+
+    @Override
+    protected DataResult<?> getDataResult(User user, PageControl pc, ActionForm formIn) {
+        //dummy implementation, never used since execute() is overridden and calls getDataResultImpl
+        return null;
     }
 }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/context/Context.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/context/Context.java
@@ -34,7 +34,7 @@ public class Context {
     private String activeLocaleLabel;
     private TimeZone timezone;
 
-    private static ThreadLocal currentContext = new ThreadLocal();
+    private static final ThreadLocal<Context> CURRENT_CONTEXT = new ThreadLocal<>();
 
     private Context() {
     }
@@ -121,10 +121,10 @@ public class Context {
      */
     public static Context getCurrentContext() {
 
-        Context retval = (Context) currentContext.get();
+        Context retval = CURRENT_CONTEXT.get();
         if (retval == null) {
-            currentContext.set(new Context());
-            retval = (Context) currentContext.get();
+            CURRENT_CONTEXT.set(new Context());
+            retval =  CURRENT_CONTEXT.get();
         }
         return retval;
     }
@@ -134,7 +134,7 @@ public class Context {
      * executing thread
      */
     public static void freeCurrentContext() {
-        currentContext.set(null);
+        CURRENT_CONTEXT.remove();
     }
 
 }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/struts/RhnLookupDispatchAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/struts/RhnLookupDispatchAction.java
@@ -84,7 +84,7 @@ public abstract class RhnLookupDispatchAction extends LookupDispatchAction {
              */
             for (String key : keyset) {
                 // Look for the alternateParameter portion in the key
-                if (key.indexOf(alternateParameter) > 0) {
+                if (key.indexOf(alternateParameter) >= 1) {
                     // if we find alternateParameter in the key, set the method name
                     methodName = key.substring(0, key.indexOf(alternateParameter) - 1);
                 }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/struts/Scrubber.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/struts/Scrubber.java
@@ -78,11 +78,11 @@ public class Scrubber {
         return getInstance(prohibitedInput).doScrub(value);
     }
     private Object doScrub(Object value) {
-        if (!canScrub(value)) {
-            return value;
-        }
         if (value == null) {
             return null;
+        }
+        if (!canScrub(value)) {
+            return value;
         }
 
         if (value instanceof String str) {

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandler.java
@@ -359,9 +359,7 @@ public class PackagesHandler extends BaseHandler {
             throw new PermissionCheckFailureException();
         }
         Package pkg = lookupPackage(loggedInUser, pid);
-        if (pkg == null) {
-            throw new NoSuchPackageException();
-        }
+
         try {
             PackageManager.schedulePackageRemoval(loggedInUser, pkg);
         }

--- a/java/core/src/main/java/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -701,11 +701,9 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
 
         if (regType.equals(RegistrationType.REACTIVATION)) {
             // Create a new activation key for the target system.
-            boolean reactivation = RegistrationType.REACTIVATION
-                    .equals(regType);
             createKickstartActivationKey(this.user, this.ksdata,
-                    reactivation ? getTargetServer() : null,
-                            this.kickstartSession, 1L, note);
+                    getTargetServer(),
+                    this.kickstartSession, 1L, note);
         }
         this.createdProfile = processProfileType(this.profileType);
         log.debug("** profile created: {}", createdProfile);

--- a/java/core/src/main/java/com/redhat/rhn/manager/session/SessionManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/session/SessionManager.java
@@ -207,7 +207,7 @@ public class SessionManager extends BaseManager {
         }
 
         if (data != null && !data.equals("") &&
-                data.indexOf(SEC_PARM_TOKENIZER_CHAR) > 0) {
+                data.indexOf(SEC_PARM_TOKENIZER_CHAR) >= 1) {
             String[] vals = StringUtils.split(data, SEC_PARM_TOKENIZER_CHAR);
             if (isNonTimestampedParamString(vals)) {
                 boolean returnboolean = isValidNonTimestampedParamString(vals);

--- a/java/core/src/main/java/com/suse/manager/api/HttpApiLoggingInvocationProcessor.java
+++ b/java/core/src/main/java/com/suse/manager/api/HttpApiLoggingInvocationProcessor.java
@@ -73,6 +73,8 @@ public class HttpApiLoggingInvocationProcessor extends LoggingInvocationProcesso
                 Optional.ofNullable(caller.get()),
                 request.ip()
             );
+
+            caller.remove();
         });
     }
 

--- a/search-server/spacewalk-search/src/java/com/redhat/satellite/search/index/ngram/tests/NGramTestSetup.java
+++ b/search-server/spacewalk-search/src/java/com/redhat/satellite/search/index/ngram/tests/NGramTestSetup.java
@@ -129,8 +129,7 @@ public class NGramTestSetup extends TestCase {
         QueryParser parser = new QueryParser("name", alyz);
         IndexSearcher searcher = new IndexSearcher(dir);
         Query q = parser.parse(query);
-        Hits hits = searcher.search(q);
-        return hits;
+        return searcher.search(q);
     }
 
     protected int thresholdHits(Hits hits) throws IOException {


### PR DESCRIPTION
## What does this PR change?

SonarCloud error reduction fix step 16, miscellaneous 8 rules

SonarCloud fix: java:S1149 Replace StringBuffer with unsynchronized class StringBuilder
SonarCloud fix: java:S1488 Local variables not immediately returned
SonarCloud fix: java:S2583 Conditionally executed code should be reachable
SonarCloud fix: java:S2692 indexOf checks should not be for positive numbers
SonarCloud fix: java:S5164 ThreadLocal variables should be cleaned up when no longer used
SonarCloud fix: java:S2226 (AdminListAction) Servlets should not have mutable instance fields
SonarCloud fix: java:S2226 (ProxyClientsAction) Servlets should not have mutable instance fields
SonarCloud fix: java:S3655 Optional value should only be accessed after calling isPresent()

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s):
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

