### PR TITLE
Add an API endpoint to get a filtered list of systems

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/serializer/SystemOverviewSerializer.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/serializer/SystemOverviewSerializer.java
@@ -32,13 +32,23 @@ import java.util.Date;
  * #struct_begin("system")
  *     #prop("int", "id")
  *     #prop("string", "name")
- *     #prop_desc("$date", "last_checkin", "last time server
- *             successfully checked in")
+ *     #prop_desc("int", "group_count", "number of groups the system is in")
+ *     #prop_desc("int", "security_errata", "number of applied security erratas")
+ *     #prop_desc("int", "bug_errata", "number of applied bug erratas")
+ *     #prop_desc("int", "enhancement_errata", "number of applied enhancement erratas")
+ *     #prop_desc("int", "outdated_pkg_count", "number of out-of-date packages")
+ *     #prop_desc("int", "config_files_with_difference", "number of configuration files changed")
+ *     #prop_desc("string", "channel_labels", "channel set on the system")
+ *     #prop_desc("$date", "last_checkin", "last time server successfully checked in")
+ *     #prop_desc("boolean", "mgr_server", "true if the system is a peripheral server")
+ *     #prop_desc("boolean", "proxy", "true if the system is a proxy")
+ *     #prop_array("entitlement", "string", "List of entitlements of the system")
+ *     #prop_desc("boolean", "virtual_host", "true if the system is a virtual host")
+ *     #prop_desc("boolean", "virtual_guest", "true if the system is a virtual guest")
+ *     #prop_desc("int", "extra_pkg_count", "number of packages not belonging to any assigned channel")
+ *     #prop_desc("boolean", "requires_reboot", "true if the systems needs to be rebooted")
  *     #prop_desc("$date", "created", "server registration time")
  *     #prop_desc("$date", "last_boot", "last server boot time")
- *     #prop_desc("int", "extra_pkg_count", "number of packages not belonging
- *             to any assigned channel")
- *     #prop_desc("int", "outdated_pkg_count", "number of out-of-date packages")
  * #struct_end()
  */
 public class SystemOverviewSerializer extends ApiResponseSerializer<SystemOverview> {
@@ -53,7 +63,22 @@ public class SystemOverviewSerializer extends ApiResponseSerializer<SystemOvervi
         SerializationBuilder builder = new SerializationBuilder()
                 .add("id", src.getId())
                 .add("name", src.getName())
-                .add("last_checkin", src.getLastCheckinDate());
+                .add("group_count", src.getGroupCount())
+                .add("security_errata", src.getSecurityErrata())
+                .add("bug_errata", src.getBugErrata())
+                .add("enhancement_errata", src.getEnhancementErrata())
+                .add("outdated_pkg_count", src.getOutdatedPackages())
+                .add("config_files_with_difference", src.getConfigFilesWithDifferences())
+                .add("channel_labels", src.getChannelLabels())
+                .add("last_checkin", src.getLastCheckinDate())
+                .add("mgr_server", src.isMgrServer())
+                .add("proxy", src.isProxy())
+                .add("entitlement", src.getEntitlement())
+                .add("virtual_host", src.getVirtualHost())
+                .add("virtual_guest", src.getVirtualGuest())
+                .add("extra_pkg_count", src.getExtraPkgCount())
+                .add("requires_reboot", src.getRequiresReboot())
+                .add("status_type", src.getStatusType());
 
         Date regDate = src.getCreated();
         if (regDate != null) {
@@ -64,8 +89,6 @@ public class SystemOverviewSerializer extends ApiResponseSerializer<SystemOvervi
         if (lastBoot != null) {
             builder.add("last_boot", lastBoot);
         }
-        builder.add("extra_pkg_count", src.getExtraPkgCount());
-        builder.add("outdated_pkg_count", src.getOutdatedPackages());
         return builder.build();
     }
 }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -114,6 +114,7 @@ import com.redhat.rhn.frontend.dto.SystemEventDto;
 import com.redhat.rhn.frontend.dto.SystemOverview;
 import com.redhat.rhn.frontend.dto.VirtualSystemOverview;
 import com.redhat.rhn.frontend.events.SsmDeleteServersEvent;
