### PR TITLE
[master-leap16] testsuite: srv_salt_git_pillar: use proper repos for openSUSE Leap 16.0

### DIFF
--- a/testsuite/features/secondary/srv_salt_git_pillar.feature
+++ b/testsuite/features/secondary/srv_salt_git_pillar.feature
@@ -7,9 +7,14 @@
 Feature: Salt master integration with Git pillar
 
   # Workaround: Enabling repositories for installing git-core
+  @susemanager
   Scenario: Pre-requisite: Enabling repositories for installing git-core
     When I add repository "SLE-Module-Basesystem15-SP7-Updates" with url "http://minima-mirror-ci-bv.mgr.suse.de/SUSE/Updates/SLE-Module-Basesystem/15-SP7/x86_64/update/" on "server" without error control
     And I add repository "SLE-Module-Basesystem15-SP7-Pool" with url "http://minima-mirror-ci-bv.mgr.suse.de/SUSE/Products/SLE-Module-Basesystem/15-SP7/x86_64/product/" on "server" without error control
+
+  @uyuni
+  Scenario: Pre-requisite: Enabling repositories for installing git-core
+    When I add repository "repo-oss" with url "http://minima-mirror-ci-bv.mgr.suse.de/distribution/leap/16.0/repo/oss/" on "server" without error control
 
   Scenario: Preparing Git pillar configuration for Salt master
     When I setup a git_pillar environment on the Salt master
@@ -34,6 +39,11 @@ Feature: Salt master integration with Git pillar
     And the pillar data for "org_id" should be "1" on "sle_minion"
     And the pillar data for "git_pillar_foobar" should be empty on the Salt master
 
+  @susemanager
   Scenario: Pre-Cleanup: Disabling repositories for uninstalling git-core
     When I remove repository "SLE-Module-Basesystem15-SP7-Updates" on "server" without error control
     And I remove repository "SLE-Module-Basesystem15-SP7-Pool" on "server" without error control
+
+  @uyuni
+  Scenario: Pre-Cleanup: Disabling repositories for uninstalling git-core
+    When I remove repository "repo-oss" on "server" without error control


### PR DESCRIPTION
## What does this PR change?

This PR makes `features/secondary/srv_salt_git_pillar.feature` to add the right repository for installing `git-core` and `openssh-server` inside the server container.

For Uyuni:
- Use leap 16.0 repo

For MLM:
- Use SLE15SP7 repos

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
