### PR TITLE
Fix duplicate remaining-length counter on custom key form

### DIFF
--- a/web/html/javascript/spacewalk-essentials.js
+++ b/web/html/javascript/spacewalk-essentials.js
@@ -401,37 +401,74 @@ jQuery(document).on('keyup change', '.activationKey-check', function(e) {
   }
 });
 
+let generatedTextareaLengthNotificationIndex = 0;
+
+function getTextareaLengthNotificationId(textarea) {
+  let textareaId = textarea.attr('id');
+  if (!textareaId) {
+    do {
+      textareaId = 'textarea-with-maxlength-' + generatedTextareaLengthNotificationIndex;
+      generatedTextareaLengthNotificationIndex += 1;
+    } while (document.getElementById(textareaId));
+    textarea.attr('id', textareaId);
+  }
+  return textareaId + '-remaining-length';
+}
+
+function getRemainingTextareaLength(textarea) {
+  const maxLength = parseInt(textarea.attr('maxlength'), 10);
+  if (isNaN(maxLength)) {
+    return null;
+  }
+  return maxLength - textarea.val().length;
+}
+
+function updateTextareaLengthNotification(textarea) {
+  const notificationId = getTextareaLengthNotificationId(textarea);
+  const existingWrapper = textarea.nextAll('.remaining-length-wrapper')
+    .filter('[data-maxlength-for="' + notificationId + '"]');
+  const remainingLength = getRemainingTextareaLength(textarea);
+
+  if (remainingLength === null) {
+    existingWrapper.remove();
+    return;
+  }
+
+  if (existingWrapper.length === 0) {
+    textarea.after(
+      jQuery('<div/>')
+        .attr('data-maxlength-for', notificationId)
+        .addClass('remaining-length-wrapper text-right')
+        .append(
+          jQuery('<span/>')
+            .append(
+              jQuery('<span/>')
+                .addClass('remaining-length-value')
+                .attr('id', notificationId)
+                .text(remainingLength)
+            )
+            .append(jQuery('<span/>').text(' ' + t('remaining')))
+        )
+    );
+    return;
+  }
+
+  existingWrapper.slice(1).remove();
+  existingWrapper.first().find('.remaining-length-value').text(remainingLength);
+}
+
 function addTextareaLengthNotification() {
   // Add a notification text of the remaining length for a textarea
-  jQuery('textarea.with-maxlength').each(function () {
-    const textarea = jQuery(this);
-    const textareaId = textarea.attr('id');
-
-    if (textarea.next('.remaining-length-wrapper').length) {
-        return;
-    }
-
-    textarea.after(
-        jQuery('<div/>')
-            .attr('id', textareaId + '-remaining-wrapper')
-            .addClass('remaining-length-wrapper text-right')
-            .append(
-                jQuery('<span/>')
-                    .append(
-                        jQuery('<span/>')
-                            .attr('id', textareaId + '-remaining-length')
-                            .text(textarea.attr('maxlength') - textarea.val().length)
-                    )
-                    .append(' ' + t('remaining'))
-            )
-    );
-});
+  jQuery('textarea.with-maxlength').each(function() {
+    updateTextareaLengthNotification(jQuery(this));
+  });
 
   // Update the remaining length text of the related textarea
-  jQuery(document).on('input', 'textarea.with-maxlength', function() {
-    jQuery('#' + jQuery(this).attr('id') + '-remaining-length')
-      .html(jQuery(this).attr('maxlength') - jQuery(this).val().length);
-  });
+  jQuery(document)
+    .off('input.spacewalk-maxlength change.spacewalk-maxlength', 'textarea.with-maxlength')
+    .on('input.spacewalk-maxlength change.spacewalk-maxlength', 'textarea.with-maxlength', function() {
+      updateTextareaLengthNotification(jQuery(this));
+    });
 }
 
 function initIEWarningUse() {


### PR DESCRIPTION
## What does this PR change?

This PR fixes the duplicated remaining-length counter shown under the Description field on the Custom System Info key creation page.

The legacy textarea helper was not idempotent, so running the old JS initialization more than once appended another counter wrapper for the same textarea and rebound the handler again. This change reuses the existing counter for a textarea, removes duplicate wrappers if they already exist, uses stable unique generated ids for textareas without an id, and skips rendering the counter when `maxlength` is missing or invalid.

Closes #6823.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

Before:
- The Description field could show two overlapping remaining-length counters after the page initialization ran more than once.

After:
- The Description field shows a single remaining-length counter and it stays in sync while typing.

- [X] **DONE**

## Documentation
- No documentation needed: GUI bug fix only

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: focused WSL validation covered duplicate-counter reproduction, repeated initialization, generated ids after DOM changes, and invalid `maxlength` handling for this legacy frontend path

- [X] **DONE**

## Links

Issue(s): #6823
Port(s): none

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
