### PR TITLE
Normalize 'unknown' arch to null

### DIFF
--- a/java/core/src/main/java/com/suse/scc/model/SCCProductJson.java
+++ b/java/core/src/main/java/com/suse/scc/model/SCCProductJson.java
@@ -20,6 +20,8 @@ import com.redhat.rhn.domain.product.ReleaseStage;
 import com.google.gson.annotations.SerializedName;
 
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.List;
@@ -28,6 +30,8 @@ import java.util.List;
  * This is a SUSE product as parsed from JSON coming in from SCC.
  */
 public class SCCProductJson {
+
+    private static final Logger LOG = LogManager.getLogger(SCCProductJson.class);
 
     /**
      * Product Builder
@@ -512,6 +516,10 @@ public class SCCProductJson {
      * @return the arch
      */
     public String getArch() {
+        if ("unknown".equals(arch)) {
+            LOG.debug("Product '{}' (id={}) has arch='unknown' from SCC, treating as no-arch", identifier, id);
+            return null;
+        }
         if (arch != null && List.of("amd64", "arm64").contains(arch)) {
             return arch + "-deb";
         }

--- a/java/core/src/test/java/com/suse/scc/SCCClientTest.java
+++ b/java/core/src/test/java/com/suse/scc/SCCClientTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.redhat.rhn.domain.product.ProductType;
+import com.redhat.rhn.domain.product.ReleaseStage;
 import com.redhat.rhn.testing.httpservermock.HttpServerMock;
 import com.redhat.rhn.testing.httpservermock.Responder;
 
@@ -288,5 +290,19 @@ public class SCCClientTest  {
         };
 
         serverMock.getResult(requester, errorResponder);
+    }
+
+    /**
+     * Tests that {@link SCCProductJson#getArch()} normalizes "unknown" to null,
+     * matching the behavior of a null arch (used for arch-independent products like Rancher).
+     */
+    @Test
+    public void testGetArchUnknownNormalizesToNull() {
+        SCCProductJson product = new SCCProductJson(
+                2284L, "SUSE Rancher", "rancher", "2.5.8", null, "unknown",
+                "SUSE Rancher 2.5.8", "RANCHER-X86", ReleaseStage.released,
+                "cpe:/o:suse:rancher:2.5.8", false, null, "",
+                List.of(), List.of(), List.of(), List.of(), ProductType.base, false);
+        assertNull(product.getArch());
     }
 }

--- a/java/spacewalk-java.changes.abid.handle-arch-change-done-in-scc
+++ b/java/spacewalk-java.changes.abid.handle-arch-change-done-in-scc
@@ -1,0 +1,1 @@
+- Handle the 'unknown' arch as no arch


### PR DESCRIPTION

## What does this PR change?

Treat the string "unknown" for arch as a null architecture in SCCProductJson#getArch so arch-independent products are handled like a null arch.


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/30848
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
