### PR TITLE
proxy-httpd-image: fix "CERTIFICATE_VERIFY_FAILED" error on openSUSE Leap 16.0

### DIFF
--- a/containers/proxy-httpd-image/proxy-httpd-image.changes.meaksh.master-fix-python313-ssl-issue
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes.meaksh.master-fix-python313-ssl-issue
@@ -1,0 +1,2 @@
+- Fix CERTIFICATE_VERIFY_FAILED error when running
+  uyuni-configure.py on openSUSE Leap 16.0

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -8,6 +8,7 @@ import subprocess
 import re
 import yaml
 import socket
+import ssl
 import sys
 import urllib.request
 import json
@@ -63,7 +64,11 @@ def get_server_version(fqdn):
     """
     url = f"https://{fqdn}/rhn/manager/api/api/systemVersion"
 
-    with urllib.request.urlopen(url, timeout=10) as response:
+    # Disable the strict X509 validation flag (Python 3.13+)
+    ctx = ssl.create_default_context()
+    ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
+
+    with urllib.request.urlopen(url, timeout=10, context=ctx) as response:
         body = response.read().decode("utf-8")
         data = json.loads(body)
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue we see when running `uyuni-configure.py` script at `proxy-httpd` container based on openSUSE Leap 16.0:

```
uyuni-proxy-httpd[141890]:      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
uyuni-proxy-httpd[141890]:     sock=sock,
uyuni-proxy-httpd[141890]:     ^^^^^^^^^^
uyuni-proxy-httpd[141890]:   ...<5 lines>...
uyuni-proxy-httpd[141890]:     session=session
uyuni-proxy-httpd[141890]:     ^^^^^^^^^^^^^^^
uyuni-proxy-httpd[141890]:   )
uyuni-proxy-httpd[141890]:   ^
uyuni-proxy-httpd[141890]:  File "/usr/lib64/python3.13/ssl.py", line 1076, in _create
uyuni-proxy-httpd[141890]:   self.do_handshake()
uyuni-proxy-httpd[141890]:   ~~~~~~~~~~~~~~~~~^^
uyuni-proxy-httpd[141890]:  File "/usr/lib64/python3.13/ssl.py", line 1372, in do_handshake
uyuni-proxy-httpd[141890]:   self._sslobj.do_handshake()
uyuni-proxy-httpd[141890]:   ~~~~~~~~~~~~~~~~~~~~~~~~~^^
uyuni-proxy-httpd[141890]: ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Basic Constraints of CA cert not marked critical (_ssl.c:1032)
uyuni-proxy-httpd[141890]:
uyuni-proxy-httpd[141890]: During handling of the above exception, another exception occurred:
uyuni-proxy-httpd[141890]:
uyuni-proxy-httpd[141890]: Traceback (most recent call last):
uyuni-proxy-httpd[141890]:  File "/usr/bin/uyuni-configure.py", line 125, in <module> 
uyuni-proxy-httpd[141890]:   server_version = get_server_version(config["server"])
uyuni-proxy-httpd[141890]:  File "/usr/bin/uyuni-configure.py", line 66, in get_server_version
uyuni-proxy-httpd[141890]:   with urllib.request.urlopen(url, timeout=10) as response:
uyuni-proxy-httpd[141890]:     ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
uyuni-proxy-httpd[141890]:  File "/usr/lib64/python3.13/urllib/request.py", line 189, in urlopen
uyuni-proxy-httpd[141890]:   return opener.open(url, data, timeout)
uyuni-proxy-httpd[141890]:      ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
uyuni-proxy-httpd[141890]:  File "/usr/lib64/python3.13/urllib/request.py", line 489, in open
uyuni-proxy-httpd[141890]:   response = self._open(req, data)
uyuni-proxy-httpd[141890]:  File "/usr/lib64/python3.13/urllib/request.py", line 506, in _open
uyuni-proxy-httpd[141890]:   result = self._call_chain(self.handle_open, protocol, protocol +
uyuni-proxy-httpd[141890]:                '_open', req)
uyuni-proxy-httpd[141890]:  File "/usr/lib64/python3.13/urllib/request.py", line 466, in _call_chain
uyuni-proxy-httpd[141890]:   result = func(*args)
uyuni-proxy-httpd[141890]:  File "/usr/lib64/python3.13/urllib/request.py", line 1367, in https_open
uyuni-proxy-httpd[141890]:   return self.do_open(http.client.HTTPSConnection, req,
uyuni-proxy-httpd[141890]:      ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
uyuni-proxy-httpd[141890]:             context=self._context)
uyuni-proxy-httpd[141890]:             ^^^^^^^^^^^^^^^^^^^^^^
uyuni-proxy-httpd[141890]:  File "/usr/lib64/python3.13/urllib/request.py", line 1322, in do_open
uyuni-proxy-httpd[141890]:   raise URLError(err)
uyuni-proxy-httpd[141890]: urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Basic Constraints of CA cert not marked critical (_ssl.c:1032)>
podman[141965]: 2026-06-01 14:35:35.489360979 +0200 CEST m=+0.015195028 container died 594d3e9751a4adb2cc817a653211a5873edc879d2d8785fe61d4abda2c787af0
```

Starting in Python 3.13, the standard library's ssl module tightened its default security profile. Specifically,  `ssl.create_default_context()` now automatically enables the OpenSSL flag `ssl.VERIFY_X509_STRICT`.

This PR simply drop this flag from the context to allow the SSL request to succeed with self-signed certificate.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
