### PR TITLE
Remove overriding on setup and teardown in test classes

### DIFF
--- a/java/core/src/test/java/com/redhat/rhn/common/conf/ConfigTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/conf/ConfigTest.java
@@ -42,10 +42,8 @@ public class ConfigTest extends RhnBaseTestCase {
     static final String TEST_CONF_LOCATION = "/usr/share/rhn/unit-tests/";
     private Config c;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         // create test config path
         String confPath = "/tmp/" + TestUtils.randomString();

--- a/java/core/src/test/java/com/redhat/rhn/common/db/NamedPreparedStatementTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/db/NamedPreparedStatementTest.java
@@ -82,17 +82,14 @@ public class NamedPreparedStatementTest extends RhnBaseTestCase {
                                      "FROM FOOBAR";
 
 
-    @Override
     @BeforeEach
     public void setUp() {
         session = HibernateFactory.getSession();
     }
 
-    @Override
     @AfterEach
     public void tearDown() throws Exception {
         session = null;
-        super.tearDown();
     }
 
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/common/db/datasource/AdvDataSourceTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/db/datasource/AdvDataSourceTest.java
@@ -303,7 +303,6 @@ public class AdvDataSourceTest extends RhnBaseTestCase {
     }
 
 
-    @Override
     @BeforeEach
     public void setUp() {
         HibernateFactory.getSession().doWork(connection -> {
@@ -330,8 +329,7 @@ public class AdvDataSourceTest extends RhnBaseTestCase {
         });
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() {
         HibernateFactory.getSession().doWork(connection -> {
             Statement statement = null;

--- a/java/core/src/test/java/com/redhat/rhn/common/db/datasource/DataListTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/db/datasource/DataListTest.java
@@ -37,7 +37,6 @@ public class DataListTest extends RhnBaseTestCase {
     private HookedSelectMode hsm;
     private Map<String, Object> elabParams;
 
-    @Override
     @BeforeEach
     public void setUp() {
         String dbUser = Config.get().getString(ConfigDefaults.DB_USER);
@@ -48,10 +47,8 @@ public class DataListTest extends RhnBaseTestCase {
         elabParams.put("user_name", dbUser);
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         hsm = null;
         elabParams = null;
     }

--- a/java/core/src/test/java/com/redhat/rhn/common/hibernate/HibernateBaseTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/hibernate/HibernateBaseTest.java
@@ -34,14 +34,13 @@ import java.util.stream.Collectors;
 abstract class HibernateBaseTest extends RhnBaseTestCase {
     private static final Logger LOG = LogManager.getLogger(HibernateBaseTest.class);
 
-    @Override
     @BeforeEach
-    public void setUp() {
+    public void setUpHibernateBaseTest() {
         TestFactory.getSession();
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDownHibernateBaseTest() {
         try {
             if (HibernateFactory.inTransaction()) {
                 HibernateFactory.commitTransaction();

--- a/java/core/src/test/java/com/redhat/rhn/common/localization/LocalizationServiceTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/localization/LocalizationServiceTest.java
@@ -47,7 +47,6 @@ public class LocalizationServiceTest extends RhnBaseTestCase {
     /**
      * sets up the test
      */
-    @Override
     @BeforeEach
     public void setUp() {
         ls = LocalizationService.getInstance();
@@ -66,11 +65,9 @@ public class LocalizationServiceTest extends RhnBaseTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @AfterEach
     public void tearDown() throws Exception {
         TestUtils.enableLocalizationLogging();
-        super.tearDown();
     }
 
 

--- a/java/core/src/test/java/com/redhat/rhn/common/localization/MessagesTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/localization/MessagesTest.java
@@ -44,7 +44,6 @@ public class MessagesTest extends RhnBaseTestCase {
     /**
      * sets up the test
      */
-    @Override
     @BeforeEach
     public void setUp() {
         getMessage = "Get this";
@@ -63,10 +62,8 @@ public class MessagesTest extends RhnBaseTestCase {
     /*
      * Setup before each test.
      */
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         getMessage = null;
         oneArg = null;
         twoArg = null;

--- a/java/core/src/test/java/com/redhat/rhn/common/messaging/MessageQueueTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/messaging/MessageQueueTest.java
@@ -33,7 +33,6 @@ public class MessageQueueTest extends RhnBaseTestCase {
     private static Logger logger = LogManager.getLogger(MessageQueueTest.class);
     protected User user;
 
-    @Override
     @BeforeEach
     public void setUp() {
         logger.debug("setUp - start");
@@ -45,10 +44,8 @@ public class MessageQueueTest extends RhnBaseTestCase {
         logger.debug("setUp - end");
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         logger.debug("tearDown - start");
         TestAction.deRegisterAction();
         TestDBAction.deRegisterAction();

--- a/java/core/src/test/java/com/redhat/rhn/common/security/acl/AccessTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/security/acl/AccessTest.java
@@ -74,10 +74,8 @@ public class AccessTest extends BaseTestCaseWithUser {
             new SystemUnentitler(saltApi), new SystemEntitler(saltApi)
     );
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         acl = new Acl();
         acl.registerHandler(new Access());
     }

--- a/java/core/src/test/java/com/redhat/rhn/common/security/acl/BaseHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/security/acl/BaseHandlerTest.java
@@ -32,7 +32,6 @@ public class BaseHandlerTest extends RhnBaseTestCase {
 
     private TestHandler th;
 
-    @Override
     @BeforeEach
     public void setUp() {
         th = new TestHandler();

--- a/java/core/src/test/java/com/redhat/rhn/common/security/acl/SystemAclHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/security/acl/SystemAclHandlerTest.java
@@ -42,10 +42,8 @@ import java.util.Map;
 public class SystemAclHandlerTest extends BaseTestCaseWithUser {
     private Server srvr;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         srvr = ServerFactoryTest.createTestServer(user);
         Long version = 1L;
         SystemManagerTest.giveCapability(srvr.getId(),

--- a/java/core/src/test/java/com/redhat/rhn/domain/action/ActionFormatterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/action/ActionFormatterTest.java
@@ -25,7 +25,6 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,16 +35,9 @@ public class ActionFormatterTest extends RhnBaseTestCase {
 
     private User user;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user = UserTestUtils.createUser(this);
-    }
-
-    @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
     }
 
     /**

--- a/java/core/src/test/java/com/redhat/rhn/domain/channel/AccessTokenFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/channel/AccessTokenFactoryTest.java
@@ -41,10 +41,8 @@ import java.util.Set;
 
 public class AccessTokenFactoryTest extends BaseTestCaseWithUser {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         Config.get().setString("server.secret_key",
                 DigestUtils.sha256Hex(TestUtils.randomString()));
     }

--- a/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/ContentFilterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/ContentFilterTest.java
@@ -58,10 +58,8 @@ public class ContentFilterTest extends JMockBaseTestCaseWithUser {
 
     private ContentManager contentManager;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         contentManager = new ContentManager();
         UserTestUtils.addUserRole(user, ORG_ADMIN);
     }

--- a/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/ContentProjectFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/ContentProjectFactoryTest.java
@@ -59,10 +59,8 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
 
     private ContentManager contentManager;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         contentManager = new ContentManager();
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/ModuleFilterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/ModuleFilterTest.java
@@ -33,10 +33,8 @@ public class ModuleFilterTest extends BaseTestCaseWithUser {
 
     private ContentManager contentManager;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         contentManager = new ContentManager();
         UserTestUtils.addUserRole(user, ORG_ADMIN);
     }

--- a/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/PtfFilterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/PtfFilterTest.java
@@ -42,10 +42,8 @@ public class PtfFilterTest extends BaseTestCaseWithUser {
     private Package testTwoPackage;
     private Package ptfTwoPackage;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         UserTestUtils.addUserRole(user, ORG_ADMIN);
         contentManager = new ContentManager();

--- a/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/validation/ContentValidatorTestBase.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/validation/ContentValidatorTestBase.java
@@ -55,10 +55,8 @@ public abstract class ContentValidatorTestBase extends BaseTestCaseWithUser {
         loc = LocalizationService.getInstance();
     }
 
-    @Override
     @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
+    public void setUpContentValidatorTestBase() throws Exception {
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
 
         manager = new ContentManager(new MockModulemdApi());

--- a/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/validation/ModularDependencyValidatorTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/validation/ModularDependencyValidatorTest.java
@@ -30,10 +30,8 @@ public class ModularDependencyValidatorTest extends ContentValidatorTestBase {
 
     private static final String ENTITY_FILTERS = "filters";
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         validator = new ModularDependencyValidator(new MockModulemdApi());
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/validation/ModularSourcesValidatorTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/contentmgmt/validation/ModularSourcesValidatorTest.java
@@ -29,10 +29,8 @@ public class ModularSourcesValidatorTest extends ContentValidatorTestBase {
     private final String msgNoModuleFilters = getLoc().getMessage("contentmanagement.validation.nomodulefilters");
     private final String msgNoModularSources = getLoc().getMessage("contentmanagement.validation.nomodularsources");
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         validator = new ModularSourcesValidator();
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/credentials/CredentialsTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/credentials/CredentialsTest.java
@@ -29,10 +29,8 @@ import java.util.Optional;
 
 public class CredentialsTest extends JMockBaseTestCaseWithUser {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         UserTestUtils.addUserRole(user, ORG_ADMIN);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/entitlement/BaseEntitlementTestCase.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/entitlement/BaseEntitlementTestCase.java
@@ -48,10 +48,8 @@ public abstract class BaseEntitlementTestCase extends BaseTestCaseWithUser {
             new SystemUnentitler(saltApi), new SystemEntitler(saltApi)
     );
 
-    @Override
     @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
+    public void setUpBaseEntitlementTestCase() throws Exception {
         createEntitlement();
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/entitlement/OSImageBuildHostEntitlementTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/entitlement/OSImageBuildHostEntitlementTest.java
@@ -44,10 +44,8 @@ public class OSImageBuildHostEntitlementTest extends BaseEntitlementTestCase {
             new SystemUnentitler(saltApi), new SystemEntitler(saltApi)
     );
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         Config.get().setBoolean(ConfigDefaults.KIWI_OS_IMAGE_BUILDING_ENABLED, "true");
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/image/ImageInfoFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/image/ImageInfoFactoryTest.java
@@ -100,10 +100,8 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
             new SystemUnentitler(saltApi), new SystemEntitler(saltApi)
     );
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         saltApiMock = context.mock(TestSaltApi.class);
     }

--- a/java/core/src/test/java/com/redhat/rhn/domain/kickstart/KickstartRawDataTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/kickstart/KickstartRawDataTest.java
@@ -43,10 +43,8 @@ public class KickstartRawDataTest extends BaseTestCaseWithUser {
     private KickstartRawData ksdata;
     private final String fileContents = "test kickstart file\n";
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         tree = KickstartableTreeTest.createTestKickstartableTree();
         ksdata = createRawData(user, "boring" + TestUtils.randomString(), tree,

--- a/java/core/src/test/java/com/redhat/rhn/domain/kickstart/KickstartSessionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/kickstart/KickstartSessionTest.java
@@ -43,10 +43,8 @@ public class KickstartSessionTest extends BaseTestCaseWithUser {
     private KickstartSession ksession;
     private Server s;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         k = KickstartDataTest.createKickstartWithOptions(user.getOrg());
         assertNotNull(k);

--- a/java/core/src/test/java/com/redhat/rhn/domain/kickstart/builder/KickstartBuilderTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/kickstart/builder/KickstartBuilderTest.java
@@ -50,10 +50,8 @@ import java.util.List;
 public class KickstartBuilderTest extends BaseTestCaseWithUser {
 
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         UserTestUtils.addUserRole(user, RoleFactory.ORG_ADMIN);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/notification/NotificationFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/notification/NotificationFactoryTest.java
@@ -34,10 +34,8 @@ import java.util.Set;
 public class NotificationFactoryTest extends BaseTestCaseWithUser {
 
     private MockMail mailer;
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         mailer = new MockMail();
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/notification/types/SubscriptionWarningTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/notification/types/SubscriptionWarningTest.java
@@ -20,16 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.redhat.rhn.testing.RhnBaseTestCase;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class SubscriptionWarningTest extends RhnBaseTestCase {
-
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
-    }
 
     @Test
     public void testSubscriptionWarning() {

--- a/java/core/src/test/java/com/redhat/rhn/domain/product/SUSEProductSetTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/product/SUSEProductSetTest.java
@@ -39,11 +39,8 @@ public class SUSEProductSetTest extends RhnBaseTestCase {
     private SUSEProduct serverApps;
     private SUSEProduct publicCloud;
 
-    @Override
     @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
-
         ChannelFamily channelFamily = createTestChannelFamily();
 
         // Setup some products

--- a/java/core/src/test/java/com/redhat/rhn/domain/rhnset/RhnSetTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/rhnset/RhnSetTest.java
@@ -36,17 +36,14 @@ public class RhnSetTest extends RhnBaseTestCase {
     private static final String[] TEST_ELEMS = {"100", "150", "300", "175", "35"};
     private RhnSetImpl set;
 
-    @Override
     @BeforeEach
     public void setUp() {
         set = new RhnSetImpl();
         set.sync();
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         set = null;
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/scc/SCCCachingFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/scc/SCCCachingFactoryTest.java
@@ -142,10 +142,8 @@ public class SCCCachingFactoryTest extends BaseTestCaseWithUser {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         SCCCachingFactory.clearRepositories();
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/ServerFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/ServerFactoryTest.java
@@ -122,10 +122,8 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
             new SystemUnentitler(SALT_API), new SystemEntitler(SALT_API)
     );
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         server = createTestServer(user);
         assertNotNull(server.getId());
     }

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/ServerFactoryVirtualizationTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/ServerFactoryVirtualizationTest.java
@@ -35,7 +35,6 @@ public class ServerFactoryVirtualizationTest extends RhnBaseTestCase {
     private VirtualInstanceManufacturer virtualInstanceFactory;
     private User user;
 
-    @Override
     @BeforeEach
     public void setUp() {
         user = UserTestUtils.createUser(this);

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/ServerGroupFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/ServerGroupFactoryTest.java
@@ -37,10 +37,8 @@ import java.util.HashSet;
 public class ServerGroupFactoryTest extends BaseTestCaseWithUser {
     private ManagedServerGroup managedGroup;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         managedGroup = ServerGroupFactory.create(
                             ServerGroupTestUtils.NAME,
                             ServerGroupTestUtils.DESCRIPTION,

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/VirtualInstanceFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/VirtualInstanceFactoryTest.java
@@ -51,10 +51,8 @@ public class VirtualInstanceFactoryTest extends RhnBaseTestCase {
     private GuestBuilder builder;
     private SystemEntitlementManager systemEntitlementManager;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         virtualInstanceDAO = new VirtualInstanceFactory();
         user = UserTestUtils.createUser(this);
         builder = new GuestBuilder(user);

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/VirtualInstanceTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/VirtualInstanceTest.java
@@ -24,7 +24,6 @@ import com.redhat.rhn.testing.Sequence;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -42,16 +41,9 @@ public class VirtualInstanceTest extends RhnBaseTestCase {
 
     private Sequence idSequence;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         idSequence = new Sequence();
-    }
-
-    @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
     }
 
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/virtualhostmanager/VirtualHostManagerFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/virtualhostmanager/VirtualHostManagerFactoryTest.java
@@ -48,10 +48,8 @@ public class VirtualHostManagerFactoryTest extends BaseTestCaseWithUser {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         factory = VirtualHostManagerFactory.getInstance();
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/token/ActivationKeyTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/token/ActivationKeyTest.java
@@ -58,10 +58,8 @@ import java.util.List;
  * ActivationKeyTest
  */
 public class ActivationKeyTest extends BaseTestCaseWithUser {
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
     }
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/domain/token/TokenPackageTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/token/TokenPackageTest.java
@@ -33,10 +33,8 @@ import org.junit.jupiter.api.Test;
  */
 public class TokenPackageTest extends BaseTestCaseWithUser {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/user/UserFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/user/UserFactoryTest.java
@@ -50,10 +50,8 @@ import java.util.TimeZone;
 public class UserFactoryTest extends RhnBaseTestCase {
     private UserFactory factory;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         factory = UserFactory.getInstance();
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/domain/user/UserTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/user/UserTest.java
@@ -52,8 +52,6 @@ public class UserTest extends RhnJmockBaseTestCase {
 
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
-
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         TestUtils.disableLocalizationLogging();
     }
@@ -61,11 +59,9 @@ public class UserTest extends RhnJmockBaseTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @AfterEach
     public void tearDown() throws Exception {
         TestUtils.enableLocalizationLogging();
-        super.tearDown();
     }
 
     /**

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/ResetLinkActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/ResetLinkActionTest.java
@@ -74,10 +74,8 @@ public class ResetLinkActionTest extends BaseTestCaseWithUser {
         assertEquals(valid, rc);
     }
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         action = new ResetLinkAction();
 
         mapping = new ActionMapping();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/ResetPasswordSubmitActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/ResetPasswordSubmitActionTest.java
@@ -104,10 +104,8 @@ public class ResetPasswordSubmitActionTest extends BaseTestCaseWithUser {
         assertEquals(badpwd.getName(), rc.getName(), "whitespace");
     }
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         adminUser = new UserTestUtils.UserBuilder()
                 .userName("testAdminUser")
                 .orgAdmin(true)

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/SearchActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/SearchActionTest.java
@@ -28,10 +28,8 @@ import org.junit.jupiter.api.Test;
 public class SearchActionTest extends RhnMockStrutsTestCase {
 
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/Search");
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/common/DownloadActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/common/DownloadActionTest.java
@@ -44,10 +44,8 @@ public class DownloadActionTest extends RhnMockStrutsTestCase {
     private KickstartData ksdata;
     private KickstartableTree tree;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         ksdata = KickstartDataTest.createKickstartWithChannel(user.getOrg());
         tree = ksdata.getTree();
         tree.setBasePath("/tmp");

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/common/RhnSetActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/common/RhnSetActionTest.java
@@ -55,7 +55,6 @@ public class RhnSetActionTest extends RhnBaseTestCase {
     private static Logger log = LogManager.getLogger(RhnSetActionTest.class);
     private TestAction action = null;
 
-    @Override
     @BeforeEach
     public void setUp() {
         action = new TestAction();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/AffectedSystemsSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/AffectedSystemsSetupActionTest.java
@@ -31,10 +31,8 @@ import org.junit.jupiter.api.Test;
  */
 public class AffectedSystemsSetupActionTest extends RhnMockStrutsTestCase {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/errata/details/SystemsAffected");
 
     }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/CloneConfirmActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/CloneConfirmActionTest.java
@@ -41,10 +41,8 @@ import java.util.List;
  */
 public class CloneConfirmActionTest extends RhnPostMockStrutsTestCase {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/errata/manage/CloneConfirmSubmit");
         user.getOrg().addRole(RoleFactory.CHANNEL_ADMIN);
     }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/CloneConfirmSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/CloneConfirmSetupActionTest.java
@@ -38,10 +38,8 @@ import org.junit.jupiter.api.Test;
  */
 public class CloneConfirmSetupActionTest extends RhnMockStrutsTestCase {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/errata/manage/CloneConfirm");
         user.getOrg().addRole(RoleFactory.CHANNEL_ADMIN);
     }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/CloneErrataActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/CloneErrataActionTest.java
@@ -37,10 +37,8 @@ import org.junit.jupiter.api.Test;
  */
 public class CloneErrataActionTest extends RhnMockStrutsTestCase {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/errata/manage/CloneErrata");
         user.getOrg().addRole(RoleFactory.CHANNEL_ADMIN);
     }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/ErrataDetailsSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/errata/ErrataDetailsSetupActionTest.java
@@ -45,9 +45,8 @@ import java.util.Locale;
 public class ErrataDetailsSetupActionTest extends RhnBaseTestCase {
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
 
         // Set the locale explicitly to check the dates in an known format
         Context.getCurrentContext().setLocale(Locale.US);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/keys/CryptoKeyCreateActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/keys/CryptoKeyCreateActionTest.java
@@ -31,11 +31,9 @@ import org.junit.jupiter.api.Test;
  */
 public class CryptoKeyCreateActionTest extends RhnPostMockStrutsTestCase {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
         TestUtils.disableLocalizationLogging();
-        super.setUp();
     }
 
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/BaseKickstartEditTestCase.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/BaseKickstartEditTestCase.java
@@ -31,10 +31,8 @@ public class BaseKickstartEditTestCase extends RhnPostMockStrutsTestCase {
 
     protected KickstartData ksdata;
 
-    @Override
     @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
+    public void setUpBaseKickstartEditTestCase() throws Exception {
         UserTestUtils.addAccessGroup(user, AccessGroupFactory.CONFIG_ADMIN);
         this.ksdata = KickstartDataTest.createKickstartWithChannel(user.getOrg());
         ksdata = TestUtils.saveAndFlush(ksdata);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/CreateProfileWizardTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/CreateProfileWizardTest.java
@@ -50,9 +50,8 @@ public class CreateProfileWizardTest extends RhnMockStrutsTestCase {
     private String label;
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
         label = TestUtils.randomString();
 
         // Create some crypto keys that should get associated

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartAdvancedOptionsActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartAdvancedOptionsActionTest.java
@@ -33,10 +33,8 @@ public class KickstartAdvancedOptionsActionTest extends RhnPostMockStrutsTestCas
     protected KickstartData ksdata;
     protected KickstartData ksdataOptions;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         this.ksdata = KickstartDataTest.createKickstartWithChannel(user.getOrg());
         this.ksdataOptions = KickstartDataTest.createKickstartWithOptions(user.getOrg());
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartCryptoKeysEditActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartCryptoKeysEditActionTest.java
@@ -36,10 +36,8 @@ public class KickstartCryptoKeysEditActionTest extends BaseKickstartEditTestCase
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         key = CryptoTest.createTestKey(user.getOrg());
         KickstartFactory.saveCryptoKey(key);
         TestUtils.flushAndEvict(key);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartHelperTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartHelperTest.java
@@ -55,10 +55,8 @@ public class KickstartHelperTest extends BaseTestCaseWithUser {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         UserFactory.save(user);
         ksdata = KickstartDataTest.createKickstartWithOptions(user.getOrg());

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartIpRangeActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartIpRangeActionTest.java
@@ -40,10 +40,8 @@ public class KickstartIpRangeActionTest extends RhnPostMockStrutsTestCase {
     protected KickstartIpRange ip1;
     protected KickstartIpRange ip2;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         this.ksdata = KickstartDataTest.createKickstartWithChannel(user.getOrg());
         this.ksdata.setOrg(user.getOrg());
         ksdata = TestUtils.saveAndFlush(ksdata);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartPackageProfileActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartPackageProfileActionTest.java
@@ -40,10 +40,8 @@ public class KickstartPackageProfileActionTest extends RhnMockStrutsTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         ksdata = KickstartDataTest.createKickstartWithProfile(user);
         ksdata.getKickstartDefaults().setProfile(null);
         addRequestParameter(RequestContext.KICKSTART_ID, ksdata.getId().toString());

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartPartitionActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartPartitionActionTest.java
@@ -35,10 +35,8 @@ import org.junit.jupiter.api.Test;
 public class KickstartPartitionActionTest extends RhnPostMockStrutsTestCase {
     private KickstartData ksdata;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         this.ksdata = KickstartDataTest.createKickstartWithOptions(user.getOrg());
         ksdata = TestUtils.saveAndFlush(ksdata);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartPreservationListTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartPreservationListTest.java
@@ -37,10 +37,8 @@ public class KickstartPreservationListTest extends BaseKickstartEditTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         list1 = KickstartDataTest.createFileList1(user.getOrg());
         CommonFactory.saveFileList(list1);
         list2 = KickstartDataTest.createFileList2(user.getOrg());

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartSoftwareEditActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartSoftwareEditActionTest.java
@@ -40,10 +40,8 @@ public class KickstartSoftwareEditActionTest extends BaseKickstartEditTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/kickstart/KickstartSoftwareEdit");
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartSystemDetailsTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/KickstartSystemDetailsTest.java
@@ -32,11 +32,8 @@ public class KickstartSystemDetailsTest extends BaseKickstartEditTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        // TODO Auto-generated method stub
-        super.setUp();
         KickstartWizardHelper cmd = new KickstartWizardHelper(user);
         cmd.createCommand("selinux", "--permissive", ksdata);
     }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/PowerManagementActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/PowerManagementActionTest.java
@@ -72,10 +72,8 @@ public class PowerManagementActionTest extends RhnMockStrutsTestCase {
      * Sets up action path and mocked Cobbler connection.
      * @throws Exception if something goes wrong
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         MockConnection.clear();
         setRequestPathInfo("/systems/details/kickstart/PowerManagement");
     }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/ScheduleKickstartWizardTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/ScheduleKickstartWizardTest.java
@@ -67,10 +67,8 @@ public class ScheduleKickstartWizardTest extends RhnMockStrutsTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/systems/details/kickstart/ScheduleWizard");
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         s = ServerFactoryTest.createTestServer(user, true);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/rhnpackage/ssm/ScheduleRemovePackagesActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/rhnpackage/ssm/ScheduleRemovePackagesActionTest.java
@@ -29,10 +29,8 @@ public class ScheduleRemovePackagesActionTest extends RhnMockStrutsTestCase {
 
     private SsmActionTestUtils utils;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/ssm/PackageRemoveSchedule");
         addRequestParameter("mode", "remove");
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/rhnpackage/ssm/ScheduleVerifyPackagesActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/rhnpackage/ssm/ScheduleVerifyPackagesActionTest.java
@@ -29,10 +29,8 @@ public class ScheduleVerifyPackagesActionTest extends RhnMockStrutsTestCase {
 
     private SsmActionTestUtils utils;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/ssm/PackageVerifySchedule");
 
         utils = new SsmActionTestUtils(user);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/rhnpackage/ssm/SelectRemovePackagesActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/rhnpackage/ssm/SelectRemovePackagesActionTest.java
@@ -34,10 +34,8 @@ public class SelectRemovePackagesActionTest extends RhnMockStrutsTestCase {
 
     private SsmActionTestUtils utils;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/ssm/PackageRemove");
 
         utils = new SsmActionTestUtils(user);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/rhnpackage/ssm/SelectVerifyPackagesActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/rhnpackage/ssm/SelectVerifyPackagesActionTest.java
@@ -34,10 +34,8 @@ public class SelectVerifyPackagesActionTest extends RhnMockStrutsTestCase {
 
     private SsmActionTestUtils utils;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/ssm/PackageVerify");
 
         utils = new SsmActionTestUtils(user);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/satellite/BootstrapConfigActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/satellite/BootstrapConfigActionTest.java
@@ -35,10 +35,8 @@ public class BootstrapConfigActionTest extends RhnPostMockStrutsTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user.getOrg().addRole(RoleFactory.SAT_ADMIN);
         user.addPermanentRole(RoleFactory.SAT_ADMIN);
         Config.get().setString("web.com.redhat.rhn.frontend." +

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/satellite/RestartActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/satellite/RestartActionTest.java
@@ -34,10 +34,8 @@ public class RestartActionTest extends RhnPostMockStrutsTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user.getOrg().addRole(RoleFactory.SAT_ADMIN);
         user.addPermanentRole(RoleFactory.SAT_ADMIN);
         setRequestPathInfo("/admin/config/Restart");

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/schedule/ArchivedActionsSetupTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/schedule/ArchivedActionsSetupTest.java
@@ -26,10 +26,8 @@ import org.junit.jupiter.api.Test;
  */
 public class ArchivedActionsSetupTest extends RhnMockStrutsTestCase {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/schedule/ArchivedActions");
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/schedule/CompletedActionsSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/schedule/CompletedActionsSetupActionTest.java
@@ -37,10 +37,8 @@ import org.junit.jupiter.api.Test;
  */
 public class CompletedActionsSetupActionTest extends RhnPostMockStrutsTestCase {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/schedule/CompletedActions");
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/schedule/FailedActionsSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/schedule/FailedActionsSetupActionTest.java
@@ -38,10 +38,8 @@ import org.junit.jupiter.api.Test;
 public class FailedActionsSetupActionTest extends RhnPostMockStrutsTestCase {
 
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/schedule/FailedActions");
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/schedule/PendingActionsSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/schedule/PendingActionsSetupActionTest.java
@@ -39,10 +39,8 @@ public class PendingActionsSetupActionTest extends RhnPostMockStrutsTestCase {
 
 
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/schedule/PendingActions");
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/ssm/PowerManagementConfigurationActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/ssm/PowerManagementConfigurationActionTest.java
@@ -45,10 +45,8 @@ public class PowerManagementConfigurationActionTest extends RhnMockStrutsTestCas
      * @throws Exception if things go wrong
      * @see com.redhat.rhn.testing.RhnMockStrutsTestCase#setUp()
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         connection = CobblerXMLRPCHelper.getConnection(user.getLogin());
         servers = setUpTestProvisionableSsmServers(user);
     }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/ErrataConfirmActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/ErrataConfirmActionTest.java
@@ -45,10 +45,8 @@ import java.util.TimeZone;
  */
 public class ErrataConfirmActionTest extends RhnPostMockStrutsTestCase {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/systems/details/ErrataConfirm");
 
         TaskomaticApi tapi = new TaskomaticApi() {

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/ErrataSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/ErrataSetupActionTest.java
@@ -34,10 +34,8 @@ import org.junit.jupiter.api.Test;
  * ErrataSetupActionTest
  */
 public class ErrataSetupActionTest extends RhnMockStrutsTestCase {
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/systems/details/ErrataList");
     }
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/SystemSearchActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/SystemSearchActionTest.java
@@ -39,10 +39,8 @@ public class SystemSearchActionTest extends RhnMockStrutsTestCase {
 
     private Server s;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/systems/Search");
         s = ServerFactoryTest.createTestServer(user, true,
                 ServerConstants.getServerGroupTypeEnterpriseEntitled());

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/audit/ScapSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/audit/ScapSetupActionTest.java
@@ -40,9 +40,8 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
     private Server server;
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
 
         action = new TestScapSetupAction();
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/entitlements/SystemEntitlementsSetupActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/entitlements/SystemEntitlementsSetupActionTest.java
@@ -67,10 +67,8 @@ public class SystemEntitlementsSetupActionTest extends RhnMockStrutsTestCase {
     private SaltService saltServiceMock;
     private SystemEntitlementManager systemEntitlementManager;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         Config.get().setBoolean(ConfigDefaults.KIWI_OS_IMAGE_BUILDING_ENABLED, "true");
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         saltServiceMock = context.mock(SaltService.class);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/entitlements/SystemEntitlementsSubmitActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/entitlements/SystemEntitlementsSubmitActionTest.java
@@ -73,10 +73,8 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/systems/SystemEntitlementsSubmit");
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/provisioning/PreservationListConfirmDeleteActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/provisioning/PreservationListConfirmDeleteActionTest.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.Test;
 public class PreservationListConfirmDeleteActionTest extends RhnBaseTestCase {
     private Action action = null;
 
-    @Override
     @BeforeEach
     public void setUp() {
         action = new PreservationListConfirmDeleteAction();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/provisioning/PreservationListDeleteActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/provisioning/PreservationListDeleteActionTest.java
@@ -39,7 +39,6 @@ import java.util.List;
 public class PreservationListDeleteActionTest extends RhnBaseTestCase {
     private Action action = null;
 
-    @Override
     @BeforeEach
     public void setUp() {
         action = new PreservationListDeleteAction();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/provisioning/PreservationListDeleteSubmitActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/provisioning/PreservationListDeleteSubmitActionTest.java
@@ -38,7 +38,6 @@ import java.util.List;
 public class PreservationListDeleteSubmitActionTest extends RhnBaseTestCase {
     private Action action = null;
 
-    @Override
     @BeforeEach
     public void setUp() {
         action = new PreservationListDeleteSubmitAction();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/provisioning/kickstart/BaseSessionTestCase.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/provisioning/kickstart/BaseSessionTestCase.java
@@ -42,10 +42,8 @@ public class BaseSessionTestCase extends RhnMockStrutsTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
+    public void setUpBaseSessionTestCase() throws Exception {
         KickstartData k = KickstartDataTest.createKickstartWithOptions(user.getOrg());
 
         sess = KickstartSessionTest.createKickstartSession(k, user);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/sdc/AddToSSMTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/sdc/AddToSSMTest.java
@@ -38,10 +38,8 @@ public class AddToSSMTest extends RhnMockStrutsTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         server = ServerTestUtils.createTestSystem(user);
 
         addRequestParameter(RequestContext.SID, server.getId().toString());

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/sdc/RemoveFromSSMTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/sdc/RemoveFromSSMTest.java
@@ -38,10 +38,8 @@ public class RemoveFromSSMTest extends RhnMockStrutsTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         server = ServerTestUtils.createTestSystem(user);
 
         addRequestParameter(RequestContext.SID, server.getId().toString());

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/sdc/SystemChannelsActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/sdc/SystemChannelsActionTest.java
@@ -44,10 +44,8 @@ public class SystemChannelsActionTest extends RhnMockStrutsTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         server = ServerTestUtils.createTestSystem(user);
         // Create some child channels so we can subscribe to them
         Channel child1 = ChannelTestUtils.createChildChannel(user, server.getBaseChannel());

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditActionTest.java
@@ -66,10 +66,8 @@ public class SystemDetailsEditActionTest extends RhnPostMockStrutsTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/systems/details/Edit");
         user.setOrg(TestUtils.saveAndFlush(user.getOrg()));
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewActionTest.java
@@ -63,10 +63,8 @@ public class SystemOverviewActionTest extends RhnMockStrutsTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setRequestPathInfo("/systems/details/Overview");
 
         s = ServerFactoryTest.createTestServer(user, true,

--- a/java/core/src/test/java/com/redhat/rhn/frontend/dto/BooleanWrapperTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/dto/BooleanWrapperTest.java
@@ -31,7 +31,6 @@ public class BooleanWrapperTest extends RhnBaseTestCase {
 
     private BooleanWrapper bw;
 
-    @Override
     @BeforeEach
     public void setUp() {
         bw = new BooleanWrapper();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/dto/UserOverviewTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/dto/UserOverviewTest.java
@@ -30,7 +30,6 @@ public class UserOverviewTest extends RhnBaseTestCase {
     /*
      * @see RhnBaseTestCase#setUp()
      */
-    @Override
     @BeforeEach
     public void setUp() {
         uo = new UserOverview();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/events/CloneErrataActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/events/CloneErrataActionTest.java
@@ -49,10 +49,8 @@ public class CloneErrataActionTest extends BaseTestCaseWithUser {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         admin = UserTestUtils.createUser("admin", user.getOrg().getId());
         admin.addPermanentRole(RoleFactory.ORG_ADMIN);
         admin = TestUtils.saveAndFlush(admin);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/events/NewUserEventTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/events/NewUserEventTest.java
@@ -39,7 +39,6 @@ public class NewUserEventTest extends RhnBaseTestCase {
 
     private MockMail mailer;
 
-    @Override
     @BeforeEach
     public void setUp() {
         mailer = new MockMail();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/events/SsmPowerManagementActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/events/SsmPowerManagementActionTest.java
@@ -49,10 +49,8 @@ public class SsmPowerManagementActionTest extends BaseTestCaseWithUser {
      * @throws Exception if things go wrong
      * @see com.redhat.rhn.testing.RhnMockStrutsTestCase#setUp()
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         connection = CobblerXMLRPCHelper.getConnection(user.getLogin());
         servers = PowerManagementConfigurationActionTest
             .setUpTestProvisionableSsmServers(user);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/events/TraceBackEventTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/events/TraceBackEventTest.java
@@ -42,7 +42,6 @@ public class TraceBackEventTest extends RhnBaseTestCase {
 
     private MockMail mailer;
 
-    @Override
     @BeforeEach
     public void setUp() {
         mailer = new MockMail();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/filter/TreeFilterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/filter/TreeFilterTest.java
@@ -36,7 +36,6 @@ public class TreeFilterTest extends RhnBaseTestCase {
     private TreeFilter filter;
 
 
-    @Override
     @BeforeEach
     public void setUp() {
         main = populate();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/nav/NavNodeTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/nav/NavNodeTest.java
@@ -37,7 +37,6 @@ public class NavNodeTest extends RhnBaseTestCase {
 
     private NavNode node;
 
-    @Override
     @BeforeEach
     public void setUp() {
         node = new NavNode();
@@ -163,10 +162,8 @@ public class NavNodeTest extends RhnBaseTestCase {
         assertTrue(rc);
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         node = null;
     }
 }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/nav/NavTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/nav/NavTest.java
@@ -36,7 +36,6 @@ public class NavTest extends RhnBaseTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() {
         TestUtils.disableLocalizationLogging();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/security/AuthenticationServiceAbstractTestCase.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/security/AuthenticationServiceAbstractTestCase.java
@@ -41,7 +41,7 @@ public abstract class AuthenticationServiceAbstractTestCase extends MockObjectTe
 
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUpAuthenticationServiceAbstractTestCase() throws Exception {
         mockRequest = mock(HttpServletRequest.class);
         mockResponse = mock(HttpServletResponse.class);
         mockPxtDelegate = mock(PxtSessionDelegate.class);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/security/PxtAuthenticationServiceTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/security/PxtAuthenticationServiceTest.java
@@ -38,10 +38,8 @@ public class PxtAuthenticationServiceTest extends AuthenticationServiceAbstractT
 
     private PxtAuthenticationService service;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         service = new PxtAuthenticationServiceStub();
         service.setPxtSessionDelegate(getPxtDelegate());
     }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/servlets/BaseFilterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/servlets/BaseFilterTest.java
@@ -35,10 +35,7 @@ public abstract class BaseFilterTest extends RhnJmockBaseTestCase {
     protected FilterChain chain;
 
     @BeforeEach
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-
+    public void setUpBaseFilterTest() throws Exception {
         request = new RhnMockHttpServletRequest();
 
         PxtCookieManager pcm = new PxtCookieManager();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/servlets/EnvironmentFilterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/servlets/EnvironmentFilterTest.java
@@ -30,10 +30,8 @@ import org.junit.jupiter.api.Test;
  */
 public class EnvironmentFilterTest extends BaseFilterTest {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         this.request.setRequestURL("https://rhn.webdev.redhat.com/rhn/manager/login");
 
         context.checking(new Expectations() {{

--- a/java/core/src/test/java/com/redhat/rhn/frontend/struts/BaseSetListActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/struts/BaseSetListActionTest.java
@@ -43,7 +43,6 @@ public class BaseSetListActionTest extends RhnBaseTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
         tla = new TestSetupListAction();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/AddressTagTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/AddressTagTest.java
@@ -41,7 +41,6 @@ public class AddressTagTest extends RhnBaseTestCase {
      * Called once per test method.
      * @throws Exception if an error occurs during setup.
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
         sah = new ActionHelper();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/BaseTestToolbarTag.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/BaseTestToolbarTag.java
@@ -42,9 +42,8 @@ public abstract class BaseTestToolbarTag extends RhnBaseTestCase {
     protected ToolbarTag tt;
     protected RhnMockJspWriter out;
 
-    @Override
     @BeforeEach
-    public void setUp() {
+    public void setUpBaseTestToolbarTag() {
         tt = new ToolbarTag();
         tth = TagTestUtils.setupTagTest(tt, null);
         out = (RhnMockJspWriter) tth.getPageContext().getOut();
@@ -52,10 +51,8 @@ public abstract class BaseTestToolbarTag extends RhnBaseTestCase {
         req.setAttributes(new HashMap<>());
     }
 
-    @Override
     @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
+    public void tearDownBaseTestToolbarTag() throws Exception {
         tt = null;
         tth = null;
         out = null;

--- a/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/HighlightTagTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/HighlightTagTest.java
@@ -40,10 +40,8 @@ public class HighlightTagTest extends RhnBaseTestCase {
     private RhnMockJspWriter out;
 
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         ht = new HighlightTag();
         tth = TagTestUtils.setupTagTest(ht, null);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/NavDialogMenuTagTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/NavDialogMenuTagTest.java
@@ -44,7 +44,6 @@ public class NavDialogMenuTagTest extends RhnBaseTestCase {
     private static final String DIALOG_NAV = "com.redhat.rhn.frontend.nav.DialognavRenderer";
     private NavDialogMenuTag nmt;
 
-    @Override
     @BeforeEach
     public void setUp() {
         nmt = new NavDialogMenuTag();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/RequireTagTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/RequireTagTest.java
@@ -39,17 +39,14 @@ public class RequireTagTest extends RhnBaseTestCase {
     private RequireTag rt;
     private TagTestHelper tth;
 
-    @Override
     @BeforeEach
     public void setUp() {
         rt = new RequireTag();
         tth = TagTestUtils.setupTagTest(rt, null);
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         rt = null;
         tth = null;
     }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/RhnHiddenTagTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/RhnHiddenTagTest.java
@@ -38,7 +38,6 @@ public class RhnHiddenTagTest extends RhnBaseTestCase {
     private RhnHiddenTag ht;
     private RhnMockJspWriter out;
 
-    @Override
     @BeforeEach
     public void setUp() {
         ht = new RhnHiddenTag();
@@ -47,10 +46,8 @@ public class RhnHiddenTagTest extends RhnBaseTestCase {
         out = (RhnMockJspWriter) tth.getPageContext().getOut();
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         ht = null;
         tth = null;
         out = null;

--- a/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/RhnTagFunctionsTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/RhnTagFunctionsTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
  */
 public class RhnTagFunctionsTest extends RhnBaseTestCase {
 
-    @Override
     @BeforeEach
     public void setUp() {
         TestUtils.disableLocalizationLogging();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/BaseHandlerTestCase.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/BaseHandlerTestCase.java
@@ -48,11 +48,8 @@ public class BaseHandlerTestCase extends RhnBaseTestCase {
     protected String satAdminKey;
     private boolean committed;
 
-    @Override
     @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
-
+    public void setUpBaseHandlerTestCase() throws Exception {
         committed = false;
 
         admin = new UserTestUtils.UserBuilder()
@@ -83,10 +80,7 @@ public class BaseHandlerTestCase extends RhnBaseTestCase {
     }
 
     @AfterEach
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-
+    public void tearDownBaseHandlerTestCase() throws Exception {
         // If at some point we created a user and committed the transaction, we need
         // clean up our mess
         if (committed) {

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/HandlerFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/HandlerFactoryTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 public class HandlerFactoryTest extends RhnBaseTestCase {
     private HandlerFactory factory = null;
 
-    @Override
     @BeforeEach
     public void setUp() {
         factory = HandlerFactory.getDefaultHandlerFactory();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/XmlRpcLoggingInvocationProcessorTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/XmlRpcLoggingInvocationProcessorTest.java
@@ -42,7 +42,6 @@ public class XmlRpcLoggingInvocationProcessorTest extends RhnBaseTestCase {
     private XmlRpcLoggingInvocationProcessor lip;
     private Writer writer;
 
-    @Override
     @BeforeEach
     public void setUp() {
         lip = new XmlRpcLoggingInvocationProcessor();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandlerTest.java
@@ -89,10 +89,8 @@ public class ActivationKeyHandlerTest extends BaseHandlerTestCase {
     private Channel baseChannel;
     private String baseChannelLabel;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         baseChannel = ChannelTestUtils.createBaseChannel(admin);
         baseChannelLabel = baseChannel.getLabel();
     }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/admin/configuration/AdminConfigurationHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/admin/configuration/AdminConfigurationHandlerTest.java
@@ -129,10 +129,8 @@ public class AdminConfigurationHandlerTest extends BaseHandlerTestCase {
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }};
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         testSaltApi = context.mock(SaltApi.class);
         adminConfigurationHandler = new AdminConfigurationHandler(
                                   orgHandler, serverGroupHandler, userHandler, activationKeyHandler,

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/admin/ssh/AdminSshHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/admin/ssh/AdminSshHandlerTest.java
@@ -44,10 +44,8 @@ public class AdminSshHandlerTest extends BaseHandlerTestCase {
     private SaltApi saltApi;
     private AdminSshHandler handler;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         saltApi = context.mock(SaltApi.class);
         handler = new AdminSshHandler(saltApi);
     }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandlerTest.java
@@ -74,10 +74,8 @@ class AnsibleHandlerTest extends BaseHandlerTestCase {
 
     private SaltApi saltApi;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         ActionChainManager.setTaskomaticApi(getTaskomaticApi());
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/chain/ActionChainHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/chain/ActionChainHandlerTest.java
@@ -104,10 +104,8 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
      * {@inheritDoc}
      */
     @SuppressWarnings("deprecation")
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         this.server = ServerFactoryTest.createTestServer(this.admin, true);
         this.server2 = ServerFactoryTest.createTestServer(this.admin, true);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/channel/org/ChannelOrgHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/channel/org/ChannelOrgHandlerTest.java
@@ -47,10 +47,8 @@ public class ChannelOrgHandlerTest extends BaseHandlerTestCase {
     private ChannelOrgHandler handler = new ChannelOrgHandler();
     private OrgHandler orgHandler = new OrgHandler(new MigrationManager(new ServerGroupManager(new TestSaltApi())));
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         admin.addPermanentRole(RoleFactory.SAT_ADMIN);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandlerTest.java
@@ -134,10 +134,8 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         Context ctx = Context.getCurrentContext();
         ctx.setLocale(Locale.getDefault());

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandlerTest.java
@@ -80,10 +80,8 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
     private ErrataHandler handler = new ErrataHandler();
     private User user;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user = new UserTestUtils.UserBuilder().orgId(admin.getOrg().getId()).build();
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandlerTest.java
@@ -100,10 +100,8 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
     private SaltService saltServiceMock;
     private SystemEntitlementManager systemEntitlementManager;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         Config.get().setBoolean(ConfigDefaults.KIWI_OS_IMAGE_BUILDING_ENABLED, "true");
         saltServiceMock = context.mock(SaltService.class);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/image/profile/ImageProfileHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/image/profile/ImageProfileHandlerTest.java
@@ -57,10 +57,8 @@ public class ImageProfileHandlerTest extends BaseHandlerTestCase {
 
     private ImageProfileHandler handler = new ImageProfileHandler();
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         Config.get().setBoolean(ConfigDefaults.KIWI_OS_IMAGE_BUILDING_ENABLED, "true");
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/system/SystemDetailsHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/system/SystemDetailsHandlerTest.java
@@ -60,10 +60,8 @@ public class SystemDetailsHandlerTest  extends BaseHandlerTestCase {
     private FilePreservationListHandler fpHandler = new FilePreservationListHandler();
     private User userNotOrgOne;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         userNotOrgOne = UserTestUtils.createUser();
         userNotOrgOne.addPermanentRole(RoleFactory.ORG_ADMIN);
     }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/org/OrgHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/org/OrgHandlerTest.java
@@ -68,10 +68,8 @@ public class OrgHandlerTest extends BaseHandlerTestCase {
     private ChannelFamily channelFamily = null;
 
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         admin.addPermanentRole(RoleFactory.SAT_ADMIN);
         for (int i = 0; i < orgName.length; i++) {
             orgName[i] = "Test Org " + TestUtils.randomString();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/org/trusts/OrgTrustHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/org/trusts/OrgTrustHandlerTest.java
@@ -58,10 +58,8 @@ public class OrgTrustHandlerTest extends BaseHandlerTestCase {
     private OrgTrustHandler handler = new OrgTrustHandler();
     private OrgHandler orgHandler = new OrgHandler(new MigrationManager(new ServerGroupManager(new TestSaltApi())));
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         admin.addPermanentRole(RoleFactory.SAT_ADMIN);
         admin = TestUtils.saveAndFlush(admin);
     }

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandlerTest.java
@@ -89,7 +89,6 @@ public class ProxyHandlerTest extends RhnJmockBaseTestCase {
 
     @BeforeEach
     public void setup() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandlerTest.java
@@ -60,10 +60,8 @@ public class RecurringActionHandlerTest extends JMockBaseTestCaseWithUser {
         context().setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         highstateHandler = new RecurringHighstateHandler();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringCustomStateHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringCustomStateHandlerTest.java
@@ -55,10 +55,8 @@ public class RecurringCustomStateHandlerTest extends JMockBaseTestCaseWithUser {
         context().setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         handler = new RecurringCustomStateHandler();

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/serializer/UserSerializerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/serializer/UserSerializerTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringWriter;
@@ -31,15 +30,6 @@ import redstone.xmlrpc.XmlRpcSerializer;
  * UserSerializer test
  */
 public class UserSerializerTest extends BaseTestCaseWithUser {
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
-    }
 
     /**
      * Minimal test

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/serializer/VirtualHostManagerSerializerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/serializer/VirtualHostManagerSerializerTest.java
@@ -44,10 +44,8 @@ public class VirtualHostManagerSerializerTest extends BaseTestCaseWithUser {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         manager = new VirtualHostManager();
         manager.setLabel("myLabel");
         manager.setGathererModule("myModule");

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/sync/content/ContentSyncHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/sync/content/ContentSyncHandlerTest.java
@@ -26,10 +26,8 @@ public class ContentSyncHandlerTest extends BaseHandlerTestCase {
 
     private final ContentSyncHandler handler = new ContentSyncHandler();
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         admin.addPermanentRole(RoleFactory.SAT_ADMIN);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerProvisioningTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerProvisioningTest.java
@@ -108,10 +108,8 @@ public class SystemHandlerProvisioningTest extends BaseHandlerTestCase {
                 setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         }};
 
-        @Override
         @BeforeEach
         public void setUp() throws Exception {
-                super.setUp();
                 mockRequest = mockContext.mock(HttpServletRequest.class);
 
                 TaskomaticApi testApi = new TaskomaticApi() {
@@ -123,10 +121,8 @@ public class SystemHandlerProvisioningTest extends BaseHandlerTestCase {
                 KickstartScheduleCommand.setTaskomaticApi(testApi);
         }
 
-        @Override
         @AfterEach
         public void tearDown() throws Exception {
-                super.tearDown();
                 KickstartScheduleCommand.setTaskomaticApi(new TaskomaticApi());
         }
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerPtfTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerPtfTest.java
@@ -94,10 +94,8 @@ public class SystemHandlerPtfTest extends BaseHandlerTestCase {
         mockContext.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         TaskomaticApi taskomaticApi = new TaskomaticApi() {
             @Override

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerTest.java
@@ -186,7 +186,6 @@ import org.jmock.Mockery;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.junit5.JUnit5Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -243,12 +242,6 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         setThreadingPolicy(new Synchroniser());
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }};
-
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
-    }
 
     @Test
     public void testCreateSupportdataAction() throws Exception {

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/scap/SystemScapHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/scap/SystemScapHandlerTest.java
@@ -67,10 +67,8 @@ public class SystemScapHandlerTest extends BaseHandlerTestCase {
      * Setup the test environment
      * @throws Exception
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         handler = new SystemScapHandler();
         taskomaticApi = mockContext.mock(TaskomaticApi.class);
         ActionManager.setTaskomaticApi(taskomaticApi);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/util/MapBuilderTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/util/MapBuilderTest.java
@@ -35,7 +35,6 @@ public class MapBuilderTest extends RhnBaseTestCase {
     private MapBuilder builder;
     private TestBean bean;
 
-    @Override
     @BeforeEach
     public void setUp() {
         builder = new MapBuilder();

--- a/java/core/src/test/java/com/redhat/rhn/manager/action/ActionChainManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/action/ActionChainManagerTest.java
@@ -70,10 +70,8 @@ public class ActionChainManagerTest extends JMockBaseTestCaseWithUser {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         ActionChainManager.setTaskomaticApi(TASKO_TEST_API);
     }

--- a/java/core/src/test/java/com/redhat/rhn/manager/action/ActionManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/action/ActionManagerTest.java
@@ -157,10 +157,8 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
     private final SystemManager systemManager =
             new SystemManager(ServerFactory.SINGLETON, new ServerGroupFactory(), saltApi);
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         context.setThreadingPolicy(new Synchroniser());
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         Config.get().setString("server.secret_key",

--- a/java/core/src/test/java/com/redhat/rhn/manager/action/MinionActionManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/action/MinionActionManagerTest.java
@@ -109,10 +109,8 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
     private SystemManager systemManager =
             new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/audit/ScapManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/audit/ScapManagerTest.java
@@ -54,10 +54,8 @@ import jakarta.xml.bind.JAXBContext;
  */
 public class ScapManagerTest extends JMockBaseTestCaseWithUser {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/channel/CreateCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/channel/CreateCommandTest.java
@@ -38,7 +38,6 @@ public class CreateCommandTest extends RhnBaseTestCase {
     private int labelCount = 0;
     private User user = null;
 
-    @Override
     @BeforeEach
     public void setUp() {
         ccc = new CreateChannelCommand();

--- a/java/core/src/test/java/com/redhat/rhn/manager/channel/CreateRepoCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/channel/CreateRepoCommandTest.java
@@ -39,10 +39,8 @@ public class CreateRepoCommandTest extends BaseTestCaseWithUser {
     private CreateRepoCommand repoCommand;
     private int labelCount = 0;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         repoCommand = new CreateRepoCommand(user.getOrg());
     }

--- a/java/core/src/test/java/com/redhat/rhn/manager/channel/EditRepoCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/channel/EditRepoCommandTest.java
@@ -40,10 +40,8 @@ public class EditRepoCommandTest extends BaseTestCaseWithUser {
 
     private Long contentSourceId;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         contentSourceId = createInitialContentSource(user.getOrg());
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/configuration/ConfigurationManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/configuration/ConfigurationManagerTest.java
@@ -107,10 +107,8 @@ public class ConfigurationManagerTest extends BaseTestCaseWithUser {
         setThreadingPolicy(new Synchroniser());
     }};
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         //Create a user and an org
         user = UserTestUtils.createUser("testyman", "orgman");
         pc = new PageControl();
@@ -120,13 +118,11 @@ public class ConfigurationManagerTest extends BaseTestCaseWithUser {
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
-    @Override
     @AfterEach
     public void tearDown() throws Exception {
         user = null;
         pc = null;
         cm = null;
-        super.tearDown();
     }
 
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/manager/content/ContentSyncManagerPaygTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/content/ContentSyncManagerPaygTest.java
@@ -118,18 +118,14 @@ public class ContentSyncManagerPaygTest extends RhnBaseTestCase {
 
     private int portNumber;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
-
         portNumber = 7777;
     }
 
-    @Override
     @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
+        super.tearDownRhnBaseTestCase();
         clearDb();
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/content/ContentSyncManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/content/ContentSyncManagerTest.java
@@ -2432,21 +2432,16 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
-
         // Clear data for all tests
         clearCredentials();
         SCCCachingFactory.clearRepositories();
         renameVendorChannels();
     }
 
-    @Override
     @AfterEach
     public void tearDown() throws Exception {
         Config.clear();
-        super.tearDown();
     }
 }

--- a/java/core/src/test/java/com/redhat/rhn/manager/content/MgrSyncUtilsTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/content/MgrSyncUtilsTest.java
@@ -40,18 +40,14 @@ public class MgrSyncUtilsTest extends BaseTestCaseWithUser {
 
     private static Path fromdir;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         fromdir = Files.createTempDirectory("sumatest");
         Config.get().setString(ContentSyncManager.RESOURCE_PATH, fromdir.toString());
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         Config.get().remove(ContentSyncManager.RESOURCE_PATH);
         FileUtils.deleteDirectory(fromdir.toFile());
         Config.get().setString(ConfigDefaults.SCC_UPDATE_HOST_DOMAIN, ".suse.com");

--- a/java/core/src/test/java/com/redhat/rhn/manager/contentmgmt/ContentManagerChannelAlignmentTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/contentmgmt/ContentManagerChannelAlignmentTest.java
@@ -92,10 +92,8 @@ public class ContentManagerChannelAlignmentTest extends BaseTestCaseWithUser {
      *
      * @throws Exception if anything goes wrong
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         contentManager = new ContentManager();
         user.addPermanentRole(ORG_ADMIN);
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/contentmgmt/ContentManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/contentmgmt/ContentManagerTest.java
@@ -92,10 +92,8 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
 
     private ContentManager contentManager;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         contentManager = new ContentManager();
         contentManager.setModulemdApi(new MockModulemdApi());
         user.addPermanentRole(ORG_ADMIN);

--- a/java/core/src/test/java/com/redhat/rhn/manager/contentmgmt/DependencyResolverTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/contentmgmt/DependencyResolverTest.java
@@ -57,10 +57,8 @@ public class DependencyResolverTest extends BaseTestCaseWithUser {
     private DependencyResolver resolver;
     private MockModulemdApi api;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         user.addPermanentRole(ORG_ADMIN);
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/distupgrade/DistUpgradeManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/distupgrade/DistUpgradeManagerTest.java
@@ -99,10 +99,8 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         setThreadingPolicy(new Synchroniser());
     }};
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/errata/ErrataManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/errata/ErrataManagerTest.java
@@ -101,10 +101,8 @@ import java.util.stream.Collectors;
  */
 public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/errata/cache/PtfPackagesCacheManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/errata/cache/PtfPackagesCacheManagerTest.java
@@ -50,10 +50,8 @@ public class PtfPackagesCacheManagerTest extends BaseTestCaseWithUser {
 
     private Package newerPackage;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         server = ServerFactoryTest.createTestServer(user);
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/errata/cache/RetractedPatchesCacheManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/errata/cache/RetractedPatchesCacheManagerTest.java
@@ -56,10 +56,8 @@ public class RetractedPatchesCacheManagerTest extends BaseTestCaseWithUser {
     private Package newerPkg;
     private Package newestPkg;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         server = ServerFactoryTest.createTestServer(user);
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/formula/FormulaManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/formula/FormulaManagerTest.java
@@ -82,10 +82,8 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
     private FormulaManager manager;
     private Path metadataDir;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         MockConnection.clear();
         saltServiceMock = mock(SaltService.class);
@@ -95,10 +93,8 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
         createMetadataFiles();
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         FileUtils.deleteDirectory(metadataDir.toFile());
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/formula/FormulaMonitoringManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/formula/FormulaMonitoringManagerTest.java
@@ -65,19 +65,15 @@ public class FormulaMonitoringManagerTest extends BaseTestCaseWithUser {
     private FormulaMonitoringManager manager = new FormulaMonitoringManager(saltApi);
     private Path metadataDir;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         metadataDir = Files.createTempDirectory("metadata");
         FormulaFactory.setMetadataDirOfficial(metadataDir.toString());
         createMetadataFiles();
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         FileUtils.deleteDirectory(metadataDir.toFile());
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/kickstart/BaseKickstartCommandTestCase.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/kickstart/BaseKickstartCommandTestCase.java
@@ -27,10 +27,8 @@ public class BaseKickstartCommandTestCase extends BaseTestCaseWithUser {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
+    public void setUpBaseKickstartCommandTestCase() throws Exception {
         this.ksdata = KickstartDataTest.
             createKickstartWithChannel(user.getOrg());
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/kickstart/KickstartScheduleCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/kickstart/KickstartScheduleCommandTest.java
@@ -79,10 +79,8 @@ public class KickstartScheduleCommandTest extends BaseKickstartCommandTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         server = ServerFactoryTest.createTestServer(user, true,

--- a/java/core/src/test/java/com/redhat/rhn/manager/kickstart/KickstartScriptCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/kickstart/KickstartScriptCommandTest.java
@@ -22,24 +22,12 @@ import com.redhat.rhn.domain.kickstart.KickstartFactory;
 import com.redhat.rhn.domain.kickstart.KickstartScript;
 import com.redhat.rhn.testing.TestUtils;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * KickstartScriptTest
  */
 public class KickstartScriptCommandTest extends BaseKickstartCommandTestCase {
-
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
-
-    }
 
     @Test
     public void testPreCreate() {

--- a/java/core/src/test/java/com/redhat/rhn/manager/kickstart/KickstartUrlHelperTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/kickstart/KickstartUrlHelperTest.java
@@ -39,10 +39,8 @@ public class KickstartUrlHelperTest extends BaseKickstartCommandTestCase {
 
     private KickstartUrlHelper helper;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         helper = new KickstartUrlHelper(ksdata, "spacewalk.example.com");
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/kickstart/cobbler/CobblerCommandTestBase.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/kickstart/cobbler/CobblerCommandTestBase.java
@@ -57,11 +57,8 @@ public abstract class CobblerCommandTestBase extends BaseTestCaseWithUser {
      *
      * @throws Exception if anything goes wrong
      */
-    @Override
     @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
-
+    public void setUpCobblerCommandTestBase() throws Exception {
         // Make the default user admin
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         UserFactory.save(user);

--- a/java/core/src/test/java/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCreateCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroCreateCommandTest.java
@@ -39,10 +39,8 @@ public class CobblerDistroCreateCommandTest extends CobblerCommandTestBase {
      *
      * @throws Exception if anything goes wrong
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         tree = ksdata.getTree();
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroEditCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroEditCommandTest.java
@@ -41,10 +41,8 @@ public class CobblerDistroEditCommandTest extends CobblerCommandTestBase {
      *
      * @throws Exception if anything goes wrong
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         connection = CobblerXMLRPCHelper.getAutomatedConnection();
         sourceTree = ksdata.getTree();

--- a/java/core/src/test/java/com/redhat/rhn/manager/org/MigrationManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/org/MigrationManagerTest.java
@@ -82,10 +82,8 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
     );
     private final MigrationManager migrationManager = new MigrationManager(serverGroupManager);
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         // Create 2 orgs, each with multiple org admins
         origOrgAdmins.add(

--- a/java/core/src/test/java/com/redhat/rhn/manager/profile/ProfileManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/profile/ProfileManagerTest.java
@@ -64,10 +64,8 @@ import java.util.Set;
  */
 public class ProfileManagerTest extends BaseTestCaseWithUser {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         // Give our user ORG_ADMIN
         user.addPermanentRole(RoleFactory.ORG_ADMIN);

--- a/java/core/src/test/java/com/redhat/rhn/manager/recurringactions/RecurringActionManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/recurringactions/RecurringActionManagerTest.java
@@ -77,10 +77,8 @@ public class RecurringActionManagerTest extends BaseTestCaseWithUser {
         taskomaticMock = CONTEXT.mock(TaskomaticApi.class);
     }
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         anotherUser = UserTestUtils.createUser("anotherUser", "anotherOrg");
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/rhnpackage/PackageManagerPtfTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/rhnpackage/PackageManagerPtfTest.java
@@ -60,10 +60,8 @@ public class PackageManagerPtfTest extends BaseTestCaseWithUser {
 
     private Channel channel;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         server = ServerFactoryTest.createTestServer(user);
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/rhnpackage/PackageManagerRetractedTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/rhnpackage/PackageManagerRetractedTest.java
@@ -60,10 +60,8 @@ public class PackageManagerRetractedTest extends BaseTestCaseWithUser {
     private Package newestPkg;
     private Channel channel;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         server = ServerFactoryTest.createTestServer(user, true);
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/rhnset/RhnSetDeclTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/rhnset/RhnSetDeclTest.java
@@ -26,7 +26,6 @@ import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -42,17 +41,9 @@ public class RhnSetDeclTest extends RhnBaseTestCase {
 
     private User user;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user = UserTestUtils.createUser(this);
-    }
-
-    @Override
-    @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
     }
 
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/manager/rhnset/RhnSetManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/rhnset/RhnSetManagerTest.java
@@ -40,19 +40,16 @@ public class RhnSetManagerTest extends RhnBaseTestCase {
     private static final String TEST_USER_NAME = "automated_test_user_jesusr";
     private static final String TEST_ORG_NAME = "automated_test_org_jesusr";
 
-    @Override
     @BeforeEach
     public void setUp() {
         userId = UserTestUtils.createUser(TEST_USER_NAME, TEST_ORG_NAME).getId();
         cleanup = new TestSetCleanup();
     }
 
-    @Override
     @AfterEach
     public void tearDown() throws Exception {
         userId = null;
         cleanup = null;
-        super.tearDown();
     }
     /**
      * Looks for an RhnSet for a non-existent user.

--- a/java/core/src/test/java/com/redhat/rhn/manager/satellite/ConfigureSatelliteCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/satellite/ConfigureSatelliteCommandTest.java
@@ -48,10 +48,8 @@ public class ConfigureSatelliteCommandTest extends BaseTestCaseWithUser {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user.addPermanentRole(RoleFactory.SAT_ADMIN);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/satellite/ImportCustomStatesTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/satellite/ImportCustomStatesTest.java
@@ -49,18 +49,15 @@ public class ImportCustomStatesTest extends BaseTestCaseWithUser {
 
     private Path legacyStatesBackupDirectory;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         createTask(UpgradeCommand.UPGRADE_CUSTOM_STATES);
         legacyStatesBackupDirectory = Files.createTempDirectory("legacy_states");
     }
 
-    @Override
     @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
+        removeTask(UpgradeCommand.UPGRADE_CUSTOM_STATES);
         assertTaskDoesNotExist(UpgradeCommand.UPGRADE_CUSTOM_STATES);
         FileUtils.deleteDirectory(legacyStatesBackupDirectory.toFile());
     }
@@ -320,5 +317,10 @@ public class ImportCustomStatesTest extends BaseTestCaseWithUser {
     private void assertTaskDoesNotExist(String taskName) {
         List<Task> tasks = TaskFactory.getTaskListByNameLike(taskName);
         assertTrue((tasks == null || tasks.isEmpty()));
+    }
+
+    private void removeTask(String taskName) {
+        List<Task> tasks = TaskFactory.getTaskListByNameLike(taskName);
+        tasks.forEach(TaskFactory::remove);
     }
 }

--- a/java/core/src/test/java/com/redhat/rhn/manager/setup/MirrorCredentialsManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/setup/MirrorCredentialsManagerTest.java
@@ -219,20 +219,16 @@ public class MirrorCredentialsManagerTest extends RhnMockStrutsTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         credsManager = new MirrorCredentialsManager();
     }
 
     /**
      * {@inheritDoc}
      */
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
 
         // Tear down the manager class instance
         credsManager = null;

--- a/java/core/src/test/java/com/redhat/rhn/manager/ssm/SsmManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/ssm/SsmManagerTest.java
@@ -75,10 +75,8 @@ public class SsmManagerTest extends JMockBaseTestCaseWithUser {
 
     private TaskomaticApi taskomaticMock;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         // Create a SUSE product and channel products
         ChannelFamily channelFamily = createTestChannelFamily();
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/ssm/SsmOperationDataPopulatorTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/ssm/SsmOperationDataPopulatorTest.java
@@ -44,7 +44,6 @@ import java.util.List;
 @Disabled
 public class SsmOperationDataPopulatorTest extends RhnBaseTestCase {
 
-    @Override
     @AfterEach
     public void tearDown() {
         // Override so the base class' tearDown doesn't rollback the transaction

--- a/java/core/src/test/java/com/redhat/rhn/manager/ssm/SsmOperationManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/ssm/SsmOperationManagerTest.java
@@ -33,7 +33,6 @@ import com.redhat.rhn.manager.rhnset.RhnSetManager;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,17 +50,10 @@ public class SsmOperationManagerTest extends RhnBaseTestCase {
     private RhnSet serverSet;
     private String serverSetLabel;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         ssmUser = UserTestUtils.createUser("ssmuser", "ssmorg");
         serverSetLabel = populateRhnSet();
-    }
-
-    @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
     }
 
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/AnsibleManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/AnsibleManagerTest.java
@@ -58,10 +58,8 @@ class AnsibleManagerTest extends BaseTestCaseWithUser {
         setThreadingPolicy(new Synchroniser());
     }};
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         saltApi = context.mock(SaltApi.class);
         ansibleManager = new AnsibleManager(saltApi);
     }

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/ServerGroupManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/ServerGroupManagerTest.java
@@ -52,10 +52,8 @@ public class ServerGroupManagerTest extends BaseTestCaseWithUser {
 
     private ServerGroupManager manager;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         manager = new ServerGroupManager(new TestSaltApi());
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerMockTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerMockTest.java
@@ -53,10 +53,8 @@ import java.util.Optional;
  */
 public class SystemManagerMockTest extends JMockBaseTestCaseWithUser {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         Config.get().setString(CobblerXMLRPCHelper.class.getName(),
                 MockXMLRPCInvoker.class.getName());
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
@@ -193,10 +193,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
     private SystemEntitlementManager systemEntitlementManager;
     private SystemManager systemManager;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         Config.get().setString(CobblerXMLRPCHelper.class.getName(),
                 MockXMLRPCInvoker.class.getName());
         MockConnection.clear();
@@ -223,10 +221,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         createMetadataFiles();
     }
 
-    @Override
     @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         try {
             FileUtils.deleteDirectory(tmpSaltRoot.toFile());
             FileUtils.deleteDirectory(metadataDirOfficial.toFile());

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/VirtualInstanceManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/VirtualInstanceManagerTest.java
@@ -31,7 +31,6 @@ import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.webui.utils.salt.custom.GuestProperties;
 import com.suse.manager.webui.utils.salt.custom.VmInfo;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -63,18 +62,11 @@ public class VirtualInstanceManagerTest extends RhnBaseTestCase {
     private User user;
     private Server server;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user = UserTestUtils.createUser(this);
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         server = ServerFactoryTest.createTestServer(user, true);
-    }
-
-    @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
     }
 
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/entitling/SystemEntitlementManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/entitling/SystemEntitlementManagerTest.java
@@ -50,10 +50,8 @@ public class SystemEntitlementManagerTest extends JMockBaseTestCaseWithUser {
     private SaltService saltServiceMock;
     private SystemEntitlementManager systemEntitlementManager;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         saltServiceMock = mock(SaltService.class);
         systemEntitlementManager = new SystemEntitlementManager(

--- a/java/core/src/test/java/com/redhat/rhn/manager/token/ActivationKeyManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/token/ActivationKeyManagerTest.java
@@ -54,10 +54,8 @@ import java.util.Set;
 public class ActivationKeyManagerTest extends BaseTestCaseWithUser {
     private ActivationKeyManager manager;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         manager = ActivationKeyManager.getInstance();
     }
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/manager/user/CreateUserCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/user/CreateUserCommandTest.java
@@ -36,7 +36,6 @@ public class CreateUserCommandTest extends RhnBaseTestCase {
 
     private CreateUserCommand command;
 
-    @Override
     @BeforeEach
     public void setUp() {
         command = new CreateUserCommand();

--- a/java/core/src/test/java/com/redhat/rhn/manager/user/UpdateUserCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/user/UpdateUserCommandTest.java
@@ -40,7 +40,6 @@ public class UpdateUserCommandTest extends RhnBaseTestCase {
 
     private UpdateUserCommand command;
 
-    @Override
     @BeforeEach
     public void setUp() {
         User user = UserTestUtils.createUser();

--- a/java/core/src/test/java/com/redhat/rhn/manager/user/UserManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/user/UserManagerTest.java
@@ -87,10 +87,8 @@ public class UserManagerTest extends RhnBaseTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         this.users = new HashSet<>();
         SaltApi saltApi = new TestSaltApi();
         systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
@@ -99,10 +97,8 @@ public class UserManagerTest extends RhnBaseTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
 
         this.users = null;
     }

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/ChannelRepodataTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/ChannelRepodataTest.java
@@ -56,9 +56,8 @@ public class ChannelRepodataTest extends JMockBaseTestCaseWithUser {
     private Path tmpMountPoint;
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
 
         channelRepodata = new ChannelRepodata();
         jobContext = mock(JobExecutionContext.class);
@@ -71,9 +70,7 @@ public class ChannelRepodataTest extends JMockBaseTestCaseWithUser {
     }
 
     @AfterEach
-    @Override
     public void tearDown() throws Exception {
-        super.tearDown();
 
         // Delete all the runs we created
         TaskoFactory.listRunsByBunch("channel-repodata-bunch")

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/ForwardRegistrationTaskTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/ForwardRegistrationTaskTest.java
@@ -466,10 +466,8 @@ public class ForwardRegistrationTaskTest extends BaseTestCaseWithUser {
         }
     }
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         synchronized (this) {
             systemSize = 15;
             batchSize = 3;

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/KickstartCleanupTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/KickstartCleanupTest.java
@@ -44,7 +44,6 @@ import java.util.Date;
 
 public class KickstartCleanupTest extends RhnBaseTestCase {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
         verifyDatasourceConfig();

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/MinionActionChainExecutorTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/MinionActionChainExecutorTest.java
@@ -65,9 +65,8 @@ public class MinionActionChainExecutorTest extends JMockBaseTestCaseWithUser {
     private TriggerFiredBundle firedBundle;
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
 
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/MinionActionExecutorTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/MinionActionExecutorTest.java
@@ -63,9 +63,8 @@ public class MinionActionExecutorTest extends JMockBaseTestCaseWithUser {
     private TriggerFiredBundle firedBundle;
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
 
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/MinionCheckinTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/MinionCheckinTest.java
@@ -45,10 +45,8 @@ public class MinionCheckinTest extends JMockBaseTestCaseWithUser {
 
     private int thresholdMax;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         RhnConfigurationFactory factory = RhnConfigurationFactory.getSingleton();
         this.thresholdMax = factory.getLongConfiguration(RhnConfiguration.KEYS.SYSTEM_CHECKIN_THRESHOLD).getValue()
                 .intValue() * 86400;

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/PackageCleanupTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/PackageCleanupTest.java
@@ -25,7 +25,6 @@ import java.sql.Statement;
 
 public class PackageCleanupTest extends RhnBaseTestCase {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
         HibernateFactory.getSession().doWork(connection -> {

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/SubscribeChannelsActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/SubscribeChannelsActionTest.java
@@ -58,10 +58,8 @@ import java.util.stream.Collectors;
 public class SubscribeChannelsActionTest extends JMockBaseTestCaseWithUser {
 
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/gatherer/VirtualHostManagerProcessorTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/gatherer/VirtualHostManagerProcessorTest.java
@@ -51,10 +51,8 @@ public class VirtualHostManagerProcessorTest extends BaseTestCaseWithUser {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         virtualHostManager = new VirtualHostManager();
         virtualHostManager.setId(101L);

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataProcessorTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataProcessorTest.java
@@ -74,10 +74,8 @@ public class PaygAuthDataProcessorTest extends BaseHandlerTestCase {
         CHANNEL_SUFFIX.put("Installer", true);
     }
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         paygData = createPaygSshData();
         PaygSshDataFactory.savePaygSshData(paygData);
         paygInstanceInfo = createPaygInstanceInfo();

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/payg/PaygUpdateAuthTaskTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/payg/PaygUpdateAuthTaskTest.java
@@ -91,10 +91,8 @@ public class PaygUpdateAuthTaskTest extends JMockBaseTestCaseWithUser {
     private PaygInstanceInfo paygInstanceInfo;
     private ContentSyncManager contentSyncManagerMock;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         clearDb();
 
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
@@ -116,10 +114,8 @@ public class PaygUpdateAuthTaskTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.closeSession();
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         clearDb();
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/repomd/DebPackageWriterTest.java
@@ -46,10 +46,8 @@ public class DebPackageWriterTest extends JMockBaseTestCaseWithUser {
 
     private Path tmpDir;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         tmpDir = Files.createTempDirectory("debPkgWriterTest");
     }
 
@@ -171,10 +169,8 @@ public class DebPackageWriterTest extends JMockBaseTestCaseWithUser {
         return packagesContent;
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         FileUtils.deleteDirectory(tmpDir.toFile());
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/repomd/DebReleaseWriterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/repomd/DebReleaseWriterTest.java
@@ -38,10 +38,8 @@ public class DebReleaseWriterTest extends BaseTestCaseWithUser {
 
     private String prefix;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         prefix = Files.createTempDirectory("debreleasewriter").toAbsolutePath() + File.separator;
     }
 
@@ -95,10 +93,8 @@ public class DebReleaseWriterTest extends BaseTestCaseWithUser {
         assertEquals(rel, releaseContent.replaceAll(" [^ ]+ [^ ]+ Packages.gz\n", ""));
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         org.apache.commons.io.FileUtils.deleteDirectory(new File(prefix));
     }
 }

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/repomd/DebRepositoryWriterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/repomd/DebRepositoryWriterTest.java
@@ -45,10 +45,8 @@ public class DebRepositoryWriterTest extends JMockBaseTestCaseWithUser {
 
     private Path tmpDir;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         tmpDir = Files.createTempDirectory("debPkgWriterTest");
     }
 
@@ -96,10 +94,8 @@ public class DebRepositoryWriterTest extends JMockBaseTestCaseWithUser {
         }
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         FileUtils.deleteDirectory(tmpDir.toFile());
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriterTest.java
@@ -60,10 +60,8 @@ public class RpmRepositoryWriterTest extends JMockBaseTestCaseWithUser {
     private Path metadataPath;
     private Channel channel;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         mountPointDir = Files.createTempDirectory("rpmrepotest");
 
         channel = ChannelFactoryTest.createTestChannel(user);
@@ -277,10 +275,8 @@ public class RpmRepositoryWriterTest extends JMockBaseTestCaseWithUser {
         return ret;
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         FileUtils.deleteDirectory(mountPointDir.toFile());
     }
 }

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/repomd/UpdateInfoWriterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/repomd/UpdateInfoWriterTest.java
@@ -32,7 +32,6 @@ import com.redhat.rhn.frontend.dto.ErrataOverview;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringWriter;
@@ -43,12 +42,6 @@ import java.text.SimpleDateFormat;
  * Tests for the {@link com.redhat.rhn.taskomatic.task.repomd.UpdateInfoWriter} generator.
  */
 public class UpdateInfoWriterTest extends BaseTestCaseWithUser {
-
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
-    }
 
     @Test
     public void testSUSEPatchNames() throws Exception {

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/sshservice/SSHServiceWorkerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/sshservice/SSHServiceWorkerTest.java
@@ -78,10 +78,8 @@ public class SSHServiceWorkerTest extends JMockBaseTestCaseWithUser {
     private SystemInfo sampleSystemInfo;
 
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         sshPushSystemMock = mock(SystemSummary.class);
         saltSSHServiceMock = mock(SaltSSHService.class);

--- a/java/core/src/test/java/com/redhat/rhn/testing/BaseTestCaseWithUser.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/BaseTestCaseWithUser.java
@@ -30,10 +30,8 @@ public abstract class BaseTestCaseWithUser extends RhnBaseTestCase {
     protected User user;
     private boolean committed = false;
 
-    @Override
     @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
+    public void setUpBaseTestCaseWithUser() throws Exception {
         user = UserTestUtils.createUser(this);
         KickstartDataTest.setupTestConfiguration(user);
     }
@@ -41,11 +39,9 @@ public abstract class BaseTestCaseWithUser extends RhnBaseTestCase {
     /**
      * {@inheritDoc}
      */
-    @Override
     @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
-
+    public void tearDownBaseTestCaseWithUser() throws Exception {
+        super.tearDownRhnBaseTestCase();
         // If at some point we created a user and committed the transaction, we need
         // clean up our mess
         if (committed) {

--- a/java/core/src/test/java/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
@@ -36,19 +36,14 @@ public abstract class JMockBaseTestCaseWithUser extends RhnJmockBaseTestCase {
      * @throws Exception if an error occurs during setup
      */
     @BeforeEach
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-
+    public void setUpJMockBaseTestCaseWithUser() throws Exception {
         user = UserTestUtils.createUser();
         KickstartDataTest.setupTestConfiguration(user);
     }
 
-    @Override
     @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
-
+    public void tearDownJMockBaseTestCaseWithUser() throws Exception {
+        super.tearDownRhnJmockBaseTestCase();
         // If at some point we created a user and committed the transaction, we need
         // clean up our mess
         if (committed) {

--- a/java/core/src/test/java/com/redhat/rhn/testing/RhnBaseTestCase.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/RhnBaseTestCase.java
@@ -56,7 +56,7 @@ public abstract class RhnBaseTestCase implements SaltTestCaseUtils  {
      * @throws Exception if an error occurs during setup.
      */
     @BeforeEach
-    protected void setUp() throws Exception {
+    protected void setUpRhnBaseTestCase() throws Exception {
         tmpSaltRoot = setupSaltConfigurationForTests();
     }
 
@@ -65,7 +65,7 @@ public abstract class RhnBaseTestCase implements SaltTestCaseUtils  {
      * @see HibernateFactory#closeSession()
      */
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDownRhnBaseTestCase() throws Exception {
         TestCaseHelper.tearDownHelper();
 
         cleanupSaltConfiguration(tmpSaltRoot);

--- a/java/core/src/test/java/com/redhat/rhn/testing/RhnJmockBaseTestCase.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/RhnJmockBaseTestCase.java
@@ -24,7 +24,7 @@ public abstract class RhnJmockBaseTestCase extends MockObjectTestCase implements
     protected Path tmpSaltRoot;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUpRhnJmockBaseTestCase() throws Exception {
         tmpSaltRoot = setupSaltConfigurationForTests();
     }
 
@@ -34,7 +34,7 @@ public abstract class RhnJmockBaseTestCase extends MockObjectTestCase implements
      * @throws Exception if an error occurs during tear down
      */
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDownRhnJmockBaseTestCase() throws Exception {
         TestCaseHelper.tearDownHelper();
 
         cleanupSaltConfiguration(tmpSaltRoot);

--- a/java/core/src/test/java/com/redhat/rhn/testing/RhnMockStrutsTestCase.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/RhnMockStrutsTestCase.java
@@ -55,9 +55,9 @@ public class RhnMockStrutsTestCase extends BaseStrutsTestCase implements SaltTes
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUpRhnMockStrutsTestCase() throws Exception {
+        // Warning: MockStrutsTestCase.setUp() is not automatically called.
         super.setUp();
 
         RequestContext requestContext = new RequestContext(request);
@@ -89,10 +89,8 @@ public class RhnMockStrutsTestCase extends BaseStrutsTestCase implements SaltTes
     /**
      * Tears down the fixture, and closes the HibernateSession.
      */
-    @Override
     @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
+    public void tearDownRhnMockStrutsTestCase() throws Exception {
         TestCaseHelper.tearDownHelper();
         if (committed) {
             OrgFactory.deleteOrg(user.getOrg().getId(), user);
@@ -102,6 +100,9 @@ public class RhnMockStrutsTestCase extends BaseStrutsTestCase implements SaltTes
         user = null;
 
         cleanupSaltConfiguration(tmpSaltRoot);
+
+        // Warning: MockStrutsTestCase.tearDown() is not automatically called.
+        super.tearDown();
     }
 
     /**

--- a/java/core/src/test/java/com/redhat/rhn/testing/RhnPostMockStrutsTestCase.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/RhnPostMockStrutsTestCase.java
@@ -34,10 +34,8 @@ public class RhnPostMockStrutsTestCase extends RhnMockStrutsTestCase {
      * override the setupUp method
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
+    public void setUpRhnPostMockStrutsTestCase() throws Exception {
         request.setMethod("POST");
         UploadsHandler.clear();
     }

--- a/java/core/src/test/java/com/suse/manager/api/HttpApiRegistryTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/HttpApiRegistryTest.java
@@ -52,9 +52,8 @@ public class HttpApiRegistryTest extends RhnJmockBaseTestCase {
     }
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
         context().setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 

--- a/java/core/src/test/java/com/suse/manager/api/RouteFactoryTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/RouteFactoryTest.java
@@ -63,10 +63,8 @@ public class RouteFactoryTest extends BaseControllerTestCase {
     private RouteFactory routeFactory;
     private TestHandler handler;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         handler = new TestHandler();
         routeFactory = new RouteFactory(createTestSerializerFactory());
     }

--- a/java/core/src/test/java/com/suse/manager/attestation/AttestationManagerTest.java
+++ b/java/core/src/test/java/com/suse/manager/attestation/AttestationManagerTest.java
@@ -68,10 +68,8 @@ public class AttestationManagerTest extends JMockBaseTestCaseWithUser {
     private AttestationManager mgr;
     private static TaskomaticApi taskomaticApi;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         context.setThreadingPolicy(new Synchroniser());
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         user2 = UserTestUtils.createUser("user2", user.getOrg().getId());

--- a/java/core/src/test/java/com/suse/manager/hub/HubControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/hub/HubControllerTest.java
@@ -94,10 +94,8 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     private static final String TEST_ERROR_MESSAGE = "test error message";
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
         context().checking(new Expectations() {{

--- a/java/core/src/test/java/com/suse/manager/hub/HubManagerTest.java
+++ b/java/core/src/test/java/com/suse/manager/hub/HubManagerTest.java
@@ -208,9 +208,8 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
     private SystemEntitlementManager systemEntitlementManager;
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
 
         satAdmin = UserTestUtils.createUser(TestStatics.TEST_SAT_USER, user.getOrg().getId());
         satAdmin.addPermanentRole(RoleFactory.SAT_ADMIN);
@@ -246,9 +245,7 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
     }
 
     @AfterEach
-    @Override
     public void tearDown() throws Exception {
-        super.tearDown();
 
         Config.get().setString(ConfigDefaults.SERVER_HOSTNAME, originalFqdn);
         Config.get().setString("server.secret_key", originalServerSecret);

--- a/java/core/src/test/java/com/suse/manager/hub/migration/IssMigratorTest.java
+++ b/java/core/src/test/java/com/suse/manager/hub/migration/IssMigratorTest.java
@@ -110,9 +110,8 @@ public class IssMigratorTest extends JMockBaseTestCaseWithUser {
     }
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
 
         Config.get().setString(ConfigDefaults.SERVER_HOSTNAME, LOCAL_SERVER_FQDN);
 
@@ -143,9 +142,7 @@ public class IssMigratorTest extends JMockBaseTestCaseWithUser {
     }
 
     @AfterEach
-    @Override
     public void tearDown() throws Exception {
-        super.tearDown();
 
         Config.get().setString(ConfigDefaults.SERVER_HOSTNAME, originalFqdn);
     }

--- a/java/core/src/test/java/com/suse/manager/kubernetes/KubernetesManagerTest.java
+++ b/java/core/src/test/java/com/suse/manager/kubernetes/KubernetesManagerTest.java
@@ -53,10 +53,8 @@ public class KubernetesManagerTest extends JMockBaseTestCaseWithUser {
     private SaltService saltServiceMock;
     private KubernetesManager manager;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 
         saltServiceMock = mock(SaltService.class);

--- a/java/core/src/test/java/com/suse/manager/maintenance/MaintenanceManagerScheduleActionsTest.java
+++ b/java/core/src/test/java/com/suse/manager/maintenance/MaintenanceManagerScheduleActionsTest.java
@@ -65,10 +65,8 @@ public class MaintenanceManagerScheduleActionsTest extends JMockBaseTestCaseWith
     private static final String TESTDATAPATH = "/com/suse/manager/maintenance/testdata";
     private static final String KDE_ICS = "maintenance-windows-kde.ics";
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 
         user.addPermanentRole(ORG_ADMIN);

--- a/java/core/src/test/java/com/suse/manager/maintenance/MaintenanceManagerTest.java
+++ b/java/core/src/test/java/com/suse/manager/maintenance/MaintenanceManagerTest.java
@@ -83,10 +83,8 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
     private static final String EXCHANGE_MULTI2_ICS = "maintenance-windows-multi-exchange-2.ics";
     private static final String EXCHANGE_MULTI3_ICS = "maintenance-windows-multi-exchange-3.ics";
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         user = TestUtils.saveAndFlush(user);
     }

--- a/java/core/src/test/java/com/suse/manager/matcher/MatcherJsonIOTest.java
+++ b/java/core/src/test/java/com/suse/manager/matcher/MatcherJsonIOTest.java
@@ -96,10 +96,8 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
     private SystemEntitlementManager systemEntitlementManager;
     private BaseProductManager baseProductManagerMock;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 
         SaltApi saltApi = new TestSaltApi();

--- a/java/core/src/test/java/com/suse/manager/model/attestation/AttestationFactoryTest.java
+++ b/java/core/src/test/java/com/suse/manager/model/attestation/AttestationFactoryTest.java
@@ -43,10 +43,8 @@ public class AttestationFactoryTest extends BaseTestCaseWithUser {
     private Server server;
     private AttestationFactory attestationFactory;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         server = ServerFactoryTest.createTestServer(user);
         attestationFactory = new AttestationFactory();
     }

--- a/java/core/src/test/java/com/suse/manager/model/hub/HubFactoryTest.java
+++ b/java/core/src/test/java/com/suse/manager/model/hub/HubFactoryTest.java
@@ -48,10 +48,8 @@ public class HubFactoryTest extends BaseTestCaseWithUser {
 
     private HubFactory hubFactory;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         hubFactory = new HubFactory();
     }
 

--- a/java/core/src/test/java/com/suse/manager/model/maintenance/CalendarFactoryTest.java
+++ b/java/core/src/test/java/com/suse/manager/model/maintenance/CalendarFactoryTest.java
@@ -36,10 +36,8 @@ public class CalendarFactoryTest extends JMockBaseTestCaseWithUser {
     private CalendarFactory calendarFactory;
     private ScheduleFactory scheduleFactory;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         this.calendarFactory = new CalendarFactory();
         this.scheduleFactory = new ScheduleFactory();
     }

--- a/java/core/src/test/java/com/suse/manager/model/products/migration/MigrationDataFactoryTest.java
+++ b/java/core/src/test/java/com/suse/manager/model/products/migration/MigrationDataFactoryTest.java
@@ -41,11 +41,8 @@ public class MigrationDataFactoryTest extends RhnBaseTestCase {
     private SUSEProduct serverApps;
     private SUSEProduct publicCloud;
 
-    @Override
     @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
-
         ChannelFamily channelFamily = createTestChannelFamily();
 
         // Setup some products

--- a/java/core/src/test/java/com/suse/manager/reactor/RebootInfoBeaconTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/RebootInfoBeaconTest.java
@@ -52,9 +52,8 @@ public class RebootInfoBeaconTest extends RhnJmockBaseTestCase {
     private JsonParser<Event> eventParser;
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
 
         user = UserTestUtils.createUser(this);
         this.eventParser = new JsonParser<>(new TypeToken<>() {

--- a/java/core/src/test/java/com/suse/manager/reactor/RegisterMinionActionTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/RegisterMinionActionTest.java
@@ -264,10 +264,8 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
     private Consumer<Void> cleanupFunction = (arg) -> MinionServerFactory.findByMachineId(MACHINE_ID)
             .ifPresent(ServerFactory::delete);
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         UserFactory.save(user);
 
@@ -291,10 +289,8 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
        }});
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         FileUtils.deleteDirectory(metadataDirOfficial.toFile());
     }
 

--- a/java/core/src/test/java/com/suse/manager/reactor/messaging/BatchStartedEventMessageActionTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/messaging/BatchStartedEventMessageActionTest.java
@@ -55,10 +55,8 @@ public class BatchStartedEventMessageActionTest extends BaseTestCaseWithUser {
     private JsonParser<Event> eventParser;
     private BatchStartedEventMessageAction messageAction;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         this.messageAction = new BatchStartedEventMessageAction();
         this.eventParser = new JsonParser<>(new TypeToken<>() {
         });

--- a/java/core/src/test/java/com/suse/manager/reactor/messaging/ImageDeployedEventMessageActionTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/messaging/ImageDeployedEventMessageActionTest.java
@@ -80,10 +80,8 @@ public class ImageDeployedEventMessageActionTest extends JMockBaseTestCaseWithUs
     private SystemQuery systemQuery;
     private TaskomaticApi taskomaticMock;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 
         saltMock = mock(SaltService.class);

--- a/java/core/src/test/java/com/suse/manager/reactor/messaging/ImageSyncedEventMessageActionTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/messaging/ImageSyncedEventMessageActionTest.java
@@ -50,10 +50,8 @@ public class ImageSyncedEventMessageActionTest extends JMockBaseTestCaseWithUser
     private MinionServer testMinion;
     private ManagedServerGroup testGroup1, testGroup2;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         // setup a minion
         testMinion = MinionServerFactoryTest.createTestMinionServer(user);

--- a/java/core/src/test/java/com/suse/manager/reactor/messaging/JobReturnEventMessageActionTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/messaging/JobReturnEventMessageActionTest.java
@@ -150,10 +150,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
     private SaltServerActionService saltServerActionService;
 
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         Config.get().setString("server.secret_key",
                 DigestUtils.sha256Hex(TestUtils.randomString()));

--- a/java/core/src/test/java/com/suse/manager/reactor/messaging/MinionActionCleanupTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/messaging/MinionActionCleanupTest.java
@@ -71,10 +71,8 @@ import java.util.stream.Collectors;
  */
 public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 

--- a/java/core/src/test/java/com/suse/manager/reactor/messaging/RefreshGeneratedSaltFilesEventMessageActionTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/messaging/RefreshGeneratedSaltFilesEventMessageActionTest.java
@@ -47,17 +47,13 @@ public class RefreshGeneratedSaltFilesEventMessageActionTest extends BaseTestCas
 
     private Path tmpFileRoot;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         tmpFileRoot = Files.createTempDirectory("refgensalt");
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         FileUtils.deleteDirectory(tmpFileRoot.toFile());
     }
 

--- a/java/core/src/test/java/com/suse/manager/reactor/utils/RhelUtilsTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/utils/RhelUtilsTest.java
@@ -82,10 +82,8 @@ public class RhelUtilsTest extends JMockBaseTestCaseWithUser {
 
     }
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 

--- a/java/core/src/test/java/com/suse/manager/saltboot/PXEEventTest.java
+++ b/java/core/src/test/java/com/suse/manager/saltboot/PXEEventTest.java
@@ -67,10 +67,8 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
     private static final String MAC_ADDRESS = "00:11:22:33:44:55";
 
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         cobblerMock = new MockConnection("http://localhost", "token");
 
@@ -93,10 +91,8 @@ public class PXEEventTest extends JMockBaseTestCaseWithUser {
         profile.save();
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         MockConnection.clear();
     }
 

--- a/java/core/src/test/java/com/suse/manager/saltboot/SaltbootMigrationUtilsTest.java
+++ b/java/core/src/test/java/com/suse/manager/saltboot/SaltbootMigrationUtilsTest.java
@@ -43,19 +43,15 @@ public class SaltbootMigrationUtilsTest extends JMockBaseTestCaseWithUser {
 
     private CobblerConnection client;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         MockConnection.clear();
         client = new MockConnection("http://localhost", "token");
     }
 
-    @Override
     @AfterEach
     public void tearDown() throws Exception {
         MockConnection.clear();
-        super.tearDown();
     }
 
     @Test

--- a/java/core/src/test/java/com/suse/manager/saltboot/SaltbootUtilsTest.java
+++ b/java/core/src/test/java/com/suse/manager/saltboot/SaltbootUtilsTest.java
@@ -60,19 +60,15 @@ public class SaltbootUtilsTest extends JMockBaseTestCaseWithUser {
 
     private CobblerConnection client;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         MockConnection.clear();
         client = new MockConnection("http://localhost", "token");
     }
 
-    @Override
     @AfterEach
     public void tearDown() throws Exception {
         MockConnection.clear();
-        super.tearDown();
     }
 
     static ImageInfo createImageHelper(User user, String label, String version, int revision) throws Exception {

--- a/java/core/src/test/java/com/suse/manager/ssl/SSLCertManagerTest.java
+++ b/java/core/src/test/java/com/suse/manager/ssl/SSLCertManagerTest.java
@@ -41,9 +41,8 @@ public class SSLCertManagerTest extends RhnJmockBaseTestCase {
     private SSLCertManager certManager;
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
 
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         runtime = mock(Runtime.class);
@@ -53,9 +52,7 @@ public class SSLCertManagerTest extends RhnJmockBaseTestCase {
     }
 
     @AfterEach
-    @Override
     public void tearDown() throws Exception {
-        super.tearDown();
         org.apache.commons.io.FileUtils.deleteDirectory(tempDir);
     }
 

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/BaseControllerTestCase.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/BaseControllerTestCase.java
@@ -36,11 +36,8 @@ public class BaseControllerTestCase extends JMockBaseTestCaseWithUser {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
-
+    public void setUpBaseControllerTestCase() throws Exception {
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         response = RequestResponseFactory.create(new RhnMockHttpServletResponse());

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/DownloadControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/DownloadControllerTest.java
@@ -117,10 +117,8 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
         originalMountPoint = Config.get().getString(ConfigDefaults.MOUNT_POINT);
     }
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         this.channel = ErrataTestUtils.createTestChannel(user);
         this.mockResponse = new RhnMockHttpServletResponse();
@@ -173,10 +171,8 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
         downloadController.setCheckTokens(true);
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         if (originalMountPoint != null) {
             Config.get().setString(ConfigDefaults.MOUNT_POINT, originalMountPoint);
         }

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/LoginControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/LoginControllerTest.java
@@ -66,23 +66,18 @@ public class LoginControllerTest extends BaseControllerTestCase {
     private boolean ssoEnabled;
     private Saml2Settings saml2Settings;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         ssoEnabled = Config.get().getBoolean(ConfigDefaults.SINGLE_SIGN_ON_ENABLED);
         saml2Settings = SSOTestUtils.getSaml2Settings();
         loginController = new LoginController(new OidcAuthHandler(), Optional.of(saml2Settings));
     }
 
-    @Override
     @AfterEach
     public void tearDown() throws Exception {
         // Restore the original SSO Enabled value
         Config.get().setBoolean(ConfigDefaults.SINGLE_SIGN_ON_ENABLED, Boolean.toString(ssoEnabled));
-
-        super.tearDown();
     }
 
     @Test

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/ProxyControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/ProxyControllerTest.java
@@ -46,9 +46,8 @@ public class ProxyControllerTest extends BaseControllerTestCase {
     private SystemManager systemManager;
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
         systemManager = context().mock(SystemManager.class);
         proxyController = new ProxyController(systemManager);
     }

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/RecurringActionControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/RecurringActionControllerTest.java
@@ -73,10 +73,8 @@ public class RecurringActionControllerTest extends BaseControllerTestCase {
         context().setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
 

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/SSOControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/SSOControllerTest.java
@@ -46,22 +46,17 @@ public class SSOControllerTest extends BaseControllerTestCase {
 
     private boolean ssoEnabled;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         ssoEnabled = Config.get().getBoolean(ConfigDefaults.SINGLE_SIGN_ON_ENABLED);
         ssoController = new SSOController(Optional.of(SSOTestUtils.getSaml2Settings()));
     }
 
-    @Override
     @AfterEach
     public void tearDown() throws Exception {
         // Restore the original SSO Enabled value
         Config.get().setBoolean(ConfigDefaults.SINGLE_SIGN_ON_ENABLED, Boolean.toString(ssoEnabled));
-
-        super.tearDown();
     }
 
     @Test

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/SaltbootControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/SaltbootControllerTest.java
@@ -29,7 +29,6 @@ import com.suse.utils.Json;
 import com.google.gson.reflect.TypeToken;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -41,12 +40,6 @@ import spark.Request;
 
 public class SaltbootControllerTest extends BaseControllerTestCase {
     private static final String TEST_DIR = "/com/suse/manager/webui/controllers/";
-
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
-    }
 
     @Test
     public void testSaltbootController() throws Exception {

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/ScapAuditControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/ScapAuditControllerTest.java
@@ -100,10 +100,8 @@ public class ScapAuditControllerTest extends BaseControllerTestCase {
     }
 
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         controller = new ScapAuditController();
         System.setProperty("javax.xml.transform.TransformerFactory",
           "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl");

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/SetControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/SetControllerTest.java
@@ -51,10 +51,8 @@ public class SetControllerTest extends BaseControllerTestCase {
                                                       .create();
 
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         initializeSet(SetLabels.SYSTEM_LIST, user);
     }

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/SystemsControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/SystemsControllerTest.java
@@ -68,10 +68,8 @@ public class SystemsControllerTest extends BaseControllerTestCase {
     private Map<String, Server> serversByHostServerName;
     private SystemsController systemsController;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/VirtualHostManagerControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/VirtualHostManagerControllerTest.java
@@ -90,10 +90,8 @@ public class VirtualHostManagerControllerTest extends BaseTestCaseWithUser {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         response = RequestResponseFactory.create(new RhnMockHttpServletResponse());
         factory = VirtualHostManagerFactory.getInstance();

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/admin/handlers/PaygApiControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/admin/handlers/PaygApiControllerTest.java
@@ -61,10 +61,8 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
     private PaygApiContoller paygApiContoller;
     private User satAdmin;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         clearDb();
 
         satAdmin = UserTestUtils.createUser(TestStatics.TEST_SAT_USER, user.getOrg().getId());
@@ -75,10 +73,8 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
         paygApiContoller = new PaygApiContoller(new PaygAdminManager(taskomaticMock));
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         clearDb();
     }
 

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappersTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappersTest.java
@@ -42,10 +42,8 @@ public class ResponseMappersTest extends BaseTestCaseWithUser {
 
     private ContentManager manager;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         manager = new ContentManager();
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
     }

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapperTestBase.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapperTestBase.java
@@ -66,10 +66,8 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
     // tested object, initialized in subclasses
     protected AbstractMinionBootstrapper bootstrapper;
 
-    @Override
     @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
+    public void setUpAbstractMinionBootstrapperTestBase() throws Exception {
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         saltServiceMock = mock(SaltService.class);
         paygManager = new TestCloudPaygManagerBuilder().build();

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/utils/RegularMinionBootstrapperTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/utils/RegularMinionBootstrapperTest.java
@@ -56,10 +56,8 @@ import java.util.Optional;
  */
 public class RegularMinionBootstrapperTest extends AbstractMinionBootstrapperTestBase {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         bootstrapper = new RegularMinionBootstrapper(saltServiceMock, saltServiceMock, paygManager, attestationManager);
     }
 

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapperTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapperTest.java
@@ -39,10 +39,8 @@ import java.util.Optional;
  */
 public class SSHMinionBootstrapperTest extends AbstractMinionBootstrapperTestBase {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         bootstrapper = new SSHMinionBootstrapper(saltServiceMock, saltServiceMock, paygManager, attestationManager);
     }
 

--- a/java/core/src/test/java/com/suse/manager/webui/services/ConfigChannelSaltManagerFileSystemTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/ConfigChannelSaltManagerFileSystemTest.java
@@ -36,10 +36,8 @@ public class ConfigChannelSaltManagerFileSystemTest extends BaseTestCaseWithUser
     /** the instance used for testing **/
     private ConfigChannelSaltManager manager;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         this.manager = ConfigChannelSaltManager.getInstance();
     }
 

--- a/java/core/src/test/java/com/suse/manager/webui/services/ConfigChannelSaltManagerLifecycleTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/ConfigChannelSaltManagerLifecycleTest.java
@@ -56,10 +56,8 @@ import java.util.Random;
  */
 public class ConfigChannelSaltManagerLifecycleTest extends BaseTestCaseWithUser {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         user.getOrg().addRole(RoleFactory.CONFIG_ADMIN);
         user.addToGroup(AccessGroupFactory.CONFIG_ADMIN);
         user = TestUtils.saveAndFlush(user);

--- a/java/core/src/test/java/com/suse/manager/webui/services/OidcAuthHandlerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/OidcAuthHandlerTest.java
@@ -74,10 +74,8 @@ public class OidcAuthHandlerTest extends JMockBaseTestCaseWithUser {
     private KeyPair rsaKeyPair;
 
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         enableOidcLogin();
         rsaKeyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
     }

--- a/java/core/src/test/java/com/suse/manager/webui/services/SaltServerActionServiceTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/SaltServerActionServiceTest.java
@@ -121,10 +121,8 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     private TaskomaticApi taskomaticMock;
     private SaltService saltService;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 
         saltService = new SaltService() {

--- a/java/core/src/test/java/com/suse/manager/webui/services/SaltStateGeneratorServiceTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/SaltStateGeneratorServiceTest.java
@@ -54,10 +54,8 @@ import java.util.Map;
  */
 public class SaltStateGeneratorServiceTest extends BaseTestCaseWithUser {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         Config.get().setString("server.secret_key",
                 DigestUtils.sha256Hex(TestUtils.randomString()));
     }

--- a/java/core/src/test/java/com/suse/manager/webui/services/StateSourceServiceTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/StateSourceServiceTest.java
@@ -40,10 +40,8 @@ public class StateSourceServiceTest extends BaseTestCaseWithUser {
 
     private MinionServer server;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         server = MinionServerFactoryTest.createTestMinionServer(user);
     }
 

--- a/java/core/src/test/java/com/suse/manager/webui/services/impl/SaltSSHServiceTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/impl/SaltSSHServiceTest.java
@@ -43,10 +43,8 @@ import java.util.Set;
  */
 public class SaltSSHServiceTest extends JMockBaseTestCaseWithUser {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         Config.get().setString("ssh_push_port_https", "1233");
         Config.get().setString("ssh_push_sudo_user", "mgruser");

--- a/java/core/src/test/java/com/suse/manager/webui/services/impl/SaltServiceTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/impl/SaltServiceTest.java
@@ -57,10 +57,8 @@ public class SaltServiceTest extends JMockBaseTestCaseWithUser {
 
     private Path tempDir;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         tempDir = Files.createTempDirectory("saltservice");
     }
@@ -194,10 +192,8 @@ public class SaltServiceTest extends JMockBaseTestCaseWithUser {
         assertFalse(listAppender.matchInLogs(dummyServerRSAKey));
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         try {
             if (tempDir.toFile().exists()) {
                 FileUtils.deleteDirectory(tempDir.toFile());

--- a/java/core/src/test/java/com/suse/manager/webui/services/pillar/MinionGroupMembershipPillarGeneratorTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/pillar/MinionGroupMembershipPillarGeneratorTest.java
@@ -43,10 +43,8 @@ public class MinionGroupMembershipPillarGeneratorTest extends BaseTestCaseWithUs
     protected MinionPillarGenerator minionGroupMembershipPillarGenerator =
             new MinionGroupMembershipPillarGenerator();
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         Config.get().setString("server.secret_key",
                 DigestUtils.sha256Hex(TestUtils.randomString()));
     }

--- a/java/core/src/test/java/com/suse/manager/webui/services/pillar/MinionPillarManagerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/pillar/MinionPillarManagerTest.java
@@ -47,10 +47,8 @@ import java.util.Set;
  */
 public class MinionPillarManagerTest extends BaseTestCaseWithUser {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         Config.get().setString("server.secret_key",
                 DigestUtils.sha256Hex(TestUtils.randomString()));
     }

--- a/java/core/src/test/java/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessorTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessorTest.java
@@ -60,10 +60,8 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
     /**
      * {@inheritDoc}
      */
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         processor = new SubscriptionMatchProcessor();
         input = new InputJson(new Date(), new LinkedList<>(), new LinkedList<>(),
                 new LinkedList<>(), new LinkedList<>(), new LinkedList<>());

--- a/java/core/src/test/java/com/suse/manager/webui/utils/MinionActionUtilsTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/utils/MinionActionUtilsTest.java
@@ -63,16 +63,13 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
     private final SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi);
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
         saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));
     }
 
     @AfterEach
-    @Override
     public void tearDown() throws Exception {
-        super.tearDown();
         Files.delete(saltUtils.getScriptsDir());
     }
 

--- a/java/core/src/test/java/com/suse/manager/webui/utils/salt/ImageDeployedEventTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/utils/salt/ImageDeployedEventTest.java
@@ -40,10 +40,8 @@ import java.util.Optional;
  */
 public class ImageDeployedEventTest extends JMockBaseTestCaseWithUser {
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 

--- a/java/core/src/test/java/com/suse/manager/xmlrpc/admin/AdminPaygHandlerTest.java
+++ b/java/core/src/test/java/com/suse/manager/xmlrpc/admin/AdminPaygHandlerTest.java
@@ -62,19 +62,15 @@ public class AdminPaygHandlerTest extends BaseHandlerTestCase {
         setThreadingPolicy(new Synchroniser());
     }};
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         taskoApiMock = context.mock(TaskomaticApi.class);
         handler = new AdminPaygHandler(taskoApiMock);
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         PaygSshDataFactory.lookupPaygSshData().forEach(PaygSshDataFactory::deletePaygSshData);
         HibernateFactory.commitTransaction();
     }

--- a/java/core/src/test/java/com/suse/manager/xmlrpc/maintenance/MaintenanceHandlerTest.java
+++ b/java/core/src/test/java/com/suse/manager/xmlrpc/maintenance/MaintenanceHandlerTest.java
@@ -32,7 +32,6 @@ import com.suse.manager.model.maintenance.MaintenanceCalendar;
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
 import com.suse.manager.xmlrpc.serializer.RescheduleResultSerializer;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -54,12 +53,6 @@ public class MaintenanceHandlerTest extends BaseHandlerTestCase {
     private static final String EXCHANGE_MULTI1_ICS = "maintenance-windows-multi-exchange-1.ics";
     private static final String EXCHANGE_MULTI2_ICS = "maintenance-windows-multi-exchange-2.ics";
     private static final String TESTDATAPATH = "/com/suse/manager/maintenance/testdata";
-
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
-    }
 
     @Test
     public void testMultiScheduleUpdate() throws Exception {

--- a/java/core/src/test/java/com/suse/proxy/ProxyConfigGetFacadeImplTest.java
+++ b/java/core/src/test/java/com/suse/proxy/ProxyConfigGetFacadeImplTest.java
@@ -65,15 +65,12 @@ public class ProxyConfigGetFacadeImplTest extends BaseTestCaseWithUser {
     }};
 
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws NoSuchFieldException, IllegalAccessException {
         setConfigDefaultsInstance(configDefaults);
     }

--- a/java/core/src/test/java/com/suse/proxy/ProxyConfigGetFormDataAcquisitorTest.java
+++ b/java/core/src/test/java/com/suse/proxy/ProxyConfigGetFormDataAcquisitorTest.java
@@ -52,10 +52,8 @@ public class ProxyConfigGetFormDataAcquisitorTest extends BaseTestCaseWithUser {
 
     private MinionServer testMinionServer;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         testMinionServer = MinionServerFactoryTest.createTestMinionServer(user);
     }
 

--- a/java/core/src/test/java/com/suse/proxy/ProxyConfigGetFormDefaultsTest.java
+++ b/java/core/src/test/java/com/suse/proxy/ProxyConfigGetFormDefaultsTest.java
@@ -66,17 +66,14 @@ public class ProxyConfigGetFormDefaultsTest extends BaseTestCaseWithUser {
         setThreadingPolicy(new Synchroniser());
     }};
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         testMinionServer = MinionServerFactoryTest.createTestMinionServer(user);
         testMinionServer.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
     }
 
-    @Override
-    @AfterEach
+        @AfterEach
     public void tearDown() throws NoSuchFieldException, IllegalAccessException {
         setConfigDefaultsInstance(configDefaults);
     }

--- a/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateAcquisitorTest.java
+++ b/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateAcquisitorTest.java
@@ -94,10 +94,8 @@ public class ProxyConfigUpdateAcquisitorTest extends BaseTestCaseWithUser {
         setThreadingPolicy(new Synchroniser());
     }};
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 

--- a/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateApplySaltStateTest.java
+++ b/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateApplySaltStateTest.java
@@ -54,10 +54,8 @@ public class ProxyConfigUpdateApplySaltStateTest extends BaseTestCaseWithUser {
         setThreadingPolicy(new Synchroniser());
     }};
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         ActionManager.setTaskomaticApi(getTaskomaticApi());
     }

--- a/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateFileAcquisitorTest.java
+++ b/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateFileAcquisitorTest.java
@@ -83,10 +83,8 @@ public class ProxyConfigUpdateFileAcquisitorTest extends BaseTestCaseWithUser {
         setThreadingPolicy(new Synchroniser());
     }};
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 

--- a/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateInitializerTest.java
+++ b/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateInitializerTest.java
@@ -67,9 +67,8 @@ public class ProxyConfigUpdateInitializerTest extends JMockBaseTestCaseWithUser 
     private MinionServer mockMinionServer;
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         this.mockMinionServer = mock(MinionServer.class);
     }

--- a/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateSavePillarsTest.java
+++ b/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateSavePillarsTest.java
@@ -94,10 +94,8 @@ public class ProxyConfigUpdateSavePillarsTest extends BaseTestCaseWithUser {
 
     private MinionServer minion;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         this.minion = MinionServerFactoryTest.createTestMinionServer(user);
         minion.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
         minion.addFqdn(DUMMY_PROXY_FQDN);

--- a/java/core/src/test/java/com/suse/proxy/get/formdata/ProxyConfigGetFormDataPreConditionsTest.java
+++ b/java/core/src/test/java/com/suse/proxy/get/formdata/ProxyConfigGetFormDataPreConditionsTest.java
@@ -77,18 +77,15 @@ public class ProxyConfigGetFormDataPreConditionsTest extends RhnJmockBaseTestCas
     private User user;
 
     @BeforeEach
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
+
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         this.mockServer = mock(Server.class);
         this.user = UserTestUtils.createUser();
     }
 
     @AfterEach
-    @Override
     public void tearDown() throws Exception {
-        super.tearDown();
 
         try {
             setConfigDefaultsInstance(configDefaults);

--- a/java/core/src/test/java/com/suse/scc/SCCSystemRegistrationTest.java
+++ b/java/core/src/test/java/com/suse/scc/SCCSystemRegistrationTest.java
@@ -59,10 +59,8 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
 
     private SCCProxyFactory sccProxyFactory = new SCCProxyFactory();
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         this.credentials = CredentialsFactory.createSCCCredentials("username", "password");
         this.credentials.setUrl("https://scc.suse.com");


### PR DESCRIPTION
## What does this PR change?

since JUnit5, the `@BeforeEach` and `@AfterEach` annotations are executed in the base classes and then in the derived ones.
Hence, calling `super.setUp()` and` super.tearDown()` is not necessary anymore if the base class has the right annotations.

This PR aims to:

- change the  name to `setUp` and `tearDown` methods in base test classes and add the the `@BeforeEach` and `@AfterEach` annotations (those two names are left in leaf test classes)
- remove overriding on `setUp` and `tearDown` in leaf test classes, and the calls to` super.setUp` and `super.tearDown`

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/30951
Port(s): none (5.2)
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
