### PR TITLE
Allow "mgr_events" to run on openSUSE Leap 16.0

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -67,7 +67,7 @@ except ImportError:
     HAS_PSYCOPG2 = False
 
 # Import salt libs
-import salt.ext.tornado
+import tornado
 import salt.utils.event
 
 log = logging.getLogger(__name__)
@@ -239,7 +239,7 @@ class Responder:
                 # Reset the counter if there was no exception
                 self._insert_exceptions = 0
 
-    @salt.ext.tornado.gen.coroutine
+    @tornado.gen.coroutine
     def add_event_to_queue(self, raw):
         try:
             tag, data = self.event_bus.unpack(raw)
@@ -289,7 +289,7 @@ def start(**config):
     """
     Listen to events and write them to the Postgres database
     """
-    io_loop = salt.ext.tornado.ioloop.IOLoop(make_current=False)
+    io_loop = tornado.ioloop.IOLoop(make_current=False)
     io_loop.make_current()
     event_bus = salt.utils.event.get_master_event(
         # pylint: disable-next=undefined-variable

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.master-fix-tornado
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.master-fix-tornado
@@ -1,0 +1,1 @@
+- Allow mgr_events to run on openSUSE Leap 16.0


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue caused by `mgr_events` when running on openSUSE Leap 16.0:

```
[salt.loader.lazy :300 ][ERROR  ][36797] Failed to import engines mgr_events, this is due most likely to a syntax error:
Traceback (most recent call last):
 File "/usr/lib/python3.13/site-packages/salt/loader/lazy.py", line 772, in _load_module
  mod = self.run(spec.loader.load_module)
 File "/usr/lib/python3.13/site-packages/salt/loader/lazy.py", line 1234, in run
  return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
      ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/usr/lib/python3.13/site-packages/salt/loader/lazy.py", line 1249, in _run_as
  ret = _func_or_method(*args, **kwargs)
 File "<frozen importlib._bootstrap_external>", line 677, in _check_name_wrapper
 File "<frozen importlib._bootstrap_external>", line 1204, in load_module
 File "<frozen importlib._bootstrap_external>", line 1028, in load_module
 File "<frozen importlib._bootstrap>", line 537, in _load_module_shim
 File "<frozen importlib._bootstrap>", line 966, in _load
 File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
 File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
 File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
 File "/usr/share/susemanager/modules/engines/mgr_events.py", line 85, in <module>
  class Responder:
  ...<199 lines>...
        self.counters = [0] * (self._thread_pool_size + 1)
 File "/usr/share/susemanager/modules/engines/mgr_events.py", line 242, in Responder
  @salt.ext.tornado.gen.coroutine
   ^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'salt.ext.tornado' has no attribute 'gen'
```

We have implemented a mechanism inside Salt that determines which tornado version should be used depending on the Python version. For Python >= 3.11 we do not use the vendored tornado, otherwise we do.

This is transparent code wise, as we simply import "tornado" and the mechanism will provide the necessary one.

More details at: https://github.com/openSUSE/salt/pull/755

With this PR, we ensure the `mgr_events` engine will successfully import the corresponding tornado for Python 3.6 (openSUSE Leap 15.6) and Python 3.13 (openSUSE Leap 16.0)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
