### PR TITLE
proxy-ssh-image: find sshd configuration properly in openSUSE Leap 16.0

### DIFF
--- a/containers/proxy-ssh-image/proxy-ssh-image.changes.meaksh.master-leap16-fix-etc-ssh
+++ b/containers/proxy-ssh-image/proxy-ssh-image.changes.meaksh.master-leap16-fix-etc-ssh
@@ -1,0 +1,1 @@
+- Find sshd configuration in openSUSE Leap 16.0

--- a/containers/proxy-ssh-image/uyuni-configure.py
+++ b/containers/proxy-ssh-image/uyuni-configure.py
@@ -54,7 +54,13 @@ with open(config_path + "ssh.yaml", encoding="utf-8") as sshSource:
         file.write(sshConfig.get("server_ssh_key_pub"))
 
     # append to existing config file
-    with open("/etc/ssh/sshd_config", "r+", encoding="utf-8") as config_file:
+    if os.path.exists("/etc/ssh/sshd_config"):
+        # openSUSE Leap 15.6
+        sshd_config_file = "/etc/ssh/sshd_config"
+    else:
+        # openSUSE Leap 16.0
+        sshd_config_file = "/usr/etc/ssh/sshd_config"
+    with open(sshd_config_file, "r+", encoding="utf-8") as config_file:
         file_content = config_file.read()
         file_content = re.sub(
             r"#HostKey .*",
@@ -66,16 +72,14 @@ with open(config_path + "ssh.yaml", encoding="utf-8") as sshSource:
         config_file.seek(0, 0)
         config_file.write(file_content)
         config_file.truncate()
-        config_file.write(
-            f"""Match user {SSH_PUSH_USER}
+        config_file.write(f"""Match user {SSH_PUSH_USER}
         ForceCommand /usr/sbin/mgr-proxy-ssh-force-cmd
         KbdInteractiveAuthentication no
         PasswordAuthentication no
         PubkeyAuthentication yes
         X11Forwarding no
         PermitTTY no
-        """
-        )
+        """)
 
 # Note: we don't need pam_loginuid.so module to be loaded. In the container's world users from the outside to the inside are different,
 # and they do not match with the pam_loginuid module's logic behavior. The module makes the sshd process to crash if it fails itself, but
@@ -88,7 +92,13 @@ with open(config_path + "ssh.yaml", encoding="utf-8") as sshSource:
 # So, we configure it to disable the module
 #
 # edit the existing config file
-with open("/etc/pam.d/sshd", "r+", encoding="utf-8") as config_file:
+if os.path.exists("/etc/pam.d/sshd"):
+    # openSUSE Leap 15.6
+    pamd_sshd_file = "/etc/pam.d/sshd"
+else:
+    # openSUSE Leap 16.0
+    pamd_sshd_file = "/usr/lib/pam.d/sshd"
+with open(pamd_sshd_file, "r+", encoding="utf-8") as config_file:
     file_content = config_file.read()
     file_content = re.sub(
         r"(session( *)required( *)pam_loginuid.so)", "#\0", file_content


### PR DESCRIPTION
## What does this PR change?

The `/etc/ssh/sshd_config` and `/etc/pam.d/sshd` files have different location in openSUSE Leap 16.0, so `uyuni-configure.py` script is failing for `proxy-ssh-image` with:

```
Jun 01 16:59:26 uyuni-ci-main-podman-proxy systemd[1]: Started Uyuni proxy ssh container service.
Jun 01 16:59:27 uyuni-ci-main-podman-proxy uyuni-proxy-ssh[307003]: Traceback (most recent call last):
Jun 01 16:59:27 uyuni-ci-main-podman-proxy uyuni-proxy-ssh[307003]:  File "/usr/bin/uyuni-configure.py", line 57, in <module>
Jun 01 16:59:27 uyuni-ci-main-podman-proxy uyuni-proxy-ssh[307003]:   with open("/etc/ssh/sshd_config", "r+", encoding="utf-8") as config_file:
Jun 01 16:59:27 uyuni-ci-main-podman-proxy uyuni-proxy-ssh[307003]:     ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 01 16:59:27 uyuni-ci-main-podman-proxy uyuni-proxy-ssh[307003]: FileNotFoundError: [Errno 2] No such file or directory: '/etc/ssh/sshd_config'
```

This PR just makes the `uyuni-configure.py` script to consider an alternative file is that file is not existing.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
