### PR TITLE
Fix Channel/Errata/Package bidirectional relationship mappings

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/channel/Channel.java
@@ -189,13 +189,13 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
             inverseJoinColumns = @JoinColumn(name = "org_trust_id"))
     private Set<Org> trustedOrgs;
 
-    @ManyToMany(fetch = FetchType.LAZY)
+    @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST}, fetch = FetchType.LAZY)
     @JoinTable(name = "rhnChannelErrata",
             joinColumns = @JoinColumn(name = "channel_id"),
             inverseJoinColumns = @JoinColumn(name = "errata_id"))
-    private Set<Errata> erratas;
+    private Set<Errata> erratas = new HashSet<>();
 
-    @ManyToMany(fetch = FetchType.LAZY)
+    @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST}, fetch = FetchType.LAZY)
     @JoinTable(name = "rhnChannelPackage",
             joinColumns = @JoinColumn(name = "channel_id"),
             inverseJoinColumns = @JoinColumn(name = "package_id"))
@@ -604,41 +604,12 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     }
 
     /**
-     * Sets the erratas set for this channel
-     * @param erratasIn The set of erratas
-     */
-    public void setErratas(Set<Errata> erratasIn) {
-        this.erratas = erratasIn;
-    }
-
-    /**
      * Adds a single errata to the channel
      * @param errataIn The errata to add
      */
     public void addErrata(Errata errataIn) {
-        if (erratas.add(errataIn)) {
-            errataIn.getChannels().add(this);
-        }
-    }
-
-    /**
-     * Removes a single errata from the channel
-     * @param errataIn The errata to remove
-     */
-    public void removeErrata(Errata errataIn) {
-        if (erratas.remove(errataIn)) {
-            errataIn.getChannels().remove(this);
-        }
-    }
-
-    /**
-     * Adds a single package to the channel
-     * @param packageIn The package to add
-     */
-    public void addPackage(Package packageIn) {
-        if (packages.add(packageIn)) {
-            packageIn.getChannels().add(this);
-        }
+        erratas.add(errataIn);
+        errataIn.getChannels().add(this);
     }
 
     /**
@@ -652,6 +623,16 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     }
 
     /**
+     * Removes a single errata from the channel
+     * @param errataIn The errata to remove
+     */
+    public void removeErrata(Errata errataIn) {
+        erratas.remove(errataIn);
+        errataIn.getChannels().remove(this);
+    }
+
+
+    /**
      * Removes multiple erratas from the channel
      * @param erratasIn The collection of erratas to remove
      */
@@ -659,6 +640,22 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
         for (Errata errata : erratasIn) {
             removeErrata(errata);
         }
+    }
+
+    /**
+     * Clears out the errata associated with this channel.
+     */
+    public void clearErratas() {
+        removeErratas(new ArrayList<>(getErratas()));
+    }
+
+    /**
+     * Adds a single package to the channel
+     * @param packageIn The package to add
+     */
+    public void addPackage(Package packageIn) {
+        packages.add(packageIn);
+        packageIn.getChannels().add(this);
     }
 
     /**
@@ -672,14 +669,22 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     }
 
     /**
+     * Removes a package from the packages set.
+     * @param packageIn The package to remove.
+     */
+    public void removePackage(Package packageIn) {
+        packages.remove(packageIn);
+        packageIn.getChannels().remove(this);
+    }
+
+
+    /**
      * Removes multiple packages from the channel
      * @param packagesIn The collection of packages to remove
      */
     public void removePackages(Collection<Package> packagesIn) {
         for (Package pkg : packagesIn) {
-            if (packages.remove(pkg)) {
-                pkg.getChannels().remove(this);
-            }
+            removePackage(pkg);
         }
     }
 
@@ -710,15 +715,6 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
         return ChannelFactory.getErrataCount(this);
     }
 
-
-    /**
-     * Sets the packages set for this channel
-     * @param packagesIn The set of erratas
-     */
-    public void setPackages(Set<Package> packagesIn) {
-        this.packages = packagesIn;
-    }
-
     /**
      *
      * @param sourcesIn The set of yum repo sources
@@ -733,15 +729,6 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      */
     public Set<ContentSource> getSources() {
         return sources;
-    }
-
-    /**
-     * Removes a package from the packages set.
-     * @param packageIn The package to remove.
-     */
-    public void removePackage(Package packageIn) {
-        packages.remove(packageIn);
-        packageIn.getChannels().remove(this);
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/channel/Channel.java
@@ -27,6 +27,7 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.system.SystemManager;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -37,6 +38,7 @@ import org.hibernate.type.YesNoConverter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -193,13 +195,13 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     @JoinTable(name = "rhnChannelErrata",
             joinColumns = @JoinColumn(name = "channel_id"),
             inverseJoinColumns = @JoinColumn(name = "errata_id"))
-    private Set<Errata> erratas = new HashSet<>();
+    private Set<Errata> erratas;
 
     @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST}, fetch = FetchType.LAZY)
     @JoinTable(name = "rhnChannelPackage",
             joinColumns = @JoinColumn(name = "channel_id"),
             inverseJoinColumns = @JoinColumn(name = "package_id"))
-    private Set<Package> packages = new HashSet<>();
+    private Set<Package> packages;
 
     @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST}, fetch = FetchType.LAZY)
     @JoinTable(name = "rhnChannelContentSource",
@@ -600,7 +602,7 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      * @return Returns the set of erratas for this channel.
      */
     public Set<Errata> getErratas() {
-        return erratas;
+        return Collections.unmodifiableSet(erratas);
     }
 
     /**
@@ -608,8 +610,11 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      * @param errataIn The errata to add
      */
     public void addErrata(Errata errataIn) {
+        if (errataIn == null) {
+            return;
+        }
         erratas.add(errataIn);
-        errataIn.getChannels().add(this);
+        errataIn.addChannelInternal(this);
     }
 
     /**
@@ -617,9 +622,10 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      * @param erratasIn The collection of erratas to add
      */
     public void addErratas(Collection<Errata> erratasIn) {
-        for (Errata errata : erratasIn) {
-            addErrata(errata);
+        if (CollectionUtils.isEmpty(erratasIn)) {
+            return;
         }
+        erratasIn.forEach(this::addErrata);
     }
 
     /**
@@ -627,8 +633,11 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      * @param errataIn The errata to remove
      */
     public void removeErrata(Errata errataIn) {
+        if (errataIn == null) {
+            return;
+        }
         erratas.remove(errataIn);
-        errataIn.getChannels().remove(this);
+        errataIn.removeChannelInternal(this);
     }
 
 
@@ -637,9 +646,10 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      * @param erratasIn The collection of erratas to remove
      */
     public void removeErratas(Collection<Errata> erratasIn) {
-        for (Errata errata : erratasIn) {
-            removeErrata(errata);
+        if (CollectionUtils.isEmpty(erratasIn)) {
+            return;
         }
+        erratasIn.forEach(this::removeErrata);
     }
 
     /**
@@ -654,8 +664,11 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      * @param packageIn The package to add
      */
     public void addPackage(Package packageIn) {
+        if (packageIn == null) {
+            return;
+        }
         packages.add(packageIn);
-        packageIn.getChannels().add(this);
+        packageIn.addChannelInternal(this);
     }
 
     /**
@@ -663,9 +676,10 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      * @param packagesIn The collection of packages to add
      */
     public void addPackages(Collection<Package> packagesIn) {
-        for (Package pkg : packagesIn) {
-            addPackage(pkg);
+        if (CollectionUtils.isEmpty(packagesIn)) {
+            return;
         }
+        packagesIn.forEach(this::addPackage);
     }
 
     /**
@@ -673,8 +687,11 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      * @param packageIn The package to remove.
      */
     public void removePackage(Package packageIn) {
+        if (packageIn == null) {
+            return;
+        }
         packages.remove(packageIn);
-        packageIn.getChannels().remove(this);
+        packageIn.removeChannelInternal(this);
     }
 
 
@@ -683,9 +700,17 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      * @param packagesIn The collection of packages to remove
      */
     public void removePackages(Collection<Package> packagesIn) {
-        for (Package pkg : packagesIn) {
-            removePackage(pkg);
+        if (CollectionUtils.isEmpty(packagesIn)) {
+            return;
         }
+        packagesIn.forEach(this::removePackage);
+    }
+
+    /**
+     * Clears out the packaged associated with this channel.
+     */
+    public void clearPackages() {
+        removePackages(new ArrayList<>(getPackages()));
     }
 
     /**
@@ -694,7 +719,7 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      * @return Returns the set of packages for this channel.
      */
     public Set<Package> getPackages() {
-        return packages;
+        return Collections.unmodifiableSet(packages);
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/channel/Channel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 SUSE LLC
+ * Copyright (c) 2025--2026 SUSE LLC
  * Copyright (c) 2009--2018 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -36,6 +36,7 @@ import org.hibernate.type.YesNoConverter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -188,17 +189,17 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
             inverseJoinColumns = @JoinColumn(name = "org_trust_id"))
     private Set<Org> trustedOrgs;
 
-    @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST}, fetch = FetchType.LAZY)
+    @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "rhnChannelErrata",
             joinColumns = @JoinColumn(name = "channel_id"),
             inverseJoinColumns = @JoinColumn(name = "errata_id"))
     private Set<Errata> erratas;
 
-    @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST}, fetch = FetchType.LAZY)
+    @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "rhnChannelPackage",
             joinColumns = @JoinColumn(name = "channel_id"),
             inverseJoinColumns = @JoinColumn(name = "package_id"))
