### PR TITLE
SonarCloud error reduction fix step 19, Unused assignments should be removed (java:S1854)

### DIFF
--- a/java/core/src/test/java/com/redhat/rhn/common/security/acl/AccessTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/security/acl/AccessTest.java
@@ -287,7 +287,7 @@ public class AccessTest extends BaseTestCaseWithUser {
 
         // Check with a minion system with bootstrap entitlement
         SystemManager.addMinionInfoToServer(s.getId(), "testMid");
-        s = TestUtils.saveAndReload(s);
+        TestUtils.saveAndReload(s); //reassign variable if still needed
 
         assertTrue(acl.evalAcl(context, "system_is_bootstrap_minion_server()"));
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/action/ActionFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/action/ActionFactoryTest.java
@@ -636,7 +636,7 @@ public class ActionFactoryTest extends BaseTestCaseWithUser {
         PackageName name = new PackageName();
         name.setName(testname);
         d.setPackageName(name);
-        name = TestUtils.saveAndFlush(name);
+        TestUtils.saveAndFlush(name); //reassign variable if still needed
 
         //create packageEvr
         PackageEvr evr = PackageEvrFactory.lookupOrCreatePackageEvr("" +

--- a/java/core/src/test/java/com/redhat/rhn/domain/action/ActionFormatterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/action/ActionFormatterTest.java
@@ -79,7 +79,7 @@ public class ActionFormatterTest extends BaseTestCase {
                 ">1 system</a></strong> failed to complete this action.<br/><br/>"));
 
         sa.setStatusCompleted();
-        sa = TestUtils.saveAndReload(sa);
+        TestUtils.saveAndReload(sa); //reassign variable if still needed
         assertTrue(af.getNotes().startsWith(
                 "<a href=\"/rhn/schedule/CompletedSystems.do?aid="));
         assertTrue(af.getNotes().endsWith(

--- a/java/core/src/test/java/com/redhat/rhn/domain/channel/ChannelFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/channel/ChannelFactoryTest.java
@@ -481,7 +481,7 @@ public class ChannelFactoryTest extends BaseTestCase {
         cp.setPath("redhat/1/c7d/some-package-child/2.13.1-6.fc9/" +
                 "x86_64/c7dd5e9b6975bc7f80f2f4657260af53/" +
                 fileNameChild);
-        child = TestUtils.saveAndFlush(child);
+        TestUtils.saveAndFlush(child); //reassign variable if still needed
 
         Package lookedUpChild = ChannelFactory.lookupPackageByFilename(channel,
                 fileNameChild);

--- a/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/ContentFilterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/ContentFilterTest.java
@@ -305,7 +305,7 @@ public class ContentFilterTest extends BaseTestCaseWithUser {
         packageProvides.setCapability(capability);
         packageProvides.setPack(pack);
         packageProvides.setSense(0L);
-        packageProvides = TestUtils.saveAndFlush(packageProvides);
+        TestUtils.saveAndFlush(packageProvides); //reassign variable if still needed
 
         pack = TestUtils.saveAndReload(pack);
         String packageName = pack.getPackageName().getName();
@@ -668,7 +668,7 @@ public class ContentFilterTest extends BaseTestCaseWithUser {
         packageProvides.setCapability(capability);
         packageProvides.setPack(pack);
         packageProvides.setSense(0L);
-        packageProvides = TestUtils.saveAndFlush(packageProvides);
+        TestUtils.saveAndFlush(packageProvides); //reassign variable if still needed
 
         pack = TestUtils.saveAndReload(pack);
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/kickstart/KickstartDataTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/kickstart/KickstartDataTest.java
@@ -87,7 +87,7 @@ public class KickstartDataTest extends KickstartBaseTest {
         kf.setKsdata(k);
 
         kf.setFileList(TestUtils.saveAndReload(kf.getFileList()));
-        kf = TestUtils.saveAndFlush(kf);
+        TestUtils.saveAndFlush(kf); //reassign variable if still needed
 
         KickstartDefaults d = createDefaults(k, user);
         assertNotNull(d);
@@ -96,7 +96,7 @@ public class KickstartDataTest extends KickstartBaseTest {
         KickstartDefaultRegToken t = new KickstartDefaultRegToken();
         t.setKsdata(k);
         t.setToken(TokenTest.createTestToken());
-        t = TestUtils.saveAndFlush(t);
+        TestUtils.saveAndFlush(t); //reassign variable if still needed
     }
 
     @Test
@@ -360,7 +360,7 @@ public class KickstartDataTest extends KickstartBaseTest {
         d.setCfgManagementFlag(Boolean.FALSE);
         d.setRemoteCommandFlag(Boolean.FALSE);
         KickstartDefaults kickstartDefaults = TestUtils.saveAndFlush(d);
-        t = TestUtils.saveAndFlush(t);
+        TestUtils.saveAndFlush(t); //reassign variable if still needed
         return kickstartDefaults;
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/kickstart/KickstartScriptTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/kickstart/KickstartScriptTest.java
@@ -81,7 +81,7 @@ public class KickstartScriptTest extends KickstartBaseTest {
         ksdata.addScript(kss2);
         assertTrue(kss1.getPosition() < kss2.getPosition());
         KickstartFactory.saveKickstartData(ksdata);
-        ksdata = TestUtils.reload(ksdata);
+        TestUtils.reload(ksdata); //reassign variable if still needed
         assertTrue(kss1.getPosition() < kss2.getPosition());
     }
 
@@ -105,8 +105,8 @@ public class KickstartScriptTest extends KickstartBaseTest {
         scriptEmpty.setPosition(2L);
         ksdata.addScript(script);
         ksdata.addScript(scriptEmpty);
-        script = TestUtils.saveAndFlush(script);
-        scriptEmpty = TestUtils.saveAndFlush(scriptEmpty);
+        TestUtils.saveAndFlush(script); //reassign variable if still needed
+        TestUtils.saveAndFlush(scriptEmpty); //reassign variable if still needed
 
         KickstartFactory.saveKickstartData(ksdata);
         ksdata = TestUtils.reload(ksdata);

--- a/java/core/src/test/java/com/redhat/rhn/domain/product/SUSEProductTestUtils.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/product/SUSEProductTestUtils.java
@@ -169,7 +169,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         ltssSP1ProdRepo.setChannelName(baseChannel.getLabel());
         ltssSP1ProdRepo.setChannelLabel(channel.getLabel());
         ltssSP1ProdRepo.setMandatory(true);
-        ltssSP1ProdRepo = TestUtils.saveAndReload(ltssSP1ProdRepo);
+        TestUtils.saveAndReload(ltssSP1ProdRepo); //reassign variable if still needed
     }
 
     /**
@@ -331,7 +331,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setChannelFamily(cfsles);
         product.setBase(true);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("sle-ha");
@@ -341,7 +341,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setProductId(1324);
         product.setChannelFamily(cfha);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("sles");
@@ -352,7 +352,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setChannelFamily(cfsles);
         product.setBase(true);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("sle-module-basesystem");
@@ -363,7 +363,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setChannelFamily(cfsles);
         product.setBase(false);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("sle-module-server-applications");
@@ -374,7 +374,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setChannelFamily(cfsles);
         product.setBase(false);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("sle-module-containers");
@@ -385,7 +385,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setChannelFamily(cfsles);
         product.setBase(false);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("caasp");
@@ -395,7 +395,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setProductId(1340);
         product.setBase(false);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("sle-micro");
@@ -406,7 +406,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setChannelFamily(cfslem);
         product.setBase(true);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         ChannelFamily cfSlesSap = ChannelFamilyFactory.lookupByLabel("AiO", null);
         if (cfSlesSap == null) {
@@ -425,7 +425,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setChannelFamily(cfSlesSap);
         product.setBase(true);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("sle-module-certifications");
@@ -436,7 +436,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setChannelFamily(cfsles);
         product.setBase(false);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("sle-module-basesystem");
@@ -447,7 +447,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setChannelFamily(cfsles);
         product.setBase(false);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
     }
 
     /**
@@ -472,7 +472,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setChannelFamily(toolsChannelFamily);
         product.setBase(false);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
     }
 
     public static Channel createBaseChannelForBaseProduct(SUSEProduct product, User admin) throws Exception {
@@ -660,7 +660,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setFriendlyName("SUSE Manager Mgmt Unlimited Virtual Z 1.2");
         product.setProductId(1200);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("suse-manager-prov-unlimited-virtual-z");
@@ -668,7 +668,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setFriendlyName("SUSE Manager Prov Unlimited Virtual Z 1.2");
         product.setProductId(1205);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("suse-manager-mgmt-unlimited-virtual");
@@ -676,7 +676,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setFriendlyName("SUSE Manager Mgmt Unlimited Virtual 1.2");
         product.setProductId(1078);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("suse-manager-prov-unlimited-virtual");
@@ -684,7 +684,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setFriendlyName("SUSE Manager Prov Unlimited Virtual 1.2");
         product.setProductId(1204);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("suse-manager-mgmt-single");
@@ -692,7 +692,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setFriendlyName("SUSE Manager Mgmt Single 1.2");
         product.setProductId(1076);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("suse-manager-prov-single");
@@ -700,7 +700,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setFriendlyName("SUSE Manager Prov Single 1.2");
         product.setProductId(1097);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("suse-manager-mon-single");
@@ -708,7 +708,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setFriendlyName("SUSE Manager Monitoring Single 1.2");
         product.setProductId(1201);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("suse-manager-mon-unlimited-virtual");
@@ -716,7 +716,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setFriendlyName("SUSE Manager Monitoring Unlimited Virtual 1.2");
         product.setProductId(1202);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
 
         product = new SUSEProduct();
         product.setName("suse-manager-mon-unlimited-virtual-z");
@@ -724,7 +724,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setFriendlyName("SUSE Manager Monitoring Unlimited Virtual Z 1.2");
         product.setProductId(1203);
         product.setReleaseStage(ReleaseStage.released);
-        product = TestUtils.saveAndFlush(product);
+        TestUtils.saveAndFlush(product); //reassign variable if still needed
     }
 
     /**

--- a/java/core/src/test/java/com/redhat/rhn/domain/rhnpackage/PackageFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/rhnpackage/PackageFactoryTest.java
@@ -151,7 +151,7 @@ public class PackageFactoryTest extends BaseTestCaseWithUser {
        provideProduct.setCapability(productCap);
        provideProduct.setPack(testPackage);
        provideProduct.setSense(0L);
-       provideProduct = TestUtils.saveAndFlush(provideProduct);
+       TestUtils.saveAndFlush(provideProduct); //reassign variable if still needed
 
        ServerFactory.save(testServer);
        testServer = TestUtils.reload(testServer);
@@ -176,7 +176,7 @@ public class PackageFactoryTest extends BaseTestCaseWithUser {
         provideProduct.setCapability(productCap);
         provideProduct.setPack(testPackage);
         provideProduct.setSense(0L);
-        provideProduct = TestUtils.saveAndFlush(provideProduct);
+        TestUtils.saveAndFlush(provideProduct); //reassign variable if still needed
 
         ServerFactory.save(testServer);
         testServer = TestUtils.reload(testServer);
@@ -202,7 +202,7 @@ public class PackageFactoryTest extends BaseTestCaseWithUser {
        provideProduct.setCapability(productCap);
        provideProduct.setPack(testPackage);
        provideProduct.setSense(0L);
-       provideProduct = TestUtils.saveAndFlush(provideProduct);
+       TestUtils.saveAndFlush(provideProduct); //reassign variable if still needed
 
        InstalledPackage testInstPack = new InstalledPackage();
        testInstPack.setArch(testPackage.getPackageArch());
@@ -237,7 +237,7 @@ public class PackageFactoryTest extends BaseTestCaseWithUser {
        provideProduct.setPack(testPackage1);
        provideProduct.setSense(0L);
 
-       provideProduct = TestUtils.saveAndFlush(provideProduct);
+       TestUtils.saveAndFlush(provideProduct); //reassign variable if still needed
 
        Package testPackage2 = ErrataTestUtils.createTestPackage(user, channel, "x86_64");
 
@@ -254,7 +254,7 @@ public class PackageFactoryTest extends BaseTestCaseWithUser {
        provideProduct3.setPack(testPackage2);
        provideProduct3.setSense(0L);
 
-       provideProduct3 = TestUtils.saveAndFlush(provideProduct3);
+       TestUtils.saveAndFlush(provideProduct3); //reassign variable if still needed
 
        InstalledPackage testInstPack = new InstalledPackage();
        testInstPack.setArch(testPackage2.getPackageArch());
@@ -288,7 +288,7 @@ public class PackageFactoryTest extends BaseTestCaseWithUser {
        provideProduct.setCapability(productCap);
        provideProduct.setPack(testPackage1);
        provideProduct.setSense(0L);
-       provideProduct = TestUtils.saveAndFlush(provideProduct);
+       TestUtils.saveAndFlush(provideProduct); //reassign variable if still needed
 
        Package testPackage2 = ErrataTestUtils.createTestPackage(user, channel, "x86_64");
 
@@ -296,7 +296,7 @@ public class PackageFactoryTest extends BaseTestCaseWithUser {
        provideProduct2.setCapability(productCap);
        provideProduct2.setPack(testPackage2);
        provideProduct2.setSense(0L);
-       provideProduct2 = TestUtils.saveAndFlush(provideProduct2);
+       TestUtils.saveAndFlush(provideProduct2); //reassign variable if still needed
 
        PackageCapability pkg1Cap = PackageCapabilityTest.createTestCapability(
                testPackage1.getPackageName().getName());
@@ -305,7 +305,7 @@ public class PackageFactoryTest extends BaseTestCaseWithUser {
        provideProduct3.setCapability(pkg1Cap);
        provideProduct3.setPack(testPackage2);
        provideProduct3.setSense(0L);
-       provideProduct3 = TestUtils.saveAndFlush(provideProduct3);
+       TestUtils.saveAndFlush(provideProduct3); //reassign variable if still needed
 
        InstalledPackage testInstPack = new InstalledPackage();
        testInstPack.setArch(testPackage1.getPackageArch());
@@ -364,7 +364,7 @@ public class PackageFactoryTest extends BaseTestCaseWithUser {
        prop.setCapability(cap);
        prop.setPack(pkg);
        prop.setSense(0L);
-       prop = TestUtils.saveAndFlush(prop);
+       TestUtils.saveAndFlush(prop); //reassign variable if still needed
    }
 }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/ServerFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/ServerFactoryTest.java
@@ -1009,7 +1009,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         link.setServer(server2);
         link.setSnapshot(snap);
         link.setTag(tag);
-        link = TestUtils.saveAndFlush(link);
+        TestUtils.saveAndFlush(link); //reassign variable if still needed
 
         List<SnapshotTag> tags = ServerFactory.getSnapshotTags(snap);
         TestUtils.assertContains(tags, tag);
@@ -1198,11 +1198,12 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         ChannelFactory.save(baseChan);
         ChannelFactory.save(childChan);
 
-        e1 = TestUtils.saveAndFlush(e1);
-        e2 = TestUtils.saveAndFlush(e2);
-        e3 = TestUtils.saveAndFlush(e3);
-        e4 = TestUtils.saveAndFlush(e4);
-        e5 = TestUtils.saveAndFlush(e5);
+        //reassign variable(s) if still needed
+        TestUtils.saveAndFlush(e1);
+        TestUtils.saveAndFlush(e2);
+        TestUtils.saveAndFlush(e3);
+        TestUtils.saveAndFlush(e4);
+        TestUtils.saveAndFlush(e5);
 
         Map<Long, Map<String, Tuple2<String, String>>> out =
                 ServerFactory.listNewestPkgsForServerErrata(serverIds, errataIds);
@@ -1295,7 +1296,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         TestUtils.flushAndClearSession();
 
         minion = TestUtils.reload(minion);
-        proxy = TestUtils.reload(proxy);
+        TestUtils.reload(proxy); //reassign variable if still needed
 
         Server s = ServerFactory.lookupById(minion.getId());
         assertEquals(serverPaths.stream().findFirst().get(),

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/ServerGroupFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/ServerGroupFactoryTest.java
@@ -74,7 +74,7 @@ public class ServerGroupFactoryTest extends BaseTestCaseWithUser {
         EntitlementServerGroup sg = ServerGroupFactory.lookupEntitled(user.getOrg(),
                     ServerConstants.getServerGroupTypeEnterpriseEntitled());
         ServerGroupFactory.save(sg);
-        sg = TestUtils.saveAndFlush(sg);
+        TestUtils.saveAndFlush(sg); //reassign variable if still needed
     }
 
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/ServerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/ServerTest.java
@@ -73,7 +73,7 @@ public class ServerTest extends BaseTestCaseWithUser {
                 "Channel 2", "cfg-channel-2");
         s.subscribeConfigChannels(List.of(channel1, channel2), user);
         long sid = s.getId();
-        s = TestUtils.saveAndFlush(s);
+        TestUtils.saveAndFlush(s); //reassign variable if still needed
         RhnSetDecl.SYSTEMS.get(user).addElement(sid);
         RhnSet ssm = RhnSetDecl.SYSTEMS.get(user);
         ssm.addElement(sid);
@@ -181,7 +181,7 @@ public class ServerTest extends BaseTestCaseWithUser {
     public void testNetworkInterfaces() throws Exception {
         Server s = ServerTestUtils.createTestSystem(user);
         NetworkInterfaceTest.createTestNetworkInterface(s);
-        s = TestUtils.saveAndReload(s);
+        TestUtils.saveAndReload(s); //reassign variable if still needed
         Server s2 = ServerTestUtils.createTestSystem(user);
         s2 = TestUtils.saveAndReload(s2);
         NetworkInterfaceTest.createTestNetworkInterface(s2);

--- a/java/core/src/test/java/com/redhat/rhn/domain/token/ActivationKeyTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/token/ActivationKeyTest.java
@@ -72,7 +72,7 @@ public class ActivationKeyTest extends BaseTestCaseWithUser {
         String note = k.getNote();
         String key = k.getKey();
 
-        k = TestUtils.saveAndFlush(k);
+        TestUtils.saveAndFlush(k); //reassign variable if still needed
 
         ActivationKey k2 = ActivationKeyFactory.lookupByKey(key);
         assertEquals(key, k2.getKey());
@@ -163,7 +163,7 @@ public class ActivationKeyTest extends BaseTestCaseWithUser {
         KickstartFactory.saveKickstartSession(sess);
         k.setKickstartSession(sess);
         ActivationKeyFactory.save(k);
-        k = TestUtils.reload(k);
+        TestUtils.reload(k); //reassign variable if still needed
 
         ActivationKey lookedUp = ActivationKeyFactory.lookupByKickstartSession(sess);
         assertNotNull(lookedUp);

--- a/java/core/src/test/java/com/redhat/rhn/domain/user/UserFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/user/UserFactoryTest.java
@@ -355,7 +355,7 @@ public class UserFactoryTest extends BaseTestCase {
 
         UserServerPreference usp = new UserServerPreference(user, s, UserServerPreferenceId.RECEIVE_NOTIFICATIONS);
         usp.setValue("0");
-        usp = TestUtils.saveAndFlush(usp);
+        TestUtils.saveAndFlush(usp); //reassign variable if still needed
 
         usp = factory.lookupServerPreferenceByUserServerAndName(user, s,
                                       UserServerPreferenceId.RECEIVE_NOTIFICATIONS);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/common/DownloadActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/common/DownloadActionTest.java
@@ -83,7 +83,7 @@ public class DownloadActionTest extends RhnMockStrutsTestCase {
         p.setPath("redhat/1/c7d/some-package/2.13.1-6.fc9/" +
                 "x86_64/c7dd5e9b6975bc7f80f2f4657260af53/" +
                 fileName);
-        p = TestUtils.saveAndFlush(p);
+        TestUtils.saveAndFlush(p); //reassign variable if still needed
 
         addRequestParameter("url", "/ks/dist/" + tree.getLabel() + "/Server/" + fileName);
         request.setQueryString("url=/ks/dist/" + tree.getLabel() + "/Server/" + fileName);
@@ -128,7 +128,7 @@ public class DownloadActionTest extends RhnMockStrutsTestCase {
         p.setPath("redhat/1/c7d/some-package/2.13.1-6.fc9/" +
                 "x86_64/c7dd5e9b6975bc7f80f2f4657260af53/" +
                 fileName);
-        p = TestUtils.saveAndFlush(p);
+        TestUtils.saveAndFlush(p); //reassign variable if still needed
 
         FileUtils.touch(new File("/tmp/Server/" + fileName));
 
@@ -159,7 +159,7 @@ public class DownloadActionTest extends RhnMockStrutsTestCase {
         // /ks/dist/f9-x86_64-distro/images/boot.iso
         KickstartSession ksession =
             KickstartSessionTest.createKickstartSession(ksdata, user);
-        ksession = TestUtils.saveAndFlush(ksession);
+        TestUtils.saveAndFlush(ksession); //reassign variable if still needed
         addRequestParameter("url", "/ks/dist/" + tree.getLabel() + "/images/");
         request.setQueryString("url=/ks/dist/" + tree.getLabel() + "/images/");
         actionPerform();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartIpSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartIpSetupActionTest.java
@@ -63,7 +63,7 @@ public class KickstartIpSetupActionTest extends RhnMockStrutsTestCase {
         k.addIpRange(ip1);
         k.addIpRange(ip2);
 
-        k = TestUtils.saveAndFlush(k);
+        TestUtils.saveAndFlush(k); //reassign variable if still needed
 
         setRequestPathInfo("/kickstart/KickstartIpRanges");
         actionPerform();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/schedule/CompletedActionsSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/schedule/CompletedActionsSetupActionTest.java
@@ -66,7 +66,7 @@ public class CompletedActionsSetupActionTest extends RhnPostMockStrutsTestCase {
         Action act = ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
         ServerAction sAction = ActionFactoryTest.createServerAction(server, act);
         sAction.setStatusCompleted();
-        sAction = TestUtils.saveAndFlush(sAction);
+        TestUtils.saveAndFlush(sAction); //reassign variable if still needed
 
 
         RhnSet set = RhnSetDecl.ACTIONS_COMPLETED.get(user);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/schedule/FailedActionsSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/schedule/FailedActionsSetupActionTest.java
@@ -66,7 +66,7 @@ public class FailedActionsSetupActionTest extends RhnPostMockStrutsTestCase {
         Action act = ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
         ServerAction sAction = ActionFactoryTest.createServerAction(server, act);
         sAction.setStatusFailed();
-        sAction = TestUtils.saveAndFlush(sAction);
+        TestUtils.saveAndFlush(sAction); //reassign variable if still needed
 
 
         RhnSet set = RhnSetDecl.ACTIONS_FAILED.get(user);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/schedule/PendingActionsSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/schedule/PendingActionsSetupActionTest.java
@@ -67,7 +67,7 @@ public class PendingActionsSetupActionTest extends RhnPostMockStrutsTestCase {
         Action act = ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
         ServerAction sAction = ActionFactoryTest.createServerAction(server, act);
         sAction.setStatusQueued();
-        sAction = TestUtils.saveAndFlush(sAction);
+        TestUtils.saveAndFlush(sAction); //reassign variable if still needed
 
 
         RhnSet set = RhnSetDecl.ACTIONS_PENDING.get(user);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/sdc/SystemChannelsActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/sdc/SystemChannelsActionTest.java
@@ -53,7 +53,7 @@ public class SystemChannelsActionTest extends RhnMockStrutsTestCase {
         Channel child2 = ChannelTestUtils.createChildChannel(user, server.getBaseChannel());
         child2.setOrg(null);
 
-        child1 = TestUtils.saveAndFlush(child1);
+        TestUtils.saveAndFlush(child1); //reassign variable if still needed
         child2 = TestUtils.saveAndFlush(child2);
 
         server.addChannel(child2);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/kickstart/KickstartHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/kickstart/KickstartHandlerTest.java
@@ -283,7 +283,7 @@ public class KickstartHandlerTest extends BaseHandlerTestCase {
         KickstartData ks  = KickstartDataTest.createKickstartWithProfile(admin);
         String label = ks.getLabel();
         KickstartFactory.saveKickstartData(ks);
-        ks = TestUtils.reload(ks);
+        TestUtils.reload(ks); //reassign variable if still needed
 
         List<KickstartDto> list = handler.listKickstarts(admin);
         boolean foundKs = false;

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerTest.java
@@ -657,7 +657,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
         // Try setting base channel to child
         try {
-            result = handler.setBaseChannel(admin, sid, child1.getLabel());
+            handler.setBaseChannel(admin, sid, child1.getLabel());
             fail("SystemHandler.setBaseChannel allowed invalid base channel to be set.");
         }
         catch (InvalidChannelException e) {
@@ -674,7 +674,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
             ServerFactory.save(server);
 
 
-            result = handler.setBaseChannel(admin, sid, base1.getLabel());
+            handler.setBaseChannel(admin, sid, base1.getLabel());
             fail("allowed channel with incompatible arch to be set");
         }
         catch (InvalidChannelException e) {
@@ -1367,7 +1367,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         assertNull(val);
 
         try {
-            pillar = readCustomInfoPillar(server);
+            readCustomInfoPillar(server);
             fail("Custom info pillar was not deleted.");
         }
         catch (java.util.NoSuchElementException e) {
@@ -2638,7 +2638,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         assertEquals(0, keys.size());
 
         key.getToken().getActivatedServers().add(server);
-        key = TestUtils.saveAndFlush(key);
+        TestUtils.saveAndFlush(key); //reassign variable if still needed
 
         keys = handler.listActivationKeys(admin, server.getId().intValue());
         assertEquals(1, keys.size());

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/SnapshotHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/SnapshotHandlerTest.java
@@ -124,7 +124,7 @@ public class SnapshotHandlerTest extends BaseHandlerTestCase {
         generateSnapshot(server);
         generateSnapshot(server);
         generateSnapshot(server);
-        snap = TestUtils.saveAndFlush(snap);
+        TestUtils.saveAndFlush(snap); //reassign variable if still needed
 
         handler.deleteSnapshots(admin, server.getId().intValue(), new HashMap<>());
         List<ServerSnapshot> list = handler.listSnapshots(admin, server.getId().intValue(), new HashMap<>());

--- a/java/core/src/test/java/com/redhat/rhn/manager/channel/ChannelManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/channel/ChannelManagerTest.java
@@ -268,7 +268,7 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
         Channel parent = ChannelFactoryTest.createBaseChannel(user);
         Channel child = ChannelFactoryTest.createTestChannel(user);
         child.setParentChannel(parent);
-        child = TestUtils.saveAndFlush(child);
+        TestUtils.saveAndFlush(child); //reassign variable if still needed
         parent = TestUtils.saveAndFlush(parent);
 
         List<Channel> dr =
@@ -442,13 +442,13 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
 
         Channel c = ChannelTestUtils.createTestChannel(user);
         c.setName("A Channel");
-        c = TestUtils.saveAndReload(c);
+        TestUtils.saveAndReload(c); //reassign variable if still needed
         c = ChannelTestUtils.createTestChannel(user);
         c.setName("C Channel");
-        c = TestUtils.saveAndReload(c);
+        TestUtils.saveAndReload(c); //reassign variable if still needed
         c = ChannelTestUtils.createTestChannel(user);
         c.setName("B Channel");
-        c = TestUtils.saveAndReload(c);
+        TestUtils.saveAndReload(c); //reassign variable if still needed
 
         List<String> channelNames = ChannelManager.listBaseChannelsForSystem(user, s).stream()
                 .map(EssentialChannelDto::getName).toList();
@@ -1147,7 +1147,7 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
         child1.setOriginal(damagedChild2);
 
         child1 = TestUtils.saveAndFlush(child1);
-        parent1 = TestUtils.saveAndFlush(parent1);
+        TestUtils.saveAndFlush(parent1); //reassign variable if still needed
         damagedChild2 = TestUtils.saveAndFlush(damagedChild2);
         TestUtils.flushAndEvict(child1);
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/channel/CloneChannelCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/channel/CloneChannelCommandTest.java
@@ -238,7 +238,7 @@ public class CloneChannelCommandTest extends BaseTestCaseWithUser {
 
         ProductName pn = ChannelFactoryTest.lookupOrCreateProductName("sap-ha");
         childrenChannel.setProductName(pn);
-        pn = TestUtils.saveAndFlush(pn);
+        TestUtils.saveAndFlush(pn); //reassign variable if still needed
         ChannelFactory.save(childrenChannel);
 
         return childrenChannel;

--- a/java/core/src/test/java/com/redhat/rhn/manager/content/ContentSyncManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/content/ContentSyncManagerTest.java
@@ -1572,12 +1572,12 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         if (SUSEProductFactory.lookupByProductId(10012345) == null) {
             p = SUSEProductTestUtils.createTestSUSEProduct(family);
             p.setProductId(10012345);
-            p = TestUtils.saveAndFlush(p);
+            TestUtils.saveAndFlush(p); //reassign variable if still needed
         }
         if (SUSEProductFactory.lookupByProductId(10012346) == null) {
             p = SUSEProductTestUtils.createTestSUSEProduct(family);
             p.setProductId(10012346);
-            p = TestUtils.saveAndFlush(p);
+            TestUtils.saveAndFlush(p); //reassign variable if still needed
         }
 
         // Update the upgrade paths
@@ -2288,12 +2288,12 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         for (Channel c : ChannelFactory.listVendorChannels()) {
             c.setLabel(TestUtils.randomString());
             c.setName(TestUtils.randomString());
-            c = TestUtils.saveAndFlush(c);
+            TestUtils.saveAndFlush(c); //reassign variable if still needed
         }
         for (ContentSource cs : ChannelFactory.listVendorContentSources()) {
             cs.setLabel(TestUtils.randomString());
             cs.setSourceUrl(TestUtils.randomString());
-            cs = TestUtils.saveAndFlush(cs);
+            TestUtils.saveAndFlush(cs); //reassign variable if still needed
         }
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/distupgrade/DistUpgradeManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/distupgrade/DistUpgradeManagerTest.java
@@ -229,7 +229,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
                 sourceAddonProduct, sourceBaseChannel, user);
         SUSEProductExtension e = new SUSEProductExtension(
                 sourceBaseProduct, sourceAddonProduct, sourceBaseProduct, false);
-        e = TestUtils.saveAndReload(e);
+        TestUtils.saveAndReload(e); //reassign variable if still needed
 
         sourceAddons.add(sourceAddonProduct);
         SUSEProductSet sourceProducts = new SUSEProductSet(sourceBaseProduct, sourceAddons);
@@ -253,8 +253,8 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
                 sourceBaseProduct, targetAddonProduct, sourceBaseProduct, false);
         SUSEProductExtension e3 = new SUSEProductExtension(
                 targetBaseProduct, targetAddonProduct, targetBaseProduct, false);
-        e2 = TestUtils.saveAndReload(e2);
-        e3 = TestUtils.saveAndReload(e3);
+        TestUtils.saveAndReload(e2); //reassign variable if still needed
+        TestUtils.saveAndReload(e3); //reassign variable if still needed
 
         SCCRepository base = SUSEProductTestUtils.createSCCRepository();
         SUSEProductTestUtils.createSCCRepositoryTokenAuth(sccc, base);
@@ -317,7 +317,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
                 sourceAddonProduct, sourceBaseChannel, user);
         SUSEProductExtension e = new SUSEProductExtension(
                 sourceBaseProduct, sourceAddonProduct, sourceBaseProduct, false);
-        e = TestUtils.saveAndReload(e);
+        TestUtils.saveAndReload(e); //reassign variable if still needed
 
         sourceAddons.add(sourceAddonProduct);
         SUSEProductSet sourceProducts = new SUSEProductSet(sourceBaseProduct, sourceAddons);
@@ -341,8 +341,8 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
                 sourceBaseProduct, targetAddonProduct, sourceBaseProduct, false);
         SUSEProductExtension e3 = new SUSEProductExtension(
                 targetBaseProduct, targetAddonProduct, targetBaseProduct, false);
-        e2 = TestUtils.saveAndReload(e2);
-        e3 = TestUtils.saveAndReload(e3);
+        TestUtils.saveAndReload(e2); //reassign variable if still needed
+        TestUtils.saveAndReload(e3); //reassign variable if still needed
 
         SUSEProductTestUtils.populateRepository(targetBaseProduct, targetBaseChannel, targetBaseProduct,
                 targetBaseChannel, user);
@@ -394,7 +394,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         sourceChildChannel.setLabel("sourceChildChannel");
         SUSEProductExtension e = new SUSEProductExtension(
                 sourceBaseProduct, sourceAddonProduct, sourceBaseProduct, false);
-        e = TestUtils.saveAndReload(e);
+        TestUtils.saveAndReload(e); //reassign variable if still needed
 
         sourceAddons.add(sourceAddonProduct);
         SUSEProductSet sourceProducts = new SUSEProductSet(sourceBaseProduct, sourceAddons);
@@ -420,8 +420,8 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
                 sourceBaseProduct, targetAddonProduct, sourceBaseProduct, false);
         SUSEProductExtension e3 = new SUSEProductExtension(
                 targetBaseProduct, targetAddonProduct, targetBaseProduct, false);
-        e2 = TestUtils.saveAndReload(e2);
-        e3 = TestUtils.saveAndReload(e3);
+        TestUtils.saveAndReload(e2); //reassign variable if still needed
+        TestUtils.saveAndReload(e3); //reassign variable if still needed
 
         SUSEProductTestUtils.populateRepository(targetBaseProduct, targetBaseChannel, targetBaseProduct,
                 targetBaseChannel, user);
@@ -437,7 +437,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         template.setParentChannelLabel(targetBaseChannel.getLabel());
         template.setChannelName(targetBaseChannel.getLabel());
         template.setMandatory(true);
-        template = TestUtils.saveAndReload(template);
+        TestUtils.saveAndReload(template); //reassign variable if still needed
 
         // Verify that target products are returned correctly
 
@@ -523,7 +523,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         if (name == null) {
             name = zyppPlugin.getPackageName();
             name.setName("zypp-plugin-spacewalk");
-            name = TestUtils.saveAndFlush(name);
+            TestUtils.saveAndFlush(name); //reassign variable if still needed
         }
         else {
             // Handle the case that the package name exists in the DB
@@ -536,7 +536,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         Action action = ActionFactoryTest.createAction(user,
                 ActionFactory.TYPE_DIST_UPGRADE);
         ServerAction serverAction = ActionFactoryTest.createServerAction(server, action);
-        serverAction = TestUtils.saveAndFlush(serverAction);
+        TestUtils.saveAndFlush(serverAction); //reassign variable if still needed
 
         try {
             DistUpgradeManager.performServerChecks(server.getId(), user);
@@ -728,7 +728,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
                 ltssSP1AddonProduct, slesSP1BaseChannel, user);
         SUSEProductExtension e = new SUSEProductExtension(
                 slesSP1BaseProduct, ltssSP1AddonProduct, slesSP1BaseProduct, false);
-        e = TestUtils.saveAndReload(e);
+        TestUtils.saveAndReload(e); //reassign variable if still needed
 
         slesSP1Addons.add(ltssSP1AddonProduct);
         SUSEProductSet sourceProducts = new SUSEProductSet(slesSP1BaseProduct, slesSP1Addons);
@@ -766,7 +766,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         ltssSP1AddonProduct.setUpgrades(Collections.singleton(ltssSP2AddonProduct));
         SUSEProductExtension e3 = new SUSEProductExtension(
                 slesSP2BaseProduct, ltssSP2AddonProduct, slesSP2BaseProduct, false);
-        e3 = TestUtils.saveAndReload(e3);
+        TestUtils.saveAndReload(e3); //reassign variable if still needed
         SUSEProductTestUtils.populateRepository(slesSP2BaseProduct, slesSP2BaseChannel, ltssSP2AddonProduct,
                 ltssSP2AddonChannel, user);
         targetProductSets = DistUpgradeManager.getTargetProductSets(Optional.of(sourceProducts), arch, user);
@@ -857,7 +857,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         sourceAddonManagerTools.setFriendlyName("Test SUSE Manager Client Tools for RHEL, Liberty and Clones 9 x86_64");
         SUSEProductExtension eManagerTools = new SUSEProductExtension(
                 sourceBaseProductRocky9, sourceAddonManagerTools, sourceBaseProductRocky9, false);
-        eManagerTools = TestUtils.saveAndReload(eManagerTools);
+        TestUtils.saveAndReload(eManagerTools); //reassign variable if still needed
         Channel sourceChildChannelManagerTools = SUSEProductTestUtils.createChildChannelsForProduct(
                 sourceAddonManagerTools, sourceBaseChannelRocky9, user);
         SUSEProductTestUtils.populateRepository(sourceBaseProductRocky9, sourceBaseChannelRocky9,
@@ -876,7 +876,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
 
         SUSEProductExtension eTargetRhelManagerTools = new SUSEProductExtension(
                 targetBaseProductRhel9, sourceAddonManagerTools, targetBaseProductRhel9, false);
-        eTargetRhelManagerTools = TestUtils.saveAndReload(eTargetRhelManagerTools);
+        TestUtils.saveAndReload(eTargetRhelManagerTools); //reassign variable if still needed
 
         SUSEProduct targetAddonLiberty9 = SUSEProductTestUtils.createTestSUSEProduct(family);
         targetAddonLiberty9.setName("sll");
@@ -884,7 +884,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         targetAddonLiberty9.setFriendlyName("Test SUSE Liberty Linux 9 x86_64");
         SUSEProductExtension eLiberty9 = new SUSEProductExtension(
                 targetBaseProductRhel9, targetAddonLiberty9, targetBaseProductRhel9, false);
-        eLiberty9 = TestUtils.saveAndReload(eLiberty9);
+        TestUtils.saveAndReload(eLiberty9); //reassign variable if still needed
         Channel targeChildChannelLiberty9 = SUSEProductTestUtils.createChildChannelsForProduct(
                 targetAddonLiberty9, targetBaseChannelRhel9, user);
         SUSEProductTestUtils.populateRepository(targetBaseProductRhel9, targetBaseChannelRhel9,
@@ -970,7 +970,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         sourceAddonManagerTools.setFriendlyName("Test SUSE Manager Client Tools for RHEL, Liberty and Clones 9 x86_64");
         SUSEProductExtension eManagerTools = new SUSEProductExtension(
                 sourceBaseProductRhel9, sourceAddonManagerTools, sourceBaseProductRhel9, false);
-        eManagerTools = TestUtils.saveAndReload(eManagerTools);
+        TestUtils.saveAndReload(eManagerTools); //reassign variable if still needed
         Channel sourceChildChannelManagerTools = SUSEProductTestUtils.createChildChannelsForProduct(
                 sourceAddonManagerTools, sourceBaseChannelRhel9, user);
         SUSEProductTestUtils.populateRepository(sourceBaseProductRhel9, sourceBaseChannelRhel9,
@@ -983,7 +983,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         sourceAddonLiberty9.setFriendlyName("Test SUSE Liberty Linux 9 x86_64");
         SUSEProductExtension eLiberty9 = new SUSEProductExtension(
                 sourceBaseProductRhel9, sourceAddonLiberty9, sourceBaseProductRhel9, false);
-        eLiberty9 = TestUtils.saveAndReload(eLiberty9);
+        TestUtils.saveAndReload(eLiberty9); //reassign variable if still needed
         Channel sourceChildChannelLiberty9 = SUSEProductTestUtils.createChildChannelsForProduct(
                 sourceAddonLiberty9, sourceBaseChannelRhel9, user);
         SUSEProductTestUtils.populateRepository(sourceBaseProductRhel9, sourceBaseChannelRhel9,

--- a/java/core/src/test/java/com/redhat/rhn/manager/errata/ErrataManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/errata/ErrataManagerTest.java
@@ -757,7 +757,7 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         if (name == null) {
             name = zypperPkg.getPackageName();
             name.setName("zypper");
-            name = TestUtils.saveAndFlush(name);
+            TestUtils.saveAndFlush(name); //reassign variable if still needed
         }
         else {
             // Handle the case that the package name exists in the DB
@@ -1295,7 +1295,7 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         if (name == null) {
             name = zypperPkg.getPackageName();
             name.setName("zypper");
-            name = TestUtils.saveAndFlush(name);
+            TestUtils.saveAndFlush(name); //reassign variable if still needed
         }
         else {
             // Handle the case that the package name exists in the DB
@@ -1563,7 +1563,7 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         k.setErrata(errata3);
         kw.add(k);
         errata3.setKeywords(kw);
-        errata3 = TestUtils.saveAndFlush(errata3);
+        TestUtils.saveAndFlush(errata3); //reassign variable if still needed
 
         assertTrue(ErrataManager.updateStackUpdateNeeded(user, server));
     }

--- a/java/core/src/test/java/com/redhat/rhn/manager/kickstart/KickstartScheduleCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/kickstart/KickstartScheduleCommandTest.java
@@ -95,7 +95,7 @@ public class KickstartScheduleCommandTest extends BaseKickstartCommandTestCase {
                 createKickstartSession(ksdata, user);
         ksession.setNewServer(server);
         ksession.setOldServer(server);
-        ksession = TestUtils.saveAndFlush(ksession);
+        TestUtils.saveAndFlush(ksession); //reassign variable if still needed
     }
 
     private static void assertCmdSuccess(KickstartScheduleCommand cmd) {
@@ -135,7 +135,7 @@ public class KickstartScheduleCommandTest extends BaseKickstartCommandTestCase {
                 KickstartVirtualizationType.none());
         x86ks.getChannel().setChannelArch(ChannelFactory.lookupArchByName("x86_64"));
         TestUtils.saveAndFlush(x86ks.getChannel());
-        x86ks = TestUtils.saveAndFlush(x86ks);
+        TestUtils.saveAndFlush(x86ks); //reassign variable if still needed
 
 
         server.setServerArch(ServerConstants.getArchI686());
@@ -291,7 +291,7 @@ public class KickstartScheduleCommandTest extends BaseKickstartCommandTestCase {
                 KickstartScheduleCommand.UP2DATE_VERSION, "0",
                 c.getChannelArch().getArchType().getPackageType());
         p.setPackageEvr(pevr);
-        p = TestUtils.saveAndFlush(p);
+        TestUtils.saveAndFlush(p); //reassign variable if still needed
     }
 
     // Like the number of params on this one?  Nice eh?  At least its private and

--- a/java/core/src/test/java/com/redhat/rhn/manager/kickstart/KickstartWizardCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/kickstart/KickstartWizardCommandTest.java
@@ -50,7 +50,7 @@ public class KickstartWizardCommandTest extends KickstartBaseTest {
         KickstartableTree tree  = KickstartableTreeTest.createTestKickstartableTree(c);
         tree.setChannel(c);
         tree = TestUtils.saveAndFlush(tree);
-        c = TestUtils.saveAndFlush(c);
+        TestUtils.saveAndFlush(c); //reassign variable if still needed
 
         KickstartWizardHelper cmd = new KickstartWizardHelper(user);
         List trees = cmd.getKickstartableTrees();

--- a/java/core/src/test/java/com/redhat/rhn/manager/setup/ProductSyncManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/setup/ProductSyncManagerTest.java
@@ -562,7 +562,7 @@ public class ProductSyncManagerTest extends BaseTestCaseWithUser {
         template.setParentChannelLabel(prefix + "-" + Objects.requireNonNullElse(rootChannelLabel, channelLabel));
         template.setChannelName(channelName);
         template.setMandatory(true);
-        template = TestUtils.saveAndReload(template);
+        TestUtils.saveAndReload(template); //reassign variable if still needed
     }
 
     private static void createProductExtension(SUSEProduct product, SUSEProduct parent, SUSEProduct root) {
@@ -571,7 +571,7 @@ public class ProductSyncManagerTest extends BaseTestCaseWithUser {
         productExtension.setBaseProduct(parent);
         productExtension.setRootProduct(root);
         productExtension.setRecommended(true);
-        productExtension = TestUtils.saveAndReload(productExtension);
+        TestUtils.saveAndReload(productExtension); //reassign variable if still needed
     }
 
     private static SUSEProduct createProduct(String prefix, String name, String version, String desc,

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/CancelKickstartSessionOperationTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/CancelKickstartSessionOperationTest.java
@@ -50,7 +50,7 @@ public class CancelKickstartSessionOperationTest extends BaseTestCaseWithUser {
         ksession.setAction(a);
         ActionFactory.save(a);
         KickstartFactory.saveKickstartData(k);
-        ksession = TestUtils.saveAndFlush(ksession);
+        TestUtils.saveAndFlush(ksession); //reassign variable if still needed
 
         CancelKickstartSessionOperation dso = new CancelKickstartSessionOperation(user, s.getId());
         dso.store();

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
@@ -2126,7 +2126,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
 
         systemEntitlementManager.setBaseEntitlement(proxy, EntitlementManager.FOREIGN);
         ServerFactory.save(proxy);
-        proxy = TestUtils.saveAndFlush(proxy);
+        TestUtils.saveAndFlush(proxy); //reassign variable if still needed
     }
 
     private Map<String, String> readTarData(byte[] data) throws IOException {

--- a/java/core/src/test/java/com/redhat/rhn/manager/user/UserManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/user/UserManagerTest.java
@@ -611,7 +611,7 @@ public class UserManagerTest extends BaseTestCase {
        UserServerPreference usp = new UserServerPreference(user, s, UserServerPreferenceId.RECEIVE_NOTIFICATIONS);
        usp.setValue("0");
 
-       usp = TestUtils.saveAndFlush(usp);
+       TestUtils.saveAndFlush(usp); //reassign variable if still needed
 
        assertFalse(UserManager.lookupUserServerPreferenceValue(user,
                                                                s,

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/MinionCheckinTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/MinionCheckinTest.java
@@ -72,7 +72,7 @@ public class MinionCheckinTest extends JMockBaseTestCaseWithUser {
         ServerInfo serverInfo = minion1.getServerInfo();
         serverInfo.setCheckin(new Date());
         minion1.setServerInfo(serverInfo);
-        minion1 = TestUtils.saveAndFlush(minion1);
+        TestUtils.saveAndFlush(minion1); //reassign variable if still needed
 
         SaltService saltServiceMock = mock(SaltService.class);
 
@@ -105,7 +105,7 @@ public class MinionCheckinTest extends JMockBaseTestCaseWithUser {
         ServerInfo serverInfo = minion1.getServerInfo();
         serverInfo.setCheckin(DateUtils.addHours(new Date(), -this.thresholdMax));
         minion1.setServerInfo(serverInfo);
-        minion1 = TestUtils.saveAndFlush(minion1);
+        TestUtils.saveAndFlush(minion1); //reassign variable if still needed
 
         SaltService saltServiceMock = mock(SaltService.class);
 

--- a/java/core/src/test/java/com/redhat/rhn/testing/ErrataTestUtils.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/ErrataTestUtils.java
@@ -137,7 +137,7 @@ public class ErrataTestUtils {
         Channel channel = createTestChannel(user);
         channel.setParentChannel(parent);
         Channel managed = TestUtils.saveAndFlush(channel);
-        parent = TestUtils.saveAndFlush(parent);
+        TestUtils.saveAndFlush(parent); //reassign variable if still needed
 
         return managed;
     }
@@ -333,7 +333,7 @@ public class ErrataTestUtils {
         m.executeUpdate(params, list);
         HibernateFactory.getSession().refresh(channel);
 
-        channel = TestUtils.saveAndFlush(channel);
+        TestUtils.saveAndFlush(channel); //reassign variable if still needed
 
         if (errata != null) {
             errata.addPackage(result);

--- a/java/core/src/test/java/com/redhat/rhn/testing/ImageTestUtils.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/ImageTestUtils.java
@@ -178,7 +178,7 @@ public class ImageTestUtils {
         }
 
         profile.getCustomDataValues().add(val);
-        profile = TestUtils.saveAndFlush(profile);
+        TestUtils.saveAndFlush(profile); //reassign variable if still needed
 
         return val;
     }
@@ -207,7 +207,7 @@ public class ImageTestUtils {
         }
 
         info.getCustomDataValues().add(val);
-        info = TestUtils.saveAndFlush(info);
+        TestUtils.saveAndFlush(info); //reassign variable if still needed
 
         return val;
     }

--- a/java/core/src/test/java/com/redhat/rhn/testing/PackageTestUtils.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/PackageTestUtils.java
@@ -222,8 +222,8 @@ public class PackageTestUtils {
         addRequiresHeader(ptfPackage, findOrCreateCapability(masterPtfPackage.getPackageName().getName(),
             masterPtfPackage.getPackageEvr().getVersion() + "-0"), 8L);
 
-        masterPtfPackage = TestUtils.saveAndFlush(masterPtfPackage);
-        ptfPackage = TestUtils.saveAndFlush(ptfPackage);
+        TestUtils.saveAndFlush(masterPtfPackage); //reassign variable if still needed
+        TestUtils.saveAndFlush(ptfPackage); //reassign variable if still needed
     }
 
     /**
@@ -237,7 +237,7 @@ public class PackageTestUtils {
         packageProvides.setCapability(capability);
         packageProvides.setPack(pack);
         packageProvides.setSense(sense);
-        packageProvides = TestUtils.saveAndFlush(packageProvides);
+        TestUtils.saveAndFlush(packageProvides); //reassign variable if still needed
     }
 
     /**
@@ -251,7 +251,7 @@ public class PackageTestUtils {
         packageProvides.setCapability(capability);
         packageProvides.setPack(pack);
         packageProvides.setSense(sense);
-        packageProvides = TestUtils.saveAndFlush(packageProvides);
+        TestUtils.saveAndFlush(packageProvides); //reassign variable if still needed
     }
 
     /**

--- a/java/core/src/test/java/com/redhat/rhn/testing/ServerTestUtils.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/ServerTestUtils.java
@@ -276,7 +276,7 @@ public class ServerTestUtils {
         Package upgradedPackage = PackageTest.createTestPackage(org);
         upgradedPackage.setPackageName(installedPackage.getPackageName());
         upgradedPackage.setPackageEvr(upgradedPackageEvr);
-        upgradedPackage = TestUtils.saveAndFlush(upgradedPackage);
+        TestUtils.saveAndFlush(upgradedPackage); //reassign variable if still needed
 
         ErrataCacheManager.insertNeededErrataCache(
                 server.getId(), errata.getId(), installedPackage.getId());

--- a/java/core/src/test/java/com/redhat/rhn/testing/UserTestUtils.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/UserTestUtils.java
@@ -222,7 +222,7 @@ public class UserTestUtils {
         EntitlementServerGroup sg =
                 ServerGroupTestUtils.createEntitled(orgIn,
                         ServerConstants.getServerGroupTypeVirtualizationEntitled());
-        sg = TestUtils.saveAndFlush(sg);
+        TestUtils.saveAndFlush(sg); //reassign variable if still needed
     }
 
     /**
@@ -236,7 +236,7 @@ public class UserTestUtils {
         if (retval == null) {
             retval = new UserTestUtils.UserBuilder().orgId(orgIn.getId()).build();
             UserTestUtils.addUserRole(retval, RoleFactory.ORG_ADMIN);
-            orgIn = TestUtils.saveAndFlush(orgIn);
+            TestUtils.saveAndFlush(orgIn); //reassign variable if still needed
         }
         return retval;
     }

--- a/java/core/src/test/java/com/suse/manager/reactor/messaging/JobReturnEventMessageActionTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/messaging/JobReturnEventMessageActionTest.java
@@ -1658,7 +1658,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         Long actionId = ImageInfoFactory.scheduleImport(
                 server.getId(), imageName, imageVersion, store, Optional.empty(), new Date(), user);
         Action action = ActionFactory.lookupById(actionId);
-        action = TestUtils.reload(action);
+        action = TestUtils.reload(action); //reassign variable if still needed
 
         // Process the image inspect return event
         Map<String, String> placeholders = new HashMap<>();
@@ -1997,7 +1997,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         // schedule an inspect action
         ImageInspectAction inspectAction = (ImageInspectAction) ActionFactory.lookupById(actionId);
-        inspectAction = TestUtils.reload(inspectAction);
+        TestUtils.reload(inspectAction); //reassign variable if still needed
         // Process the image inspect return event
         Optional<JobReturnEvent> event = JobReturnEvent
                 .parse(getJobReturnEvent(returnEventJson, actionId));

--- a/java/core/src/test/java/com/suse/manager/reactor/utils/RhelUtilsTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/utils/RhelUtilsTest.java
@@ -453,7 +453,7 @@ public class RhelUtilsTest extends JMockBaseTestCaseWithUser {
 
         suseProduct.getSuseProductChannels().add(spc);
 
-        spc = TestUtils.saveAndFlush(spc);
+        TestUtils.saveAndFlush(spc); //reassign variable if still needed
 
         ChannelFactory.save(c);
         return c;

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/DownloadControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/DownloadControllerTest.java
@@ -232,7 +232,7 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
         m.executeUpdate(params, list);
         HibernateFactory.getSession().refresh(debChannel);
 
-        debChannel = TestUtils.saveAndFlush(debChannel);
+        TestUtils.saveAndFlush(debChannel); //reassign variable if still needed
 
         final String debNvra = String.format("%s_%s-%s.%s",
                 dpkg.getPackageName().getName(), dpkg.getPackageEvr().getVersion(),


### PR DESCRIPTION
## What does this PR change?

SonarCloud error reduction fix step 19, Unused assignments should be removed (java:S1854)

Divided in 5 chunks
SonarCloud fix: java:S1854 Unused assignments should be removed


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s): 
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
