### PR TITLE
taskotop needs to properly handle timezones (bsc#1267871)

### DIFF
--- a/containers/server-postgresql-image/root/docker-entrypoint-initdb.d/uyuni-postgres-config.sh
+++ b/containers/server-postgresql-image/root/docker-entrypoint-initdb.d/uyuni-postgres-config.sh
@@ -101,6 +101,10 @@ if [ -f $SSL_KEY ] ; then
     postgres_reconfig "ssl_key_file" "'$SSL_KEY'"
 fi
 
+if test -n "$TZ"; then
+    postgres_reconfig "log_timezone" "$TZ"
+fi
+
 mkdir -p /var/lib/pgsql/data/postgresql.conf.d
 postgres_reconfig "include_dir" "'postgresql.conf.d'"
 

--- a/containers/server-postgresql-image/root/docker-entrypoint-upgdb.d/03-timezone.sh
+++ b/containers/server-postgresql-image/root/docker-entrypoint-upgdb.d/03-timezone.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+POSTGRESQL=/var/lib/pgsql/data/postgresql.conf
+
+postgres_reconfig() {
+    echo "Setting $1 = $2"
+    if test $(sed -n "/^$1[[:space:]]*=/p" $POSTGRESQL | wc -l) -ne 0; then
+        sed -i "s|^$1[[:space:]]*=.*|$1 = $2|" $POSTGRESQL
+    else
+        echo "$1 = $2" >> $POSTGRESQL
+    fi
+}
+
+if test -n "$TZ"; then
+    postgres_reconfig "log_timezone" "$TZ"
+fi

--- a/containers/server-postgresql-image/server-postgresql-image.changes.cbosdo.taskotop-timezone
+++ b/containers/server-postgresql-image/server-postgresql-image.changes.cbosdo.taskotop-timezone
@@ -1,0 +1,1 @@
+- Automatically set the log timezone for TZ env (bsc#1267871)

--- a/utils/spacewalk-utils.changes.cbosdo.taskotop-timezone
+++ b/utils/spacewalk-utils.changes.cbosdo.taskotop-timezone
@@ -1,0 +1,1 @@
+- Taskotop now handles timezone (bsc#1267871)

--- a/utils/taskotop
+++ b/utils/taskotop
@@ -27,7 +27,6 @@ from spacewalk.server import rhnSQL
 
 from io import BytesIO
 
-
 DEFAULT_LOGFILE = "./taskotop.log"
 
 parser = argparse.ArgumentParser(
@@ -207,7 +206,8 @@ class CursesDisplayBuilder:
             value = value[0:-1]
         log_debug(
             # pylint: disable-next=consider-using-f-string
-            "y=%d x=%d value '%s'  value length %d" % (ypos, addxpos, value, len(value))
+            "y=%d x=%d value '%s'  value length %d"
+            % (ypos, addxpos, value, len(value))
         )
         if len(value) > 0:
             screen.addstr(ypos, addxpos, value)
@@ -305,8 +305,7 @@ class CursesDisplayColumn:
 
 def get_tasko_runs_newer_than_age(maximum_age):
     """Returns data about recent Taskomatic task runs from the database."""
-    task_query = rhnSQL.prepare(
-        """
+    task_query = rhnSQL.prepare("""
         SELECT
             task.name AS name,
             run.id AS id,
@@ -324,8 +323,7 @@ def get_tasko_runs_newer_than_age(maximum_age):
                     AND (run.end_time IS NULL OR run.end_time > :timelimit)
 
             ORDER BY end_time DESC NULLS FIRST, start_time ASC
-    """
-    )
+    """)
     # trim those older than maximum_age
     task_query.execute(
         timelimit=datetime.datetime.now() - datetime.timedelta(seconds=maximum_age)
@@ -344,8 +342,7 @@ def get_tasko_runs_newer_than_age(maximum_age):
 
 def get_tasko_runs_latest_each_task():
     """Returns data about latest of each Taskomatic task runs from the database."""
-    task_query = rhnSQL.prepare(
-        """
+    task_query = rhnSQL.prepare("""
         SELECT
             task.name AS name,
             run.id AS id,
@@ -365,8 +362,7 @@ def get_tasko_runs_latest_each_task():
                 JOIN rhnTaskoTask task ON task.id = template.task_id
 
             ORDER BY end_time DESC NULLS FIRST, start_time ASC
-    """
-    )
+    """)
 
     task_query.execute()
 
@@ -393,9 +389,7 @@ def get_channel_names(ids):
             FROM rhnChannel
             WHERE id IN ({0})
             ORDER BY label
-    """.format(
-            ",".join(ids)
-        )
+    """.format(",".join(ids))
     )
     query.execute()
 
@@ -404,14 +398,12 @@ def get_channel_names(ids):
 
 def get_current_repodata_channel_names():
     """Gets the channel names of currenlty running repodata tasks from the database."""
-    query = rhnSQL.prepare(
-        """
+    query = rhnSQL.prepare("""
         SELECT DISTINCT channel_label
             FROM rhnRepoRegenQueue
             WHERE next_action IS NULL
             ORDER BY channel_label
-    """
-    )
+    """)
     query.execute()
 
     return [row[0] for row in query.fetchall()]
@@ -663,7 +655,7 @@ def format_elapsed_time(rowdata, data_key, width):
     if rowdata["end_time"]:
         end = rowdata["end_time"]
 
-    td = end.replace(tzinfo=None) - rowdata["start_time"].replace(tzinfo=None)
+    td = end.astimezone() - rowdata["start_time"].astimezone()
     seconds = int(
         (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
     )
@@ -676,7 +668,7 @@ def format_elapsed_time(rowdata, data_key, width):
 # pylint: disable-next=unused-argument
 def format_datetime(rowdata, data_key, width):
     if rowdata[data_key]:
-        return rowdata[data_key].strftime("%Y-%m-%d %H:%M:%S")
+        return rowdata[data_key].astimezone().strftime("%Y-%m-%d %H:%M:%S")
     return ""
 
 
@@ -865,7 +857,8 @@ if args.verbose > 0:
     if dirname != "" and not os.path.isdir(os.path.dirname(args.logfile)):
         system_exit(
             # pylint: disable-next=consider-using-f-string
-            1, "ERROR: Directory %s in specified logfile doesn't exist" % dirname
+            1,
+            "ERROR: Directory %s in specified logfile doesn't exist" % dirname,
         )
     try:
         # pylint: disable-next=unspecified-encoding


### PR DESCRIPTION
## What does this PR change?

The data taskotop contain the timezone. Converting to local timezone will show correct times while the current way drops it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: taskotop is an ncurses tool

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30904
Port(s): 5.1: https://github.com/SUSE/spacewalk/pull/30927 5.2: https://github.com/SUSE/spacewalk/pull/31391

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
