### PR TITLE
Fix wsgi cryptography import crash on openSUSE Leap 16.0

### DIFF
--- a/proxy/proxy/httpd-conf/spacewalk-proxy-wsgi.conf
+++ b/proxy/proxy/httpd-conf/spacewalk-proxy-wsgi.conf
@@ -52,3 +52,6 @@ WSGIScriptAlias /SAT-DUMP-INTERNAL /usr/share/rhn/wsgi/xmlrpc.py
 WSGIScriptAlias /XMLRPC_REDIRECT /usr/share/rhn/wsgi/xmlrpc_redirect.py
 WSGIScriptAlias /XMLRPC_SSL /usr/share/rhn/wsgi/xmlrpc_redirect.py
 
+# Force all WSGI apps to use the main Python interpreter to fix PyO3/cryptography errors
+WSGIApplicationGroup %{GLOBAL}
+

--- a/proxy/proxy/spacewalk-proxy.changes.meaksh.master-leap16-fix-wsgihandler-errors
+++ b/proxy/proxy/spacewalk-proxy.changes.meaksh.master-leap16-fix-wsgihandler-errors
@@ -1,0 +1,1 @@
+- Fix wsgiHandler errors on openSUSE Leap 16.0

--- a/python/spacewalk/apache-conf/zz-spacewalk-server-wsgi.conf
+++ b/python/spacewalk/apache-conf/zz-spacewalk-server-wsgi.conf
@@ -18,6 +18,9 @@ WSGIScriptAlias /APP /usr/share/rhn/wsgi/app.py
 WSGIScriptAlias /PACKAGE-PUSH /usr/share/rhn/wsgi/package_push.py
 WSGIScriptAlias /XMLRPC /usr/share/rhn/wsgi/xmlrpc.py
 
+# Force all WSGI apps to use the main Python interpreter to fix PyO3/cryptography errors
+WSGIApplicationGroup %{GLOBAL}
+
 <IfVersion >= 2.4>
     <Directory  /usr/share/rhn/wsgi>
         Require all granted

--- a/python/spacewalk/spacewalk-backend.changes.meaksh.master-leap16-fix-wsgihandler-errors
+++ b/python/spacewalk/spacewalk-backend.changes.meaksh.master-leap16-fix-wsgihandler-errors
@@ -1,0 +1,1 @@
+- Fix wsgiHandler errors on openSUSE Leap 16.0


### PR DESCRIPTION
## What does this PR change?

This PR fixes an error raised by `wsgiHandler.py` while processing requests via wsgi on openSUSE Leap 16.0:

```
mod_wsgi (pid=58): Exception occurred processing WSGI script '/usr/share/rhn/wsgi/xmlrpc.py'.
 Traceback (most recent call last):
   File "/usr/share/rhn/wsgi/xmlrpc.py", line 22, in application
     return wsgiHandler.handle(
            ~~~~~~~~~~~~~~~~~~^
         environ, start_response, "broker", "proxy.broker", "proxy.apacheServer"
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     )
     ^
   File "/usr/share/rhn/wsgi/wsgiHandler.py", line 48, in handle
     parseServ = get_handle(servertype, "HeaderParserHandler")
   File "/usr/share/rhn/wsgi/wsgiHandler.py", line 76, in get_handle
     handler_module = __import__(
         servertype, globals(), locals(), [servertype.split(".")[-1]]
     )
   File "/usr/share/rhn/proxy/apacheServer.py", line 21, in <module>
     from spacewalk.common.rhnTB import Traceback
   File "/usr/lib/python3.13/site-packages/spacewalk/common/rhnTB.py", line 30, in <module>
     from rhn.connections import idn_puny_to_unicode
   File "/usr/lib/python3.13/site-packages/rhn/connections.py", line 18, in <module>
     from rhn import SSL
   File "/usr/lib/python3.13/site-packages/rhn/SSL.py", line 29, in <module>
     from OpenSSL import crypto
   File "/usr/lib/python3.13/site-packages/OpenSSL/__init__.py", line 8, in <module>
     from OpenSSL import SSL, crypto
   File "/usr/lib/python3.13/site-packages/OpenSSL/SSL.py", line 16, in <module>
     from cryptography import x509
   File "/usr/lib64/python3.13/site-packages/cryptography/x509/__init__.py", line 7, in <module>
     from cryptography.x509 import certificate_transparency, verification
   File "/usr/lib64/python3.13/site-packages/cryptography/x509/certificate_transparency.py", line 8, in <module>
     from cryptography.hazmat.bindings._rust import x509 as rust_x509
 ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process
```

The core of `cryptography` library was reimplemented in Rust, and PyO3 modules (Rust) cannot be initialized by multiple interpreter processes, dealing to the above error.

To solve this, we make all wsgi request to be handled by the same Python interpreter process. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
