### PR TITLE
Server chart: separate the scc and registry secrets

### DIFF
--- a/containers/server-helm/README.md
+++ b/containers/server-helm/README.md
@@ -15,10 +15,15 @@ They need to contain a `username` and a `password` key.
 - `reportdb-credentials`: credentials for the report database user
 - `admin-credentials`: credentials for the server administrator
 
+SCC organization mirroring credentials can be automatically set if the name of secret of `kubernetes.io/basic-auth` type with those credentials is set as `server.sccSecret` value.
+
 The following TLS secrets are expected:
 
 - `db-cert`: is the TLS certificate for the report database and needs to have the `db` and `reportdb` Subject Alternate Names as well as the FQDN exposed to the outside world
 - `uyuni-cert`: is the TLS certificate for the ingress rule and needs to have the public FQDN as Subject Alternate Name.
+
+Pulling images from a registry requiring authentication requires a secret of `kubernetes.io/dockerconfigjson` type.
+Its name needs to be passed as the `registrySecret` value.
 
 ### ConfigMaps
 

--- a/containers/server-helm/server-helm.changes.cbosdo.creds-fix
+++ b/containers/server-helm/server-helm.changes.cbosdo.creds-fix
@@ -1,0 +1,1 @@
+- Separate SCC and registry secrets (bsc#1266938)

--- a/containers/server-helm/templates/server.yaml
+++ b/containers/server-helm/templates/server.yaml
@@ -107,18 +107,18 @@ spec:
         - name: DEBUG_JAVA
           value: "true"
 {{- end }}
-{{- if .Values.registrySecret }}
+{{- if .Values.server.sccSecret }}
         - name: SCC_USER
           valueFrom:
             secretKeyRef:
               key: username
-              name: {{ .Values.registrySecret }}
+              name: {{ .Values.server.sccSecret }}
               optional: false
         - name: SCC_PASS
           valueFrom:
             secretKeyRef:
               key: password
-              name: {{ .Values.registrySecret }}
+              name: {{ .Values.server.sccSecret }}
               optional: false
 {{- end }}
 {{- if .Values.server.systemdLogLevel }}

--- a/containers/server-helm/tests/db_test.yaml
+++ b/containers/server-helm/tests/db_test.yaml
@@ -35,3 +35,13 @@ tests:
       - hasDocuments:
           count: 0
         template: db.yaml
+
+  - it: should use the registry credentials if set
+    set:
+      global.fqdn: uyuni.example.com
+      registrySecret: mycreds
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: mycreds

--- a/containers/server-helm/tests/deployment_test.yaml
+++ b/containers/server-helm/tests/deployment_test.yaml
@@ -30,3 +30,39 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name=="uyuni")].image
           value: my-custom-registry/uyuni-server:5.0.0
+
+  - it: should use the registry credentials if set
+    set:
+      global.fqdn: uyuni.example.com
+      registrySecret: mycreds
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: mycreds
+
+  - it: should use the SCC credentials if set
+    set:
+      global.fqdn: uyuni.example.com
+      server:
+        sccSecret: myscccreds
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="uyuni")].env
+          content:
+            name: SCC_USER
+            valueFrom:
+              secretKeyRef:
+                key: username
+                name: myscccreds
+                optional: false
+
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="uyuni")].env
+          content:
+            name: SCC_PASS
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: myscccreds
+                optional: false

--- a/containers/server-helm/tests/hub_test.yaml
+++ b/containers/server-helm/tests/hub_test.yaml
@@ -47,3 +47,14 @@ tests:
           path: spec.template.spec.containers[?(@.name=="hub-xmlrpc")].image
           value: my-custom-registry/uyuni-server-api:1.2.3
 
+  - it: should use the registry credentials if set
+    set:
+      global.fqdn: uyuni.example.com
+      registrySecret: mycreds
+      hubAPI:
+        enable: true
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: mycreds

--- a/containers/server-helm/tests/optional_components_test.yaml
+++ b/containers/server-helm/tests/optional_components_test.yaml
@@ -139,7 +139,7 @@ tests:
         documentSelector:
           path: metadata.name
           value: hub-xmlrpc
-  
+
   - it: should override the images and tags when set
     set:
       global.fqdn: uyuni.example.com
@@ -177,3 +177,19 @@ tests:
         documentSelector:
           path: metadata.name
           value: hub-xmlrpc
+
+  - it: should use the registry credentials if set
+    set:
+      global.fqdn: uyuni.example.com
+      registrySecret: mycreds
+      hubAPI:
+        enable: true
+      saline:
+        enable: true
+      coco:
+        replicas: 3
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: mycreds

--- a/containers/server-helm/values.schema.json
+++ b/containers/server-helm/values.schema.json
@@ -23,7 +23,7 @@
     },
     "registrySecret": {
       "type": "string",
-      "description": "Name of the secret containing credentials for the registry",
+      "description": "Name of the secret which contains the credentials for the registry",
       "default": ""
     },
     "timezone": {
@@ -85,6 +85,11 @@
               "type": "string"
             }
           }
+        },
+        "sccSecret": {
+            "type": "string",
+            "description": "the name of a basic-auth secret with the organization mirroring credentials to set up on the server.",
+            "default": ""
         }
       }
     },

--- a/containers/server-helm/values.yaml
+++ b/containers/server-helm/values.yaml
@@ -28,6 +28,9 @@ server:
   # Email will be the email used for the notifications sent by the server.
   email: "admin@uyuni.lab.org"
 
+  # sccSecret is the name of a basic-auth secret with the organization mirroring credentials to set up on the server.
+  sccSecret: ""
+
   # mirror defines a volume or host path to mount in the container as server.susemanager.fromdir value.
   # Use either claimName or hostPath to reference the volume source.
   #


### PR DESCRIPTION
## What does this PR change?

The registry and SCC credentials secrets expect different secret types. Creating a variable just for SCC secrets will make it cleaner. (bsc#1266938)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documented in the chart README

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30856
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
