### PR TITLE
guard legacy rpm function

### DIFF
--- a/python/spacewalk/server/importlib/headerSource.py
+++ b/python/spacewalk/server/importlib/headerSource.py
@@ -642,7 +642,8 @@ def createPackage(
 
     # bug #524231 - we need to call fullFilelist() for RPM v3 file list
     # to expand correctly
-    header.hdr.fullFilelist()
+    if hasattr(header.hdr, "fullFilelist"):
+        header.hdr.fullFilelist()
     p.populate(
         header,
         size,

--- a/python/spacewalk/spacewalk-backend.changes.mcalmer.guard-legacy-rpm-functions
+++ b/python/spacewalk/spacewalk-backend.changes.mcalmer.guard-legacy-rpm-functions
@@ -1,0 +1,2 @@
+- Guard legacy RPM function that was deprecated and removed in
+  newer versions


### PR DESCRIPTION
## What does this PR change?

The rpm software management library deprecated and completely stripped out several legacy wrapper methods on header objects. Specifically, the helper method fullFilelist() has been removed from the C-bindings wrapper (rpm.hdr).

Because modern RPM libraries handle file lists internally, we can safely guard this call.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410
Port(s): No port needed

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