+import com.redhat.rhn.frontend.listview.PageControl;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.DuplicateProfileNameException;
 import com.redhat.rhn.frontend.xmlrpc.EntityNotExistsFaultException;
@@ -200,6 +201,7 @@ import com.suse.manager.model.attestation.CoCoEnvironmentType;
 import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
 import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
 import com.suse.manager.model.products.migration.MigrationDataFactory;
+import com.suse.manager.webui.controllers.SystemsController;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.utils.gson.BootstrapParameters;
 import com.suse.manager.xmlrpc.NoSuchHistoryEventException;
@@ -6565,6 +6567,66 @@ public class SystemHandler extends BaseHandler {
         DataResult<SystemOverview> dr = SystemManager.physicalList(loggedInUser);
         dr.elaborate();
         return dr.toArray();
+    }
+
+    /**
+     * Gets a list of all systems visible to user with a filter applied.
+     * @param loggedInUser The current user
+     * @param filterKey the column to filter on
+     * @param filterValue the filter value
+     * @param page the number of the page to get
+     * @param pageSize the number of items per page
+     * @return Returns an array of maps representing all systems visible to user
+     *
+     * @throws FaultException A FaultException is thrown if a valid user can not be found
+     * from the passed in session key
+     *
+     * @apidoc.doc Returns a list of all filtered servers visible to the user.
+     * The field value can start with an operator like > < >= <= !=.
+     * The field key can be one of:
+     *      server_name
+     *      creator_name
+     *      outdated_packages
+     *      extra_pkg_count
+     *      config_files_with_differences
+     *      group_count
+     *      requires_reboot
+     *      total_errata_count
+     *      channel_labels
+     *      entitlement_level
+     *      system_kind (one of proxy, mgr_server, virtual_host, virtual_guest, physical)
+     *      created_days
+     *
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("string", "filterKey", "what field to filter on")
+     * @apidoc.param #param_desc("string", "filterValue", "the value to look for")
+     * @apidoc.param #param_desc("int", "page", "the number of the page to return")
+     * @apidoc.param #param_desc("int", "pageSize", "the number of items per page to return")
+     * @apidoc.returntype
+     *      #struct_begin("system details page")
+     *        #prop_desc("int", "total", "Total count of systems for all pages")
+     *        #prop_array_begin_desc("data", "the requested page of systems")
+     *          $SystemOverviewSerializer
+     *        #prop_array_end()
+     *      #struct_end()
+     */
+    @ReadOnly
+    public Map<String, Object> listSystemsFiltered(
+            User loggedInUser, String filterKey, String filterValue, int page, int pageSize
+    ) throws FaultException {
+        PageControl pc = new PageControl();
+        pc.setPageSize(page);
+        pc.setFilter(true);
+        pc.setStart(page * pageSize + 1);
+        pc.setFilterColumn(filterKey);
+        pc.setFilterData(filterValue);
+        DataResult<SystemOverview> dr = SystemManager.systemListNew(
+                loggedInUser, SystemsController.getFilterParser(pc), pc);
+        dr.elaborate();
+        Map<String, Object> result = new HashMap<>();
+        result.put("total", dr.getTotalSize());
+        result.put("data", dr.toArray());
+        return result;
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -115,6 +115,7 @@ import com.redhat.rhn.frontend.dto.SystemEventDto;
 import com.redhat.rhn.frontend.dto.SystemOverview;
 import com.redhat.rhn.frontend.dto.VirtualSystemOverview;
 import com.redhat.rhn.frontend.events.SsmDeleteServersEvent;
+import com.redhat.rhn.frontend.listview.PageControl;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.DuplicateProfileNameException;
 import com.redhat.rhn.frontend.xmlrpc.EntityNotExistsFaultException;
@@ -201,6 +202,7 @@ import com.suse.manager.model.attestation.CoCoEnvironmentType;
 import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
 import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
 import com.suse.manager.model.products.migration.MigrationDataFactory;
+import com.suse.manager.webui.controllers.SystemsController;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.utils.gson.BootstrapParameters;
 import com.suse.manager.xmlrpc.NoSuchHistoryEventException;
@@ -6564,6 +6566,75 @@ public class SystemHandler extends BaseHandler {
         DataResult<SystemOverview> dr = SystemManager.physicalList(loggedInUser);
         dr.elaborate();
         return dr.toArray();
+    }
+
+    /**
+     * Gets a list of all systems visible to user with a filter applied.
+     * @param loggedInUser The current user
+     * @param filterKey the column to filter on
+     * @param filterValue the filter value
+     * @param page the number of the page to get
+     * @param pageSize the number of items per page
+     * @param sortKey the column to use for sorting, no key set means the data won't be sorted
+     * @param sortDescending indicates the sort order
+     * @return Returns an array of maps representing all systems visible to user
+     *
+     * @throws FaultException A FaultException is thrown if a valid user can not be found
+     * from the passed in session key
+     *
+     * @apidoc.doc Returns a list of all filtered servers visible to the user.
+     * The field value can start with an operator like > < >= <= !=.
+     * The field key can be one of:
+     *      server_name
+     *      creator_name
+     *      outdated_packages
+     *      extra_pkg_count
+     *      config_files_with_differences
+     *      group_count
+     *      requires_reboot
+     *      total_errata_count
+     *      channel_labels
+     *      entitlement_level
+     *      system_kind (one of proxy, mgr_server, virtual_host, virtual_guest, physical)
+     *      created_days
+     *
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("string", "filterKey", "what field to filter on")
+     * @apidoc.param #param_desc("string", "filterValue", "the value to look for")
+     * @apidoc.param #param_desc("int", "page", "the number of the page to return")
+     * @apidoc.param #param_desc("int", "pageSize", "the number of items per page to return")
+     * @apidoc.param #param_desc("string", "sortKey", "the column to use for sorting if not empty")
+     * @apidoc.param #param_desc("boolean", "sortDescending", "indicates the sort order")
+     * @apidoc.returntype
+     *      #struct_begin("system details page")
+     *        #prop_desc("int", "total", "Total count of systems for all pages")
+     *        #prop_array_begin_desc("data", "the requested page of systems")
+     *          $SystemOverviewSerializer
+     *        #prop_array_end()
+     *      #struct_end()
+     */
+    @ReadOnly
+    public Map<String, Object> listSystemsFiltered(
+            User loggedInUser, String filterKey, String filterValue, int page, int pageSize,
+            String sortKey, boolean sortDescending
+    ) throws FaultException {
+        PageControl pc = new PageControl();
+        pc.setPageSize(pageSize);
+        pc.setFilter(true);
+        pc.setStart(page * pageSize + 1);
+        pc.setFilterColumn(filterKey);
+        pc.setFilterData(filterValue);
+        if (sortKey != null && !sortKey.isEmpty()) {
+            pc.setSortColumn(sortKey);
+        }
+        pc.setSortDescending(sortDescending);
+        DataResult<SystemOverview> dr = SystemManager.systemListNew(
+                loggedInUser, SystemsController.getFilterParser(pc), pc);
+        dr.elaborate();
+        Map<String, Object> result = new HashMap<>();
+        result.put("total", dr.getTotalSize());
+        result.put("data", dr.toArray());
+        return result;
     }
 
     /**

--- a/java/doclets/src/main/java/com/redhat/rhn/internal/doclet/ApiCall.java
+++ b/java/doclets/src/main/java/com/redhat/rhn/internal/doclet/ApiCall.java
@@ -141,7 +141,7 @@ public class ApiCall implements Comparable<ApiCall> {
      * @return the ID
      */
     public String getId() {
-        return name + "-" + String.join("-", paramNames);
+        return name + "-" + String.join("-", paramNames).hashCode();
     }
 
     /**

--- a/java/doclets/src/main/java/com/redhat/rhn/internal/doclet/JSPWriter.java
+++ b/java/doclets/src/main/java/com/redhat/rhn/internal/doclet/JSPWriter.java
@@ -27,6 +27,7 @@ import java.util.Map;
 public class JSPWriter extends DocWriter {
 
     private static final String[] OTHER_FILES = {"faqs", "scripts"};
+    private static final String CALL_FILE = "call.txt";
 
     /**
      * @param outputIn path to the output folder
@@ -58,13 +59,31 @@ public class JSPWriter extends DocWriter {
         writeFile(output + "index.jsp", generateIndex(handlers, templates));
 
         for (Handler handler : handlers) {
-
             writeFile(handlersDir + handler.getClassName() + ".jsp",
                     generateHandler(handler, templates));
+
+            writeCalls(handler);
         }
 
         for (String file : OTHER_FILES) {
             writeFile(output + file + ".jsp", readFile(templates + file + ".txt"));
+        }
+    }
+
+    private void writeCalls(Handler handler) throws IOException {
+        String callsDir = String.format("%s/handlers/%s/", output, handler.getName());
+        File handlerFolder = new File(callsDir);
+        handlerFolder.mkdirs();
+
+        for (ApiCall call: handler.getCalls()) {
+            VelocityHelper vh = new VelocityHelper(templates);
+            vh.addMatch("call", call);
+            String out = vh.renderTemplateFile(CALL_FILE);
+
+            //Now we render the serializers
+            out = serializerRenderer.renderTemplate(out);
+
+            writeFile(callsDir + call.getId() + ".jsp", out);
         }
     }
 }

--- a/java/spacewalk-java.changes.cbosdo.systems-list-api
+++ b/java/spacewalk-java.changes.cbosdo.systems-list-api
@@ -1,0 +1,1 @@
+- Add an API endpoint to list and filter systems

--- a/java/webapp/src/apidoc/jsp/call.txt
+++ b/java/webapp/src/apidoc/jsp/call.txt
@@ -1,0 +1,41 @@
+#if($call.deprecated)
+<h3 class="deprecated"><a name="$call.id" href="#$call.id">Method: $call.name</a></h3>
+#else
+<h3> <a name="$call.id" href="#$call.id">Method: $call.name</a></h3>
+#end
+
+<div>
+#if($call.readOnly)
+<span>HTTP <code>GET</code></span>
+#else
+<span>HTTP <code>POST</code></span>
+#end
+</div>
+
+<h4>Description</h4>
+$call.doc
+
+#if($call.deprecated)
+<p/>
+Deprecated - $call.deprecatedReason
+<p/>
+#end
+
+<h4>Parameters</h4>
+<ul>
+#foreach( $param in $call.params)
+<li>$param</li>
+#end
+</ul>
+<p />
+<h4>Returns</h4>
+<ul><li>
+<code>
+$call.returnDoc
+</code>
+</li></ul>
+<p />
+#if($call.sinceAvailable)
+Available since API version: $call.sinceVersion <p />
+#end
+<hr />

--- a/java/webapp/src/apidoc/jsp/handler.txt
+++ b/java/webapp/src/apidoc/jsp/handler.txt
@@ -30,54 +30,13 @@ $handler.name
 <ul class="apidoc">
 
 #foreach( $call in $handler.calls )
-<li><a href="#$call.name"/>$call.name</a></li>
+<li><a href="#$call.id"/>$call.name</a></li>
 #end
 </ul>
 </div>
 <hr />
 #foreach( $call in $handler.calls )
-
-#if($call.deprecated)
-<h3 class="deprecated"><a name="$call.name" href="#$call.name">Method: $call.name</a></h3>
-#else
-<h3> <a name="$call.name" href="#$call.name">Method: $call.name</a></h3>
-#end
-
-<div>
-#if($call.readOnly)
-<span>HTTP <code>GET</code></span>
-#else
-<span>HTTP <code>POST</code></span>
-#end
-</div>
-
-<h4>Description</h4>
-$call.doc
-
-#if($call.deprecated)
-<p/>
-Deprecated - $call.deprecatedReason
-<p/>
-#end
-
-<h4>Parameters</h4>
-<ul>
-#foreach( $param in $call.params)
-<li>$param</li>
-#end
-</ul>
-<p />
-<h4>Returns</h4>
-<ul><li>
-<code>
-$call.returnDoc
-</code>
-</li></ul>
-<p />
-#if($call.sinceAvailable)
-Available since API version: $call.sinceVersion <p />
-#end
-<hr />
+  <jsp:include page="${handler.name}/${call.id}.jsp" />
 #end
 </body>
 </html>

--- a/schema/spacewalk/common/data/endpoint.sql
+++ b/schema/spacewalk/common/data/endpoint.sql
@@ -5678,6 +5678,9 @@ INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_re
     VALUES ('com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.listSystems', '/manager/api/system/listSystems', 'GET', 'A', True)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.listSystemsFiltered', '/manager/api/system/listSystemsFiltered', 'GET', 'A', True)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.listSystemsWithEntitlement', '/manager/api/system/listSystemsWithEntitlement', 'GET', 'A', True)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)

--- a/schema/spacewalk/common/data/endpoint.sql
+++ b/schema/spacewalk/common/data/endpoint.sql
@@ -5690,6 +5690,9 @@ INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_re
     VALUES ('com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.listSystems', '/manager/api/system/listSystems', 'GET', 'A', True)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.listSystemsFiltered', '/manager/api/system/listSystemsFiltered', 'GET', 'A', True)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.listSystemsWithEntitlement', '/manager/api/system/listSystemsWithEntitlement', 'GET', 'A', True)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)

--- a/schema/spacewalk/common/data/endpointNamespace.sql
+++ b/schema/spacewalk/common/data/endpointNamespace.sql
@@ -9061,6 +9061,11 @@ INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'api.system.list_systems_filtered' AND ns.access_mode = 'R'
+    AND ep.endpoint = '/manager/api/system/listSystemsFiltered' AND ep.http_method = 'GET'
+    ON CONFLICT DO NOTHING;
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
     WHERE ns.namespace = 'api.system.list_systems_with_entitlement' AND ns.access_mode = 'R'
     AND ep.endpoint = '/manager/api/system/listSystemsWithEntitlement' AND ep.http_method = 'GET'
     ON CONFLICT DO NOTHING;

--- a/schema/spacewalk/common/data/endpointNamespace.sql
+++ b/schema/spacewalk/common/data/endpointNamespace.sql
@@ -9076,6 +9076,11 @@ INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'api.system.list_systems_filtered' AND ns.access_mode = 'R'
+    AND ep.endpoint = '/manager/api/system/listSystemsFiltered' AND ep.http_method = 'GET'
+    ON CONFLICT DO NOTHING;
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
     WHERE ns.namespace = 'api.system.list_systems_with_entitlement' AND ns.access_mode = 'R'
     AND ep.endpoint = '/manager/api/system/listSystemsWithEntitlement' AND ep.http_method = 'GET'
     ON CONFLICT DO NOTHING;

--- a/schema/spacewalk/common/data/namespace.sql
+++ b/schema/spacewalk/common/data/namespace.sql
@@ -2739,6 +2739,9 @@ INSERT INTO access.namespace (namespace, access_mode, description)
     VALUES ('api.system.list_systems', 'R', 'Returns a list of all servers visible to the user.')
     ON CONFLICT (namespace, access_mode) DO NOTHING;
 INSERT INTO access.namespace (namespace, access_mode, description)
+    VALUES ('api.system.list_systems_filtered', 'R', 'List systems using a filter.')
+    ON CONFLICT (namespace, access_mode) DO NOTHING;
+INSERT INTO access.namespace (namespace, access_mode, description)
     VALUES ('api.system.list_systems_with_entitlement', 'R', 'Lists the systems that have the given entitlement')
     ON CONFLICT (namespace, access_mode) DO NOTHING;
 INSERT INTO access.namespace (namespace, access_mode, description)

--- a/schema/spacewalk/common/data/namespace.sql
+++ b/schema/spacewalk/common/data/namespace.sql
@@ -2748,6 +2748,9 @@ INSERT INTO access.namespace (namespace, access_mode, description)
     VALUES ('api.system.list_systems', 'R', 'Returns a list of all servers visible to the user.')
     ON CONFLICT (namespace, access_mode) DO NOTHING;
 INSERT INTO access.namespace (namespace, access_mode, description)
+    VALUES ('api.system.list_systems_filtered', 'R', 'List systems using a filter.')
+    ON CONFLICT (namespace, access_mode) DO NOTHING;
+INSERT INTO access.namespace (namespace, access_mode, description)
     VALUES ('api.system.list_systems_with_entitlement', 'R', 'Lists the systems that have the given entitlement')
     ON CONFLICT (namespace, access_mode) DO NOTHING;
 INSERT INTO access.namespace (namespace, access_mode, description)

--- a/schema/spacewalk/susemanager-schema.changes.cbosdo.systems-list-api
+++ b/schema/spacewalk/susemanager-schema.changes.cbosdo.systems-list-api
@@ -1,0 +1,1 @@
+- Add an API endpoint to list and filter systems

--- a/schema/spacewalk/upgrade/susemanager-schema-5.3.0-to-susemanager-schema-5.3.1/001-systemslistfiltered-endpoints.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.3.0-to-susemanager-schema-5.3.1/001-systemslistfiltered-endpoints.sql
@@ -1,0 +1,13 @@
+INSERT INTO access.namespace (namespace, access_mode, description)
+    SELECT 'api.system.list_systems_filtered', 'R', 'List systems using a filter.'
+    WHERE NOT EXISTS (SELECT 1 FROM access.namespace WHERE namespace = 'api.system.list_systems_filtered' AND access_mode = 'R');
+
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT 'com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.listSystemsFiltered', '/manager/api/system/listSystemsFiltered', 'GET', 'A', True
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/api/system/listSystemsFiltered' AND http_method = 'GET');
+
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'api.system.list_systems_filtered' AND ns.access_mode = 'R'
+    AND ep.endpoint = '/manager/api/system/listSystemsFiltered' AND ep.http_method = 'GET'
+    ON CONFLICT DO NOTHING;

--- a/schema/spacewalk/upgrade/susemanager-schema-5.3.1-to-susemanager-schema-5.3.2/001-systemslistfiltered-endpoints.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.3.1-to-susemanager-schema-5.3.2/001-systemslistfiltered-endpoints.sql
@@ -1,0 +1,13 @@
+INSERT INTO access.namespace (namespace, access_mode, description)
+    SELECT 'api.system.list_systems_filtered', 'R', 'List systems using a filter.'
+    WHERE NOT EXISTS (SELECT 1 FROM access.namespace WHERE namespace = 'api.system.list_systems_filtered' AND access_mode = 'R');
+
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT 'com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.listSystemsFiltered', '/manager/api/system/listSystemsFiltered', 'GET', 'A', True
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/api/system/listSystemsFiltered' AND http_method = 'GET');
+
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'api.system.list_systems_filtered' AND ns.access_mode = 'R'
+    AND ep.endpoint = '/manager/api/system/listSystemsFiltered' AND ep.http_method = 'GET'
+    ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## What does this PR change?

This API endpoint provides the same features than the systems list page, with filtering and paging and the same output data. More data could be added later on.

## End-User Impact & Release Notes

Add an API entrypoint offering the same data than the systems list UI.

- [x] **DONE**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: API doc added

- [x] **DONE**

## Test coverage
- No tests: using the same underlying code than the systems list page

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
