### PR TITLE
[master-leap16] testsuite: wait for zypper to finish when killing reposync

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -363,7 +363,14 @@ def kill_reposync_for_channel(channel)
       next
     elsif channel_synchronizing == channel
       pid = process.split[0]
-      get_target('server').run("kill #{pid}", verbose: true, check_errors: false)
+      node = get_target('server')
+      node.run("kill #{pid}", verbose: true, check_errors: false)
+      # Even if spacewalk-repo-sync is killed, it is possible that zypper
+      # is still running for some moments while refreshing metadata.
+      # If there is another execution of spacewalk-repo-sync again while
+      # zypper is still running, then the reposync will fail.
+      # We need to wait until zypper is finished
+      node.wait_while_process_running('zypper')
       log "Reposync of channel #{channel} killed"
       break
     else


### PR DESCRIPTION
## What does this PR change?

This PR fixes a race condition that happen when the testsuite is killing `spacewalk-repo-sync` executions during reposync stages, that affects later when testing Ansible.

Let me elaborate this:

When `spacewalk-repo-sync` is executed to sync a channel, it first triggers an underlying call to `zypper` to refresh repository metadata. If we kill reposync while zypper is refreshing metadata, the current mechanism assumes reposync was killed (allowing other spacewalk-repo-sync calls to be performed) while in reality the underlying zypper call could be still running for some more time until it finished. If another reposync call is triggered while zypper is still running, then this reposync call will fail. 

We see currently this situation happening on Uyuni acceptance tests, where tumbleweed channel is failing to sync due to this:

```
2026/06/09 09:37:00 +02:00 Command: ['/usr/bin/spacewalk-repo-sync', '--channel', 'opensuse_tumbleweed-x86_64', '--type', 'yum', '--non-interactive']
2026/06/09 09:37:00 +02:00 Sync of channel started.
2026/06/09 09:37:11 +02:00 Command: ['/usr/bin/spacewalk-repo-sync', '-c', 'opensuse_tumbleweed-x86_64', '--include', 'dmidecode', '--include', 'libunwind', '--include', 'golang-github-prometheus-node_exporter', '--include', 'golang-github-lusitaniae-apache_exporter', '--include', 'prometheus-postgres_exporter', '--include', 'golang-github-QubitProducts-exporter_exporter', '--include', 'system-user-prometheus', '--include', 'ansible', '--include', 'python313-packaging', '--include', 'python313-rpm', '--include', 'ansible-core', '--include', 'libgomp1', '--include', 'python313-resolvelib', '--include', 'librpmbuild10', '--include', 'python313-defusedxml', '--include', 'python313-pyOpenSSL', '--include', 'python313-cffi', '--include', 'python313-cryptography', '--include', 'python313-pycparser', '--include', 'python313-bcrypt', '--include', 'glibc-locale', '--include', 'glibc-locale-base']
2026/06/09 09:37:11 +02:00 Sync of channel started.
2026/06/09 09:37:12 +02:00 RepoMDError: Cannot access repository.
System management is locked by the application with pid 12879 (zypper).
Close this application before trying again.
```

This situation leads to `ansible-core` package not being available on the minion channels and causing the failures while testing Ansible feature.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30410

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
