### PR TITLE
Fix peripheral servers root certificates handling

### DIFF
--- a/java/core/src/main/java/com/suse/manager/api/LoggingInvocationProcessor.java
+++ b/java/core/src/main/java/com/suse/manager/api/LoggingInvocationProcessor.java
@@ -20,6 +20,8 @@ import org.apache.commons.lang3.time.StopWatch;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
@@ -90,7 +92,7 @@ public class LoggingInvocationProcessor {
         Optional<Map<String, String>> arguments,
         String ip,
         Optional<User> caller,
-        Duration duration
+        Optional<Duration> duration
     ) {
         Optional<Map<String, String>> argumentsAfterRedaction = arguments.map(args ->
                 args.entrySet().stream()
@@ -120,10 +122,14 @@ public class LoggingInvocationProcessor {
         buf.append(")");
         buf.append(" CALLER: (");
         buf.append(caller.map(User::getLogin).orElse("none"));
-        buf.append(") TIME: ");
+        buf.append(")");
 
-        buf.append(duration.toMillis() / 1000.0);
-        buf.append(" seconds");
+        duration.ifPresent(durationIn -> {
+            buf.append(" TIME: ");
+            buf.append(durationIn.toMillis() / 1000.0);
+            buf.append(" seconds");
+        });
+
         return buf;
     }
 
@@ -147,9 +153,11 @@ public class LoggingInvocationProcessor {
             Throwable exception) {
         try {
             StringBuilder buf = logMessage(handlerName, methodName, arguments, ip,
-                    caller, Duration.ofMillis(stopTimer()));
+                    caller, stopTimer().map(d -> Duration.ofMillis(d)));
             buf.append(System.lineSeparator());
-            buf.append(exception);
+            StringWriter stackTrace = new StringWriter();
+            exception.printStackTrace(new PrintWriter(stackTrace));
+            buf.append(stackTrace);
 
             LOGGER.info(buf);
         }
@@ -177,7 +185,7 @@ public class LoggingInvocationProcessor {
     ) {
         try {
             LOGGER.info(logMessage(handlerName, methodName, arguments, ip,
-                    caller, Duration.ofMillis(stopTimer())));
+                    caller, stopTimer().map(d -> Duration.ofMillis(d))));
         }
         catch (RuntimeException e) {
             LOGGER.error("postProcess error CALL: {} {}", handlerName, methodName, e);
@@ -188,9 +196,14 @@ public class LoggingInvocationProcessor {
      * Stop the timer
      * @return the time registered in this timer.
      */
-    private long stopTimer() {
-        getStopWatch().stop();
-        return getStopWatch().getTime();
+    private Optional<Long> stopTimer() {
+        try {
+            getStopWatch().stop();
+            return Optional.of(getStopWatch().getTime());
+        }
+        catch (IllegalStateException e) {
+            return Optional.empty();
+        }
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/hub/HubManager.java
+++ b/java/core/src/main/java/com/suse/manager/hub/HubManager.java
@@ -1208,7 +1208,9 @@ public class HubManager {
                 Map<String, Object> details = new HashMap<>();
                 details.put("fqdn", peripheral.getFqdn());
                 details.put("id", s.getId());
-                details.put("root_ca", peripheral.getRootCa());
+                if (peripheral.getRootCa() != null) {
+                    details.put("root_ca", peripheral.getRootCa());
+                }
                 result.add(details);
             });
         }

--- a/java/core/src/test/java/com/suse/manager/api/LoggingInvocationProcessorTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/LoggingInvocationProcessorTest.java
@@ -43,7 +43,7 @@ public class LoggingInvocationProcessorTest {
                 Optional.of(Map.of(param, value)),
                 "127.0.0.1",
                 Optional.empty(),
-                Duration.ofMillis(1234)
+                Optional.of(Duration.ofMillis(1234))
         ).toString(), shouldRedact ? not(containsString(value)) : containsString(value));
     }
 
@@ -87,7 +87,7 @@ public class LoggingInvocationProcessorTest {
         String withExplicitOverride = p.logMessage("test", "method", Optional.of(Map.of(
                 "explicitlyRedacted", "shouldBeRedacted",
                 "explicitlyLoggedPassword", "passwordInLogMessage"
-        )), "127.0.0.1", Optional.empty(), Duration.ZERO).toString();
+        )), "127.0.0.1", Optional.empty(), Optional.of(Duration.ZERO)).toString();
         MatcherAssert.assertThat(withExplicitOverride, containsString("passwordInLogMessage"));
         MatcherAssert.assertThat(withExplicitOverride, not(containsString("shouldBeRedacted")));
 
@@ -99,7 +99,7 @@ public class LoggingInvocationProcessorTest {
         String withoutExplicitOverride = p.logMessage("test", "method", Optional.of(Map.of(
                         "explicitlyRedacted", "shouldBeRedacted",
                         "explicitlyLoggedPassword", "passwordInLogMessage"
-        )), "127.0.0.1", Optional.empty(), Duration.ZERO).toString();
+        )), "127.0.0.1", Optional.empty(), Optional.of(Duration.ZERO)).toString();
         MatcherAssert.assertThat(withoutExplicitOverride, not(containsString("passwordInLogMessage")));
         MatcherAssert.assertThat(withoutExplicitOverride, containsString("shouldBeRedacted"));
     }

--- a/java/spacewalk-java.changes.cbosdo.hub-https
+++ b/java/spacewalk-java.changes.cbosdo.hub-https
@@ -1,1 +1,3 @@
+- Do not serialize null root CA in listPeripheralServers
+  (bsc#1262720)
 - Fix Stopwatch is not running errors in API logs (bsc#1262720)

--- a/java/spacewalk-java.changes.cbosdo.hub-https
+++ b/java/spacewalk-java.changes.cbosdo.hub-https
@@ -1,0 +1,1 @@
+- Fix Stopwatch is not running errors in API logs (bsc#1262720)


### PR DESCRIPTION
## What does this PR change?

Fixes two issues:

* Fix an exception when logging API exceptions. The fix duplicates the entry with no duration, but at least the full stack trace now lands in the log.
* Do not try to write `null` root CAs when listing peripheral servers: it raises an NPE when serializing them.

Both fix issues found in bsc#1262720

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: hub api

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30457
Port(s): https://github.com/SUSE/spacewalk/pull/30876

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
