### PR TITLE
Fix html index error filter screenshot

### DIFF
--- a/testsuite/features/secondary/minssh_tunnel.feature
+++ b/testsuite/features/secondary/minssh_tunnel.feature
@@ -48,8 +48,7 @@ Feature: Register a Salt system to be managed via SSH tunnel
     When I follow "Software" in the content area
     And I follow "Install"
     And I enter "milkyway-dummy" as the filtered package name
-    And I click on the filter button
-    And I wait until I see "milkyway-dummy" text
+    And I click on the filter button until page does contain "milkyway-dummy" text
     And I check row with "milkyway-dummy" and arch of "ssh_minion"
     And I click on "Install Packages"
     And I click on "Confirm"
@@ -62,8 +61,7 @@ Feature: Register a Salt system to be managed via SSH tunnel
     And I follow "Software" in the content area
     And I follow "List / Remove"
     And I enter "milkyway-dummy" as the filtered package name
-    And I click on the filter button
-    And I wait until I see "milkyway-dummy" text
+    And I click on the filter button until page does contain "milkyway-dummy" text
     And I check "milkyway-dummy" in the list
     And I click on "Remove Packages"
     And I click on "Confirm"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -614,13 +614,19 @@ Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd
   rescue NoMethodError => e
     log "The browser session could not be cleaned because there is no browser available: #{e.message}"
     capybara_register_driver
+    Capybara.reset_sessions!
   rescue StandardError => e
     log "The browser session could not be cleaned for unknown issue: #{e.message}"
     capybara_register_driver
+    Capybara.reset_sessions!
   ensure
     visit Capybara.app_host
   end
-  next if all(:xpath, "//header//span[text()='#{$current_user}']", wait: 0).any?
+  begin
+    next if all(:xpath, "//header//span[text()='#{$current_user}']", wait: 0).any?
+  rescue NoMethodError, Capybara::NotSupportedByDriverError
+    # driver is not ready yet after session reset, proceed to full login
+  end
 
   begin
     find(:xpath, '//header//i[@class=\'fa fa-sign-out\']').click
@@ -931,7 +937,7 @@ end
 
 When(/^I click on the filter button$/) do
   find_and_wait_click('button.spacewalk-button-filter').click
-  has_text?('is filtered', wait: 10)
+  raise ScriptError, "Filter was not applied: 'filtered' text did not appear" unless check_text?('filtered', timeout: 20)
 end
 
 Then(/^I click on the filter button until page does not contain "([^"]*)" text$/) do |text|

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -125,14 +125,13 @@ def check_text?(text1, text2: nil, timeout: Capybara.default_max_wait_time)
   # WORKAROUND: Chrome 134+ raises Capybara::ElementNotFound, StaleElementReferenceError, or
   # NoMethodError (CDP response type mismatch) during page navigation, bypassing Capybara's
   # synchronize() retry mechanism. All three are caught and retried. All other exceptions still
-  # propagate. When text is stably absent, return false immediately so the page remains in a
-  # settled state (allowing screenshots on failure).
-  repeat_until_timeout(timeout: timeout) do
+  # propagate. Uses a plain Time.now loop instead of repeat_until_timeout / Timeout.timeout to
+  # avoid interrupting WebDriver mid-call, which corrupts the Selenium session.
+  deadline = Time.now + timeout
+  while Time.now < deadline
     begin
-      return true if has_text?(text1, wait: timeout)
-      return true if !text2.nil? && has_text?(text2, wait: timeout)
-
-      return false # text not found, page was stable - exit without looping
+      return true if has_text?(text1, wait: 1)
+      return true if !text2.nil? && has_text?(text2, wait: 1)
     rescue Capybara::ElementNotFound,
            Selenium::WebDriver::Error::StaleElementReferenceError,
            Selenium::WebDriver::Error::NoSuchElementError,
@@ -142,8 +141,6 @@ def check_text?(text1, text2: nil, timeout: Capybara.default_max_wait_time)
       sleep 2
     end
   end
-  false
-rescue Timeout::Error
   false
 end
 

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -209,6 +209,13 @@ def web_session_is_active?
   return false unless capybara_session_created?
 
   page.has_selector?('header', wait: 0) || page.has_selector?('#username-field', wait: 0)
+rescue Capybara::ElementNotFound,
+       Selenium::WebDriver::Error::StaleElementReferenceError,
+       Selenium::WebDriver::Error::NoSuchElementError,
+       NoMethodError
+
+  # Chrome 134+ CDP type mismatch during page navigation - page is not in a usable state
+  false
 end
 
 # Take a screenshot and try to log back at suse manager server


### PR DESCRIPTION
## What does this PR change?

Filter was not using the check_text and so didn't have the catch error.
Same for relog and screenshot capture.
Also, check for text is waiting for 10 sec in addition to the 1 sec sleep. Making it slow.

I found the issue related to filter:
<img width="1545" height="524" alt="image" src="https://github.com/user-attachments/assets/e23868e8-def3-4468-beb2-b1f2ee61f7ae" />
When we click on filter button, we expect the `is filtered` text. But with last version, if you have one package in the patch list and the text you are filtering with match the full list the message says `is not filtered`. The solution to detect if the filtered button was used is to check text `filtered` than match `is filtered` and `is not filtered`.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): 
Port(s): 
same than https://github.com/uyuni-project/uyuni/pull/12019

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
