### PR TITLE
Fix removal of ansible controller node (bsc#1267964)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/server/AnsibleFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/server/AnsibleFactory.java
@@ -56,10 +56,11 @@ public class AnsibleFactory extends HibernateFactory {
      * @return optional of {@link AnsiblePath}
      */
     public static Optional<AnsiblePath> lookupAnsiblePathByPathAndMinion(Path path, long minionServerId) {
-        return HibernateFactory.getSession().createQuery("""
-                                                         FROM AnsiblePath p
-                                                         WHERE p.path = :path
-                                                         AND p.minionServer.id = :minionServerId""", AnsiblePath.class)
+        return HibernateFactory.getSession()
+                .createQuery("""
+                             FROM AnsiblePath p
+                             WHERE p.path = :path
+                             AND p.minionServer.id = :minionServerId""", AnsiblePath.class)
                 .setParameter("path", path)
                 .setParameter("minionServerId", minionServerId)
                 .uniqueResultOptional();
@@ -125,20 +126,17 @@ public class AnsibleFactory extends HibernateFactory {
     /**
      * List all ansible managed {@link Server}s linked to given {@link Server}
      *
-     * @param minionId the id of the contorl node
+     * @param minionId the id of the control node
      * @return the list of inventory servers
      */
     public static List<Server> listAnsibleInventoryServersByControlNode(long minionId) {
-        return HibernateFactory.getSession().createNativeQuery("""
-                 SELECT DISTINCT s.*, 0 as clazz_ FROM suseAnsiblePath ap
-                 JOIN suseAnsibleInventoryServers ais ON ap.id = ais.inventory_id
-                 JOIN rhnServer s ON ais.server_id = s.id
-                 WHERE ap.server_id = :server_id""", Server.class)
-                .addSynchronizedEntityClass(AnsiblePath.class)
-                .addSynchronizedEntityClass(InventoryPath.class)
-                .addSynchronizedEntityClass(Server.class)
-                .setParameter("server_id", minionId)
-                .getResultList();
+        return HibernateFactory.getSession()
+                .createQuery("""
+                             SELECT DISTINCT ip.inventoryServers
+                             FROM InventoryPath ip
+                             WHERE ip.minionServer.id = :serverId""", Server.class)
+                .setParameter("serverId", minionId)
+                .list();
     }
 
     /**
@@ -148,12 +146,13 @@ public class AnsibleFactory extends HibernateFactory {
      * @return the list of inventory servers
      */
     public static List<Server> listAnsibleInventoryServersExcludingPath(InventoryPath path) {
-        return HibernateFactory.getSession().createQuery("""
-                 SELECT DISTINCT p.inventoryServers
-                 FROM InventoryPath p
-                 WHERE p.id != :inventoryId""", Server.class)
+        return HibernateFactory.getSession()
+                .createQuery("""
+                             SELECT DISTINCT p.inventoryServers
+                             FROM InventoryPath p
+                             WHERE p.id != :inventoryId""", Server.class)
                 .setParameter("inventoryId", path.getId())
-                .getResultList();
+                .list();
     }
 
     /**
@@ -163,16 +162,13 @@ public class AnsibleFactory extends HibernateFactory {
      * @return the list of inventory servers
      */
     public static List<Server> listAnsibleInventoryServersExcludingControlNode(long minionId) {
-        return HibernateFactory.getSession().createNativeQuery("""
-                 SELECT DISTINCT s.*, 0 as clazz_ FROM suseAnsiblePath ap
-                 JOIN suseAnsibleInventoryServers ais ON ap.id = ais.inventory_id
-                 JOIN rhnServer s ON ais.server_id = s.id
-                 WHERE ap.server_id != :server_id""", Server.class)
-                .addSynchronizedEntityClass(AnsiblePath.class)
-                .addSynchronizedEntityClass(InventoryPath.class)
-                .addSynchronizedEntityClass(Server.class)
-                .setParameter("server_id", minionId)
-                .getResultList();
+        return HibernateFactory.getSession()
+                .createQuery("""
+                             SELECT DISTINCT ip.inventoryServers
+                             FROM InventoryPath ip
+                             WHERE ip.minionServer.id != :serverId""", Server.class)
+                .setParameter("serverId", minionId)
+                .list();
     }
 
     /**
@@ -198,5 +194,4 @@ public class AnsibleFactory extends HibernateFactory {
     protected Logger getLogger() {
         return log;
     }
-
 }

--- a/java/core/src/main/java/com/redhat/rhn/domain/server/ansible/AnsiblePath.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/server/ansible/AnsiblePath.java
@@ -86,14 +86,18 @@ public abstract class AnsiblePath extends BaseDomainHelper {
     /**
      * Standard constructor
      */
-    protected AnsiblePath() { }
+    protected AnsiblePath() {
+        // Default constructor for hibernate
+    }
 
     /**
      * Standard constructor
      * @param minionServerIn the minion server
+     * @param pathIn the path
      */
-    protected AnsiblePath(MinionServer minionServerIn) {
+    protected AnsiblePath(MinionServer minionServerIn, Path pathIn) {
         this.minionServer = minionServerIn;
+        this.path = pathIn;
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/domain/server/ansible/InventoryPath.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/server/ansible/InventoryPath.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.domain.server.Server;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -44,16 +45,18 @@ public class InventoryPath extends AnsiblePath {
     /**
      * Standard constructor
      */
-    public InventoryPath() {
+    protected InventoryPath() {
         inventoryServers = new HashSet<>();
     }
 
     /**
      * Standard constructor
      * @param minionServer the minion server
+     * @param path the path
      */
-    public InventoryPath(MinionServer minionServer) {
-        super(minionServer);
+    public InventoryPath(MinionServer minionServer, Path path) {
+        super(minionServer, path);
+
         inventoryServers = new HashSet<>();
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/domain/server/ansible/InventoryPath.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/server/ansible/InventoryPath.java
@@ -55,9 +55,19 @@ public class InventoryPath extends AnsiblePath {
      * @param path the path
      */
     public InventoryPath(MinionServer minionServer, Path path) {
+        this(minionServer, path, Set.of());
+    }
+
+    /**
+     * Standard constructor
+     * @param minionServer the minion server
+     * @param path the path
+     * @param servers the inventory servers
+     */
+    public InventoryPath(MinionServer minionServer, Path path, Set<Server> servers) {
         super(minionServer, path);
 
-        inventoryServers = new HashSet<>();
+        inventoryServers = new HashSet<>(servers);
     }
 
     @Override

--- a/java/core/src/main/java/com/redhat/rhn/domain/server/ansible/PlaybookPath.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/server/ansible/PlaybookPath.java
@@ -17,6 +17,8 @@ package com.redhat.rhn.domain.server.ansible;
 
 import com.redhat.rhn.domain.server.MinionServer;
 
+import java.nio.file.Path;
+
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Transient;
@@ -31,14 +33,17 @@ public class PlaybookPath extends AnsiblePath {
     /**
      * Standard constructor
      */
-    public PlaybookPath() { }
+    protected PlaybookPath() {
+        // Default constructor for hibernate
+    }
 
     /**
      * Standard constructor
      * @param minionServer the minion server
+     * @param path the path
      */
-    public PlaybookPath(MinionServer minionServer) {
-        super(minionServer);
+    public PlaybookPath(MinionServer minionServer, Path path) {
+        super(minionServer, path);
     }
 
     @Override

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/AnsibleManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/AnsibleManager.java
@@ -164,17 +164,15 @@ public class AnsibleManager extends BaseManager {
         AnsiblePath.Type type = AnsiblePath.Type.fromLabel(typeLabel);
         switch (type) {
             case INVENTORY:
-                ansiblePath = new InventoryPath();
+                ansiblePath = new InventoryPath(minionServer, Path.of(path));
                 break;
             case PLAYBOOK:
-                ansiblePath = new PlaybookPath();
+                ansiblePath = new PlaybookPath(minionServer, Path.of(path));
                 break;
             default:
                 throw new UnsupportedOperationException("Unsupported type " + type);
         }
 
-        ansiblePath.setMinionServer(minionServer);
-        ansiblePath.setPath(Path.of(path));
         ansiblePath = AnsibleFactory.saveAnsiblePath(ansiblePath);
 
         if (type == AnsiblePath.Type.INVENTORY) {

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/AnsibleFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/AnsibleFactoryTest.java
@@ -36,10 +36,8 @@ class AnsibleFactoryTest extends BaseTestCaseWithUser {
         MinionServer minionServer1 = MinionServerFactoryTest.createTestMinionServer(user);
         MinionServer minionServer2 = MinionServerFactoryTest.createTestMinionServer(user);
 
-        AnsiblePath inventoryPath = new InventoryPath(minionServer1);
-        inventoryPath.setPath(Path.of("/tmp/test1"));
-        AnsiblePath playbookPath = new PlaybookPath(minionServer2);
-        playbookPath.setPath(Path.of("/tmp/test2"));
+        AnsiblePath inventoryPath = new InventoryPath(minionServer1, Path.of("/tmp/test1"));
+        AnsiblePath playbookPath = new PlaybookPath(minionServer2, Path.of("/tmp/test2"));
 
         inventoryPath = AnsibleFactory.saveAnsiblePath(inventoryPath);
         playbookPath = AnsibleFactory.saveAnsiblePath(playbookPath);
@@ -62,8 +60,7 @@ class AnsibleFactoryTest extends BaseTestCaseWithUser {
     @Test
     void testRemoveAnsiblePath() {
         MinionServer minionServer1 = MinionServerFactoryTest.createTestMinionServer(user);
-        AnsiblePath inventoryPath = new InventoryPath(minionServer1);
-        inventoryPath.setPath(Path.of("/tmp/test1"));
+        AnsiblePath inventoryPath = new InventoryPath(minionServer1, Path.of("/tmp/test1"));
         inventoryPath = AnsibleFactory.saveAnsiblePath(inventoryPath);
 
         AnsibleFactory.removeAnsiblePath(inventoryPath);

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/AnsibleFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/AnsibleFactoryTest.java
@@ -22,14 +22,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.redhat.rhn.domain.server.ansible.AnsiblePath;
 import com.redhat.rhn.domain.server.ansible.InventoryPath;
 import com.redhat.rhn.domain.server.ansible.PlaybookPath;
-import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
+import com.suse.manager.webui.services.iface.SaltApi;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 
-class AnsibleFactoryTest extends BaseTestCaseWithUser {
+class AnsibleFactoryTest extends JMockBaseTestCaseWithUser {
+
+    private SaltApi saltApi;
+
+    @BeforeEach
+    void setup() {
+        saltApi = context.mock(SaltApi.class);
+    }
 
     @Test
     void testSaveAndFindAnsiblePath() {
@@ -65,6 +80,63 @@ class AnsibleFactoryTest extends BaseTestCaseWithUser {
 
         AnsibleFactory.removeAnsiblePath(inventoryPath);
         assertTrue(AnsibleFactory.lookupAnsiblePathById(inventoryPath.getId()).isEmpty());
+    }
+
+    @Test
+    void correctlyListsAnsibleInventoryServersByControlNode() {
+        MinionServer controlMinion = ServerTestUtils.createAnsibleControlNode(user, saltApi, context);
+
+        MinionServer one = MinionServerFactoryTest.createTestMinionServer(user);
+        MinionServer two = MinionServerFactoryTest.createTestMinionServer(user);
+        MinionServer three = MinionServerFactoryTest.createTestMinionServer(user);
+        MinionServer four = MinionServerFactoryTest.createTestMinionServer(user);
+
+        InventoryPath firstInventory = new InventoryPath(controlMinion, Path.of("/tmp/test/one"), Set.of(one, two));
+        AnsibleFactory.saveAnsiblePath(firstInventory);
+
+        InventoryPath secondInventory = new InventoryPath(controlMinion, Path.of("/tmp/test/two"), Set.of(three, four));
+        AnsibleFactory.saveAnsiblePath(secondInventory);
+
+        TestUtils.flushAndClearSession();
+
+        List<Server> allServers = AnsibleFactory.listAnsibleInventoryServersByControlNode(controlMinion.getId());
+        assertNotNull(allServers);
+        assertEquals(
+            Stream.of(one, two, three, four).sorted(Comparator.comparing(Server::getId)).toList(),
+            allServers.stream().sorted(Comparator.comparing(Server::getId)).toList()
+        );
+    }
+
+    @Test
+    void correctlyListsAnsibleInventoryServersExcludingControlNode() {
+        MinionServer controlOne = ServerTestUtils.createAnsibleControlNode(user, saltApi, context);
+        MinionServer controlTwo = ServerTestUtils.createAnsibleControlNode(user, saltApi, context);
+        MinionServer controlThree = ServerTestUtils.createAnsibleControlNode(user, saltApi, context);
+
+        MinionServer one = MinionServerFactoryTest.createTestMinionServer(user);
+        MinionServer two = MinionServerFactoryTest.createTestMinionServer(user);
+        MinionServer three = MinionServerFactoryTest.createTestMinionServer(user);
+        MinionServer four = MinionServerFactoryTest.createTestMinionServer(user);
+        MinionServer five = MinionServerFactoryTest.createTestMinionServer(user);
+        MinionServer six = MinionServerFactoryTest.createTestMinionServer(user);
+
+        InventoryPath firstInventory = new InventoryPath(controlOne, Path.of("/tmp/test/one"), Set.of(one, two));
+        AnsibleFactory.saveAnsiblePath(firstInventory);
+
+        InventoryPath secondInventory = new InventoryPath(controlTwo, Path.of("/tmp/test/two"), Set.of(three, four));
+        AnsibleFactory.saveAnsiblePath(secondInventory);
+
+        InventoryPath thirdInventory = new InventoryPath(controlThree, Path.of("/tmp/test/three"), Set.of(five, six));
+        AnsibleFactory.saveAnsiblePath(thirdInventory);
+
+        TestUtils.flushAndClearSession();
+
+        List<Server> allServers = AnsibleFactory.listAnsibleInventoryServersExcludingControlNode(controlTwo.getId());
+        assertNotNull(allServers);
+        assertEquals(
+            Stream.of(one, two, five, six).sorted(Comparator.comparing(Server::getId)).toList(),
+            allServers.stream().sorted(Comparator.comparing(Server::getId)).toList()
+        );
     }
 
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/AnsibleFactoryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/AnsibleFactoryTest.java
@@ -29,17 +29,10 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 
-/**
- * Tests for {@link AnsibleFactory}
- */
-public class AnsibleFactoryTest extends BaseTestCaseWithUser {
+class AnsibleFactoryTest extends BaseTestCaseWithUser {
 
-    /**
-     * Test basic save - read cycle of AnsiblePath implementations
-     * @throws Exception
-     */
     @Test
-    public void testSaveAndFindAnsiblePath() throws Exception {
+    void testSaveAndFindAnsiblePath() {
         MinionServer minionServer1 = MinionServerFactoryTest.createTestMinionServer(user);
         MinionServer minionServer2 = MinionServerFactoryTest.createTestMinionServer(user);
 
@@ -66,11 +59,8 @@ public class AnsibleFactoryTest extends BaseTestCaseWithUser {
         assertEquals(inventoryPath, AnsibleFactory.listAnsiblePaths(minionServer1.getId()).iterator().next());
     }
 
-    /**
-     * Test removing AnsiblePath
-     */
     @Test
-    public void testRemoveAnsiblePath() throws Exception {
+    void testRemoveAnsiblePath() {
         MinionServer minionServer1 = MinionServerFactoryTest.createTestMinionServer(user);
         AnsiblePath inventoryPath = new InventoryPath(minionServer1);
         inventoryPath.setPath(Path.of("/tmp/test1"));
@@ -81,7 +71,7 @@ public class AnsibleFactoryTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void generatedCoverageTestLookupAnsibleInventoryPath() {
+    void generatedCoverageTestLookupAnsibleInventoryPath() {
         // this test has been generated programmatically to test AnsibleFactory.lookupAnsibleInventoryPath
         // containing a hibernate query that is not covered by any test so far
         // feel free to modify and/or complete it
@@ -89,7 +79,7 @@ public class AnsibleFactoryTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void generatedCoverageTestListAnsiblePlaybookPaths() {
+    void generatedCoverageTestListAnsiblePlaybookPaths() {
         // this test has been generated programmatically to test AnsibleFactory.listAnsiblePlaybookPaths
         // containing a hibernate query that is not covered by any test so far
         // feel free to modify and/or complete it

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandlerTest.java
@@ -20,8 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.domain.action.Action;
@@ -29,9 +29,6 @@ import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ansible.PlaybookAction;
 import com.redhat.rhn.domain.action.ansible.PlaybookActionDetails;
 import com.redhat.rhn.domain.server.MinionServer;
-import com.redhat.rhn.domain.server.MinionServerFactoryTest;
-import com.redhat.rhn.domain.server.ServerArch;
-import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ansible.AnsiblePath;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.dto.ScheduledAction;
@@ -41,18 +38,13 @@ import com.redhat.rhn.frontend.xmlrpc.InvalidArgsException;
 import com.redhat.rhn.frontend.xmlrpc.ValidationException;
 import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.manager.action.ActionManager;
-import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.AnsibleManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitler;
-import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
-import com.redhat.rhn.testing.TestUtils;
+import com.redhat.rhn.testing.ServerTestUtils;
 
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.salt.netapi.calls.LocalCall;
-import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.utils.Xor;
 
 import org.jmock.Expectations;
@@ -69,7 +61,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @ExtendWith(JUnit5Mockery.class)
-public class AnsibleHandlerTest extends BaseHandlerTestCase {
+class AnsibleHandlerTest extends BaseHandlerTestCase {
 
     private AnsibleHandler handler;
 
@@ -95,12 +87,12 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
     }
 
     @Test
-    public void testSchedulePlaybook() throws Exception {
+    void testSchedulePlaybook() {
         MinionServer controlNode = createAnsibleControlNode(admin);
         int preScheduleSize = ActionManager.recentlyScheduledActions(admin, null, 30).size();
         Date scheduleDate = new Date();
 
-        Long actionId = handler.schedulePlaybook(admin, "/path/to/myplaybook.yml", "/path/to/hosts",
+        Long actionId = handler.schedulePlaybook(admin, "/path/to/my-playbook.yml", "/path/to/hosts",
                 controlNode.getId().intValue(), scheduleDate, null, false);
         assertNotNull(actionId);
 
@@ -116,18 +108,18 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
 
         PlaybookActionDetails details = action.getDetails();
         assertNotNull(details);
-        assertEquals("/path/to/myplaybook.yml", details.getPlaybookPath());
+        assertEquals("/path/to/my-playbook.yml", details.getPlaybookPath());
         assertEquals("/path/to/hosts", details.getInventoryPath());
         assertFalse(details.isTestMode());
     }
 
     @Test
-    public void testSchedulePlaybookTestMode() throws Exception {
+    void testSchedulePlaybookTestMode() {
         MinionServer controlNode = createAnsibleControlNode(admin);
         int preScheduleSize = ActionManager.recentlyScheduledActions(admin, null, 30).size();
         Date scheduleDate = new Date();
 
-        Long actionId = handler.schedulePlaybook(admin, "/path/to/myplaybook.yml", null,
+        Long actionId = handler.schedulePlaybook(admin, "/path/to/my-playbook.yml", null,
                 controlNode.getId().intValue(), scheduleDate, null, true,
                 Map.of(AnsibleHandler.ANSIBLE_FLUSH_CACHE, true, AnsibleHandler.ANSIBLE_EXTRA_VARS, "{test: 123}"));
         assertNotNull(actionId);
@@ -144,7 +136,7 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
 
         PlaybookActionDetails details = action.getDetails();
         assertNotNull(details);
-        assertEquals("/path/to/myplaybook.yml", details.getPlaybookPath());
+        assertEquals("/path/to/my-playbook.yml", details.getPlaybookPath());
         assertEquals("{test: 123}", details.getExtraVarsContents());
         assertNull(details.getInventoryPath());
         assertTrue(details.isTestMode());
@@ -152,7 +144,7 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
     }
 
     @Test
-    public void testCreateAndGetAnsiblePath() throws Exception {
+    void testCreateAndGetAnsiblePath() {
         MinionServer controlNode = createAnsibleControlNode(admin);
 
         AnsiblePath inventoryPath = handler.createAnsiblePath(
@@ -185,18 +177,12 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
     }
 
     @Test
-    public void testCreateInvalidAnsiblePath() {
-        try {
-            handler.createAnsiblePath(admin, Map.of());
-            fail("An exception shold have been thrown");
-        }
-        catch (ValidationException e) {
-            // expected
-        }
+    void testCreateInvalidAnsiblePath() {
+        assertThrows(ValidationException.class, () -> handler.createAnsiblePath(admin, Map.of()));
     }
 
     @Test
-    public void testUpdateAnsiblePath() throws Exception {
+    void testUpdateAnsiblePath() {
         MinionServer controlNode = createAnsibleControlNode(admin);
 
         AnsiblePath inventoryPath = handler.createAnsiblePath(
@@ -213,7 +199,7 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
     }
 
     @Test
-    public void testUpdateInvalidAnsiblePath() throws Exception {
+    void testUpdateInvalidAnsiblePath() {
         MinionServer controlNode = createAnsibleControlNode(admin);
 
         AnsiblePath inventoryPath = handler.createAnsiblePath(
@@ -224,17 +210,13 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
                         "path", "/etc/ansible/test"
                 ));
 
-        try {
-            handler.updateAnsiblePath(admin, inventoryPath.getId().intValue(), Map.of("my-path", "/tmp/new-location"));
-            fail("An exception shold have been thrown");
-        }
-        catch (ValidationException e) {
-            // expected
-        }
+        int pathId = inventoryPath.getId().intValue();
+        Map<String, Object> props = Map.of("my-path", "/tmp/new-location");
+        assertThrows(ValidationException.class, () -> handler.updateAnsiblePath(admin, pathId, props));
     }
 
     @Test
-    public void testRemoveAnsiblePath() throws Exception {
+    void testRemoveAnsiblePath() {
         MinionServer controlNode = createAnsibleControlNode(admin);
 
         AnsiblePath inventoryPath = handler.createAnsiblePath(
@@ -247,40 +229,25 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
 
         int result = handler.removeAnsiblePath(admin, inventoryPath.getId().intValue());
         assertEquals(1, result);
-        try {
-            handler.lookupAnsiblePathById(admin, inventoryPath.getId().intValue());
-            fail("An exception shold have been thrown");
-        }
-        catch (EntityNotExistsFaultException e) {
-            //expected
-        }
+
+        int pathId = inventoryPath.getId().intValue();
+        assertThrows(EntityNotExistsFaultException.class, () -> handler.lookupAnsiblePathById(admin, pathId));
     }
 
     @Test
-    public void testRemoveInvalidAnsiblePath() {
-        try {
-            handler.lookupAnsiblePathById(admin, -1234);
-            fail("An exception shold have been thrown");
-        }
-        catch (EntityNotExistsFaultException e) {
-            //expected
-        }
+    void testRemoveInvalidAnsiblePath() {
+        assertThrows(EntityNotExistsFaultException.class, () -> handler.lookupAnsiblePathById(admin, -1234));
     }
 
     @Test
-    public void testFetchPlaybookContentsInvalidPath() throws Exception {
+    void testFetchPlaybookContentsInvalidPath() {
         createAnsibleControlNode(admin);
-        try {
-            handler.fetchPlaybookContents(admin, -123, "tmp/123");
-            fail("An exception shold have been thrown");
-        }
-        catch (EntityNotExistsFaultException e) {
-            // expected
-        }
+
+        assertThrows(EntityNotExistsFaultException.class, () -> handler.fetchPlaybookContents(admin, -123, "tmp/123"));
     }
 
     @Test
-    public void testFetchPlaybookContentsInvalidRelPath() throws Exception {
+    void testFetchPlaybookContentsInvalidRelPath() {
         MinionServer controlNode = createAnsibleControlNode(admin);
         AnsiblePath playbookPath = handler.createAnsiblePath(
                 admin,
@@ -289,18 +256,14 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
                         "server_id", controlNode.getId().intValue(),
                         "path", "/etc/playbooks"
                 ));
-        try {
-            // try with absolute path
-            handler.fetchPlaybookContents(admin, playbookPath.getId().intValue(), "/tmp/123");
-            fail("An exception shold have been thrown");
-        }
-        catch (InvalidArgsException e) {
-            // expected
-        }
+
+        int pathId = playbookPath.getId().intValue();
+        assertThrows(InvalidArgsException.class,
+            () -> handler.fetchPlaybookContents(admin, pathId, "/tmp/123"));
     }
 
     @Test
-    public void testFetchPlaybookContents() throws Exception {
+    void testFetchPlaybookContents() {
         MinionServer controlNode = createAnsibleControlNode(admin);
         AnsiblePath playbookPath = handler.createAnsiblePath(
                 admin,
@@ -319,33 +282,24 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
                 handler.fetchPlaybookContents(admin, playbookPath.getId().intValue(), "tmp/123"));
     }
 
-    private MinionServer createAnsibleControlNode(User user) throws Exception {
-        SystemEntitlementManager entitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(saltApi), new SystemEntitler(saltApi)
-        );
-
-        context.checking(new Expectations() {{
-            allowing(saltApi).refreshPillar(with(any(MinionList.class)));
-        }});
-
-        MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
-        ServerArch a = ServerFactory.lookupServerArchByName("x86_64");
-        server.setServerArch(a);
-        server = TestUtils.saveAndFlush(server);
-        entitlementManager.addEntitlementToServer(server, EntitlementManager.ANSIBLE_CONTROL_NODE);
-        return server;
+    private MinionServer createAnsibleControlNode(User user) {
+        return ServerTestUtils.createAnsibleControlNode(user, saltApi, context);
     }
 
-    private TaskomaticApi getTaskomaticApi() throws TaskomaticApiException {
-        if (taskomaticApi == null) {
-            taskomaticApi = context.mock(TaskomaticApi.class);
-            context.checking(new Expectations() {
-                {
-                    allowing(taskomaticApi)
-                            .scheduleActionExecution(with(any(Action.class)));
-                }
-            });
+    private TaskomaticApi getTaskomaticApi() {
+        if (taskomaticApi != null) {
+            return taskomaticApi;
         }
+
+        taskomaticApi = context.mock(TaskomaticApi.class);
+        context.checking(new Expectations() {{
+            try {
+                allowing(taskomaticApi).scheduleActionExecution(with(any(Action.class)));
+            }
+            catch (TaskomaticApiException e) {
+                throw new IllegalStateException("Unable to mock taskomatic api", e);
+            }
+        }});
 
         return taskomaticApi;
     }

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/AnsibleManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/AnsibleManagerTest.java
@@ -16,29 +16,23 @@
 package com.redhat.rhn.manager.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactoryTest;
-import com.redhat.rhn.domain.server.ServerArch;
-import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ansible.AnsiblePath;
 import com.redhat.rhn.domain.server.ansible.InventoryPath;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitler;
-import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.utils.salt.custom.AnsiblePlaybookSlsResult;
 import com.suse.salt.netapi.calls.LocalCall;
-import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.utils.Xor;
 
 import org.jmock.Expectations;
@@ -56,7 +50,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @ExtendWith(JUnit5Mockery.class)
-public class AnsibleManagerTest extends BaseTestCaseWithUser {
+class AnsibleManagerTest extends BaseTestCaseWithUser {
 
     private SaltApi saltApi;
     private AnsibleManager ansibleManager;
@@ -74,13 +68,8 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
         ansibleManager = new AnsibleManager(saltApi);
     }
 
-    /**
-     * Test saving and looking up {@link AnsiblePath} by given user
-     *
-     * @throws Exception
-     */
     @Test
-    public void testSaveAndLookupAnsiblePath() throws Exception {
+    void testSaveAndLookupAnsiblePath() {
         MinionServer minion = createAnsibleControlNode(user);
         AnsiblePath path = new InventoryPath(minion);
         path.setPath(Path.of("/tmp/test1"));
@@ -91,68 +80,33 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
         assertEquals(path, AnsibleManager.lookupAnsiblePathById(path.getId(), user).get());
     }
 
-    /**
-     * Test saving, listing and looking up {@link AnsiblePath} by an unauthorized user
-     *
-     * @throws Exception
-     */
     @Test
-    public void testSaveAndLookupAnsiblePathNoPerms() throws Exception {
+    void testSaveAndLookupAnsiblePathNoPerms() {
         User chuck = UserTestUtils.createUser(this);
 
         MinionServer minion = createAnsibleControlNode(user);
-        AnsiblePath path = new InventoryPath(minion);
-        path.setPath(Path.of("/tmp/test1"));
+        Long minionId = minion.getId();
 
-        try {
-            ansibleManager.createAnsiblePath("inventory", minion.getId(), "/tmp/test", chuck);
-            fail("An exception should have been thrown.");
-        }
-        catch (LookupException e) {
-            // expected
-        }
+        assertThrows(LookupException.class,
+            () -> ansibleManager.createAnsiblePath("inventory", minionId, "/tmp/test", chuck));
 
         // now save with allowed user
-        path = ansibleManager.createAnsiblePath("inventory", minion.getId(), "/tmp/test", user);
+        AnsiblePath path = ansibleManager.createAnsiblePath("inventory", minionId, "/tmp/test", user);
 
-        try {
-            AnsibleManager.lookupAnsiblePathById(path.getId(), chuck);
-            fail("An exception should have been thrown.");
-        }
-        catch (LookupException e) {
-            // expected
-        }
+        long pathId = path.getId();
+        assertThrows(LookupException.class,
+            () -> AnsibleManager.lookupAnsiblePathById(pathId, chuck));
 
-        try {
-            AnsibleManager.listAnsiblePaths(minion.getId(), chuck);
-            fail("An exception should have been thrown.");
-        }
-        catch (LookupException e) {
-            // expected
-        }
+        assertThrows(LookupException.class, () -> AnsibleManager.listAnsiblePaths(minionId, chuck));
     }
 
-    /**
-     * Test updating non existing ansible path
-     */
     @Test
-    public void testUpdateNonExistingAnsiblePath() {
-        try {
-            ansibleManager.updateAnsiblePath(-12345, "/tmp/test", user);
-            fail("An exception should have been thrown.");
-        }
-        catch (LookupException e) {
-            // expected
-        }
+    void testUpdateNonExistingAnsiblePath() {
+        assertThrows(LookupException.class, () -> ansibleManager.updateAnsiblePath(-12345, "/tmp/test", user));
     }
 
-    /**
-     * Test updating an existing ansible path
-     *
-     * @throws Exception
-     */
     @Test
-    public void testUpdateAnsiblePath() throws Exception {
+    void testUpdateAnsiblePath() {
         MinionServer minion = createAnsibleControlNode(user);
         AnsiblePath path = ansibleManager.createAnsiblePath("inventory", minion.getId(), "/tmp/test", user);
         path = ansibleManager.updateAnsiblePath(path.getId(), "/tmp/test-updated", user);
@@ -163,89 +117,56 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void testCreateAnsiblePathNormalSystem() throws Exception {
+    void testCreateAnsiblePathNormalSystem() {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        Long minionId = minion.getId();
 
-        try {
-            ansibleManager.createAnsiblePath("inventory", minion.getId(), "/tmp/test", user);
-            fail("An exception should have been thrown.");
-        }
-        catch (LookupException e) {
-            // expected
-        }
+        assertThrows(LookupException.class,
+            () -> ansibleManager.createAnsiblePath("inventory", minionId, "/tmp/test", user));
     }
 
-    /**
-     * Tests creating an {@link AnsiblePath} with a relative path. This is forbidden.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testSaveAnsibleRelativePath() throws Exception {
+    void testSaveAnsibleRelativePath() {
         MinionServer minion = createAnsibleControlNode(user);
-        try {
-            ansibleManager.createAnsiblePath("inventory", minion.getId(), "relative/path", user);
-            fail("An exception should have been thrown.");
-        }
-        catch (ValidatorException e) {
-            // expected
-        }
+        Long minionId = minion.getId();
+
+        assertThrows(ValidatorException.class,
+            () -> ansibleManager.createAnsiblePath("inventory", minionId, "relative/path", user));
     }
 
-    /**
-     * Tests fetching non existing playbook path
-     */
     @Test
-    public void testFetchPlaybookInvalidPath() {
-        try {
-            ansibleManager.fetchPlaybookContents(-1234, "path/to/playbook", user);
-            fail("An exception should have been thrown.");
-        }
-        catch (LookupException e) {
-            // expected
-        }
+    void testFetchPlaybookInvalidPath() {
+        assertThrows(LookupException.class,
+            () -> ansibleManager.fetchPlaybookContents(-1234, "path/to/playbook", user));
     }
 
-    /**
-     * Tests fetching playbook path using an absolute path
-     */
     @Test
-    public void testFetchPlaybookAbsolutePath() throws Exception {
+    void testFetchPlaybookAbsolutePath() {
         MinionServer controlNode = createAnsibleControlNode(user);
         AnsiblePath path = ansibleManager.createAnsiblePath("playbook", controlNode.getId(), "/root/playbooks", user);
+        Long pathId = path.getId();
 
-        try {
-            ansibleManager.fetchPlaybookContents(path.getId(), "/absolute", user);
-            fail("An exception should have been thrown.");
-        }
-        catch (IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(IllegalArgumentException.class,
+            () -> ansibleManager.fetchPlaybookContents(pathId, "/absolute", user));
     }
 
-    /**
-     * Tests fetching playbook contents
-     */
     @Test
-    public void testFetchPlaybook() throws Exception {
+    void testFetchPlaybook() {
         MinionServer controlNode = createAnsibleControlNode(user);
         AnsiblePath path = ansibleManager.createAnsiblePath("playbook", controlNode.getId(), "/root/playbooks", user);
 
         context.checking(new Expectations() {{
             allowing(saltApi).callSync(with(any(LocalCall.class)), with(controlNode.getMinionId()));
-            will(returnValue(Optional.of(Xor.right("suchplaybookwow"))));
+            will(returnValue(Optional.of(Xor.right("such-playbook-wow"))));
         }});
 
         assertEquals(
-                Optional.of("suchplaybookwow"),
+                Optional.of("such-playbook-wow"),
                 ansibleManager.fetchPlaybookContents(path.getId(), "site.yml", user));
     }
 
-    /**
-     * Tests fetching playbook contents
-     */
     @Test
-    public void testFetchPlaybookSaltNoResult() throws Exception {
+    void testFetchPlaybookSaltNoResult() {
         MinionServer controlNode = createAnsibleControlNode(user);
         AnsiblePath path = ansibleManager.createAnsiblePath("playbook", controlNode.getId(), "/root/playbooks", user);
 
@@ -254,80 +175,73 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
             will(returnValue(Optional.of(Xor.left(false))));
         }});
 
-        try {
-            ansibleManager.fetchPlaybookContents(path.getId(), "site.yml", user);
-            fail("An exception should have been thrown.");
-        }
-        catch (IllegalStateException e) {
-            assertEquals("no result", e.getMessage());
-        }
+        Long pathId = path.getId();
+
+        var ex = assertThrows(IllegalStateException.class,
+            () -> ansibleManager.fetchPlaybookContents(pathId, "site.yml", user));
+        assertEquals("no result", ex.getMessage());
     }
 
-    /**
-     * Test scheduling playbook with an empty path
-     *
-     * @throws Exception
-     */
     @Test
-    public void testSchedulePlaybookBlankPath() throws Exception {
+    void testSchedulePlaybookBlankPath() {
         MinionServer minion = createAnsibleControlNode(user);
-        try {
-            AnsibleManager.schedulePlaybook("   ", "/etc/ansible/hosts", minion.getId(), false, false, "", new Date(),
-                    Optional.empty(), user);
-            fail("An exception should have been thrown.");
-        }
-        catch (IllegalArgumentException e) {
-            // expected
-        }
+
+        Long minionId = minion.getId();
+        Optional<String> actionChainLabel = Optional.empty();
+        Date earliestDate = new Date();
+
+        assertThrows(IllegalArgumentException.class, () -> AnsibleManager.schedulePlaybook(
+            "   ",
+            "/etc/ansible/hosts",
+            minionId,
+            false,
+            false,
+            "",
+            earliestDate,
+            actionChainLabel,
+            user
+        ));
     }
 
-    /**
-     * Test scheduling playbook on an non-existing minion
-     *
-     * @throws Exception
-     */
+
     @Test
-    public void testSchedulePlaybookNonexistingMinion() throws Exception {
-        try {
-            AnsibleManager.schedulePlaybook("/test/site.yml", "/etc/ansible/hosts", -1234, false, false, "", new Date(),
-                    Optional.empty(), user);
-            fail("An exception should have been thrown.");
-        }
-        catch (LookupException e) {
-            // expected
-        }
+    void testSchedulePlaybookNonexistingMinion() {
+        Optional<String> actionChainLabel = Optional.empty();
+        Date earliestDate = new Date();
+
+        assertThrows(LookupException.class, () -> AnsibleManager.schedulePlaybook(
+            "/test/site.yml",
+            "/etc/ansible/hosts",
+            -1234,
+            false,
+            false,
+            "",
+            earliestDate,
+            actionChainLabel,
+            user
+        ));
     }
 
-    /**
-     * Test discover playbooks
-     *
-     * @throws Exception
-     */
     @Test
-    public void testDiscoverPlaybooks() throws Exception {
+    void testDiscoverPlaybooks() {
         MinionServer controlNode = createAnsibleControlNode(user);
         AnsiblePath playbookPath = ansibleManager.createAnsiblePath("playbook", controlNode.getId(), "/tmp/test", user);
 
-        Map<String, Map<String, AnsiblePlaybookSlsResult>> expected = Map.of("/tmp/test", Map.of("site.yml",
-                new AnsiblePlaybookSlsResult("/tmp/test/site.yml", "/tmp/test/hosts")));
+        var expected = Map.of(
+            "/tmp/test", Map.of("site.yml", new AnsiblePlaybookSlsResult("/tmp/test/site.yml", "/tmp/test/hosts"))
+        );
 
         context.checking(new Expectations() {{
             allowing(saltApi).callSync(with(any(LocalCall.class)), with(controlNode.getMinionId()));
             will(returnValue(Optional.of(Xor.right(expected))));
         }});
 
-        Optional<Map<String, Map<String, AnsiblePlaybookSlsResult>>> result =
-                ansibleManager.discoverPlaybooks(playbookPath.getId(), user);
+        var result = ansibleManager.discoverPlaybooks(playbookPath.getId(), user);
         assertEquals(Optional.of(expected), result);
     }
 
-    /**
-     * Test discover playbooks
-     *
-     * @throws Exception
-     */
     @Test
-    public void testDiscoverPlaybooksSaltError() throws Exception {
+    void testDiscoverPlaybooksSaltError() {
         MinionServer controlNode = createAnsibleControlNode(user);
         AnsiblePath playbookPath = ansibleManager.createAnsiblePath("playbook", controlNode.getId(), "/tmp/test", user);
 
@@ -336,76 +250,48 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
             will(returnValue(Optional.of(Xor.left("error"))));
         }});
 
-        try {
-            ansibleManager.discoverPlaybooks(playbookPath.getId(), user);
-            fail("An exception should have been thrown.");
-        }
-        catch (IllegalStateException e) {
-            assertEquals("error", e.getMessage());
-        }
+
+        Long pathId = playbookPath.getId();
+        var ex = assertThrows(IllegalStateException.class, () -> ansibleManager.discoverPlaybooks(pathId, user));
+        assertEquals("error", ex.getMessage());
     }
 
-    /**
-     * Test discover playbooks in an non-existing path
-     *
-     */
     @Test
-    public void testDiscoverPlaybooksNonExistingPath() {
-        try {
-            ansibleManager.discoverPlaybooks(-1234, user);
-            fail("An exception should have been thrown.");
-        }
-        catch (LookupException e) {
-            // expected
-        }
+    void testDiscoverPlaybooksNonExistingPath() {
+        assertThrows(LookupException.class, () -> ansibleManager.discoverPlaybooks(-1234, user));
     }
 
-    /**
-     * Test discover playbooks in an inventory path
-     *
-     * @throws Exception
-     */
     @Test
-    public void testDiscoverPlaybooksInInventory() throws Exception {
-        MinionServer controlNode = createAnsibleControlNode(user);
-        AnsiblePath inventoryPath = ansibleManager.createAnsiblePath(
-                "inventory", controlNode.getId(), "/tmp/test/hosts", user);
-        try {
-            ansibleManager.discoverPlaybooks(inventoryPath.getId(), user);
-            fail("An exception should have been thrown.");
-        }
-        catch (IllegalArgumentException e) {
-            // expected
-        }
-    }
-
-    /**
-     * Test introspect inventory
-     */
-    @Test
-    public void testIntrospectInventory() throws Exception {
+    void testDiscoverPlaybooksInInventory() {
         MinionServer controlNode = createAnsibleControlNode(user);
         AnsiblePath inventoryPath = ansibleManager.createAnsiblePath(
                 "inventory", controlNode.getId(), "/tmp/test/hosts", user);
 
-        Map<String, Map<String, Map<String, List<String>>>> expected =
-                Map.of("minion",  Map.of("all", Map.of("children", List.of("host1", "host2"))));
+        Long pathId = inventoryPath.getId();
+        assertThrows(IllegalArgumentException.class, () -> ansibleManager.discoverPlaybooks(pathId, user));
+    }
+
+    @Test
+    void testIntrospectInventory() {
+        MinionServer controlNode = createAnsibleControlNode(user);
+        AnsiblePath inventoryPath = ansibleManager.createAnsiblePath(
+                "inventory", controlNode.getId(), "/tmp/test/hosts", user);
+
+        var expected = Map.of(
+            "minion",  Map.of("all", Map.of("children", List.of("host1", "host2")))
+        );
 
         context.checking(new Expectations() {{
             allowing(saltApi).callSync(with(any(LocalCall.class)), with(controlNode.getMinionId()));
             will(returnValue(Optional.of(Xor.right(expected))));
         }});
 
-        Optional<Map<String, Map<String, Object>>> result =
-                ansibleManager.introspectInventory(inventoryPath.getId(), user);
+        var result = ansibleManager.introspectInventory(inventoryPath.getId(), user);
         assertEquals(Optional.of(expected), result);
     }
 
-    /**
-     * Test introspect inventory
-     */
     @Test
-    public void testIntrospectInventorySaltError() throws Exception {
+    void testIntrospectInventorySaltError() {
         MinionServer controlNode = createAnsibleControlNode(user);
         AnsiblePath inventoryPath = ansibleManager.createAnsiblePath(
                 "inventory", controlNode.getId(), "/tmp/test/hosts", user);
@@ -415,27 +301,15 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
             will(returnValue(Optional.of(Xor.left("error desc"))));
         }});
 
-        try {
-            ansibleManager.introspectInventory(inventoryPath.getId(), user);
-            fail("An exception should have been thrown.");
-        }
-        catch (IllegalStateException e) {
-            assertEquals("error desc", e.getMessage());
-        }
+        Long pathId = inventoryPath.getId();
+        var ex = assertThrows(IllegalStateException.class,
+            () -> ansibleManager.introspectInventory(pathId, user));
+        assertEquals("error desc", ex.getMessage());
     }
 
-    /**
-     * Test introspecting inventory in an non-existing path
-     */
     @Test
-    public void testIntrospectInventoryNonExistingPath() {
-        try {
-            ansibleManager.introspectInventory(-1234, user);
-            fail("An exception should have been thrown.");
-        }
-        catch (LookupException e) {
-            // expected
-        }
+    void testIntrospectInventoryNonExistingPath() {
+        assertThrows(LookupException.class, () -> ansibleManager.introspectInventory(-1234, user));
     }
 
     /**
@@ -444,32 +318,15 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
      * @throws Exception
      */
     @Test
-    public void testIntrospectInventoryInPlaybook() throws Exception {
+    void testIntrospectInventoryInPlaybook() {
         MinionServer controlNode = createAnsibleControlNode(user);
         AnsiblePath playbookPath = ansibleManager.createAnsiblePath("playbook", controlNode.getId(), "/tmp/test", user);
-        try {
-            ansibleManager.introspectInventory(playbookPath.getId(), user);
-            fail("An exception should have been thrown.");
-        }
-        catch (IllegalArgumentException e) {
-            // expected
-        }
+
+        Long pathId = playbookPath.getId();
+        assertThrows(IllegalArgumentException.class, () -> ansibleManager.introspectInventory(pathId, user));
     }
 
-    private MinionServer createAnsibleControlNode(User user) throws Exception {
-        SystemEntitlementManager entitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(saltApi), new SystemEntitler(saltApi)
-        );
-
-        context.checking(new Expectations() {{
-            allowing(saltApi).refreshPillar(with(any(MinionList.class)));
-        }});
-
-        MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
-        ServerArch a = ServerFactory.lookupServerArchByName("x86_64");
-        server.setServerArch(a);
-        server = TestUtils.saveAndFlush(server);
-        entitlementManager.addEntitlementToServer(server, EntitlementManager.ANSIBLE_CONTROL_NODE);
-        return server;
+    private MinionServer createAnsibleControlNode(User user) {
+        return ServerTestUtils.createAnsibleControlNode(user, saltApi, context);
     }
 }

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/AnsibleManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/AnsibleManagerTest.java
@@ -23,7 +23,6 @@ import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.ansible.AnsiblePath;
-import com.redhat.rhn.domain.server.ansible.InventoryPath;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
@@ -43,7 +42,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -71,9 +69,7 @@ class AnsibleManagerTest extends BaseTestCaseWithUser {
     @Test
     void testSaveAndLookupAnsiblePath() {
         MinionServer minion = createAnsibleControlNode(user);
-        AnsiblePath path = new InventoryPath(minion);
-        path.setPath(Path.of("/tmp/test1"));
-        path = ansibleManager.createAnsiblePath("inventory", minion.getId(), "/tmp/test", user);
+        AnsiblePath path = ansibleManager.createAnsiblePath("inventory", minion.getId(), "/tmp/test", user);
 
         TestUtils.flushSession();
         TestUtils.evict(path);

--- a/java/core/src/test/java/com/redhat/rhn/testing/ServerTestUtils.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/ServerTestUtils.java
@@ -32,8 +32,10 @@ import com.redhat.rhn.domain.rhnset.RhnSet;
 import com.redhat.rhn.domain.rhnset.SetCleanup;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.InstalledPackage;
+import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerArch;
 import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerFactoryTest;
@@ -48,8 +50,15 @@ import com.redhat.rhn.manager.rhnpackage.PackageManager;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.rhnset.RhnSetManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
+
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.salt.netapi.datatypes.target.MinionList;
 
 import org.hibernate.Session;
+import org.jmock.Expectations;
+import org.jmock.junit5.JUnit5Mockery;
 
 import java.util.Set;
 
@@ -321,5 +330,29 @@ public class ServerTestUtils {
                 EntitlementManager.getByName("foreign_entitled"));
         ServerFactory.save(existingHost);
         return existingHost;
+    }
+
+    /**
+     * Create an ansible control node server
+     * @param user the user to own the server
+     * @param saltApi the salt api mock to use for the entitlement manager
+     * @param context the jmock context to set expectations on the salt api mock
+     * @return an ansible control node server
+     */
+    public static MinionServer createAnsibleControlNode(User user, SaltApi saltApi, JUnit5Mockery context) {
+        SystemEntitlementManager entitlementManager = new SystemEntitlementManager(
+                new SystemUnentitler(saltApi), new SystemEntitler(saltApi)
+        );
+
+        context.checking(new Expectations() {{
+            allowing(saltApi).refreshPillar(with(any(MinionList.class)));
+        }});
+
+        MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
+        ServerArch arch = ServerFactory.lookupServerArchByName("x86_64");
+        server.setServerArch(arch);
+        server = TestUtils.saveAndFlush(server);
+        entitlementManager.addEntitlementToServer(server, EntitlementManager.ANSIBLE_CONTROL_NODE);
+        return server;
     }
 }

--- a/java/spacewalk-java.changes.mackdk.fix-removal-ansible-controller-node
+++ b/java/spacewalk-java.changes.mackdk.fix-removal-ansible-controller-node
@@ -1,0 +1,2 @@
+- Fix queries to list servers in an Ansible control node server
+  (bsc#1267964)


### PR DESCRIPTION
## What does this PR change?

Currently attempting to remove a system which has the "Ansible Control Node" fails due to an query error. This PR fixes the issue by replacing the native queries (which do not extract the fields needed for `MinionServer`) with a normal Hibernate query, so that Hibernate itself can take care of extracting everything needed to properly populate the objects.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bugfix

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30933

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