-    private Set<Package> packages;
+    private Set<Package> packages = new HashSet<>();
 
     @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST}, fetch = FetchType.LAZY)
     @JoinTable(name = "rhnChannelContentSource",
@@ -615,7 +616,71 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      * @param errataIn The errata to add
      */
     public void addErrata(Errata errataIn) {
-        erratas.add(errataIn);
+        if (erratas.add(errataIn)) {
+            errataIn.getChannels().add(this);
+        }
+    }
+
+    /**
+     * Removes a single errata from the channel
+     * @param errataIn The errata to remove
+     */
+    public void removeErrata(Errata errataIn) {
+        if (erratas.remove(errataIn)) {
+            errataIn.getChannels().remove(this);
+        }
+    }
+
+    /**
+     * Adds a single package to the channel
+     * @param packageIn The package to add
+     */
+    public void addPackage(Package packageIn) {
+        if (packages.add(packageIn)) {
+            packageIn.getChannels().add(this);
+        }
+    }
+
+    /**
+     * Adds multiple erratas to the channel
+     * @param erratasIn The collection of erratas to add
+     */
+    public void addErratas(Collection<Errata> erratasIn) {
+        for (Errata errata : erratasIn) {
+            addErrata(errata);
+        }
+    }
+
+    /**
+     * Removes multiple erratas from the channel
+     * @param erratasIn The collection of erratas to remove
+     */
+    public void removeErratas(Collection<Errata> erratasIn) {
+        for (Errata errata : erratasIn) {
+            removeErrata(errata);
+        }
+    }
+
+    /**
+     * Adds multiple packages to the channel
+     * @param packagesIn The collection of packages to add
+     */
+    public void addPackages(Collection<Package> packagesIn) {
+        for (Package pkg : packagesIn) {
+            addPackage(pkg);
+        }
+    }
+
+    /**
+     * Removes multiple packages from the channel
+     * @param packagesIn The collection of packages to remove
+     */
+    public void removePackages(Collection<Package> packagesIn) {
+        for (Package pkg : packagesIn) {
+            if (packages.remove(pkg)) {
+                pkg.getChannels().remove(this);
+            }
+        }
     }
 
     /**
@@ -671,14 +736,12 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     }
 
     /**
-     * Removes a single package from the channel
-     * @param user the user doing the remove
-     * @param packageIn The package to remove
+     * Removes a package from the packages set.
+     * @param packageIn The package to remove.
      */
-    public void removePackage(Package packageIn, User user) {
-            List<Long> list = new ArrayList<>();
-            list.add(packageIn.getId());
-            ChannelManager.removePackages(this, list, user);
+    public void removePackage(Package packageIn) {
+        packages.remove(packageIn);
+        packageIn.getChannels().remove(this);
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/domain/errata/Errata.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/errata/Errata.java
@@ -154,11 +154,11 @@ public class Errata extends BaseDomainHelper {
 
     @OneToMany(mappedBy = "owningErrata", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @OrderBy("id ASC")
-    private Set<ErrataFile> files;
+    private Set<ErrataFile> files = new HashSet<>();
 
     @OneToMany(mappedBy = "errata", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @OrderBy("keyword ASC")
-    private Set<Keyword> keywords;
+    private Set<Keyword> keywords = new HashSet<>();
 
     @Column(name = "errata_from")
     private String errataFrom;

--- a/java/core/src/main/java/com/redhat/rhn/domain/errata/Errata.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/errata/Errata.java
@@ -32,6 +32,7 @@ import org.hibernate.type.YesNoConverter;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -172,9 +173,24 @@ public class Errata extends BaseDomainHelper {
      * @return channels to get
      */
     public Set<Channel> getChannels() {
-        return channels;
+        return Collections.unmodifiableSet(channels);
     }
 
+    /**
+     * Internal helper for bidirectional relationship - adds a channel to this errata
+     * @param channel The channel to add
+     */
+    public void addChannelInternal(Channel channel) {
+        channels.add(channel);
+    }
+
+    /**
+     * Internal helper for bidirectional relationship - removes a channel from this errata.
+     * @param channel The channel to remove
+     */
+    public void removeChannelInternal(Channel channel) {
+        channels.remove(channel);
+    }
 
     /**
      * Getter for cloned
@@ -756,8 +772,11 @@ public class Errata extends BaseDomainHelper {
      * @param packageIn The package to add.
      */
     public void addPackage(Package packageIn) {
+        if (packageIn == null) {
+            return;
+        }
         packages.add(packageIn);
-        packageIn.getErrata().add(this);
+        packageIn.addErrataInternal(this);
     }
 
     /**
@@ -765,6 +784,9 @@ public class Errata extends BaseDomainHelper {
      * @param packagesIn The collection of packages to add
      */
     public void addPackages(Collection<Package> packagesIn) {
+        if (packagesIn == null) {
+            return;
+        }
         for (Package pkg : packagesIn) {
             addPackage(pkg);
         }
@@ -775,8 +797,11 @@ public class Errata extends BaseDomainHelper {
      * @param packageIn The package to remove.
      */
     public void removePackage(Package packageIn) {
+        if (packageIn == null) {
+            return;
+        }
         packages.remove(packageIn);
-        packageIn.getErrata().remove(this);
+        packageIn.removeErrataInternal(this);
     }
 
 
@@ -785,6 +810,9 @@ public class Errata extends BaseDomainHelper {
      * @param packagesIn The collection of packages to remove
      */
     public void removePackages(Collection<Package> packagesIn) {
+        if (packagesIn == null) {
+            return;
+        }
         for (Package pkg : packagesIn) {
             removePackage(pkg);
         }
@@ -794,7 +822,7 @@ public class Errata extends BaseDomainHelper {
      * @return Returns the packages.
      */
     public Set<Package> getPackages() {
-        return packages;
+        return Collections.unmodifiableSet(packages);
     }
 
     /**
@@ -802,6 +830,9 @@ public class Errata extends BaseDomainHelper {
      * @param packagesIn the new packages to set
      */
     public void replacePackages(Collection<Package> packagesIn) {
+        if (packagesIn == null) {
+            return;
+        }
         clearPackages();
         addPackages(packagesIn);
     }
@@ -810,7 +841,7 @@ public class Errata extends BaseDomainHelper {
      * Clears out the Packages associated with this errata.
      */
     public void clearPackages() {
-        removePackages(new ArrayList<>(this.getPackages()));
+        removePackages(new ArrayList<>(this.packages));
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/domain/errata/Errata.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/errata/Errata.java
@@ -23,7 +23,6 @@ import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.frontend.xmlrpc.InvalidParameterException;
 import com.redhat.rhn.manager.errata.ErrataManager;
 
-import org.apache.commons.collections.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -35,7 +34,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -879,11 +877,9 @@ public class Errata extends BaseDomainHelper {
             channel.removeErrata(this);
         }
 
-        Iterator<ErrataFile> i = IteratorUtils.getIterator(this.getFiles());
-        while (i.hasNext()) {
-            ErrataFile pf = i.next();
-            if (pf.getChannels() != null) {
-                pf.getChannels().clear();
+        for (ErrataFile errataFile : this.files) {
+            if (errataFile.getChannels() != null) {
+                errataFile.getChannels().clear();
             }
         }
     }

--- a/java/core/src/main/java/com/redhat/rhn/domain/errata/Errata.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/errata/Errata.java
@@ -175,12 +175,6 @@ public class Errata extends BaseDomainHelper {
         return channels;
     }
 
-    /**
-     * @param channelsIn sets channels
-     */
-    public void setChannels(Set<Channel> channelsIn) {
-        this.channels = channelsIn;
-    }
 
     /**
      * Getter for cloned
@@ -762,8 +756,17 @@ public class Errata extends BaseDomainHelper {
      * @param packageIn The package to add.
      */
     public void addPackage(Package packageIn) {
-        if (packages.add(packageIn)) {
-            packageIn.getErrata().add(this);
+        packages.add(packageIn);
+        packageIn.getErrata().add(this);
+    }
+
+    /**
+     * Adds multiple packages to the errata
+     * @param packagesIn The collection of packages to add
+     */
+    public void addPackages(Collection<Package> packagesIn) {
+        for (Package pkg : packagesIn) {
+            addPackage(pkg);
         }
     }
 
@@ -772,26 +775,16 @@ public class Errata extends BaseDomainHelper {
      * @param packageIn The package to remove.
      */
     public void removePackage(Package packageIn) {
-        if (packages.remove(packageIn)) {
-            packageIn.getErrata().remove(this);
-        }
+        packages.remove(packageIn);
+        packageIn.getErrata().remove(this);
     }
 
-    /**
-     * Adds multiple packages to the errata
-     * @param packagesIn The collection of packages to add
-     */
-    public void addPackages(java.util.Collection<Package> packagesIn) {
-        for (Package pkg : packagesIn) {
-            addPackage(pkg);
-        }
-    }
 
     /**
      * Removes multiple packages from the errata
      * @param packagesIn The collection of packages to remove
      */
-    public void removePackages(java.util.Collection<Package> packagesIn) {
+    public void removePackages(Collection<Package> packagesIn) {
         for (Package pkg : packagesIn) {
             removePackage(pkg);
         }
@@ -805,34 +798,19 @@ public class Errata extends BaseDomainHelper {
     }
 
     /**
-     * @param p The packages to set.
-     */
-    public void setPackages(Set<Package> p) {
-        this.packages = p;
-    }
-
-    /**
      * Replace all packages with a new set, maintaining bidirectional sync
      * @param packagesIn the new packages to set
      */
     public void replacePackages(Collection<Package> packagesIn) {
-        this.clearPackages();
-        for (Package pkg : packagesIn) {
-            addPackage(pkg);
-        }
+        clearPackages();
+        addPackages(packagesIn);
     }
 
     /**
      * Clears out the Packages associated with this errata.
      */
     public void clearPackages() {
-        if (this.getPackages() != null && !this.getPackages().isEmpty()) {
-            List<Package> packagesCopy = new ArrayList<>(this.getPackages());
-            for (Package pkg : packagesCopy) {
-                this.removePackage(pkg);
-            }
-            this.getPackages().clear();
-        }
+        removePackages(new ArrayList<>(this.getPackages()));
     }
 
     /**
@@ -865,13 +843,11 @@ public class Errata extends BaseDomainHelper {
      * Clears out the Channels associated with this errata.
      */
     public void clearChannels() {
-        if (this.getChannels() != null && !this.getChannels().isEmpty()) {
-            List<Channel> channelsCopy = new ArrayList<>(this.getChannels());
-            for (Channel channel : channelsCopy) {
-                channel.removeErrata(this);
-            }
-            this.getChannels().clear();
+        List<Channel> channelsCopy = new ArrayList<>(this.getChannels());
+        for (Channel channel : channelsCopy) {
+            channel.removeErrata(this);
         }
+
         Iterator<ErrataFile> i = IteratorUtils.getIterator(this.getFiles());
         while (i.hasNext()) {
             ErrataFile pf = i.next();

--- a/java/core/src/main/java/com/redhat/rhn/domain/errata/Errata.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/errata/Errata.java
@@ -27,11 +27,11 @@ import org.apache.commons.collections.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.hibernate.annotations.Type;
 import org.hibernate.type.YesNoConverter;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -65,8 +65,6 @@ import jakarta.persistence.Table;
 @Inheritance(strategy = InheritanceType.JOINED)
 public class Errata extends BaseDomainHelper {
 
-    private static Logger log = LogManager.getLogger(Errata.class);
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "errata_seq")
     @SequenceGenerator(name = "errata_seq", sequenceName = "rhn_errata_id_seq", allocationSize = 1)
@@ -78,15 +76,12 @@ public class Errata extends BaseDomainHelper {
                 joinColumns = @JoinColumn(name = "errata_id"),
                 inverseJoinColumns = @JoinColumn(name = "package_id"))
     @OrderBy("id ASC")
-    private Set<Package> packages;
+    private Set<Package> packages = new HashSet<>();
 
     @ManyToMany(
-                cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.DETACH, CascadeType.REFRESH},
-                fetch = FetchType.LAZY)
-    @JoinTable(
-                name = "rhnChannelErrata",
-                joinColumns = @JoinColumn(name = "errata_id"),
-                inverseJoinColumns = @JoinColumn(name = "channel_id"))
+            mappedBy = "erratas",
+            cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.DETACH, CascadeType.REFRESH},
+            fetch = FetchType.LAZY)
     private Set<Channel> channels = new HashSet<>();
 
     @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST}, fetch = FetchType.LAZY)
@@ -185,18 +180,6 @@ public class Errata extends BaseDomainHelper {
      */
     public void setChannels(Set<Channel> channelsIn) {
         this.channels = channelsIn;
-    }
-
-    /**
-     * Adds a channel.
-     * @param channelIn the channel to add
-     */
-    public void addChannel(Channel channelIn) {
-        log.debug("addChannel called: {}", channelIn.getLabel());
-        if (this.channels == null) {
-            this.channels = new HashSet<>();
-        }
-        channels.add(channelIn);
     }
 
     /**
@@ -779,10 +762,9 @@ public class Errata extends BaseDomainHelper {
      * @param packageIn The package to add.
      */
     public void addPackage(Package packageIn) {
-        if (this.packages == null) {
-            this.packages = new HashSet<>();
+        if (packages.add(packageIn)) {
+            packageIn.getErrata().add(this);
         }
-        packages.add(packageIn);
     }
 
     /**
@@ -790,7 +772,29 @@ public class Errata extends BaseDomainHelper {
      * @param packageIn The package to remove.
      */
     public void removePackage(Package packageIn) {
-        packages.remove(packageIn);
+        if (packages.remove(packageIn)) {
+            packageIn.getErrata().remove(this);
+        }
+    }
+
+    /**
+     * Adds multiple packages to the errata
+     * @param packagesIn The collection of packages to add
+     */
+    public void addPackages(java.util.Collection<Package> packagesIn) {
+        for (Package pkg : packagesIn) {
+            addPackage(pkg);
+        }
+    }
+
+    /**
+     * Removes multiple packages from the errata
+     * @param packagesIn The collection of packages to remove
+     */
+    public void removePackages(java.util.Collection<Package> packagesIn) {
+        for (Package pkg : packagesIn) {
+            removePackage(pkg);
+        }
     }
 
     /**
@@ -805,6 +809,30 @@ public class Errata extends BaseDomainHelper {
      */
     public void setPackages(Set<Package> p) {
         this.packages = p;
+    }
+
+    /**
+     * Replace all packages with a new set, maintaining bidirectional sync
+     * @param packagesIn the new packages to set
+     */
+    public void replacePackages(Collection<Package> packagesIn) {
+        this.clearPackages();
+        for (Package pkg : packagesIn) {
+            addPackage(pkg);
+        }
+    }
+
+    /**
+     * Clears out the Packages associated with this errata.
+     */
+    public void clearPackages() {
+        if (this.getPackages() != null && !this.getPackages().isEmpty()) {
+            List<Package> packagesCopy = new ArrayList<>(this.getPackages());
+            for (Package pkg : packagesCopy) {
+                this.removePackage(pkg);
+            }
+            this.getPackages().clear();
+        }
     }
 
     /**
@@ -837,13 +865,19 @@ public class Errata extends BaseDomainHelper {
      * Clears out the Channels associated with this errata.
      */
     public void clearChannels() {
-        if (this.getChannels() != null) {
+        if (this.getChannels() != null && !this.getChannels().isEmpty()) {
+            List<Channel> channelsCopy = new ArrayList<>(this.getChannels());
+            for (Channel channel : channelsCopy) {
+                channel.removeErrata(this);
+            }
             this.getChannels().clear();
         }
         Iterator<ErrataFile> i = IteratorUtils.getIterator(this.getFiles());
         while (i.hasNext()) {
             ErrataFile pf = i.next();
-            pf.getChannels().clear();
+            if (pf.getChannels() != null) {
+                pf.getChannels().clear();
+            }
         }
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2019--2026 SUSE LLC
  * Copyright (c) 2009--2018 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -11,9 +12,6 @@
  * Red Hat trademarks are not licensed under GPLv2. No permission is
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
- */
-/*
- * Copyright (c) 2010 SUSE LLC
  */
 package com.redhat.rhn.domain.errata;
 
@@ -232,7 +230,7 @@ public class ErrataFactory extends HibernateFactory {
                                             User user, boolean inheritPackages, boolean performPostActions) {
         List<com.redhat.rhn.domain.errata.Errata> toReturn = new ArrayList<>();
         for (Errata errata : errataList) {
-            errata.addChannel(chan);
+            chan.addErrata(errata);
             ErrataManager.replaceChannelNotifications(errata.getId(), chan.getId(), new Date());
 
             Set<Package> packagesToPush = new HashSet<>();
@@ -284,7 +282,7 @@ public class ErrataFactory extends HibernateFactory {
      */
     public static void addToChannel(Errata errata, Channel chan, User user,
                                       Set<Package> packages) {
-        errata.addChannel(chan);
+        chan.addErrata(errata);
         addErrataPackagesToChannel(errata, chan, user, packages);
         ChannelManager.refreshWithNewestPackages(chan, "java::addErrataPackagesToChannel");
     }
@@ -1109,7 +1107,7 @@ public class ErrataFactory extends HibernateFactory {
         cloned.setAdvisoryStatus(original.getAdvisoryStatus());
 
         // Copy the packages
-        cloned.setPackages(new HashSet<>(original.getPackages()));
+        cloned.replacePackages(new HashSet<>(original.getPackages()));
 
         // Copy the keywords
         original.getKeywords().forEach(k -> cloned.addKeyword(k));

--- a/java/core/src/main/java/com/redhat/rhn/domain/rhnpackage/Package.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/rhnpackage/Package.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.io.Serial;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
@@ -756,14 +757,46 @@ public class Package extends BaseDomainHelper {
      * @return Returns the errata.
      */
     public Set<Errata> getErrata() {
-        return errata;
+        return Collections.unmodifiableSet(errata);
+    }
+
+    /**
+     * Internal helper for bidirectional relationship - adds an errata to this package
+     * @param errataIn The errata to add
+     */
+    public void addErrataInternal(Errata errataIn) {
+        errata.add(errataIn);
+    }
+
+    /**
+     * Internal helper for bidirectional relationship - removes errata from this package.
+     * @param errataIn The channel to remove
+     */
+    public void removeErrataInternal(Errata errataIn) {
+        errata.remove(errataIn);
     }
 
     /**
      * @return Returns the channels.
      */
     public Set<Channel> getChannels() {
-        return channels;
+        return Collections.unmodifiableSet(channels);
+    }
+
+    /**
+     * Internal helper for bidirectional relationship - adds a channel to this package
+     * @param channel The channel to add
+     */
+    public void addChannelInternal(Channel channel) {
+        channels.add(channel);
+    }
+
+    /**
+     * Internal helper for bidirectional relationship - removes channel from this package.
+     * @param channel The channel to remove
+     */
+    public void removeChannelInternal(Channel channel) {
+        channels.remove(channel);
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/domain/rhnpackage/Package.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/rhnpackage/Package.java
@@ -760,24 +760,10 @@ public class Package extends BaseDomainHelper {
     }
 
     /**
-     * @param errataIn The errata to set.
-     */
-    public void setErrata(Set<Errata> errataIn) {
-        this.errata = errataIn;
-    }
-
-    /**
      * @return Returns the channels.
      */
     public Set<Channel> getChannels() {
         return channels;
-    }
-
-    /**
-     * @param channelsIn The channels to set.
-     */
-    public void setChannels(Set<Channel> channelsIn) {
-        this.channels = channelsIn;
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/domain/rhnpackage/Package.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/rhnpackage/Package.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 SUSE LLC
+ * Copyright (c) 2025--2026 SUSE LLC
  * Copyright (c) 2009--2014 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -121,20 +121,10 @@ public class Package extends BaseDomainHelper {
     @Column(name = "last_modified")
     private Date lastModified;
 
-    @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST})
-    @JoinTable(
-            name = "rhnErrataPackage",
-            joinColumns = @JoinColumn(name = "package_id"),
-            inverseJoinColumns = @JoinColumn(name = "errata_id")
-    )
+    @ManyToMany(mappedBy = "packages")
     private Set<Errata> errata = new HashSet<>();
 
-    @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST})
-    @JoinTable(
-            name = "rhnChannelPackage",
-            joinColumns = @JoinColumn(name = "package_id"),
-            inverseJoinColumns = @JoinColumn(name = "channel_id")
-    )
+    @ManyToMany(mappedBy = "packages")
     private Set<Channel> channels = new HashSet<>();
 
     @OneToMany(mappedBy = "pack", fetch = FetchType.LAZY, cascade = CascadeType.ALL)

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/manage/ErrataHelper.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/manage/ErrataHelper.java
@@ -110,7 +110,7 @@ public class ErrataHelper {
         clone.getCves().addAll(original.getCves());
         clone.setSeverity(original.getSeverity());
 
-        clone.setPackages(new HashSet<>(original.getPackages()));
+        clone.replacePackages(new HashSet<>(original.getPackages()));
 
 
         for (Keyword k : original.getKeywords()) {

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -1889,7 +1889,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
                 differentPackages.add(pack);
             }
         }
-        mergeTo.getPackages().addAll(differentPackages);
+        mergeTo.addPackages(differentPackages);
         ChannelFactory.save(mergeTo);
         ChannelManager.refreshWithNewestPackages(mergeTo, "java::mergePackages");
 

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -1171,7 +1171,7 @@ public class ErrataHandler extends BaseHandler {
             newErrata.addKeyword(keyword);
         }
 
-        newErrata.setPackages(new HashSet<>());
+        newErrata.clearPackages();
         for (Integer pid : packageIds) {
             Package pack = PackageFactory.lookupByIdAndOrg(pid.longValue(),
                     loggedInUser.getOrg());

--- a/java/core/src/main/java/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
@@ -367,7 +367,7 @@ public class UbuntuErrataManager {
                                 org.orElseGet(OrgFactory::getSatelliteOrg)))
                         .collect(Collectors.toSet());
                 if (errata.getPackages() == null) {
-                    errata.setPackages(packages);
+                    errata.replacePackages(packages);
                     changedErrata.add(errata);
                 }
                 else if (errata.getPackages().addAll(packages)) {

--- a/java/core/src/main/java/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
@@ -370,8 +370,12 @@ public class UbuntuErrataManager {
                     errata.replacePackages(packages);
                     changedErrata.add(errata);
                 }
-                else if (errata.getPackages().addAll(packages)) {
-                    changedErrata.add(errata);
+                else {
+                    int packageCount = errata.getPackages().size();
+                    errata.addPackages(packages);
+                    if (errata.getPackages().size() > packageCount) {
+                        changedErrata.add(errata);
+                    }
                 }
 
                 Set<Channel> matchingChannels = e.getValue().entrySet().stream()
@@ -379,7 +383,9 @@ public class UbuntuErrataManager {
                         .map(Map.Entry::getKey)
                         .collect(Collectors.toSet());
 
-                if (errata.getChannels().addAll(matchingChannels)) {
+                int channelCount = errata.getChannels().size();
+                matchingChannels.forEach(channel -> channel.addErrata(errata));
+                if (errata.getChannels().size() > channelCount) {
                     changedErrata.add(errata);
                 }
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -1187,7 +1187,11 @@ public class ContentManager {
         // prune these items from the list so the cache calculation reflects the actual reality of the channel.
         HibernateFactory.getSession().flush();
         List<Long> realIds = ChannelFactory.getPackageIds(tgt.getId());
-        tgt.getPackages().removeIf(p -> !realIds.contains(p.getId()));
+        tgt.removePackages(
+                tgt.getPackages().stream()
+                .filter(p -> !realIds.contains(p.getId()))
+                .collect(Collectors.toSet())
+        );
 
         // align the package cache
         // this must be done after aligning errata since some packages may belong to a retracted erratum and we don't
@@ -1239,7 +1243,7 @@ public class ContentManager {
         tgtChannel.getPackages().clear();
         LOG.debug("Filtering {} entities through {} filter(s)", srcChannel.getPackages().size(), filters.size());
         Set<Package> newPackages = filterEntities(srcChannel.getPackages(), filters).getLeft();
-        tgtChannel.getPackages().addAll(newPackages);
+        tgtChannel.addPackages(newPackages);
         ChannelFactory.save(tgtChannel);
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -1240,7 +1240,7 @@ public class ContentManager {
     }
 
     private void alignPackages(Channel srcChannel, Channel tgtChannel, Collection<PackageFilter> filters) {
-        tgtChannel.getPackages().clear();
+        tgtChannel.clearPackages();
         LOG.debug("Filtering {} entities through {} filter(s)", srcChannel.getPackages().size(), filters.size());
         Set<Package> newPackages = filterEntities(srcChannel.getPackages(), filters).getLeft();
         tgtChannel.addPackages(newPackages);

--- a/java/core/src/main/java/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -215,14 +215,15 @@ public class ErrataManager extends BaseManager {
             Collection<Long> channelIds, User user) {
         log.debug("addChannelsToErrata");
 
+        Set<Channel> channels = new HashSet<>();
         for (Long channelId : channelIds) {
-            ChannelManager.lookupByIdAndUser(channelId, user);
+            channels.add(ChannelManager.lookupByIdAndUser(channelId, user));
         }
 
         //if we're publishing the errata but not pushing packages
         //  We need to add cache entries for ones that are already in the channel
         //  and associated to the errata
-        ErrataCacheManager.addErrataRefreshing(channelIds, errata.getId());
+        ErrataCacheManager.addErrataRefreshing(channels, errata);
 
 
         //Save the errata
@@ -2162,6 +2163,7 @@ public class ErrataManager extends BaseManager {
         Channel channel = ChannelManager.lookupByIdAndUser(channelId, user);
 
         Collection<Long> list = errataToClone;
+        Set<Channel> channelSet = Set.of(channel);
         List<Long> cids = new ArrayList<>();
         cids.add(channel.getId());
         // let's avoid deadlocks please
@@ -2172,20 +2174,21 @@ public class ErrataManager extends BaseManager {
                 Errata errata = ErrataFactory.lookupById(eid);
                 // we merge custom errata directly (non Redhat and cloned)
                 if (errata.getOrg() != null) {
-                    ErrataCacheManager.addErrataRefreshing(cids, eid);
+                    ErrataCacheManager.addErrataRefreshing(channelSet, errata);
                 }
                 else {
                     List<Errata> clones = ErrataFactory.lookupErrataByOriginal(user.getOrg(), errata);
                     if (clones.isEmpty()) {
                         log.debug("Cloning errata");
                         var clonedId = ErrataHelper.cloneErrataFaster(eid, user.getOrg());
-                        ErrataCacheManager.addErrataRefreshing(cids, clonedId);
+                        Errata clonedErrata = ErrataFactory.lookupById(clonedId);
+                        ErrataCacheManager.addErrataRefreshing(channelSet, clonedErrata);
                     }
                     else {
                         log.debug("Re-publishing clone");
                         Errata firstClone = clones.get(0);
 
-                        ErrataCacheManager.addErrataRefreshing(cids, firstClone.getId());
+                        ErrataCacheManager.addErrataRefreshing(channelSet, firstClone);
                     }
                 }
             }

--- a/java/core/src/main/java/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -2163,8 +2163,6 @@ public class ErrataManager extends BaseManager {
 
         Collection<Long> list = errataToClone;
         Set<Channel> channelSet = Set.of(channel);
-        List<Long> cids = new ArrayList<>();
-        cids.add(channel.getId());
         // let's avoid deadlocks please
         ChannelFactory.lock(channel);
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -230,8 +230,7 @@ public class ErrataManager extends BaseManager {
         log.debug("addChannelsToErrata - storing errata");
         ErrataFactory.save(errata);
 
-        errata = HibernateFactory.reload(errata);
-        log.debug("addChannelsToErrata - errata reloaded from DB");
+        log.debug("addChannelsToErrata - errata saved");
         return errata;
     }
 
@@ -1240,7 +1239,7 @@ public class ErrataManager extends BaseManager {
         ErrataCacheManager.insertCacheForChannelPackages(chan.getId(), null, pids);
 
         //Remove the errata from the channel
-        chan.getErratas().remove(errata);
+        chan.removeErrata(errata);
         List<Long> eList = new ArrayList<>();
         eList.add(errata.getId());
         //First delete the cache entries
@@ -1287,7 +1286,7 @@ public class ErrataManager extends BaseManager {
 
 
         //Remove the errata from the channel
-        chan.getErratas().removeAll(excludedErrata);
+        chan.removeErratas(excludedErrata);
         List<Long> eList = excludedErrata.stream().map(Errata::getId).collect(toList());
         //First delete the cache entries
         ErrataCacheManager.deleteCacheEntriesForChannelErrata(chan.getId(), eList);

--- a/java/core/src/main/java/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
@@ -264,13 +264,18 @@ public class ErrataCacheManager extends HibernateFactory {
     /**
      * Adds specified errata to a set of channels, inserting appropriate cache entries and replacing channel
      * notifications.
-     * @param channelToUpdate - channel IDs (Long) that need their errata
+     * @param channelToUpdate - channel that need their errata
      * caches updated
      * @param errata the errata to update the cache for. Assumes the errata is published
      */
     public static void addErrataRefreshing(Set<Channel> channelToUpdate, Errata errata) {
         for (Channel channel : channelToUpdate) {
             channel.addErrata(errata);
+            // Need to flush to persist the channel.addErrata(errata) change to the db.
+            // Without it, the underlying xml based query that listErrataChannelPackages
+            // will execute might not get the changes, and potentially result in missing or empty
+            // cache insertions and notifications.
+            HibernateFactory.getSession().flush();
             List<Long> pids = ErrataFactory.listErrataChannelPackages(channel.getId(), errata.getId());
             ErrataCacheManager.insertCacheForChannelPackages(channel.getId(), errata.getId(), pids);
             ErrataManager.replaceChannelNotifications(errata.getId(), channel.getId(), new Date());

--- a/java/core/src/main/java/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
@@ -264,12 +264,12 @@ public class ErrataCacheManager extends HibernateFactory {
     /**
      * Adds specified errata to a set of channels, inserting appropriate cache entries and replacing channel
      * notifications.
-     * @param channelToUpdate - channel that need their errata
+     * @param channelsToUpdate - channel that need their errata
      * caches updated
      * @param errata the errata to update the cache for. Assumes the errata is published
      */
-    public static void addErrataRefreshing(Set<Channel> channelToUpdate, Errata errata) {
-        for (Channel channel : channelToUpdate) {
+    public static void addErrataRefreshing(Set<Channel> channelsToUpdate, Errata errata) {
+        for (Channel channel : channelsToUpdate) {
             channel.addErrata(errata);
             // Need to flush to persist the channel.addErrata(errata) change to the db.
             // Without it, the underlying xml based query that listErrataChannelPackages

--- a/java/core/src/main/java/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
@@ -22,7 +22,6 @@ import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.domain.channel.Channel;
-import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.errata.AdvisoryStatus;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
@@ -34,7 +33,6 @@ import com.redhat.rhn.manager.errata.ErrataManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -266,16 +264,16 @@ public class ErrataCacheManager extends HibernateFactory {
     /**
      * Adds specified errata to a set of channels, inserting appropriate cache entries and replacing channel
      * notifications.
-     * @param channelIdsToUpdate - channel IDs (Long) that need their errata
+     * @param channelToUpdate - channel IDs (Long) that need their errata
      * caches updated
-     * @param errataId ID of the errata to update the cache for. Assumes the errata is published
+     * @param errata the errata to update the cache for. Assumes the errata is published
      */
-    public static void addErrataRefreshing(Collection<Long> channelIdsToUpdate, Long errataId) {
-        for (Long cid : channelIdsToUpdate) {
-            ChannelFactory.addErrataToChannel(Set.of(errataId), cid);
-            List<Long> pids = ErrataFactory.listErrataChannelPackages(cid, errataId);
-            ErrataCacheManager.insertCacheForChannelPackages(cid, errataId, pids);
-            ErrataManager.replaceChannelNotifications(errataId, cid, new Date());
+    public static void addErrataRefreshing(Set<Channel> channelToUpdate, Errata errata) {
+        for (Channel channel : channelToUpdate) {
+            channel.addErrata(errata);
+            List<Long> pids = ErrataFactory.listErrataChannelPackages(channel.getId(), errata.getId());
+            ErrataCacheManager.insertCacheForChannelPackages(channel.getId(), errata.getId(), pids);
+            ErrataManager.replaceChannelNotifications(errata.getId(), channel.getId(), new Date());
         }
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/channel/ChannelTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/channel/ChannelTest.java
@@ -20,9 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.errata.ErrataFactoryTest;
@@ -45,6 +47,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import jakarta.persistence.EntityExistsException;
 
 /**
  * ChannelTest
@@ -975,6 +979,64 @@ public class ChannelTest extends BaseTestCaseWithUser {
         assertEquals(1, finalErrata2.getPackages().size());
         assertTrue(finalErrata2.getPackages().contains(finalPkg2));
     }
+    /**
+     * When Channel has CascadeType.PERSIST and you add a detached Errata to it,
+     * Hibernate will try to persist the detached entity, which throws an exception.
+     * persist() is only valid for new/transient entities.
+     * Correct options:
+     * 1. Merge the detached entity first: errata = session.merge(errata)
+     * 2. Reload the entity fresh: errata = ErrataFactory.lookupById(id)
+     * 3. Use flushAndClearSession() before creating new relationships
+     */
+    @Test
+    void testPassingDetachedEntityInCascadePersistThrowsException() {
+        // Create and persist an errata
+        Errata errata = new ErrataTestBuilder().orgId(user.getOrg().getId()).buildAndSave();
+        Long errataId = errata.getId();
 
+        // Detach the errata
+        TestUtils.flushAndEvict(errata);
 
+        // At this moment, errata is detached, ie, it has an id but is not managed
+        // Anti-pattern: Create a channel and add the detached errata to it
+        Channel newChannel = ChannelFactoryTest.createTestChannel(user);
+        newChannel.addErrata(errata);
+
+        // When saving the channel, CascadeType.PERSIST will try to persist the errata
+        // But errata is DETACHED, it already has an ID so Hibernate throws exception
+        assertThrows(EntityExistsException.class, () -> {
+            ChannelFactory.save(newChannel);
+            HibernateFactory.getSession().flush();
+        });
+
+        // Quick rollback
+        newChannel.removeErrata(errata);
+
+        // A correct approach would be:
+        Errata reloadedErrata = ErrataFactory.lookupById(errataId);
+        newChannel.addErrata(reloadedErrata);
+
+        // Create a NEW errata without saving it -> fits cascade persist
+        Errata newErrata = new ErrataTestBuilder().orgId(user.getOrg().getId()).build();
+        assertNull(newErrata.getId());
+        newChannel.addErrata(newErrata);
+
+        // Create a NEW errata, saving it, managed by hibernate -> fits cascade merge
+        Errata managedErrata = new ErrataTestBuilder().orgId(user.getOrg().getId()).buildAndSave();
+        newChannel.addErrata(managedErrata);
+
+        // Save and clear session
+        ChannelFactory.save(newChannel);
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify all erratas have the channel and vice versa
+        Channel reloadedChannel = ChannelFactory.lookupById(newChannel.getId());
+        assertTrue(reloadedChannel.getErratas().contains(reloadedErrata));
+        assertTrue(reloadedChannel.getErratas().contains(newErrata));
+        assertTrue(reloadedChannel.getErratas().contains(managedErrata));
+
+        assertTrue(reloadedErrata.getChannels().contains(reloadedChannel));
+        assertTrue(newErrata.getChannels().contains(reloadedChannel));
+        assertTrue(managedErrata.getChannels().contains(reloadedChannel));
+    }
 }

--- a/java/core/src/test/java/com/redhat/rhn/domain/channel/ChannelTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/channel/ChannelTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 SUSE LLC
  * Copyright (c) 2009--2013 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -57,7 +58,7 @@ public class ChannelTest extends BaseTestCaseWithUser {
         Package p = PackageTest.createTestPackage(user.getOrg());
         ChannelTestUtility.testAddPackage(c, p);
         ChannelFactory.save(c);
-        c.removePackage(p, user);
+        c.removePackage(p);
         assertEquals(0, c.getPackageCount());
         assertTrue(c.getPackages().isEmpty());
 
@@ -175,6 +176,62 @@ public class ChannelTest extends BaseTestCaseWithUser {
         assertFalse(c.isBaseChannel());
         c.setParentChannel(null);
         assertTrue(c.isBaseChannel());
+    }
+
+    @Test
+    void testAddAndRemoveErrata() throws Exception {
+        // Create a channel and an errata
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Errata errata = ErrataFactoryTest.createTestErrata(user.getId());
+
+        // By default, neither channel has erratas nor erratas have any channel
+        assertTrue(channel.getErratas().isEmpty());
+        assertTrue(errata.getChannels().isEmpty());
+
+        // Add the errata to the channel
+        channel.addErrata(errata);
+
+        // Assert channel has errata
+        assertEquals(1, channel.getErratas().size());
+        assertEquals(errata, channel.getErratas().iterator().next());
+
+        // Assert the errata also contains the channel
+        assertEquals(1, errata.getChannels().size());
+        assertEquals(channel, errata.getChannels().iterator().next());
+
+        // Remove the errata
+        channel.removeErrata(errata);
+
+        assertTrue(channel.getErratas().isEmpty());
+        assertTrue(errata.getChannels().isEmpty());
+    }
+
+    @Test
+    void testAddAndRemovePackage() throws Exception {
+        // Create a channel and a package
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Package pkg = PackageTest.createTestPackage(user.getOrg());
+
+        // By default, neither channel has packages nor packages have any channel
+        assertTrue(channel.getPackages().isEmpty());
+        assertTrue(pkg.getChannels().isEmpty());
+
+        // Add the package to the channel
+        channel.addPackage(pkg);
+
+        // Assert channel has package
+        assertEquals(1, channel.getPackages().size());
+        assertEquals(pkg, channel.getPackages().iterator().next());
+
+        // Assert the package also contains the channel
+        assertEquals(1, pkg.getChannels().size());
+        assertEquals(channel, pkg.getChannels().iterator().next());
+
+        // Remove the package
+        channel.removePackage(pkg);
+
+        assertTrue(channel.getPackages().isEmpty());
+        assertTrue(pkg.getChannels().isEmpty());
     }
 
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/domain/channel/ChannelTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/channel/ChannelTest.java
@@ -24,7 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.errata.ErrataFactoryTest;
+import com.redhat.rhn.domain.errata.ErrataTestBuilder;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageArch;
 import com.redhat.rhn.domain.rhnpackage.PackageFactory;
@@ -39,6 +41,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -179,7 +182,7 @@ public class ChannelTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    void testAddAndRemoveErrata() throws Exception {
+    void testAddAndEditAndRemoveErrata() {
         // Create a channel and an errata
         Channel channel = ChannelFactoryTest.createTestChannel(user);
         Errata errata = ErrataFactoryTest.createTestErrata(user.getId());
@@ -190,20 +193,74 @@ public class ChannelTest extends BaseTestCaseWithUser {
 
         // Add the errata to the channel
         channel.addErrata(errata);
+        ChannelFactory.save(channel);
 
-        // Assert channel has errata
-        assertEquals(1, channel.getErratas().size());
-        assertEquals(errata, channel.getErratas().iterator().next());
+        Long channelId = channel.getId();
+        Long errataId = errata.getId();
 
-        // Assert the errata also contains the channel
-        assertEquals(1, errata.getChannels().size());
-        assertEquals(channel, errata.getChannels().iterator().next());
+        // Check persistence
+        TestUtils.flushAndClearSession();
+
+        // Reload from database
+        Channel reloadedChannel = ChannelFactory.lookupById(channelId);
+        Errata reloadedErrata = ErrataFactory.lookupById(errataId);
+
+        // Assert channel has errata and vice versa
+        assertEquals(1, reloadedChannel.getErratas().size());
+        assertTrue(reloadedChannel.getErratas().contains(reloadedErrata));
+        assertEquals(1, reloadedErrata.getChannels().size());
+        assertTrue(reloadedErrata.getChannels().contains(reloadedChannel));
+
 
         // Remove the errata
-        channel.removeErrata(errata);
+        reloadedChannel.removeErrata(errata);
+        TestUtils.flushAndClearSession();
 
-        assertTrue(channel.getErratas().isEmpty());
-        assertTrue(errata.getChannels().isEmpty());
+        // Reload from database and verify they are no longer related
+        Channel finalChannel = ChannelFactory.lookupById(channelId);
+        Errata finalErrata = ErrataFactory.lookupById(errataId);
+        assertTrue(finalChannel.getErratas().isEmpty());
+        assertTrue(finalErrata.getChannels().isEmpty());
+    }
+
+    @Test
+    void testUpdateErrataAndPackages() {
+        // Create a channel and an errata
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        String originalAdvisory = "original";
+        String updatedAdvisory = "updated";
+        String updatedDescription = TestUtils.randomString();
+
+        Errata errata = new ErrataTestBuilder().orgId(user.getOrg().getId()).advisory(originalAdvisory).buildAndSave();
+        Package pkg = PackageTest.createTestPackage(user.getOrg());
+
+        // Add the errata to the channel
+        channel.addErrata(errata);
+        channel.addPackage(pkg);
+        ChannelFactory.save(channel);
+
+        Long channelId = channel.getId();
+        Long errataId = errata.getId();
+        Long pkgId = pkg.getId();
+
+        // Check persistence
+        TestUtils.flushAndClearSession();
+
+        // Reload from database
+        Channel reloadedChannel = ChannelFactory.lookupById(channelId);
+        Errata reloadedErrata = ErrataFactory.lookupById(errataId);
+        Package reloadedPackage = PackageFactory.lookupByIdAndOrg(pkgId, user.getOrg());
+
+        // Update channel and package and save the channel
+        reloadedErrata.setAdvisoryName(updatedAdvisory);
+        reloadedPackage.setDescription(updatedDescription);
+        ChannelFactory.save(reloadedChannel);
+        TestUtils.flushAndClearSession();
+
+        Errata updatedErrata = ErrataFactory.lookupById(errataId);
+        Package updatedPackage = PackageFactory.lookupByIdAndOrg(pkgId, user.getOrg());
+        assertEquals(updatedAdvisory, updatedErrata.getAdvisoryName());
+        assertEquals(updatedDescription, updatedPackage.getDescription());
     }
 
     @Test
@@ -307,5 +364,617 @@ public class ChannelTest extends BaseTestCaseWithUser {
         assertNotNull(c.getModules());
         assertTrue(c.isModular());
     }
+
+    // ERRATA ONLY SPECIFIC
+
+    @Test
+    void testAddErratas() {
+        int numErratas = 3;
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        List<Errata> errataList = new ArrayList<>();
+        for (int i = 0; i < numErratas; i++) {
+            errataList.add(ErrataFactoryTest.createTestErrata(user.getId()));
+        }
+
+        // Initially empty
+        assertTrue(channel.getErratas().isEmpty());
+
+        // Add multiple erratas at once
+        channel.addErratas(errataList);
+
+        // Verify all erratas were added to channel
+        assertEquals(errataList.size(), channel.getErratas().size());
+        errataList.forEach(errata -> assertTrue(channel.getErratas().contains(errata)));
+
+        // Verify bidirectional (ie, all erratas have the channel)
+        errataList.forEach(errata -> {
+            assertEquals(1, errata.getChannels().size());
+            assertTrue(errata.getChannels().contains(channel));
+        });
+
+        // Check persistence
+        ChannelFactory.save(channel);
+
+        // Gather ids for later lookups
+        Long channelId = channel.getId();
+        List<Long> errataIdList = errataList.stream().map(Errata::getId).toList();
+
+        // Flush and clear session to detach entities
+        TestUtils.flushAndClearSession();
+
+        // Reload from database
+        Channel reloadedChannel = ChannelFactory.lookupById(channelId);
+        assertNotNull(reloadedChannel);
+
+        // Verify relationship persisted
+        assertEquals(errataList.size(), reloadedChannel.getErratas().size());
+        for (Long errataId : errataIdList) {
+            Errata errata = ErrataFactory.lookupById(errataId);
+            assertEquals(1, errata.getChannels().size());
+            assertTrue(errata.getChannels().contains(reloadedChannel));
+        }
+    }
+
+    @Test
+    void testRemoveErratas() {
+        // Create channel with erratas
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Errata errata1 = ErrataFactoryTest.createTestErrata(user.getId());
+        Errata errata2 = ErrataFactoryTest.createTestErrata(user.getId());
+
+        // Add erratas
+        channel.addErrata(errata1);
+        channel.addErrata(errata2);
+        ChannelFactory.save(channel);
+
+        // Gather ids for later lookups
+        Long channelId = channel.getId();
+        Long errata1Id = errata1.getId();
+        Long errata2Id = errata2.getId();
+
+        // Flush and clear session to detach entities
+        TestUtils.flushAndClearSession();
+
+        // Reload and remove one errata
+        Channel reloadedChannel = ChannelFactory.lookupById(channelId);
+        Errata reloadedErrata1 = ErrataFactory.lookupById(errata1Id);
+
+        reloadedChannel.removeErrata(reloadedErrata1);
+        assertEquals(1, reloadedChannel.getErratas().size());
+        ChannelFactory.save(reloadedChannel);
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify only errata2 remains
+        Channel finalChannel = ChannelFactory.lookupById(channelId);
+        assertEquals(1, finalChannel.getErratas().size());
+
+        Errata finalErrata1 = ErrataFactory.lookupById(errata1Id);
+        Errata finalErrata2 = ErrataFactory.lookupById(errata2Id);
+
+        assertFalse(finalErrata1.getChannels().contains(finalChannel));
+        assertTrue(finalErrata2.getChannels().contains(finalChannel));
+    }
+
+    @Test
+    void testClearErratas() {
+        // Create channel with erratas
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Errata errata1 = ErrataFactoryTest.createTestErrata(user.getId());
+        Errata errata2 = ErrataFactoryTest.createTestErrata(user.getId());
+
+        // Add erratas
+        channel.addErrata(errata1);
+        channel.addErrata(errata2);
+        ChannelFactory.save(channel);
+
+        // Gather ids for later lookups
+        Long channelId = channel.getId();
+        Long errata1Id = errata1.getId();
+        Long errata2Id = errata2.getId();
+
+        // Flush and clear session to detach entities
+        TestUtils.flushAndClearSession();
+
+        // Reload and clear all erratas
+        Channel reloadedChannel = ChannelFactory.lookupById(channelId);
+        reloadedChannel.clearErratas();
+        assertTrue(reloadedChannel.getErratas().isEmpty());
+        ChannelFactory.save(reloadedChannel);
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify channel has no erratas
+        Channel finalChannel = ChannelFactory.lookupById(channelId);
+        assertTrue(finalChannel.getErratas().isEmpty());
+
+        // Verify erratas no longer have the channel
+        Errata finalErrata1 = ErrataFactory.lookupById(errata1Id);
+        Errata finalErrata2 = ErrataFactory.lookupById(errata2Id);
+
+        assertFalse(finalErrata1.getChannels().contains(finalChannel));
+        assertFalse(finalErrata2.getChannels().contains(finalChannel));
+    }
+
+    @Test
+    void testAddDuplicateErrata() {
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Errata errata = ErrataFactoryTest.createTestErrata(user.getId());
+
+        // Add errata twice
+        channel.addErrata(errata);
+        channel.addErrata(errata);
+
+        // Should still only have one
+        assertEquals(1, channel.getErratas().size());
+        assertEquals(1, errata.getChannels().size());
+    }
+
+    @Test
+    void testRemoveNonAssociatedErrata() {
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Errata errata = ErrataFactoryTest.createTestErrata(user.getId());
+        ChannelFactory.save(channel);
+
+        // Flush and clear session to detach entities
+        TestUtils.flushAndClearSession();
+
+        // Reload and clear all erratas
+        Channel reloadedChannel = ChannelFactory.lookupById(channel.getId());
+
+        // Add errata twice
+        channel.removeErrata(errata);
+
+        // Should still only have one
+        assertTrue(reloadedChannel.getErratas().isEmpty());
+        ChannelFactory.save(reloadedChannel);
+        TestUtils.flushAndClearSession();
+
+        // Reload
+        Channel finalChannel = ChannelFactory.lookupById(channel.getId());
+        assertTrue(finalChannel.getErratas().isEmpty());
+    }
+
+    // PACKAGES ONLY SPECIFIC
+
+    @Test
+    void testAddPackages() {
+        int numPackages = 3;
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        List<Package> packageList = new ArrayList<>();
+        for (int i = 0; i < numPackages; i++) {
+            packageList.add(PackageTest.createTestPackage(user.getOrg()));
+        }
+
+        // Initially empty
+        assertTrue(channel.getPackages().isEmpty());
+
+        // Add multiple packages at once
+        channel.addPackages(packageList);
+
+        // Verify all packages were added to channel
+        assertEquals(packageList.size(), channel.getPackages().size());
+        packageList.forEach(pkg -> assertTrue(channel.getPackages().contains(pkg)));
+
+        // Verify bidirectional (ie, all packages have the channel)
+        packageList.forEach(pkg -> {
+            assertEquals(1, pkg.getChannels().size());
+            assertTrue(pkg.getChannels().contains(channel));
+        });
+
+        // Check persistence
+        ChannelFactory.save(channel);
+
+        // Gather ids for later lookups
+        Long channelId = channel.getId();
+        List<Long> packageIdList = packageList.stream().map(Package::getId).toList();
+
+        // Flush and clear session to detach entities
+        TestUtils.flushAndClearSession();
+
+        // Reload from database
+        Channel reloadedChannel = ChannelFactory.lookupById(channelId);
+        assertNotNull(reloadedChannel);
+
+        // Verify relationship persisted
+        assertEquals(packageList.size(), reloadedChannel.getPackages().size());
+        for (Long pkgId : packageIdList) {
+            Package pkg = PackageFactory.lookupByIdAndOrg(pkgId, user.getOrg());
+            assertEquals(1, pkg.getChannels().size());
+            assertTrue(pkg.getChannels().contains(reloadedChannel));
+        }
+    }
+
+    @Test
+    void testRemovePackages() {
+        // Create channel with packages
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Package package1 = PackageTest.createTestPackage(user.getOrg());
+        Package package2 = PackageTest.createTestPackage(user.getOrg());
+
+        // Add packages
+        channel.addPackage(package1);
+        channel.addPackage(package2);
+        ChannelFactory.save(channel);
+
+        // Gather ids for later lookups
+        Long channelId = channel.getId();
+        Long package1Id = package1.getId();
+        Long package2Id = package2.getId();
+
+        // Flush and clear session to detach entities
+        TestUtils.flushAndClearSession();
+
+        // Reload and remove one package
+        Channel reloadedChannel = ChannelFactory.lookupById(channelId);
+        Package reloadedPackage1 = PackageFactory.lookupByIdAndOrg(package1Id, user.getOrg());
+
+        reloadedChannel.removePackage(reloadedPackage1);
+        assertEquals(1, reloadedChannel.getPackages().size());
+        ChannelFactory.save(reloadedChannel);
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify only package2 remains
+        Channel finalChannel = ChannelFactory.lookupById(channelId);
+        assertEquals(1, finalChannel.getPackages().size());
+
+        Package finalPackage1 = PackageFactory.lookupByIdAndOrg(package1Id, user.getOrg());
+        Package finalPackage2 = PackageFactory.lookupByIdAndOrg(package2Id, user.getOrg());
+
+        assertFalse(finalPackage1.getChannels().contains(finalChannel));
+        assertTrue(finalPackage2.getChannels().contains(finalChannel));
+    }
+
+    @Test
+    void testAddDuplicatePackage() {
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Package pkg = PackageTest.createTestPackage(user.getOrg());
+
+        // Add package twice
+        channel.addPackage(pkg);
+        channel.addPackage(pkg);
+
+        // Should still only have one (Set behavior)
+        assertEquals(1, channel.getPackages().size());
+        assertEquals(1, pkg.getChannels().size());
+    }
+
+    @Test
+    void testRemoveNonAssociatedPackage() {
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Package pkg = PackageTest.createTestPackage(user.getOrg());
+        ChannelFactory.save(channel);
+
+        // Flush and clear session to detach entities
+        TestUtils.flushAndClearSession();
+
+        // Reload and clear all packages
+        Channel reloadedChannel = ChannelFactory.lookupById(channel.getId());
+
+        // Add package twice
+        channel.removePackage(pkg);
+
+        // Should still only have one
+        assertTrue(reloadedChannel.getPackages().isEmpty());
+        ChannelFactory.save(reloadedChannel);
+        TestUtils.flushAndClearSession();
+
+        // Reload
+        Channel finalChannel = ChannelFactory.lookupById(channel.getId());
+        assertTrue(finalChannel.getPackages().isEmpty());
+    }
+
+
+    // ERRATA + PACKAGES SPECIFIC
+
+    /**
+     * Test complex overlapping relationships: channel with erratas and packages,
+     * where pkg2 is shared between both erratas.
+     * Verify all relationships are persisted correctly in the database and can be reloaded.
+     */
+    @Test
+    void testChannelWithRelatedErratasAndPackages() {
+        // Create channel with both erratas and packages
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+
+        // Create packages
+        Package pkg1 = PackageTest.createTestPackage(user.getOrg());
+        Package pkg2 = PackageTest.createTestPackage(user.getOrg());
+        Package pkg3 = PackageTest.createTestPackage(user.getOrg());
+
+        // Create erratas
+        Errata errata1 = new ErrataTestBuilder().orgId(user.getOrg().getId()).buildAndSave();
+        Errata errata2 = new ErrataTestBuilder().orgId(user.getOrg().getId()).buildAndSave();
+
+        // Build the relationship graph
+        // Add packages to erratas
+        errata1.addPackage(pkg1);
+        errata1.addPackage(pkg2);
+        errata2.addPackage(pkg2);
+        errata2.addPackage(pkg3);
+
+        // Add both erratas and packages to channel
+        channel.addErrata(errata1);
+        channel.addErrata(errata2);
+        channel.addPackage(pkg1);
+        channel.addPackage(pkg2);
+        channel.addPackage(pkg3);
+
+        // Save
+        ChannelFactory.save(channel);
+        ErrataFactory.save(errata1);
+        ErrataFactory.save(errata2);
+
+        Long channelId = channel.getId();
+        Long errata1Id = errata1.getId();
+        Long errata2Id = errata2.getId();
+        Long pkg1Id = pkg1.getId();
+        Long pkg2Id = pkg2.getId();
+        Long pkg3Id = pkg3.getId();
+
+        // Clear session
+        TestUtils.flushAndClearSession();
+
+        // Reload everything
+        Channel reloadedChannel = ChannelFactory.lookupById(channelId);
+        Errata reloadedErrata1 = ErrataFactory.lookupById(errata1Id);
+        Errata reloadedErrata2 = ErrataFactory.lookupById(errata2Id);
+        Package reloadedPkg1 = PackageFactory.lookupByIdAndOrg(pkg1Id, user.getOrg());
+        Package reloadedPkg2 = PackageFactory.lookupByIdAndOrg(pkg2Id, user.getOrg());
+        Package reloadedPkg3 = PackageFactory.lookupByIdAndOrg(pkg3Id, user.getOrg());
+
+        // Verify channel-errata relationships persisted
+        assertEquals(2, reloadedChannel.getErratas().size());
+        assertTrue(reloadedErrata1.getChannels().contains(reloadedChannel));
+        assertTrue(reloadedErrata2.getChannels().contains(reloadedChannel));
+
+        // Verify channel-package relationships persisted
+        assertEquals(3, reloadedChannel.getPackages().size());
+        assertTrue(reloadedPkg1.getChannels().contains(reloadedChannel));
+        assertTrue(reloadedPkg2.getChannels().contains(reloadedChannel));
+        assertTrue(reloadedPkg3.getChannels().contains(reloadedChannel));
+
+        // Verify errata-package relationships persisted
+        assertEquals(2, reloadedErrata1.getPackages().size());
+        assertTrue(reloadedErrata1.getPackages().contains(reloadedPkg1));
+        assertTrue(reloadedErrata1.getPackages().contains(reloadedPkg2));
+
+        assertEquals(2, reloadedErrata2.getPackages().size());
+        assertTrue(reloadedErrata2.getPackages().contains(reloadedPkg2));
+        assertTrue(reloadedErrata2.getPackages().contains(reloadedPkg3));
+
+        // Verify package-errata relationships persisted
+        assertEquals(1, reloadedPkg1.getErrata().size());
+        assertTrue(reloadedPkg1.getErrata().contains(reloadedErrata1));
+
+        assertEquals(2, reloadedPkg2.getErrata().size()); // Part of both erratas
+        assertTrue(reloadedPkg2.getErrata().contains(reloadedErrata1));
+        assertTrue(reloadedPkg2.getErrata().contains(reloadedErrata2));
+
+        assertEquals(1, reloadedPkg3.getErrata().size());
+        assertTrue(reloadedPkg3.getErrata().contains(reloadedErrata2));
+    }
+
+    /**
+     * Test that removeErrata() only removes the channel-errata relationship,
+     * leaving channel's packages, errata's packages, and all other relationships
+     * intact. Verified against database persistence.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    void testRemoveErrataAffectsOnlyErrataChannelRelationship() throws Exception {
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Package pkg1 = PackageTest.createTestPackage(user.getOrg());
+        Package pkg2 = PackageTest.createTestPackage(user.getOrg());
+        Errata errata = new ErrataTestBuilder().orgId(user.getOrg().getId()).buildAndSave();
+
+        // Establish all relationships
+        errata.addPackage(pkg1);
+        errata.addPackage(pkg2);
+        channel.addErrata(errata);
+        channel.addPackage(pkg1);
+        channel.addPackage(pkg2);
+
+        // Save and reload to verify initial state from DB
+        ChannelFactory.save(channel);
+        ErrataFactory.save(errata);
+
+        Long channelId = channel.getId();
+        Long errataId = errata.getId();
+        Long pkg1Id = pkg1.getId();
+        Long pkg2Id = pkg2.getId();
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify initial persisted state
+        Channel reloadedChannel = ChannelFactory.lookupById(channelId);
+        Errata reloadedErrata = ErrataFactory.lookupById(errataId);
+
+        assertEquals(1, reloadedChannel.getErratas().size());
+        assertEquals(2, reloadedChannel.getPackages().size());
+        assertEquals(2, reloadedErrata.getPackages().size());
+
+        // Remove errata from channel
+        reloadedChannel.removeErrata(reloadedErrata);
+        ChannelFactory.save(reloadedChannel);
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify persisted state after removal
+        Channel finalChannel = ChannelFactory.lookupById(channelId);
+        Errata finalErrata = ErrataFactory.lookupById(errataId);
+        Package finalPkg1 = PackageFactory.lookupByIdAndOrg(pkg1Id, user.getOrg());
+        Package finalPkg2 = PackageFactory.lookupByIdAndOrg(pkg2Id, user.getOrg());
+
+        // Verify channel-errata relationship removed
+        assertTrue(finalChannel.getErratas().isEmpty());
+        assertFalse(finalErrata.getChannels().contains(finalChannel));
+
+        // Verify channel still has packages
+        assertEquals(2, finalChannel.getPackages().size());
+        assertTrue(finalChannel.getPackages().contains(finalPkg1));
+        assertTrue(finalChannel.getPackages().contains(finalPkg2));
+
+        // Verify errata still has packages
+        assertEquals(2, finalErrata.getPackages().size());
+        assertTrue(finalErrata.getPackages().contains(finalPkg1));
+        assertTrue(finalErrata.getPackages().contains(finalPkg2));
+
+        // Verify packages still have channel
+        assertTrue(finalPkg1.getChannels().contains(finalChannel));
+        assertTrue(finalPkg2.getChannels().contains(finalChannel));
+
+        // Verify packages still have errata
+        assertTrue(finalPkg1.getErrata().contains(finalErrata));
+        assertTrue(finalPkg2.getErrata().contains(finalErrata));
+    }
+
+    /**
+     * Test that removePackage() only removes the package-channel relationship,
+     * leaving channel's erratas, errata's packages, and all other relationships
+     * intact. Verified against database persistence.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    void testRemovePackageAffectsOnlyPackageChannelRelationship() throws Exception {
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Package pkg1 = PackageTest.createTestPackage(user.getOrg());
+        Package pkg2 = PackageTest.createTestPackage(user.getOrg());
+        Errata errata = new ErrataTestBuilder().orgId(user.getOrg().getId()).buildAndSave();
+
+        // Establish all relationships
+        errata.addPackage(pkg1);
+        errata.addPackage(pkg2);
+        channel.addErrata(errata);
+        channel.addPackage(pkg1);
+        channel.addPackage(pkg2);
+
+        // Save and reload to verify initial state from DB
+        ChannelFactory.save(channel);
+        ErrataFactory.save(errata);
+
+        Long channelId = channel.getId();
+        Long errataId = errata.getId();
+        Long pkg1Id = pkg1.getId();
+        Long pkg2Id = pkg2.getId();
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify initial persisted state
+        Channel reloadedChannel = ChannelFactory.lookupById(channelId);
+        Errata reloadedErrata = ErrataFactory.lookupById(errataId);
+        Package reloadedPkg1 = PackageFactory.lookupByIdAndOrg(pkg1Id, user.getOrg());
+
+        assertEquals(1, reloadedChannel.getErratas().size());
+        assertEquals(2, reloadedChannel.getPackages().size());
+        assertEquals(2, reloadedErrata.getPackages().size());
+
+        // Remove package from channel
+        reloadedChannel.removePackage(reloadedPkg1);
+        ChannelFactory.save(reloadedChannel);
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify persisted state after removal
+        Channel finalChannel = ChannelFactory.lookupById(channelId);
+        Errata finalErrata = ErrataFactory.lookupById(errataId);
+        Package finalPkg1 = PackageFactory.lookupByIdAndOrg(pkg1Id, user.getOrg());
+        Package finalPkg2 = PackageFactory.lookupByIdAndOrg(pkg2Id, user.getOrg());
+
+        // Verify package-channel relationship removed
+        assertEquals(1, finalChannel.getPackages().size());
+        assertFalse(finalChannel.getPackages().contains(finalPkg1));
+        assertFalse(finalPkg1.getChannels().contains(finalChannel));
+
+        // Verify channel still has errata
+        assertEquals(1, finalChannel.getErratas().size());
+        assertTrue(finalChannel.getErratas().contains(finalErrata));
+
+        // Verify errata still has the removed package
+        assertEquals(2, finalErrata.getPackages().size());
+        assertTrue(finalErrata.getPackages().contains(finalPkg1));
+        assertTrue(finalErrata.getPackages().contains(finalPkg2));
+
+        // Verify errata still has channel
+        assertTrue(finalErrata.getChannels().contains(finalChannel));
+
+        // Verify removed package still has errata
+        assertTrue(finalPkg1.getErrata().contains(finalErrata));
+    }
+
+    /**
+     * Test that clearErratas() only removes channel-errata relationships,
+     * leaving channel's packages and all errata-package relationships intact.
+     * Verified against database persistence.
+     */
+    @Test
+    void testClearErratasDoesNotAffectPackages() {
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Package pkg1 = PackageTest.createTestPackage(user.getOrg());
+        Package pkg2 = PackageTest.createTestPackage(user.getOrg());
+        Errata errata1 = new ErrataTestBuilder().orgId(user.getOrg().getId()).buildAndSave();
+        Errata errata2 = new ErrataTestBuilder().orgId(user.getOrg().getId()).buildAndSave();
+
+        // Establish relationships
+        errata1.addPackage(pkg1);
+        errata2.addPackage(pkg2);
+        channel.addErrata(errata1);
+        channel.addErrata(errata2);
+        channel.addPackage(pkg1);
+        channel.addPackage(pkg2);
+
+        // Save and reload to verify initial state from DB
+        ChannelFactory.save(channel);
+        ErrataFactory.save(errata1);
+        ErrataFactory.save(errata2);
+
+        Long channelId = channel.getId();
+        Long errata1Id = errata1.getId();
+        Long errata2Id = errata2.getId();
+        Long pkg1Id = pkg1.getId();
+        Long pkg2Id = pkg2.getId();
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify initial persisted state
+        Channel reloadedChannel = ChannelFactory.lookupById(channelId);
+        assertEquals(2, reloadedChannel.getErratas().size());
+        assertEquals(2, reloadedChannel.getPackages().size());
+
+        // Clear all erratas
+        reloadedChannel.clearErratas();
+        ChannelFactory.save(reloadedChannel);
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify persisted state after clearing
+        Channel finalChannel = ChannelFactory.lookupById(channelId);
+        Errata finalErrata1 = ErrataFactory.lookupById(errata1Id);
+        Errata finalErrata2 = ErrataFactory.lookupById(errata2Id);
+        Package finalPkg1 = PackageFactory.lookupByIdAndOrg(pkg1Id, user.getOrg());
+        Package finalPkg2 = PackageFactory.lookupByIdAndOrg(pkg2Id, user.getOrg());
+
+        // Verify erratas cleared
+        assertTrue(finalChannel.getErratas().isEmpty());
+
+        // Verify packages still exist
+        assertEquals(2, finalChannel.getPackages().size());
+        assertTrue(finalChannel.getPackages().contains(finalPkg1));
+        assertTrue(finalChannel.getPackages().contains(finalPkg2));
+
+        // Verify packages still have their erratas
+        assertTrue(finalPkg1.getErrata().contains(finalErrata1));
+        assertTrue(finalPkg2.getErrata().contains(finalErrata2));
+
+        // Verify erratas still have their packages
+        assertEquals(1, finalErrata1.getPackages().size());
+        assertTrue(finalErrata1.getPackages().contains(finalPkg1));
+        assertEquals(1, finalErrata2.getPackages().size());
+        assertTrue(finalErrata2.getPackages().contains(finalPkg2));
+    }
+
 
 }

--- a/java/core/src/test/java/com/redhat/rhn/domain/channel/ChannelTestUtility.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/channel/ChannelTestUtility.java
@@ -29,6 +29,6 @@ public class ChannelTestUtility {
             throw new IncompatibleArchException(packageIn.getPackageArch(),
                     ch.getChannelArch());
         }
-        ch.getPackages().add(packageIn);
+        ch.addPackage(packageIn);
     }
 }

--- a/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataFactoryTest.java
@@ -520,8 +520,8 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
         Errata retracted = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
         Errata notRetracted = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
         retracted.setAdvisoryStatus(AdvisoryStatus.RETRACTED);
-        retracted.addChannel(channel);
-        notRetracted.addChannel(channel);
+        channel.addErrata(retracted);
+        channel.addErrata(notRetracted);
 
         List<Package> packages = new ArrayList<>();
         for (int i = 0; i < 10; i++) {

--- a/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataFactoryTest.java
@@ -33,7 +33,6 @@ import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.ChannelFactoryTest;
 import com.redhat.rhn.domain.channel.ChannelTestUtility;
 import com.redhat.rhn.domain.org.Org;
-import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.product.Tuple2;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
@@ -60,21 +59,17 @@ import com.redhat.rhn.testing.PackageTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
-import com.suse.utils.Opt;
-
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -82,10 +77,8 @@ import java.util.stream.Collectors;
  */
 public class ErrataFactoryTest extends BaseTestCaseWithUser {
 
-    private static int advisorySeq = 1000;
-
     @Test
-    public void testAddToChannel()  throws Exception {
+    public void testAddToChannel() {
         Errata e = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
         //add bugs, keywords, and packages so we have something to work with...
         e.addBug(ErrataManagerTest.createTestBug(42L, "test bug 1"));
@@ -132,7 +125,7 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void testCreateAndLookupVendorAndUserErrata() throws Exception {
+    public void testCreateAndLookupVendorAndUserErrata() {
         Errata userErrata = createTestErrata(user.getOrg().getId());
         assertInstanceOf(Errata.class, userErrata);
         assertNotNull(userErrata.getId());
@@ -177,7 +170,7 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void testCreateAndLookupErrata() throws Exception {
+    public void testCreateAndLookupErrata() {
         Errata testErrata = createTestErrata(user.getOrg().getId());
         assertInstanceOf(Errata.class, testErrata);
         assertNotNull(testErrata.getId());
@@ -194,7 +187,7 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void testCreateAndLookupErrataNullOrg() throws Exception {
+    public void testCreateAndLookupErrataNullOrg() {
         //create an errata with null Org
         Errata testErrata = createTestErrata(null);
         assertInstanceOf(Errata.class, testErrata);
@@ -216,14 +209,14 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void testLastModified() throws Exception {
+    public void testLastModified() {
         Errata testErrata = createTestErrata(user.getOrg().getId());
         testErrata = TestUtils.reload(testErrata);
         assertNotNull(testErrata.getLastModified());
     }
 
     @Test
-    public void testBugs() throws Exception {
+    public void testBugs() {
         var e = createTestErrata(user.getOrg().getId());
         assertTrue(e.getBugs() == null || e.getBugs().isEmpty());
         e.addBug(ErrataFactory.createBug(123L, "test bug",
@@ -235,9 +228,8 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
      * Create an Errata for testing and commit it to the DB.
      * @param orgId the Org who owns this Errata
      * @return Errata created
-     * @throws Exception something bad happened
      */
-    public static Errata createTestErrata(Long orgId) throws Exception {
+    public static Errata createTestErrata(Long orgId) {
         return createTestErrata(orgId, empty());
     }
 
@@ -246,66 +238,11 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
      * @param orgId the Org who owns this Errata
      * @param advisory if specified, the advisory name
      * @return the managed {@link Errata} instance
-     * @throws Exception something bad happened
      */
-    public static Errata createTestErrata(Long orgId, Optional<String> advisory) throws Exception {
-        Errata e = new Errata();
-        fillOutErrata(e, orgId, advisory);
-        return ErrataFactory.save(e);
-
-    }
-
-    /**
-     * Creates and persists an errata that will be flagged as critical.
-     *
-     * @param orgId the org under which the errata exists
-     * @return the managed {@link Errata} instance
-     * @throws Exception if the errata cannot be created
-     */
-    public static Errata createCriticalTestErrata(Long orgId) throws Exception {
-        Errata e = new Errata();
-        fillOutErrata(e, orgId, empty());
-        e.setAdvisoryType(ErrataFactory.ERRATA_TYPE_SECURITY);
-        return ErrataFactory.save(e);
-    }
-
-    private static void fillOutErrata(Errata e, Long orgId, Optional<String> advisory) {
-        String name = Opt.fold(advisory, () -> "JAVA-Test-" + advisorySeq++, Function.identity());
-        Org org = null;
-        if (orgId != null) {
-            org = OrgFactory.lookupById(orgId);
-            e.setOrg(org);
-        }
-        e.setAdvisory(name);
-        e.setAdvisoryType(ErrataFactory.ERRATA_TYPE_BUG);
-        e.setProduct("Red Hat Linux");
-        e.setDescription("Test desc ..");
-        e.setSynopsis("Test synopsis");
-        e.setSolution("Test solution");
-        e.setNotes("Test notes for test errata");
-        e.setRights("Copyright for test errata");
-        e.setTopic("test topic");
-        e.setRefersTo("rhn unit tests");
-        e.setUpdateDate(new Date());
-        e.setIssueDate(new Date());
-        e.setAdvisoryName(name);
-        e.setAdvisoryRel(2L);
-        e.setErrataFrom("maint-coord@suse.de");
-        e.setLocallyModified(Boolean.FALSE);
-        e.addKeyword("keyword");
-        Package testPackage = PackageTest.createTestPackage(org);
-
-        ErrataFile ef;
-        Set<Package> errataFilePackages = new HashSet<>();
-        errataFilePackages.add(testPackage);
-        e.addPackage(testPackage);
-        ef = ErrataFactory.createErrataFile(ErrataFactory.
-                lookupErrataFileType("RPM"),
-                    "SOME FAKE CHECKSUM: 123456789012",
-                    "test errata file" + TestUtils.randomString(), errataFilePackages);
-
-        e.addFile(ef);
-        e.setSeverity(Severity.getById(1));
+    public static Errata createTestErrata(Long orgId, Optional<String> advisory) {
+        ErrataTestBuilder builder = new ErrataTestBuilder().orgId(orgId).addDummyPackage(true);
+        advisory.ifPresent(builder::advisory);
+        return builder.buildAndSave();
     }
 
     public static void updateNeedsErrataCache(Long packageId, Long serverId,
@@ -321,7 +258,7 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void testLookupByOriginal() throws Exception {
+    public void testLookupByOriginal() {
         Org org = UserTestUtils.createOrg("testOrgLookupByOriginal");
         Errata testErrata = createTestErrata(org.getId());
 
@@ -378,10 +315,9 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
 
     /**
      * Tests that syncing errata details syncs advisoryStatus attribute.
-     * @throws Exception
      */
     @Test
-    public void testSyncErrataAdvisoryStatus() throws Exception {
+    public void testSyncErrataAdvisoryStatus() {
         Errata oe = ErrataFactoryTest.createTestErrata(null);
 
         Long ceid = ErrataHelper.cloneErrataFaster(oe.getId(), user.getOrg());
@@ -426,11 +362,8 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
     /**
      * Helper method for testing cache consistency when syncing vendor patch
      * into cloned patch when the vendor patch changes advisoryStatus over time.
-     *
-     * @throws Exception when anything goes wrong
      */
-    private void updatePatchAndCheckUpdateCacheConsistency(AdvisoryStatus oldStatus, AdvisoryStatus newStatus)
-            throws Exception {
+    private void updatePatchAndCheckUpdateCacheConsistency(AdvisoryStatus oldStatus, AdvisoryStatus newStatus) {
         Server server = ServerFactoryTest.createTestServer(user, true);
 
         Errata originalErratum = ErrataFactoryTest.createTestErrata(null);

--- a/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataFactoryTest.java
@@ -277,15 +277,10 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
             Channel chan = ChannelTestUtils.createBaseChannel(user);
             Errata e = ErrataFactoryTest.createTestErrata(user.getId());
             Package p = PackageTest.createTestPackage(user.getOrg());
-            chan.getErratas().add(e);
-            chan.getPackages().add(p);
-            e.getPackages().add(p);
+            chan.addErrata(e);
+            chan.addPackage(p);
+            e.addPackage(p);
             ChannelFactory.save(chan);
-
-            chan = TestUtils.saveAndReload(chan);
-            e = TestUtils.saveAndReload(e);
-            p = TestUtils.saveAndReload(p);
-
 
             List<Long> list = ErrataFactory.listErrataChannelPackages(chan.getId(),
                     e.getId());
@@ -306,7 +301,7 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
     public void testListErrataByChannel() throws Exception {
         Channel chan = ChannelTestUtils.createBaseChannel(user);
         Errata e = ErrataFactoryTest.createTestErrata(user.getId());
-        chan.getErratas().add(e);
+        chan.addErrata(e);
 
         List<Errata> errata = ErrataFactory.listByChannel(user.getOrg(), chan);
         assertEquals(1, errata.size());
@@ -373,10 +368,10 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
 
         Channel originalChannel = ChannelFactoryTest.createBaseChannel(user);
         Channel cloneChannel = ChannelFactoryTest.createTestClonedChannel(originalChannel, user);
-        originalChannel.getErratas().add(originalErratum);
-        originalChannel.getPackages().addAll(originalErratum.getPackages());
-        cloneChannel.getErratas().add(clonedErratum);
-        cloneChannel.getPackages().addAll(clonedErratum.getPackages());
+        originalChannel.addErrata(originalErratum);
+        originalChannel.addPackages(originalErratum.getPackages());
+        cloneChannel.addErrata(clonedErratum);
+        cloneChannel.addPackages(clonedErratum.getPackages());
 
         // install an older pkg on server
         Package pkg = clonedErratum.getPackages().iterator().next();

--- a/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 SUSE LLC
  * Copyright (c) 2009--2012 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -47,7 +48,7 @@ public class ErrataTest extends BaseTestCaseWithUser {
     public void testNotificationQueue() throws Exception {
         Channel c = ChannelFactoryTest.createBaseChannel(user);
         Errata e = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
-        e.addChannel(c);
+        c.addErrata(e);
         ErrataFactory.save(e);
         Long id = e.getId(); //get id for later
         e.addNotification(new Date()); //add one
@@ -146,7 +147,7 @@ public class ErrataTest extends BaseTestCaseWithUser {
         e.addFile(ef);
 
         e.addPackage(p);
-        e.addChannel(c);
+        c.addErrata(e);
 
         ErrataFactory.save(e);
         e = TestUtils.reload(e);
@@ -286,9 +287,65 @@ public class ErrataTest extends BaseTestCaseWithUser {
 
         //createTestChannel calls flush, so previous errata fields with non-null constraint should not be left null
         Channel c1 = ChannelFactoryTest.createTestChannel(user.getOrg());
-        err.addChannel(c1);
+        c1.addErrata(err);
         assertEquals(1, err.getChannels().size());
         err.setChannels(null);
         assertNull(err.getChannels());
+    }
+
+    @Test
+    void testAddAndRemoveErrata() throws Exception {
+        // Create a channel and an errata
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Errata errata = ErrataFactoryTest.createTestErrata(user.getId());
+
+        // By default, neither channel has erratas nor erratas have any channel
+        assertTrue(channel.getErratas().isEmpty());
+        assertTrue(errata.getChannels().isEmpty());
+
+        // Add the errata to the channel
+        channel.addErrata(errata);
+
+        // Assert channel has errata
+        assertEquals(1, channel.getErratas().size());
+        assertEquals(errata, channel.getErratas().iterator().next());
+
+        // Assert the errata also contains the channel
+        assertEquals(1, errata.getChannels().size());
+        assertEquals(channel, errata.getChannels().iterator().next());
+
+        // Remove the errata
+        channel.removeErrata(errata);
+
+        assertTrue(channel.getErratas().isEmpty());
+        assertTrue(errata.getChannels().isEmpty());
+    }
+
+    @Test
+    void testAddAndRemovePackage() throws Exception {
+        // Create a channel and a package
+        Errata errata = new Errata();
+        Package pkg = PackageTest.createTestPackage(user.getOrg());
+
+        // By default, neither errata has packages nor errata has any channel
+        assertTrue(errata.getPackages().isEmpty());
+        assertTrue(pkg.getErrata().isEmpty());
+
+        // Add the package to the channel
+        errata.addPackage(pkg);
+
+        // Assert channel has package
+        assertEquals(1, errata.getPackages().size());
+        assertEquals(pkg, errata.getPackages().iterator().next());
+
+        // Assert the package also contains the channel
+        assertEquals(1, pkg.getErrata().size());
+        assertEquals(errata, pkg.getErrata().iterator().next());
+
+        // Remove the package
+        errata.removePackage(pkg);
+
+        assertTrue(errata.getPackages().isEmpty());
+        assertTrue(pkg.getErrata().isEmpty());
     }
 }

--- a/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataTest.java
@@ -23,9 +23,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.ChannelFactoryTest;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageFactory;
 import com.redhat.rhn.domain.rhnpackage.PackageTest;
 import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.rhnpackage.PackageManagerTest;
@@ -38,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * ErrataTest
@@ -54,9 +57,9 @@ public class ErrataTest extends BaseTestCaseWithUser {
         e.addNotification(new Date()); //add one
         e.addNotification(new Date()); //add another
         assertEquals(1, e.getNotificationQueue().size()); //should be only 1
-        //save errata and evict
+        //save errata and clear session
         ErrataFactory.save(e);
-        TestUtils.flushAndEvict(e);
+        TestUtils.flushAndClearSession();
 
         Errata e2 = ErrataManager.lookupErrata(id, user); //lookup the errata
         assertEquals(1, e2.getNotificationQueue().size()); //should be only 1
@@ -292,58 +295,286 @@ public class ErrataTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    void testAddAndRemoveErrata() {
+    void testAddAndRemoveChannelErrata() {
         // Create a channel and an errata
         Channel channel = ChannelFactoryTest.createTestChannel(user);
         Errata errata = ErrataFactoryTest.createTestErrata(user.getId());
 
-        // By default, neither channel has erratas nor erratas have any channel
-        assertTrue(channel.getErratas().isEmpty());
-        assertTrue(errata.getChannels().isEmpty());
-
-        // Add the errata to the channel
         channel.addErrata(errata);
+        ErrataFactory.save(errata);
+
+        Long channelId = channel.getId();
+        Long errataId = errata.getId();
+
+        // Flush and clear session
+        TestUtils.flushAndClearSession();
+
+        // Reload from database
+        Channel reloadedChannel = ChannelFactory.lookupById(channelId);
+        Errata reloadedErrata = ErrataFactory.lookupById(errataId);
 
         // Assert channel has errata
-        assertEquals(1, channel.getErratas().size());
-        assertEquals(errata, channel.getErratas().iterator().next());
+        assertEquals(1, reloadedChannel.getErratas().size());
+        assertTrue(reloadedChannel.getErratas().contains(reloadedErrata));
 
         // Assert the errata also contains the channel
-        assertEquals(1, errata.getChannels().size());
-        assertEquals(channel, errata.getChannels().iterator().next());
+        assertEquals(1, reloadedErrata.getChannels().size());
+        assertTrue(reloadedErrata.getChannels().contains(reloadedChannel));
 
         // Remove the errata
-        channel.removeErrata(errata);
+        reloadedChannel.removeErrata(reloadedErrata);
+        ChannelFactory.save(reloadedChannel);
 
-        assertTrue(channel.getErratas().isEmpty());
-        assertTrue(errata.getChannels().isEmpty());
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify channel does not contain the errata and vice versa
+        Channel finalChannel = ChannelFactory.lookupById(channelId);
+        Errata finalErrata = ErrataFactory.lookupById(errataId);
+
+        assertTrue(finalChannel.getErratas().isEmpty());
+        assertTrue(finalErrata.getChannels().isEmpty());
     }
 
     @Test
-    void testAddAndRemovePackage() throws Exception {
+    void testAddAndRemovePackage() {
         // Create a channel and a package
         Errata errata = new Errata();
         Package pkg = PackageTest.createTestPackage(user.getOrg());
-
-        // By default, neither errata has packages nor errata has any channel
-        assertTrue(errata.getPackages().isEmpty());
-        assertTrue(pkg.getErrata().isEmpty());
-
-        // Add the package to the channel
         errata.addPackage(pkg);
 
-        // Assert channel has package
-        assertEquals(1, errata.getPackages().size());
-        assertEquals(pkg, errata.getPackages().iterator().next());
+        ErrataFactory.save(errata);
 
-        // Assert the package also contains the channel
-        assertEquals(1, pkg.getErrata().size());
-        assertEquals(errata, pkg.getErrata().iterator().next());
+        Long errataId = errata.getId();
+        Long packageId = pkg.getId();
+
+        // Flush and clear session
+        TestUtils.flushAndClearSession();
+
+        // Reload from database
+        Errata reloadedErrata = ErrataFactory.lookupById(errataId);
+        Package reloadPackage = PackageFactory.lookupByIdAndOrg(packageId, user.getOrg());
+
+        // Assert channel has package
+        assertEquals(1, reloadedErrata.getPackages().size());
+        assertTrue(reloadedErrata.getPackages().contains(reloadPackage));
+
+        // Assert package has errata
+        assertEquals(1, reloadPackage.getErrata().size());
+        assertTrue(reloadPackage.getErrata().contains(reloadedErrata));
 
         // Remove the package
-        errata.removePackage(pkg);
+        reloadedErrata.removePackage(pkg);
+        ErrataFactory.save(errata);
+        TestUtils.flushAndClearSession();
 
-        assertTrue(errata.getPackages().isEmpty());
-        assertTrue(pkg.getErrata().isEmpty());
+        // Reload and verify errata does not contain the package and vice versa
+        Errata finalErrata = ErrataFactory.lookupById(errataId);
+        Package finalPackage = PackageFactory.lookupByIdAndOrg(packageId, user.getOrg());
+
+        // Assert channel had no package and vice verse
+        assertTrue(finalErrata.getPackages().isEmpty());
+        assertTrue(finalPackage.getErrata().isEmpty());
+    }
+
+    /**
+     * Test addPackages() maintains bidirectional relationships and persists correctly.
+     */
+    @Test
+    void testAddPackages() {
+        // Create and add packages
+        Errata errata = new ErrataTestBuilder().orgId(user.getOrg().getId()).buildAndSave();
+        Package pkg1 = PackageTest.createTestPackage(user.getOrg());
+        Package pkg2 = PackageTest.createTestPackage(user.getOrg());
+
+        errata.addPackage(pkg1);
+        errata.addPackage(pkg2);
+        ErrataFactory.save(errata);
+
+        Long errataId = errata.getId();
+        Long pkg1Id = pkg1.getId();
+        Long pkg2Id = pkg2.getId();
+
+        // Flush and clear session
+        TestUtils.flushAndClearSession();
+
+        // Reload from database
+        Errata reloadedErrata = ErrataFactory.lookupById(errataId);
+        assertNotNull(reloadedErrata);
+
+        // Verify forward relationship persisted
+        assertEquals(2, reloadedErrata.getPackages().size());
+
+        // Reload packages and verify reverse relationship persisted
+        Package reloadedPkg1 = PackageFactory.lookupByIdAndOrg(pkg1Id, user.getOrg());
+        Package reloadedPkg2 = PackageFactory.lookupByIdAndOrg(pkg2Id, user.getOrg());
+
+        assertEquals(1, reloadedPkg1.getErrata().size());
+        assertTrue(reloadedPkg1.getErrata().contains(reloadedErrata));
+        assertEquals(1, reloadedPkg2.getErrata().size());
+        assertTrue(reloadedPkg2.getErrata().contains(reloadedErrata));
+    }
+
+    @Test
+    void testRemovePackage() {
+        // Create errata with packages
+        Errata errata = new ErrataTestBuilder().orgId(user.getOrg().getId()).buildAndSave();
+        Package pkg1 = PackageTest.createTestPackage(user.getOrg());
+        Package pkg2 = PackageTest.createTestPackage(user.getOrg());
+
+        errata.addPackage(pkg1);
+        errata.addPackage(pkg2);
+        ErrataFactory.save(errata);
+
+        Long errataId = errata.getId();
+        Long pkg1Id = pkg1.getId();
+        Long pkg2Id = pkg2.getId();
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and remove one package
+        Errata reloadedErrata = ErrataFactory.lookupById(errataId);
+        Package reloadedPkg1 = PackageFactory.lookupByIdAndOrg(pkg1Id, user.getOrg());
+
+        reloadedErrata.removePackage(reloadedPkg1);
+        ErrataFactory.save(reloadedErrata);
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify only pkg2 remains
+        Errata finalErrata = ErrataFactory.lookupById(errataId);
+        assertEquals(1, finalErrata.getPackages().size());
+
+        Package finalPkg1 = PackageFactory.lookupByIdAndOrg(pkg1Id, user.getOrg());
+        Package finalPkg2 = PackageFactory.lookupByIdAndOrg(pkg2Id, user.getOrg());
+
+        assertFalse(finalPkg1.getErrata().contains(finalErrata));
+        assertTrue(finalPkg2.getErrata().contains(finalErrata));
+    }
+
+    /**
+     * Test clearPackages() removes all package relationships and persists correctly.
+     */
+    @Test
+    void testClearPackages() {
+        // Create errata with packages
+        Errata errata = new ErrataTestBuilder().orgId(user.getOrg().getId()).buildAndSave();
+        Package pkg1 = PackageTest.createTestPackage(user.getOrg());
+        Package pkg2 = PackageTest.createTestPackage(user.getOrg());
+
+        errata.addPackages(List.of(pkg1, pkg2));
+        ErrataFactory.save(errata);
+
+        Long errataId = errata.getId();
+        Long pkg1Id = pkg1.getId();
+        Long pkg2Id = pkg2.getId();
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and clear all packages
+        Errata reloadedErrata = ErrataFactory.lookupById(errataId);
+        reloadedErrata.clearPackages();
+        ErrataFactory.save(reloadedErrata);
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify errata has no packages
+        Errata finalErrata = ErrataFactory.lookupById(errataId);
+        assertTrue(finalErrata.getPackages().isEmpty());
+
+        // Verify packages no longer have the errata
+        Package finalPkg1 = PackageFactory.lookupByIdAndOrg(pkg1Id, user.getOrg());
+        Package finalPkg2 = PackageFactory.lookupByIdAndOrg(pkg2Id, user.getOrg());
+
+        assertFalse(finalPkg1.getErrata().contains(finalErrata));
+        assertFalse(finalPkg2.getErrata().contains(finalErrata));
+    }
+
+    /**
+     * Test replacePackages() atomically replaces all packages and persists correctly.
+     */
+    @Test
+    void testReplacePackages() {
+        // Create errata with old packages
+        Errata errata = new ErrataTestBuilder().orgId(user.getOrg().getId()).buildAndSave();
+        Package oldPkg1 = PackageTest.createTestPackage(user.getOrg());
+        Package oldPkg2 = PackageTest.createTestPackage(user.getOrg());
+
+        errata.addPackages(List.of(oldPkg1, oldPkg2));
+        ErrataFactory.save(errata);
+
+        Long errataId = errata.getId();
+        Long oldPkg1Id = oldPkg1.getId();
+        Long oldPkg2Id = oldPkg2.getId();
+
+        TestUtils.flushAndClearSession();
+
+        // Create new packages and replace
+        Package newPkg1 = PackageTest.createTestPackage(user.getOrg());
+        Package newPkg2 = PackageTest.createTestPackage(user.getOrg());
+        Long newPkg1Id = newPkg1.getId();
+        Long newPkg2Id = newPkg2.getId();
+
+        Errata reloadedErrata = ErrataFactory.lookupById(errataId);
+        reloadedErrata.replacePackages(List.of(newPkg1, newPkg2));
+        ErrataFactory.save(reloadedErrata);
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify only new packages exist
+        Errata finalErrata = ErrataFactory.lookupById(errataId);
+        assertEquals(2, finalErrata.getPackages().size());
+
+        Package finalOldPkg1 = PackageFactory.lookupByIdAndOrg(oldPkg1Id, user.getOrg());
+        Package finalOldPkg2 = PackageFactory.lookupByIdAndOrg(oldPkg2Id, user.getOrg());
+        Package finalNewPkg1 = PackageFactory.lookupByIdAndOrg(newPkg1Id, user.getOrg());
+        Package finalNewPkg2 = PackageFactory.lookupByIdAndOrg(newPkg2Id, user.getOrg());
+
+        // Old packages should not have the errata
+        assertFalse(finalOldPkg1.getErrata().contains(finalErrata));
+        assertFalse(finalOldPkg2.getErrata().contains(finalErrata));
+
+        // New packages should have the errata
+        assertTrue(finalNewPkg1.getErrata().contains(finalErrata));
+        assertTrue(finalNewPkg2.getErrata().contains(finalErrata));
+    }
+
+    /**
+     * Test clearChannels() removes all channel relationships and persists correctly.
+     */
+    @Test
+    void testClearChannels() {
+        // Create errata with channels
+        Errata errata = ErrataFactoryTest.createTestErrata(user.getId());
+        Channel channel1 = ChannelFactoryTest.createTestChannel(user);
+        Channel channel2 = ChannelFactoryTest.createTestChannel(user);
+
+        channel1.addErrata(errata);
+        channel2.addErrata(errata);
+        ChannelFactory.save(channel1);
+        ChannelFactory.save(channel2);
+
+        Long errataId = errata.getId();
+        Long channel1Id = channel1.getId();
+        Long channel2Id = channel2.getId();
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and clear all channels
+        Errata reloadedErrata = ErrataFactory.lookupById(errataId);
+        reloadedErrata.clearChannels();
+        ErrataFactory.save(reloadedErrata);
+
+        TestUtils.flushAndClearSession();
+
+        // Reload and verify errata has no channels
+        Errata finalErrata = ErrataFactory.lookupById(errataId);
+        assertTrue(finalErrata.getChannels().isEmpty());
+
+        // Verify channels no longer have the errata
+        Channel finalChannel1 = ChannelFactory.lookupById(channel1Id);
+        Channel finalChannel2 = ChannelFactory.lookupById(channel2Id);
+
+        assertFalse(finalChannel1.getErratas().contains(finalErrata));
+        assertFalse(finalChannel2.getErratas().contains(finalErrata));
     }
 }

--- a/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataTest.java
@@ -45,7 +45,7 @@ import java.util.Iterator;
 public class ErrataTest extends BaseTestCaseWithUser {
 
     @Test
-    public void testNotificationQueue() throws Exception {
+    public void testNotificationQueue() {
         Channel c = ChannelFactoryTest.createBaseChannel(user);
         Errata e = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
         c.addErrata(e);
@@ -289,12 +289,10 @@ public class ErrataTest extends BaseTestCaseWithUser {
         Channel c1 = ChannelFactoryTest.createTestChannel(user.getOrg());
         c1.addErrata(err);
         assertEquals(1, err.getChannels().size());
-        err.setChannels(null);
-        assertNull(err.getChannels());
     }
 
     @Test
-    void testAddAndRemoveErrata() throws Exception {
+    void testAddAndRemoveErrata() {
         // Create a channel and an errata
         Channel channel = ChannelFactoryTest.createTestChannel(user);
         Errata errata = ErrataFactoryTest.createTestErrata(user.getId());

--- a/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataTest.java
@@ -337,8 +337,8 @@ public class ErrataTest extends BaseTestCaseWithUser {
 
     @Test
     void testAddAndRemovePackage() {
-        // Create a channel and a package
-        Errata errata = new Errata();
+        // Create errata and a package
+        Errata errata = new ErrataTestBuilder().orgId(user.getOrg().getId()).buildAndSave();
         Package pkg = PackageTest.createTestPackage(user.getOrg());
         errata.addPackage(pkg);
 
@@ -363,8 +363,8 @@ public class ErrataTest extends BaseTestCaseWithUser {
         assertTrue(reloadPackage.getErrata().contains(reloadedErrata));
 
         // Remove the package
-        reloadedErrata.removePackage(pkg);
-        ErrataFactory.save(errata);
+        reloadedErrata.removePackage(reloadPackage);
+        ErrataFactory.save(reloadedErrata);
         TestUtils.flushAndClearSession();
 
         // Reload and verify errata does not contain the package and vice versa

--- a/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataTestBuilder.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/errata/ErrataTestBuilder.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.errata;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.org.OrgFactory;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageTest;
+import com.redhat.rhn.testing.TestUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Builder for creating test Errata instances with sensible defaults.
+ * Allows flexible customization while maintaining current default behavior.
+ */
+public class ErrataTestBuilder {
+
+    private static final AtomicLong ADVISORY_SEQ = new AtomicLong(1);
+
+    private Errata errata;
+    private Long orgId;
+    private Org org;
+    private String advisory;
+    private String advisoryType = ErrataFactory.ERRATA_TYPE_BUG;
+    private String product = "Red Hat Linux";
+    private String description = "Test desc ..";
+    private String synopsis = "Test synopsis";
+    private String solution = "Test solution";
+    private String notes = "Test notes for test errata";
+    private String rights = "Copyright for test errata";
+    private String topic = "test topic";
+    private String refersTo = "rhn unit tests";
+    private Date updateDate = new Date();
+    private Date issueDate = new Date();
+    private String advisoryName;
+    private Long advisoryRel = 2L;
+    private String errataFrom = "maint-coord@suse.de";
+    private Boolean locallyModified = Boolean.FALSE;
+    private String keyword = "keyword";
+    private boolean addDummyPackage = false;
+    private Integer severityId = 1;
+    private List<Package> packages = new ArrayList<>();
+    private List<Channel> channels = new ArrayList<>();
+    private List<Cve> cves = new ArrayList<>();
+    private List<Bug> bugs = new ArrayList<>();
+
+    public ErrataTestBuilder() {
+        this.errata = new Errata();
+    }
+
+    public ErrataTestBuilder orgId(Long orgIdIn) {
+        this.orgId = orgIdIn;
+        return this;
+    }
+
+    public ErrataTestBuilder advisory(String advisoryIn) {
+        this.advisory = advisoryIn;
+        return this;
+    }
+
+    public ErrataTestBuilder advisoryType(String typeIn) {
+        this.advisoryType = typeIn;
+        return this;
+    }
+
+    public ErrataTestBuilder product(String productIn) {
+        this.product = productIn;
+        return this;
+    }
+
+    public ErrataTestBuilder description(String descIn) {
+        this.description = descIn;
+        return this;
+    }
+
+    public ErrataTestBuilder synopsis(String synopsisIn) {
+        this.synopsis = synopsisIn;
+        return this;
+    }
+
+    public ErrataTestBuilder solution(String solutionIn) {
+        this.solution = solutionIn;
+        return this;
+    }
+
+    public ErrataTestBuilder notes(String notesIn) {
+        this.notes = notesIn;
+        return this;
+    }
+
+    public ErrataTestBuilder rights(String rightsIn) {
+        this.rights = rightsIn;
+        return this;
+    }
+
+    public ErrataTestBuilder topic(String topicIn) {
+        this.topic = topicIn;
+        return this;
+    }
+
+    public ErrataTestBuilder refersTo(String refersToIn) {
+        this.refersTo = refersToIn;
+        return this;
+    }
+
+    public ErrataTestBuilder updateDate(Date dateIn) {
+        this.updateDate = dateIn;
+        return this;
+    }
+
+    public ErrataTestBuilder issueDate(Date dateIn) {
+        this.issueDate = dateIn;
+        return this;
+    }
+
+    public ErrataTestBuilder advisoryRel(Long relIn) {
+        this.advisoryRel = relIn;
+        return this;
+    }
+
+    public ErrataTestBuilder errataFrom(String fromIn) {
+        this.errataFrom = fromIn;
+        return this;
+    }
+
+    public ErrataTestBuilder locallyModified(Boolean modifiedIn) {
+        this.locallyModified = modifiedIn;
+        return this;
+    }
+
+    public ErrataTestBuilder keyword(String keywordIn) {
+        this.keyword = keywordIn;
+        return this;
+    }
+
+    public ErrataTestBuilder severityId(Integer severityIdIn) {
+        this.severityId = severityIdIn;
+        return this;
+    }
+
+    public ErrataTestBuilder addDummyPackage(boolean addDummyPackageIn) {
+        this.addDummyPackage = addDummyPackageIn;
+        return this;
+    }
+
+    /**
+     * Add a package to the errata
+     * @param pkg the package to add
+     * @return this builder
+     */
+    public ErrataTestBuilder addPackage(Package pkg) {
+        this.packages.add(pkg);
+        return this;
+    }
+
+    /**
+     * Add multiple packages to the errata
+     * @param pkgs the packages to add
+     * @return this builder
+     */
+    public ErrataTestBuilder addPackages(Package... pkgs) {
+        this.packages.addAll(Arrays.asList(pkgs));
+        return this;
+    }
+
+    /**
+     * Add a channel to the errata (will use channel.addErrata)
+     * @param channel the channel to add
+     * @return this builder
+     */
+    public ErrataTestBuilder addChannel(Channel channel) {
+        this.channels.add(channel);
+        return this;
+    }
+
+    /**
+     * Add multiple channels to the errata
+     * @param channelsIn the channels to add
+     * @return this builder
+     */
+    public ErrataTestBuilder addChannels(Channel... channelsIn) {
+        this.channels.addAll(Arrays.asList(channelsIn));
+        return this;
+    }
+
+    /**
+     * Add a CVE to the errata
+     * @param cve the CVE to add
+     * @return this builder
+     */
+    public ErrataTestBuilder addCve(Cve cve) {
+        this.cves.add(cve);
+        return this;
+    }
+
+    /**
+     * Add multiple CVEs to the errata
+     * @param cvesIn the CVEs to add
+     * @return this builder
+     */
+    public ErrataTestBuilder addCves(Cve... cvesIn) {
+        this.cves.addAll(Arrays.asList(cvesIn));
+        return this;
+    }
+
+    /**
+     * Add a bug to the errata
+     * @param bug the bug to add
+     * @return this builder
+     */
+    public ErrataTestBuilder addBug(Bug bug) {
+        this.bugs.add(bug);
+        return this;
+    }
+
+    /**
+     * Add multiple bugs to the errata
+     * @param bugsIn the bugs to add
+     * @return this builder
+     */
+    public ErrataTestBuilder addBugs(Bug... bugsIn) {
+        this.bugs.addAll(Arrays.asList(bugsIn));
+        return this;
+    }
+
+    /**
+     * Build the Errata instance (not yet persisted)
+     * @return the configured Errata
+     */
+    public Errata build() {
+        // Generate advisory name if not provided
+        String name = (advisory != null) ? advisory : "JAVA-Test-" + ADVISORY_SEQ.getAndIncrement();
+        if (advisoryName == null) {
+            advisoryName = name;
+        }
+
+        // Lookup org if needed
+        if (orgId != null && org == null) {
+            org = OrgFactory.lookupById(orgId);
+        }
+
+        // Set basic fields
+        if (org != null) {
+            errata.setOrg(org);
+        }
+        errata.setAdvisory(name);
+        errata.setAdvisoryType(advisoryType);
+        errata.setProduct(product);
+        errata.setDescription(description);
+        errata.setSynopsis(synopsis);
+        errata.setSolution(solution);
+        errata.setNotes(notes);
+        errata.setRights(rights);
+        errata.setTopic(topic);
+        errata.setRefersTo(refersTo);
+        errata.setUpdateDate(updateDate);
+        errata.setIssueDate(issueDate);
+        errata.setAdvisoryName(advisoryName);
+        errata.setAdvisoryRel(advisoryRel);
+        errata.setErrataFrom(errataFrom);
+        errata.setLocallyModified(locallyModified);
+
+        // Add keyword
+        if (keyword != null) {
+            errata.addKeyword(keyword);
+        }
+
+        // Add package and file if requested
+        if (addDummyPackage) {
+            Package testPackage = PackageTest.createTestPackage(org);
+
+            if (addDummyPackage) {
+                errata.addPackage(testPackage);
+            }
+
+            Set<Package> errataFilePackages = new HashSet<>();
+            errataFilePackages.add(testPackage);
+            ErrataFile ef = ErrataFactory.createErrataFile(
+                ErrataFactory.lookupErrataFileType("RPM"),
+                "SOME FAKE CHECKSUM: 123456789012",
+                "test errata file" + TestUtils.randomString(),
+                errataFilePackages
+            );
+            errata.addFile(ef);
+        }
+
+        // Set severity
+        if (severityId != null) {
+            errata.setSeverity(Severity.getById(severityId));
+        }
+
+        // Add additional packages
+        for (Package pkg : packages) {
+            errata.addPackage(pkg);
+        }
+
+        // Add channels (using channel.addErrata to maintain proper ownership)
+        for (Channel channel : channels) {
+            channel.addErrata(errata);
+        }
+
+        // Add CVEs
+        for (Cve cve : cves) {
+            errata.getCves().add(cve);
+        }
+
+        // Add bugs
+        for (Bug bug : bugs) {
+            errata.addBug(bug);
+        }
+
+        return errata;
+    }
+
+    /**
+     * Build and persist the Errata instance
+     * @return the persisted Errata
+     */
+    public Errata buildAndSave() {
+        Errata e = build();
+        return ErrataFactory.save(e);
+    }
+}

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/ServerFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/ServerFactoryTest.java
@@ -1070,7 +1070,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         Errata e1 = ErrataFactoryTest.createTestErrata(user.getId());
         baseChan.addErrata(e1);
         e1.setAdvisoryName("SUSE-2016-1234");
-        e1.getPackages().add(p1v2);
+        e1.addPackage(p1v2);
 
         ChannelFactory.save(baseChan);
 
@@ -1167,33 +1167,33 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         Errata e1 = ErrataFactoryTest.createTestErrata(user.getId());
         errataIds.add(e1.getId());
         baseChan.addErrata(e1);
-        e1.getPackages().add(p1v2);
-        e1.getPackages().add(p2v4);
-        baseChan.getPackages().add(p1v2);
-        baseChan.getPackages().add(p2v4);
+        e1.addPackage(p1v2);
+        e1.addPackage(p2v4);
+        baseChan.addPackage(p1v2);
+        baseChan.addPackage(p2v4);
 
         Errata e2 = ErrataFactoryTest.createTestErrata(user.getId());
         errataIds.add(e2.getId());
         baseChan.addErrata(e2);
-        e2.getPackages().add(p1v3);
-        baseChan.getPackages().add(p1v3);
+        e2.addPackage(p1v3);
+        baseChan.addPackage(p1v3);
 
         Errata e3 = ErrataFactoryTest.createTestErrata(user.getId());
         errataIds.add(e3.getId());
         baseChan.addErrata(e3);
-        e3.getPackages().add(p1v3arch2);
-        baseChan.getPackages().add(p1v3arch2);
+        e3.addPackage(p1v3arch2);
+        baseChan.addPackage(p1v3arch2);
 
         Errata e4 = ErrataFactoryTest.createTestErrata(user.getId());
         errataIds.add(e4.getId());
         childChan.addErrata(e4);
-        e4.getPackages().add(p1v2);
-        childChan.getPackages().add(p1v2);
+        e4.addPackage(p1v2);
+        childChan.addPackage(p1v2);
 
         Errata e5 = ErrataFactoryTest.createTestErrata(user.getId());
         childChan.addErrata(e4);
-        e4.getPackages().add(p1v4);
-        childChan.getPackages().add(p1v4);
+        e4.addPackage(p1v4);
+        childChan.addPackage(p1v4);
 
         ChannelFactory.save(baseChan);
         ChannelFactory.save(childChan);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/ChannelSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/ChannelSetupActionTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 SUSE LLC
  * Copyright (c) 2009--2014 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -68,7 +69,7 @@ public class ChannelSetupActionTest extends BaseTestCase {
         Errata e = ErrataFactoryTest.createTestErrata(org.getId());
         //make sure we have a channel for the errata
         Channel c1 = ChannelFactoryTest.createTestChannel(org);
-        e.addChannel(c1);
+        c1.addErrata(e);
         ErrataFactory.save(e);
         //setup the request object
         sah.getRequest().addParameter("eid", e.getId().toString());

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/ErrataDetailsSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/ErrataDetailsSetupActionTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 SUSE LLC
  * Copyright (c) 2009--2010 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -85,7 +86,7 @@ public class ErrataDetailsSetupActionTest extends BaseTestCase {
         errata.addKeyword("test");
         Channel ch = ChannelFactoryTest.createTestChannel(sah.getUser().getOrg());
         ch.setUpdateTag("SLE-Module-Basesystem");
-        errata.addChannel(ch);
+        ch.addErrata(errata);
 
         ErrataFactory.save(errata);
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/NotifyActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/NotifyActionTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 SUSE LLC
  * Copyright (c) 2009--2014 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -55,7 +56,7 @@ public class NotifyActionTest extends BaseTestCase {
         User user = requestContext.getCurrentUser();
         Errata published = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
         Channel c = ChannelFactoryTest.createBaseChannel(user);
-        published.addChannel(c);
+        c.addErrata(published);
 
         //test default case
         request.addParameter("eid", published.getId().toString());

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/NotifyActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/NotifyActionTest.java
@@ -64,7 +64,7 @@ public class NotifyActionTest extends BaseTestCase {
         assertEquals(RhnHelper.DEFAULT_FORWARD, result.getName());
 
         Long id = published.getId();
-        TestUtils.flushAndEvict(published);
+        TestUtils.flushAndClearSession();
         Errata errata = ErrataManager.lookupErrata(id, user);
         assertEquals(1, errata.getNotificationQueue().size());
     }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/rhnpackage/PackageListSetupTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/rhnpackage/PackageListSetupTest.java
@@ -88,7 +88,7 @@ public class PackageListSetupTest extends RhnMockStrutsTestCase {
         zypperPackage.setPackageEvr(zyppEvr);
         zypperPackage = TestUtils.saveAndReload(zypperPackage);
 
-        channel.getPackages().addAll(List.of(standard, ptfMaster, ptfPackage, zypperPackage));
+        channel.addPackages(List.of(standard, ptfMaster, ptfPackage, zypperPackage));
         channel = TestUtils.saveAndReload(channel);
 
         SystemManager.subscribeServerToChannel(user, server, channel);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/ErrataActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/ErrataActionTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 SUSE LLC
  * Copyright (c) 2009--2012 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -78,7 +79,7 @@ public class ErrataActionTest extends RhnPostMockStrutsTestCase {
         // Create a set of Errata IDs
         for (int i = 0; i < 5; i++) {
             Errata e = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
-            e.addChannel(channel);
+            channel.addErrata(e);
             ErrataFactory.save(e);
             errata.addElement(e.getId());
             ErrataFactoryTest.updateNeedsErrataCache(

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/ErrataConfirmActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/ErrataConfirmActionTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 SUSE LLC
  * Copyright (c) 2009--2012 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -86,7 +87,7 @@ public class ErrataConfirmActionTest extends RhnPostMockStrutsTestCase {
         // Create a set of Errata IDs
         for (int i = 0; i < 5; i++) {
             Errata e = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
-            e.addChannel(channel);
+            channel.addErrata(e);
             ErrataFactory.save(e);
             errata.addElement(e.getId());
             ErrataFactoryTest.updateNeedsErrataCache(

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandlerTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 SUSE LLC
  * Copyright (c) 2009--2014 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -116,7 +117,7 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
         // clone a channel with its errata, and the errata's packages are EMPTY
         Errata emptyErrata = ErrataFactoryTest.createTestErrata(admin.getOrg().getId());
 
-        emptyErrata.setPackages(new HashSet<>());
+        emptyErrata.clearPackages();
         ErrataFactory.save(emptyErrata);
 
         foundErrata = ErrataFactory.lookupById(emptyErrata.getId());
@@ -482,7 +483,7 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
 
         //unique errata for user's org. Applicable to one user channel
         Channel channel1 = ChannelFactoryTest.createTestChannel(admin);
-        userErrata.addChannel(channel1);
+        channel1.addErrata(userErrata);
 
         ErrataFactory.save(userErrata);
 
@@ -500,7 +501,7 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
         Errata vendorErrata = ErrataFactoryTest.createTestErrata(null, Optional.of(userErrata.getAdvisory()));
 
         Channel channel2 = ChannelFactoryTest.createTestChannel(admin);
-        vendorErrata.addChannel(channel2);
+        channel2.addErrata(vendorErrata);
 
         ErrataFactory.save(vendorErrata);
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandlerTest.java
@@ -235,7 +235,8 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
 
         Errata e = ErrataFactoryTest.createTestErrata(admin.getOrg().getId());
         e.setAdvisoryType(ErrataFactory.ERRATA_TYPE_BUG);
-        e.setChannels(errataChannels);
+        // Use channel.addErrata() instead of setChannels() to maintain owning side
+        channel1.addErrata(e);
 
         ImageInfo inf1 = createImageInfo("myimage", "1.0.0", store, admin);
         UserFactory.save(admin);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerPtfTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerPtfTest.java
@@ -176,7 +176,7 @@ public class SystemHandlerPtfTest extends BaseHandlerTestCase {
 
     @Test
     public void listLatestAvailablePackageDoesNotConsiderPtfPackages() {
-        channel.getPackages().addAll(List.of(standard, standardUpdated, standardUpdatedPtf));
+        channel.addPackages(List.of(standard, standardUpdated, standardUpdatedPtf));
         PackageTestUtils.installPackageOnServer(standard, server);
 
         List<Map<String, Object>> results = handler.listLatestAvailablePackage(admin,
@@ -192,7 +192,7 @@ public class SystemHandlerPtfTest extends BaseHandlerTestCase {
 
     @Test
     public void installingPtfPackageFailsWithPtfPackageFault() {
-        channel.getPackages().add(ptfPackage);
+        channel.addPackage(ptfPackage);
 
         assertThrows(PtfPackageFault.class, () -> {
             handler.schedulePackageInstall(admin, List.of(server.getId().intValue()),
@@ -202,7 +202,7 @@ public class SystemHandlerPtfTest extends BaseHandlerTestCase {
 
     @Test
     public void upgradingToPtfPackageFailsWithPtfPackageFault() {
-        channel.getPackages().addAll(List.of(standard, standardUpdated));
+        channel.addPackages(List.of(standard, standardUpdated));
         PackageTestUtils.installPackageOnServer(standard, server);
 
         assertThrows(PtfPackageFault.class, () -> {
@@ -213,7 +213,7 @@ public class SystemHandlerPtfTest extends BaseHandlerTestCase {
 
     @Test
     public void removingPtfPackageFailsWithPtfPackageFault() {
-        channel.getPackages().add(ptfPackage);
+        channel.addPackage(ptfPackage);
         PackageTestUtils.installPackageOnServer(ptfPackage, server);
 
         assertThrows(PtfPackageFault.class, () -> {
@@ -224,7 +224,7 @@ public class SystemHandlerPtfTest extends BaseHandlerTestCase {
 
     @Test
     public void masterPtfPackagesCanBeInstalled() {
-        channel.getPackages().add(ptfMaster);
+        channel.addPackage(ptfMaster);
 
         Long[] scheduledActions = handler.schedulePackageInstall(admin, List.of(server.getId().intValue()),
             List.of(ptfMaster.getId().intValue()), new Date());
@@ -239,7 +239,7 @@ public class SystemHandlerPtfTest extends BaseHandlerTestCase {
 
     @Test
     public void removingMasterPtfFailsWithPtfMasterFault() {
-        channel.getPackages().add(ptfMaster);
+        channel.addPackage(ptfMaster);
         PackageTestUtils.installPackageOnServer(ptfMaster, server);
 
         assertThrows(PtfMasterFault.class, () -> {

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerPtfTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerPtfTest.java
@@ -144,8 +144,8 @@ public class SystemHandlerPtfTest extends BaseHandlerTestCase {
 
     @Test
     public void allInstallablePackagesDoesNotListPtfsPackages() {
-        channel.getPackages()
-               .addAll(List.of(standard, standardUpdated, ptfMaster, ptfMasterUpdated, ptfPackage, ptfPackageUpdated));
+        channel.addPackages(
+                List.of(standard, standardUpdated, ptfMaster, ptfMasterUpdated, ptfPackage, ptfPackageUpdated));
 
         List<Map<String, Object>> resultMap = handler.listAllInstallablePackages(admin, server.getId().intValue());
 
@@ -160,8 +160,8 @@ public class SystemHandlerPtfTest extends BaseHandlerTestCase {
 
     @Test
     public void latestInstallablePackagesDoesNotListPtfsPackages() {
-        channel.getPackages()
-               .addAll(List.of(standard, standardUpdated, ptfMaster, ptfMasterUpdated, ptfPackage, ptfPackageUpdated));
+        channel.addPackages(
+                List.of(standard, standardUpdated, ptfMaster, ptfMasterUpdated, ptfPackage, ptfPackageUpdated));
         ChannelFactory.refreshNewestPackageCache(channel, "java::test");
 
         List<Map<String, Object>> resultMap = handler.listLatestInstallablePackages(admin, server.getId().intValue());

--- a/java/core/src/test/java/com/redhat/rhn/manager/action/MinionActionManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/action/MinionActionManagerTest.java
@@ -437,7 +437,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         Errata e1 = ErrataFactoryTest.createTestErrata(user.getId());
         channel1.addErrata(e1);
         e1.setAdvisoryName("SUSE-2016-1234");
-        e1.getPackages().add(createTestPackage(user, channel1, "noarch"));
+        e1.addPackage(createTestPackage(user, channel1, "noarch"));
 
         ChannelFactory.save(channel1);
 
@@ -496,7 +496,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         Errata e1 = ErrataFactoryTest.createTestErrata(user.getId());
         channel1.addErrata(e1);
         e1.setAdvisoryName("SUSE-2016-1234");
-        e1.getPackages().add(createTestPackage(user, channel1, "noarch"));
+        e1.addPackage(createTestPackage(user, channel1, "noarch"));
 
         ChannelFactory.save(channel1);
         ErrataCacheManager.insertNeededErrataCache(
@@ -558,7 +558,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         Errata e1 = ErrataFactoryTest.createTestErrata(user.getId());
         channel1.addErrata(e1);
         e1.setAdvisoryName("SUSE-2016-1234");
-        e1.getPackages().add(createTestPackage(user, channel1, "noarch"));
+        e1.addPackage(createTestPackage(user, channel1, "noarch"));
 
         ChannelFactory.save(channel1);
 
@@ -625,7 +625,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         Errata e1 = ErrataFactoryTest.createTestErrata(user.getId());
         channel1.addErrata(e1);
         e1.setAdvisoryName("SUSE-2016-1234");
-        e1.getPackages().add(createTestPackage(user, channel1, "noarch"));
+        e1.addPackage(createTestPackage(user, channel1, "noarch"));
 
         ChannelFactory.save(channel1);
         ChannelFactory.save(channel2);
@@ -685,7 +685,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         Errata e1 = ErrataFactoryTest.createTestErrata(user.getId());
         channel1.addErrata(e1);
         e1.setAdvisoryName("SUSE-2016-1234");
-        e1.getPackages().add(createTestPackage(user, channel1, "noarch"));
+        e1.addPackage(createTestPackage(user, channel1, "noarch"));
 
         ChannelFactory.save(channel1);
         ErrataCacheManager.insertNeededErrataCache(

--- a/java/core/src/test/java/com/redhat/rhn/manager/channel/ChannelManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/channel/ChannelManagerTest.java
@@ -988,11 +988,7 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
 
         c.addErrata(e);
 
-        c = TestUtils.saveAndReload(c);
-        e = TestUtils.saveAndReload(e);
-
-        bothP = TestUtils.saveAndReload(bothP);
-
+        TestUtils.flushAndClearSession();
 
         List<PackageDto> list = ChannelManager.listErrataPackages(c, e);
         assertEquals(list.size(), 1);

--- a/java/core/src/test/java/com/redhat/rhn/manager/contentmgmt/ContentManagerChannelAlignmentTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/contentmgmt/ContentManagerChannelAlignmentTest.java
@@ -118,7 +118,7 @@ public class ContentManagerChannelAlignmentTest extends BaseTestCaseWithUser {
     @Test
     public void testAlignEntities() {
         // let's add a package to the target. it should be removed after aligning
-        tgtChannel.getPackages().add(PackageTest.createTestPackage(user.getOrg()));
+        tgtChannel.addPackage(PackageTest.createTestPackage(user.getOrg()));
         contentManager.alignEnvironmentTargetSync(emptyList(), srcChannel, tgtChannel, user);
 
         // check that newest packages cache has been updated
@@ -142,7 +142,7 @@ public class ContentManagerChannelAlignmentTest extends BaseTestCaseWithUser {
     public void testNewestPackagesCacheRefreshed() {
         Package pack2 = PackageTest.createTestPackage(user.getOrg());
 
-        tgtChannel.getPackages().add(pack2);
+        tgtChannel.addPackage(pack2);
         ChannelFactory.refreshNewestPackageCache(tgtChannel, "java::alignPackages");
         assertEquals(pack2.getId(),
                 ChannelManager.getLatestPackageEqual(tgtChannel.getId(), pack2.getPackageName().getName()));
@@ -177,10 +177,10 @@ public class ContentManagerChannelAlignmentTest extends BaseTestCaseWithUser {
         ChannelTestUtility.testAddPackage(srcChannel, pack4);
         ChannelTestUtility.testAddPackage(srcChannel, pack5);
 
-        tgtChannel.getPackages().add(pack2);
-        tgtChannel.getPackages().add(pack3);
-        tgtChannel.getPackages().add(pack5);
-        tgtChannel.getPackages().add(pack6);
+        tgtChannel.addPackage(pack2);
+        tgtChannel.addPackage(pack3);
+        tgtChannel.addPackage(pack5);
+        tgtChannel.addPackage(pack6);
 
         ChannelFactory.refreshNewestPackageCache(tgtChannel, "java::alignPackages");
 
@@ -229,7 +229,7 @@ public class ContentManagerChannelAlignmentTest extends BaseTestCaseWithUser {
         Server server = ServerFactoryTest.createTestServer(user);
         SystemManager.subscribeServerToChannel(user, server, tgtChannel);
         // we want to test the cache update when channel with no errata is used
-        srcChannel.getErratas().clear();
+        srcChannel.clearErratas();
 
         InstalledPackage olderPkg = copyPackage(pkg, of("0.9.9"));
         setInstalledPackage(server, olderPkg);
@@ -252,7 +252,7 @@ public class ContentManagerChannelAlignmentTest extends BaseTestCaseWithUser {
     public void testServerNeededCacheRemovedNoErrata() throws Exception {
         Server server = ServerFactoryTest.createTestServer(user);
         // we want to test the cache update when channel with no errata is used
-        srcChannel.getErratas().clear();
+        srcChannel.clearErratas();
 
         Package otherPkg = PackageTest.createTestPackage(user.getOrg());
         ChannelTestUtility.testAddPackage(tgtChannel, otherPkg);
@@ -649,7 +649,7 @@ public class ContentManagerChannelAlignmentTest extends BaseTestCaseWithUser {
         setInstalledPackage(server, installedPkg);
 
         // clear the existing patch
-        srcChannel.getErratas().clear();
+        srcChannel.clearErratas();
 
         // pkg2 is a part of a retracted patch
         Package pkg2 = PackageTest.createTestPackage(user.getOrg());

--- a/java/core/src/test/java/com/redhat/rhn/manager/contentmgmt/ContentManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/contentmgmt/ContentManagerTest.java
@@ -1057,21 +1057,22 @@ public class ContentManagerTest extends BaseTestCaseWithUser {
 
         // Remove a package from the original channel
         Package existingPackage = channel1.getPackages().iterator().next();
-        assertTrue(channel1.getPackages().remove(existingPackage));
+        channel1.removePackage(existingPackage);
+        assertFalse(channel1.getPackages().contains(existingPackage));
 
         // Add an errata with package to the original channel
         Errata errata = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
         Set<Package> errataPackages = errata.getPackages();
         Package pack = errataPackages.iterator().next();
         channel1.addErrata(errata);
-        channel1.getPackages().addAll(errataPackages);
+        channel1.addPackages(errataPackages);
 
         // add a package to the original channel and a filter for it to the project
         FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.CONTAINS, "name", "filtered-package");
         ContentFilter filter = contentManager.createFilter(
                 "my-filter", Rule.DENY, ContentFilter.EntityType.PACKAGE, criteria, user);
         Package testFilteredPackage = PackageTest.createTestPackage(user.getOrg(), "filtered-package");
-        channel1.getPackages().add(testFilteredPackage);
+        channel1.addPackage(testFilteredPackage);
         ChannelFactory.save(channel1);
         contentManager.attachFilter("cplabel", filter.getId(), user);
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/errata/ErrataManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/errata/ErrataManagerTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 SUSE LLC
  * Copyright (c) 2009--2017 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -167,7 +168,7 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         e.addPackage(p);
         ErrataFactory.save(e);
 
-        channel.ifPresent(e::addChannel);
+        channel.ifPresent(c -> c.addErrata(e));
 
         WebSession session = WebSessionFactory.createSession();
         WebSessionFactory.save(session);
@@ -1656,12 +1657,12 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         Channel channel = ChannelTestUtils.createBaseChannel(user);
 
         Errata patch = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
-        patch.addChannel(channel);
+        channel.addErrata(patch);
         ErrataFactory.save(patch);
 
         Errata retractedPatch = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
         retractedPatch.setAdvisoryStatus(AdvisoryStatus.RETRACTED);
-        retractedPatch.addChannel(channel);
+        channel.addErrata(retractedPatch);
         ErrataFactory.save(retractedPatch);
 
         DataResult<ErrataOverview> patches = ErrataManager.allErrata(user);

--- a/java/core/src/test/java/com/redhat/rhn/manager/errata/cache/PtfPackagesCacheManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/errata/cache/PtfPackagesCacheManagerTest.java
@@ -71,7 +71,7 @@ public class PtfPackagesCacheManagerTest extends BaseTestCaseWithUser {
     @Test
     public void ensurePtfPackagesNotAreInsertedByPackageInNeededCache() {
         // channel has original and ptf packages
-        subscribedChannel.getPackages().addAll(List.of(originalPackage, ptfPackage, newerPackage));
+        subscribedChannel.addPackages(List.of(originalPackage, ptfPackage, newerPackage));
 
         // original is installed on the server
         PackageTestUtils.installPackageOnServer(originalPackage, server);
@@ -103,7 +103,7 @@ public class PtfPackagesCacheManagerTest extends BaseTestCaseWithUser {
     @Test
     public void ensurePtfPackagesNotAreInsertedByErrataInNeededCache() throws Exception {
         // channel has original and ptf packages
-        subscribedChannel.getPackages().addAll(List.of(originalPackage, ptfPackage, newerPackage));
+        subscribedChannel.addPackages(List.of(originalPackage, ptfPackage, newerPackage));
 
         Errata errataPtf = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
         errataPtf.addPackage(ptfPackage);
@@ -139,7 +139,7 @@ public class PtfPackagesCacheManagerTest extends BaseTestCaseWithUser {
     @Test
     public void ensureHigherVersionCalculationIsCorrectWithPtfPackages() {
         // channel has original and ptf packages
-        subscribedChannel.getPackages().addAll(List.of(originalPackage, ptfPackage, newerPackage));
+        subscribedChannel.addPackages(List.of(originalPackage, ptfPackage, newerPackage));
 
         // original is installed on the server
         PackageTestUtils.installPackageOnServer(originalPackage, server);

--- a/java/core/src/test/java/com/redhat/rhn/manager/errata/cache/RetractedPatchesCacheManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/errata/cache/RetractedPatchesCacheManagerTest.java
@@ -75,7 +75,7 @@ public class RetractedPatchesCacheManagerTest extends BaseTestCaseWithUser {
     @Test
     public void testRetractedPatchesInCache() throws Exception {
         // channel has all packages
-        subscribedChannel.getPackages().addAll(List.of(oldPkg, newerPkg, newestPkg));
+        subscribedChannel.addPackages(List.of(oldPkg, newerPkg, newestPkg));
 
         // oldest is installed on the server
         PackageTestUtils.installPackageOnServer(oldPkg, server);
@@ -112,7 +112,7 @@ public class RetractedPatchesCacheManagerTest extends BaseTestCaseWithUser {
     @Test
     public void testRetractedPackagesInCache() throws Exception {
         // channel has all packages
-        subscribedChannel.getPackages().addAll(List.of(oldPkg, newerPkg, newestPkg));
+        subscribedChannel.addPackages(List.of(oldPkg, newerPkg, newestPkg));
 
         // oldest is installed on the server
         PackageTestUtils.installPackageOnServer(oldPkg, server);
@@ -152,7 +152,7 @@ public class RetractedPatchesCacheManagerTest extends BaseTestCaseWithUser {
         ErrataFactory.save(vendorPatch);
 
         // channel has all 3 packages
-        subscribedChannel.getPackages().addAll(List.of(oldPkg, newerPkg, newestPkg));
+        subscribedChannel.addPackages(List.of(oldPkg, newerPkg, newestPkg));
 
         // clone the channel
         CloneChannelCommand ccc = new CloneChannelCommand(CURRENT_STATE, subscribedChannel);

--- a/java/core/src/test/java/com/redhat/rhn/manager/errata/cache/RetractedPatchesCacheManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/errata/cache/RetractedPatchesCacheManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 SUSE LLC
+ * Copyright (c) 2021--2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 package com.redhat.rhn.manager.errata.cache;
 
@@ -152,7 +148,7 @@ public class RetractedPatchesCacheManagerTest extends BaseTestCaseWithUser {
         // create a null-org patch with a newest package and add it to the channel
         Errata vendorPatch = ErrataFactoryTest.createTestErrata(null);
         vendorPatch.addPackage(newestPkg);
-        vendorPatch.addChannel(subscribedChannel);
+        subscribedChannel.addErrata(vendorPatch);
         ErrataFactory.save(vendorPatch);
 
         // channel has all 3 packages

--- a/java/core/src/test/java/com/redhat/rhn/manager/rhnpackage/PackageManagerPtfTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/rhnpackage/PackageManagerPtfTest.java
@@ -90,7 +90,7 @@ public class PackageManagerPtfTest extends BaseTestCaseWithUser {
     @Test
     public void testSystemAvailablePackageList() {
         // Add the packages to the channel
-        channel.getPackages().addAll(List.of(pkg, ptfPackage, ptfMaster));
+        channel.addPackages(List.of(pkg, ptfPackage, ptfMaster));
         channel = TestUtils.saveAndReload(channel);
         ChannelFactory.refreshNewestPackageCache(channel, "java::test");
 
@@ -109,7 +109,7 @@ public class PackageManagerPtfTest extends BaseTestCaseWithUser {
 
     @Test
     public void testUpgradable() {
-        channel.getPackages().addAll(
+        channel.addPackages(
             List.of(pkg, standard, ptfPackage, ptfMaster, updatedPtfPackage, updatedPtfMaster, updatedStandard)
         );
         channel = TestUtils.saveAndReload(channel);
@@ -144,7 +144,7 @@ public class PackageManagerPtfTest extends BaseTestCaseWithUser {
     @Test
     public void testSystemInstalledPtfList() {
         // Add the packages to the channel
-        channel.getPackages().addAll(List.of(pkg, ptfPackage, ptfMaster));
+        channel.addPackages(List.of(pkg, ptfPackage, ptfMaster));
         channel = TestUtils.saveAndReload(channel);
         ChannelFactory.refreshNewestPackageCache(channel, "java::test");
 
@@ -164,7 +164,7 @@ public class PackageManagerPtfTest extends BaseTestCaseWithUser {
     @Test
     public void testSystemAvailablePtfList() {
         // Add the packages to the channel
-        channel.getPackages().addAll(List.of(pkg, ptfPackage, ptfMaster));
+        channel.addPackages(List.of(pkg, ptfPackage, ptfMaster));
         channel = TestUtils.saveAndReload(channel);
         ChannelFactory.refreshNewestPackageCache(channel, "java::test");
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/rhnpackage/PackageManagerRetractedTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/rhnpackage/PackageManagerRetractedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SUSE LLC
+ * Copyright (c) 2020--2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -7,12 +7,7 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
-
 package com.redhat.rhn.manager.rhnpackage;
 
 import static com.redhat.rhn.manager.channel.CloneChannelCommand.CloneBehavior.CURRENT_STATE;
@@ -91,7 +86,7 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
         // create a null-org patch with a package and add it to the channel
         Errata vendorPatch = ErrataFactoryTest.createTestErrata(null);
         vendorPatch.addPackage(oldPkg);
-        vendorPatch.addChannel(channel);
+        channel.addErrata(vendorPatch);
         ErrataFactory.save(vendorPatch);
 
         ChannelTestUtility.testAddPackage(channel, oldPkg);
@@ -132,7 +127,7 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
         // create a null-org patch with a newest package and add it to the channel
         Errata vendorPatch = ErrataFactoryTest.createTestErrata(null);
         vendorPatch.addPackage(newestPkg);
-        vendorPatch.addChannel(channel);
+        channel.addErrata(vendorPatch);
         ErrataFactory.save(vendorPatch);
 
         // channel has all 3 packages
@@ -169,7 +164,7 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
     public void testListPackagesInChannelForList() throws Exception {
         Errata vendorPatch = ErrataFactoryTest.createTestErrata(null);
         vendorPatch.addPackage(newerPkg);
-        vendorPatch.addChannel(channel);
+        channel.addErrata(vendorPatch);
         ErrataFactory.save(vendorPatch);
 
         // channel has all 3 packages
@@ -207,7 +202,7 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
     public void testChannelListAllPackages() throws Exception {
         Errata vendorPatch = ErrataFactoryTest.createTestErrata(null);
         vendorPatch.addPackage(newerPkg);
-        vendorPatch.addChannel(channel);
+        channel.addErrata(vendorPatch);
         ErrataFactory.save(vendorPatch);
 
         // channel has all 3 packages
@@ -245,7 +240,7 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
     public void testPotentialSystemsForPackage() throws Exception {
         Errata vendorPatch = ErrataFactoryTest.createTestErrata(null);
         vendorPatch.addPackage(newestPkg);
-        vendorPatch.addChannel(channel);
+        channel.addErrata(vendorPatch);
         ErrataFactory.save(vendorPatch);
 
         // channel has all 3 packages

--- a/java/core/src/test/java/com/redhat/rhn/manager/rhnpackage/PackageManagerRetractedTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/rhnpackage/PackageManagerRetractedTest.java
@@ -131,7 +131,7 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
         ErrataFactory.save(vendorPatch);
 
         // channel has all 3 packages
-        channel.getPackages().addAll(List.of(oldPkg, newerPkg, newestPkg));
+        channel.addPackages(List.of(oldPkg, newerPkg, newestPkg));
 
         // clone the channel
         CloneChannelCommand ccc = new CloneChannelCommand(CURRENT_STATE, channel);
@@ -168,7 +168,7 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
         ErrataFactory.save(vendorPatch);
 
         // channel has all 3 packages
-        channel.getPackages().addAll(List.of(oldPkg, newerPkg, newestPkg));
+        channel.addPackages(List.of(oldPkg, newerPkg, newestPkg));
 
         // clone the channel
         CloneChannelCommand ccc = new CloneChannelCommand(CURRENT_STATE, channel);
@@ -206,7 +206,7 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
         ErrataFactory.save(vendorPatch);
 
         // channel has all 3 packages
-        channel.getPackages().addAll(List.of(oldPkg, newerPkg, newestPkg));
+        channel.addPackages(List.of(oldPkg, newerPkg, newestPkg));
 
         // clone the channel
         CloneChannelCommand ccc = new CloneChannelCommand(CURRENT_STATE, channel);
@@ -244,7 +244,7 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
         ErrataFactory.save(vendorPatch);
 
         // channel has all 3 packages
-        channel.getPackages().addAll(List.of(oldPkg, newerPkg, newestPkg));
+        channel.addPackages(List.of(oldPkg, newerPkg, newestPkg));
 
         // clone the channel
         CloneChannelCommand ccc = new CloneChannelCommand(CURRENT_STATE, channel);

--- a/java/core/src/test/java/com/redhat/rhn/manager/task/TaskSchedulerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/task/TaskSchedulerTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 SUSE LLC
  * Copyright (c) 2009--2013 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -48,8 +49,8 @@ public class TaskSchedulerTest extends BaseTestCase {
         //add some channels
         Channel c1 = ChannelFactoryTest.createTestChannel(org);
         Channel c2 = ChannelFactoryTest.createTestChannel(org);
-        e.addChannel(c1);
-        e.addChannel(c2);
+        c1.addErrata(e);
+        c2.addErrata(e);
 
         ErrataFactory.save(e);
 

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/ReportDbUpdateTaskTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/ReportDbUpdateTaskTest.java
@@ -105,7 +105,7 @@ public class ReportDbUpdateTaskTest extends JMockBaseTestCaseWithUser {
             List<Package> packages = IntStream.range(1, 10)
                 .mapToObj(index -> PackageTest.createTestPackage(user.getOrg()))
                 .collect(Collectors.toList());
-            channel.getPackages().addAll(packages);
+            channel.addPackages(packages);
 
 
             // Create a newer version for each of the packages and add  them to the channel as well
@@ -113,7 +113,7 @@ public class ReportDbUpdateTaskTest extends JMockBaseTestCaseWithUser {
                 .map(originalPackage -> PackageTestUtils.newVersionOfPackage(originalPackage, null, "2.0.0", null,
                     user.getOrg()))
                 .collect(Collectors.toList());
-            channel.getPackages().addAll(updatedPackages);
+            channel.addPackages(updatedPackages);
             updatablePackagesMap.put(server.getId(), updatedPackages);
 
             // Install the original package on the server

--- a/java/core/src/test/java/com/redhat/rhn/testing/ErrataTestUtils.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/ErrataTestUtils.java
@@ -550,6 +550,6 @@ public class ErrataTestUtils {
         copy.setLastModified(original.getLastModified());
 
         // Copy the packages
-        copy.setPackages(new HashSet<>(original.getPackages()));
+        copy.replacePackages(new HashSet<>(original.getPackages()));
     }
 }

--- a/java/core/src/test/java/com/suse/manager/errata/BaseErrataTestCase.java
+++ b/java/core/src/test/java/com/suse/manager/errata/BaseErrataTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 SUSE LLC
+ * Copyright (c) 2021--2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 package com.suse.manager.errata;
 
@@ -51,9 +47,8 @@ abstract class BaseErrataTestCase extends BaseTestCase {
         final Errata errata = createErrata(advisory, type, issuedDate, release);
 
         Channel ch = new Channel();
-        ch.addErrata(errata);
         ch.setUpdateTag(updateTag);
-        errata.addChannel(ch);
+        ch.addErrata(errata);
 
         return errata;
     }

--- a/java/core/src/test/java/com/suse/manager/webui/services/SaltServerActionServiceTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/SaltServerActionServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 SUSE LLC
+ * Copyright (c) 2017--2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 package com.suse.manager.webui.services;
 
@@ -254,7 +250,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         SystemManager.subscribeServerToChannel(user, testMinionServer, channel);
         Package p64 = ErrataTestUtils.createTestPackage(user, channel, "x86_64");
         Errata retracted = ErrataFactoryTest.createTestErrata(null);
-        retracted.addChannel(channel);
+        channel.addErrata(retracted);
         retracted.setAdvisoryStatus(AdvisoryStatus.RETRACTED);
         Package p32 = ErrataTestUtils.createLaterTestPackage(user, retracted, channel, p64);
         p32.setPackageEvr(p64.getPackageEvr());

--- a/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateInitializerTest.java
+++ b/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateInitializerTest.java
@@ -269,7 +269,7 @@ public class ProxyConfigUpdateInitializerTest extends JMockBaseTestCaseWithUser 
         Server server = ServerTestUtils.createTestSystem(user);
         Package pkg = PackageTest.createTestPackage(user.getOrg(), MGRPXY);
         Channel channelWithMgrpxy = ChannelTestUtils.createChildChannel(user, server.getBaseChannel());
-        channelWithMgrpxy.getPackages().add(pkg);
+        channelWithMgrpxy.addPackage(pkg);
 
         context().checking(new Expectations() {{
             oneOf(mockMinionServer).getProxyInfo();

--- a/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateValidationTest.java
+++ b/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateValidationTest.java
@@ -659,7 +659,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
         server.addChannel(baseChannel);
         Package pkg = PackageTest.createTestPackage(user.getOrg(), MGRPXY);
         Channel childChannel = ChannelTestUtils.createChildChannel(user, server.getBaseChannel());
-        childChannel.getPackages().add(pkg);
+        childChannel.addPackage(pkg);
         return childChannel;
     }
 

--- a/java/core/src/test/java/com/suse/proxy/get/formdata/ProxyConfigGetFormDataPreConditionsTest.java
+++ b/java/core/src/test/java/com/suse/proxy/get/formdata/ProxyConfigGetFormDataPreConditionsTest.java
@@ -343,7 +343,7 @@ public class ProxyConfigGetFormDataPreConditionsTest extends MockObjectTestCase 
     private Channel createChannelWithPackage(String packageName, Server server) throws Exception {
         Package pkg = PackageTest.createTestPackage(user.getOrg(), packageName);
         Channel childChannel = ChannelTestUtils.createChildChannel(user, server.getBaseChannel());
-        childChannel.getPackages().add(pkg);
+        childChannel.addPackage(pkg);
         return childChannel;
     }
 

--- a/java/spacewalk-java.changes.rjpmestre.fix-channel-errata-package-relationship-mappings
+++ b/java/spacewalk-java.changes.rjpmestre.fix-channel-errata-package-relationship-mappings
@@ -1,0 +1,1 @@
+- Fix Channel/Errata/Package bidirectional relationship mappings


### PR DESCRIPTION
## What does this PR change?

While working on https://github.com/SUSE/spacewalk/issues/28058 i noticed inconsistent behavior when adding/removing erratas and packages to channels. 
Further investigation revealed these NxN relationships  between Channel/Errata/Package had incorrect hibernate mappings that violated best practices.
These are the sort of issues that may get more relevant after upgrading hibernate 5 to  7 upgrade (because it got stricter about enforcing these specifications).

Two main problems currently are:
- Both sides declaring @JoinTable. Hibernate expects one of the side to own the relationship. 
  I set the ownership hierarchy to be like: channel owns errata and package, then errata owns package
- Inappropriate cascade on peer associations. This has more to do with our usage pattern. We usually create these objects separately and link then, instead of passing the new objects for automatic persistence. As example, we dont' usually:
```
 Channel channel = new Channel();
 Errata errata = new Errata(); 
 channel.addErrata(errata);
```

instead , we usually do 
```
Channel channel = ChannelFactory.createChannel();  // Created separately
Errata errata = ErrataFactory.createErrata();     // Created separately
channel.addErrata(errata);  
```

As a follow up, this PR also updates best practices in managing/updating these relationships.
Adding now an element to these relationships like `channel.getErrata().add(errata);` will mean we'll also have to update the other side of the relationship, in this case with `errata.getChannels().add(channel);`

While doable, this it's an error prone process.  Best practice would be NOT use the direct `.getX().add(...)` (and the following reverse update), but delegate this responsibility to an `add`  method to the owner side. In this example, then, `Channel` entity we should have
``` 
public void addErrata(Errata errataIn) {
        if (erratas.add(errataIn)) { // Only sync if actually added
            errataIn.getChannels().add(this); // Only sync if actually added
        }
    }
```
Same concept for removing elements or clear.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28058

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
