### PR TITLE
Filter errata relevant to selected systems in system_applyerrata (bsc#1267261)

### DIFF
--- a/spacecmd/spacecmd.changes.mczernek.applyerrata-1267261
+++ b/spacecmd/spacecmd.changes.mczernek.applyerrata-1267261
@@ -1,0 +1,2 @@
+- Pre-filter errata in system_applyerrata to avoid using
+  API calls for all existing errata (bsc#1267261)

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -116,7 +116,7 @@ def print_package_comparison(self, results):
 def manipulate_child_channels(self, args, remove=False):
     arg_parser = get_argument_parser()
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
         if remove:
@@ -210,14 +210,10 @@ def do_system_list(self, args, doreturn=False):
 
 def help_system_reboot(self):
     print(_("system_reboot: Reboot a system"))
-    print(
-        _(
-            """usage: system_reboot <SYSTEMS> [options])
+    print(_("""usage: system_reboot <SYSTEMS> [options])
 
 options:
-  -s START_TIME"""
-        )
-    )
+  -s START_TIME"""))
 
     print("")
     print(self.HELP_SYSTEM_OPTS)
@@ -233,7 +229,7 @@ def do_system_reboot(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument("-s", "--start-time")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_reboot()
@@ -301,7 +297,7 @@ def do_system_search(self, args, doreturn=False):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1:
         self.help_system_search()
@@ -311,7 +307,7 @@ def do_system_search(self, args, doreturn=False):
 
     if re.search(":", query):
         try:
-            (field, value) = query.split(":")
+            field, value = query.split(":")
         except ValueError:
             logging.error(_N("Invalid query"))
             return []
@@ -385,9 +381,7 @@ def do_system_search(self, args, doreturn=False):
 def help_system_runscript(self):
     print(_("system_runscript: Schedule a script to run on the list of"))
     print(_("                  systems provided"))
-    print(
-        _(
-            """usage: system_runscript <SYSTEMS> [options])
+    print(_("""usage: system_runscript <SYSTEMS> [options])
 
 options:
   -u USER
@@ -395,9 +389,7 @@ options:
   -t TIMEOUT
   -s START_TIME
   -l LABEL
-  -f FILE"""
-        )
-    )
+  -f FILE"""))
     print("")
     print(self.HELP_SYSTEM_OPTS)
     print("")
@@ -417,7 +409,7 @@ def do_system_runscript(self, args):  # pylint: disable=too-many-return-statemen
     arg_parser.add_argument("-l", "--label")
     arg_parser.add_argument("-f", "--file")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_runscript()
@@ -469,7 +461,7 @@ def do_system_runscript(self, args):  # pylint: disable=too-many-return-statemen
             script_contents = read_file(os.path.abspath(options.file))
         else:
             # have the user write their script
-            (script_contents, options.file) = editor("#!/bin/bash")
+            script_contents, options.file = editor("#!/bin/bash")
             keep_script_file = False
 
         if not script_contents:
@@ -606,7 +598,7 @@ def complete_system_listhardware(self, text, line, beg, end):
 def do_system_listhardware(self, args):
     arg_parser = get_argument_parser()
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listhardware()
@@ -734,14 +726,10 @@ def do_system_listhardware(self, args):
 
 def help_system_installpackage(self):
     print(_("system_installpackage: Install a package on a system"))
-    print(
-        _(
-            """usage: system_installpackage <SYSTEMS> <PACKAGE ...> [options])
+    print(_("""usage: system_installpackage <SYSTEMS> <PACKAGE ...> [options])
 
 options:
-    -s START_TIME"""
-        )
-    )
+    -s START_TIME"""))
 
     print("")
     print(self.HELP_SYSTEM_OPTS)
@@ -764,7 +752,7 @@ def do_system_installpackage(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument("-s", "--start-time")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
         self.help_system_installpackage()
@@ -903,14 +891,10 @@ def do_system_installpackage(self, args):
 
 def help_system_removepackage(self):
     print(_("system_removepackage: Remove a package from a system"))
-    print(
-        _(
-            """usage: system_removepackage <SYSTEMS> <PACKAGE ...> [options])
+    print(_("""usage: system_removepackage <SYSTEMS> <PACKAGE ...> [options])
 
 options:
-    -s START_TIME"""
-        )
-    )
+    -s START_TIME"""))
 
     print("")
     print(self.HELP_SYSTEM_OPTS)
@@ -933,7 +917,7 @@ def do_system_removepackage(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument("-s", "--start-time")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
         self.help_system_removepackage()
@@ -1042,14 +1026,10 @@ def do_system_removepackage(self, args):
 
 def help_system_upgradepackage(self):
     print(_("system_upgradepackage: Upgrade a package on a system"))
-    print(
-        _(
-            """usage: system_upgradepackage <SYSTEMS> <PACKAGE ...>|* [options]')
+    print(_("""usage: system_upgradepackage <SYSTEMS> <PACKAGE ...>|* [options]')
 
 options:
-    -s START_TIME"""
-        )
-    )
+    -s START_TIME"""))
 
     print("")
     print(self.HELP_SYSTEM_OPTS)
@@ -1076,7 +1056,7 @@ def do_system_upgradepackage(self, args):
     # self.do_system_installpackage anyway
     orig_args = args
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
         self.help_system_upgradepackage()
@@ -1225,7 +1205,7 @@ def do_system_listupgrades(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listupgrades()
@@ -1303,7 +1283,7 @@ def do_system_listinstalledpackages(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listinstalledpackages()
@@ -1359,7 +1339,7 @@ def do_system_listconfigchannels(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listconfigchannels()
@@ -1439,16 +1419,12 @@ def print_configfiles(self, quiet, filelist):
 
 def help_system_listconfigfiles(self):
     print(_("system_listconfigfiles: List the managed config files of a system"))
-    print(
-        _(
-            """usage: system_listconfigfiles <SYSTEMS>')
+    print(_("""usage: system_listconfigfiles <SYSTEMS>')
 options:
   -s/--sandbox : list only system-sandbox files
   -l/--local   : list only locally managed files
   -c/--central : list only centrally managed files
-  -q/--quiet   : quiet mode (omits the header)"""
-        )
-    )
+  -q/--quiet   : quiet mode (omits the header)"""))
     print("")
     print(self.HELP_SYSTEM_OPTS)
 
@@ -1464,7 +1440,7 @@ def do_system_listconfigfiles(self, args):
     arg_parser.add_argument("-c", "--central", action="store_true")
     arg_parser.add_argument("-q", "--quiet", action="store_true")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if not options.sandbox and not options.local and not options.central:
         logging.debug("No sandbox/local/central option specified, listing ALL")
@@ -1546,9 +1522,7 @@ def help_system_addconfigfile(self):
     print(_("system_addconfigfile: Create a configuration file"))
     print(_("Note this is only for system sandbox or locally-managed files"))
     print(_("Centrally managed files should be created via configchannel_addfile"))
-    print(
-        _(
-            """usage: system_addconfigfile [SYSTEM] [options]
+    print(_("""usage: system_addconfigfile [SYSTEM] [options]
 
 options:
   -S/--sandbox : list only system-sandbox files
@@ -1569,9 +1543,7 @@ options:
   newlines, those containing ASCII escape characters (or other charaters not
   allowed in XML) need to be sent as binary (-b).  Some effort is made to auto-
   detect files which require this, but you may need to explicitly specify.
-"""
-        )
-    )
+"""))
 
 
 def complete_system_addconfigfile(self, text, line, beg, end):
@@ -1594,7 +1566,7 @@ def do_system_addconfigfile(self, args, update_path=""):
     arg_parser.add_argument("-b", "--binary", action="store_true")
     arg_parser.add_argument("-d", "--directory", action="store_true")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     file_info = None
 
@@ -1692,15 +1664,11 @@ def do_system_addconfigfile(self, args, update_path=""):
 
 def help_system_addconfigchannels(self):
     print(_("system_addconfigchannels: Add config channels to a system"))
-    print(
-        _(
-            """usage: system_addconfigchannels <SYSTEMS> <CHANNEL ...> [options]
+    print(_("""usage: system_addconfigchannels <SYSTEMS> <CHANNEL ...> [options]
 
 options:
   -t add channels to the top of the list
-  -b add channels to the bottom of the list"""
-        )
-    )
+  -b add channels to the bottom of the list"""))
     print("")
     print(self.HELP_SYSTEM_OPTS)
 
@@ -1721,7 +1689,7 @@ def do_system_addconfigchannels(self, args):
     arg_parser.add_argument("-t", "--top", action="store_true")
     arg_parser.add_argument("-b", "--bottom", action="store_true")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
         self.help_system_addconfigchannels()
@@ -1786,7 +1754,7 @@ def do_system_removeconfigchannels(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
         self.help_system_removeconfigchannels()
@@ -1834,7 +1802,7 @@ def do_system_setconfigchannelorder(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_setconfigchannelorder()
@@ -1883,14 +1851,10 @@ def do_system_setconfigchannelorder(self, args):
 
 def help_system_deployconfigfiles(self):
     print(_("system_deployconfigfiles: Deploy all configuration files for a system"))
-    print(
-        _(
-            """usage: system_deployconfigfiles <SYSTEMS> [options]
+    print(_("""usage: system_deployconfigfiles <SYSTEMS> [options]
 
 options:
-    -s START_TIME"""
-        )
-    )
+    -s START_TIME"""))
 
     print("")
     print(self.HELP_SYSTEM_OPTS)
@@ -1906,7 +1870,7 @@ def do_system_deployconfigfiles(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument("-s", "--start-time")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_deployconfigfiles()
@@ -1959,18 +1923,14 @@ def do_system_deployconfigfiles(self, args):
 
 def help_system_delete(self):
     print(_("system_delete: Delete a system profile"))
-    print(
-        _(
-            """usage: system_delete [options] <SYSTEMS>
+    print(_("""usage: system_delete [options] <SYSTEMS>
 
     options:
           -c TYPE - Possible values:
              *  'FAIL_ON_CLEANUP_ERR' - fail in case of cleanup error,
              *  'NO_CLEANUP' - do not cleanup, just delete,
              *  'FORCE_DELETE' - Try cleanup first but delete server anyway in case of error
-    """
-        )
-    )
+    """))
     print("")
     print(self.HELP_SYSTEM_OPTS)
 
@@ -1988,7 +1948,7 @@ def do_system_delete(self, args):
         choices=["FAIL_ON_CLEANUP_ERR", "NO_CLEANUP", "FORCE_DELETE"],
     )
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_delete()
@@ -2070,7 +2030,7 @@ def do_system_lock(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_lock()
@@ -2114,7 +2074,7 @@ def do_system_unlock(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_unlock()
@@ -2159,13 +2119,13 @@ def do_system_rename(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
         self.help_system_rename()
         return 1
 
-    (old_name, new_name) = args
+    old_name, new_name = args
 
     system_id = self.get_system_id(old_name)
     if not system_id:
@@ -2207,7 +2167,7 @@ def do_system_refreshpillar(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     sids = []
     # use the systems listed in the SSM
@@ -2252,7 +2212,7 @@ def do_system_listcustomvalues(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listcustomvalues()
@@ -2320,7 +2280,7 @@ def do_system_addcustomvalue(self, args):
         arg_parser = get_argument_parser()
 
         # pylint: disable-next=unused-variable
-        (args, _options) = parse_command_arguments(args, arg_parser)
+        args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 3:
         self.help_system_addcustomvalue()
@@ -2376,7 +2336,7 @@ def do_system_updatecustomvalue(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 3:
         self.help_system_updatecustomvalue()
@@ -2410,7 +2370,7 @@ def do_system_removecustomvalues(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
         self.help_system_removecustomvalues()
@@ -2446,15 +2406,11 @@ def do_system_removecustomvalues(self, args):
 
 def help_system_addnote(self):
     print(_("system_addnote: Set a note for a system"))
-    print(
-        _(
-            """usage: system_addnote <SYSTEM> [options]
+    print(_("""usage: system_addnote <SYSTEM> [options]
 
 options:
   -s SUBJECT
-  -b BODY"""
-        )
-    )
+  -b BODY"""))
     print("")
     print(self.HELP_SYSTEM_OPTS)
 
@@ -2468,7 +2424,7 @@ def do_system_addnote(self, args):
     arg_parser.add_argument("-s", "--subject")
     arg_parser.add_argument("-b", "--body")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 1:
         self.help_system_addnote()
@@ -2528,7 +2484,7 @@ def do_system_deletenotes(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listnotes()
@@ -2590,7 +2546,7 @@ def do_system_listnotes(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listnotes()
@@ -2651,7 +2607,7 @@ def do_system_listfqdns(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listfqdns()
@@ -2713,7 +2669,7 @@ def do_system_setbasechannel(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
         self.help_system_setbasechannel()
@@ -2770,16 +2726,12 @@ def help_system_schedulechangechannels(self):
             "system_schedulechangechannels: Schedule changing a system's software channels"
         )
     )
-    print(
-        _(
-            """usage: system_setbasechannel <SYSTEMS> [options]
+    print(_("""usage: system_setbasechannel <SYSTEMS> [options]
 
 options:
   -b BASE_CHANNEL base channel label
   -c CHILD_CHANNEL child channel labels (allowed multiple times)
-  -s START_TIME time defaults to now"""
-        )
-    )
+  -s START_TIME time defaults to now"""))
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -2797,7 +2749,7 @@ def do_system_schedulechangechannels(self, args):
     arg_parser.add_argument("-c", "--child", action="append", default=[])
     arg_parser.add_argument("-s", "--start-time", action="store")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
     # import pdb;
     # pdb.set_trace()
     if len(args) < 1:
@@ -2884,7 +2836,7 @@ def do_system_listbasechannel(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listbasechannel()
@@ -2939,7 +2891,7 @@ def do_system_listchildchannels(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listchildchannels()
@@ -3048,7 +3000,7 @@ def do_system_details(self, args, short=False):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_details()
@@ -3200,7 +3152,7 @@ def do_system_listerrata(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listerrata()
@@ -3243,15 +3195,11 @@ def do_system_listerrata(self, args):
 
 def help_system_applyerrata(self):
     print(_("system_applyerrata: Apply errata to a system"))
-    print(
-        _(
-            """usage: system_applyerrata [options] <SYSTEMS>
+    print(_("""usage: system_applyerrata [options] <SYSTEMS>
 [ERRATA|search:XXX ...]
 
 options:
-  -s START_TIME"""
-        )
-    )
+  -s START_TIME"""))
     print("")
     print(self.HELP_TIME_OPTS)
     print("")
@@ -3276,7 +3224,7 @@ def do_system_applyerrata(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument("-s", "--start-time")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
         self.help_system_applyerrata()
@@ -3296,7 +3244,7 @@ def do_system_applyerrata(self, args):
     errata_list = []
 
     # For catch-all glob (*, or search:*), return errata only for selected systems
-    if re.match(r'(search:)?\.\*$', args[0]):
+    if re.match(r"(search:)?\.\*$", args[0]):
         system_ids = []
         failed_systems = []
         for system in systems:
@@ -3307,10 +3255,14 @@ def do_system_applyerrata(self, args):
                 system_ids.append(system_id)
 
         if failed_systems:
-            logging.warning(_N("Could not find system IDs for: %s"), ", ".join(failed_systems))
+            logging.warning(
+                _N("Could not find system IDs for: %s"), ", ".join(failed_systems)
+            )
 
         if system_ids:
-            batch_results = self.client.system.getRelevantErrata(self.session, system_ids)
+            batch_results = self.client.system.getRelevantErrata(
+                self.session, system_ids
+            )
             errata_set = set()
             for result in batch_results:
                 for erratum in result.get("errata", []):
@@ -3365,7 +3317,7 @@ def do_system_listevents(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listevents()
@@ -3419,16 +3371,12 @@ def do_system_listevents(self, args):
 
 def help_system_listeventhistory(self):
     print(_("system_listeventhistory: List the event history for a system"))
-    print(
-        _(
-            """usage: system_listeventhistory <SYSTEMS> [options]
+    print(_("""usage: system_listeventhistory <SYSTEMS> [options]
 
 options:
   -s START_TIME list only the events happened after the specified time. [Default: returns all events]
   -o OFFSET skip the first events. Ignored if -l is not specified as well. [Default: 0]
-  -l LIMIT limit the results to the specified number of events. [Default: no limit]"""
-        )
-    )
+  -l LIMIT limit the results to the specified number of events. [Default: no limit]"""))
     print("")
     print(self.HELP_SYSTEM_OPTS)
 
@@ -3447,7 +3395,7 @@ def do_system_listeventhistory(self, args):
     arg_parser.add_argument("-o", "--offset")
     arg_parser.add_argument("-l", "--limit")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listeventhistory()
@@ -3551,7 +3499,7 @@ def do_system_eventdetails(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_eventdetails()
@@ -3660,7 +3608,7 @@ def do_system_listentitlements(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listentitlements()
@@ -3720,7 +3668,7 @@ def do_system_addentitlements(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
         self.help_system_addentitlements()
@@ -3776,7 +3724,7 @@ def do_system_removeentitlement(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
         self.help_system_removeentitlement()
@@ -3855,7 +3803,7 @@ def do_system_deletepackageprofile(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_deletepackageprofile()
@@ -3887,15 +3835,11 @@ def do_system_deletepackageprofile(self, args):
 
 def help_system_createpackageprofile(self):
     print(_("system_createpackageprofile: Create a package profile"))
-    print(
-        _(
-            """usage: system_createpackageprofile SYSTEM [options]
+    print(_("""usage: system_createpackageprofile SYSTEM [options]
 
 options:
   -n NAME
-  -d DESCRIPTION"""
-        )
-    )
+  -d DESCRIPTION"""))
 
 
 def complete_system_createpackageprofile(self, text, line, beg, end):
@@ -3912,7 +3856,7 @@ def do_system_createpackageprofile(self, args):
     arg_parser.add_argument("-n", "--name")
     arg_parser.add_argument("-d", "--description")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1:
         self.help_system_createpackageprofile()
@@ -3972,7 +3916,7 @@ def do_system_comparepackageprofile(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
         self.help_system_comparepackageprofile()
@@ -4029,7 +3973,7 @@ def do_system_comparepackages(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
         self.help_system_comparepackages()
@@ -4052,14 +3996,10 @@ def do_system_comparepackages(self, args):
 
 def help_system_syncpackages(self):
     print(_("system_syncpackages: Sync packages between two systems"))
-    print(
-        _(
-            """usage: system_syncpackages SOURCE TARGET [options]
+    print(_("""usage: system_syncpackages SOURCE TARGET [options]
 
 options:
-    -s START_TIME"""
-        )
-    )
+    -s START_TIME"""))
     print("")
     print(self.HELP_TIME_OPTS)
 
@@ -4072,13 +4012,13 @@ def do_system_syncpackages(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument("-s", "--start-time")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
         self.help_system_syncpackages()
         return 1
 
-    (source, target) = args
+    source, target = args
 
     source_id = self.get_system_id(source)
     target_id = self.get_system_id(target)
@@ -4296,7 +4236,7 @@ def do_system_comparewithchannel(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument("-c", "--channel")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_comparewithchannel()
@@ -4424,14 +4364,10 @@ def do_system_comparewithchannel(self, args):
 
 def help_system_schedulehardwarerefresh(self):
     print(_("system_schedulehardwarerefresh: Schedule a hardware refresh for a system"))
-    print(
-        _(
-            """usage: system_schedulehardwarerefresh <SYSTEMS> [options]
+    print(_("""usage: system_schedulehardwarerefresh <SYSTEMS> [options]
 
 options:
-  -s START_TIME"""
-        )
-    )
+  -s START_TIME"""))
 
     print("")
     print(self.HELP_SYSTEM_OPTS)
@@ -4447,7 +4383,7 @@ def do_system_schedulehardwarerefresh(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument("-s", "--start-time")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_schedulehardwarerefresh()
@@ -4496,14 +4432,10 @@ def help_system_schedulepackagerefresh(self):
             "system_schedulepackagerefresh: Schedule a software package refresh for a system"
         )
     )
-    print(
-        _(
-            """usage: system_schedulepackagerefresh <SYSTEMS> [options])
+    print(_("""usage: system_schedulepackagerefresh <SYSTEMS> [options])
 
 options:
-  -s START_TIME"""
-        )
-    )
+  -s START_TIME"""))
     print("")
     print(self.HELP_SYSTEM_OPTS)
     print("")
@@ -4518,7 +4450,7 @@ def do_system_schedulepackagerefresh(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument("-s", "--start-time")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_schedulepackagerefresh()
@@ -4585,7 +4517,7 @@ def do_system_show_packageversion(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
         self.help_system_show_packageversion()
@@ -4651,7 +4583,7 @@ def do_system_setcontactmethod(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
         self.help_system_setcontactmethod()
@@ -4690,14 +4622,10 @@ def help_system_scheduleapplyconfigchannels(self):
             "Schedule applying the assigned config channels to the System (Minion only)"
         )
     )
-    print(
-        _(
-            """usage: scheduleapplyconfigchannels <SYSTEMS> [options]
+    print(_("""usage: scheduleapplyconfigchannels <SYSTEMS> [options]
 
     options:
-        -s START_TIME"""
-        )
-    )
+        -s START_TIME"""))
     print("")
     print(self.HELP_SYSTEM_OPTS)
     print("")
@@ -4709,7 +4637,7 @@ def do_system_scheduleapplyconfigchannels(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument("-s", "--start-time")
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_scheduleapplyconfigchannels()
@@ -4776,7 +4704,7 @@ def do_system_listmigrationtargets(self, args):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1:
         self.help_system_listmigrationtargets()
@@ -4890,7 +4818,7 @@ def do_system_scheduleproductmigration(self, args):
         "-r", "--remove-products-without-successor", action="store_true", default=False
     )
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 3:
         self.help_system_scheduleproductmigration()
@@ -4958,9 +4886,7 @@ def help_system_bootstrap(self):
             "system_bootstrap: Bootstrap a system for management via either Salt or Salt SSH."
         )
     )
-    print(
-        _(
-            """usage: bootstrap [options]
+    print(_("""usage: bootstrap [options]
 
     options:
         -H HOSTNAME
@@ -4973,9 +4899,7 @@ def help_system_bootstrap(self):
         -r REACTIVATION_KEY
         --proxyid PROXY_SYSID
         --saltssh
-        """
-        )
-    )
+        """))
     print("")
 
 
@@ -4993,7 +4917,7 @@ def do_system_bootstrap(self, args):
     arg_parser.add_argument("--proxyid")
     arg_parser.add_argument("--saltssh", action="store_true", default=False)
 
-    (args, options) = parse_command_arguments(args, arg_parser)
+    args, options = parse_command_arguments(args, arg_parser)
 
     if not (options.hostname or options.ssh_password or options.ssh_privatekey_file):
         options.hostname = prompt_user(_("Hostname:"))
@@ -5103,7 +5027,7 @@ def do_system_needrebootafterupdate(self, args, short=False):
     arg_parser = get_argument_parser()
 
     # pylint: disable-next=unused-variable
-    (args, _options) = parse_command_arguments(args, arg_parser)
+    args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_needrebootafterupdate()

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -3293,8 +3293,40 @@ def do_system_applyerrata(self, args):
         logging.warning(_N("No systems selected"))
         return 1
 
-    # allow globbing and searching of errata
-    errata_list = self.expand_errata(args)
+    errata_list = []
+
+    # For catch-all glob (*, or search:*), return errata only for selected systems
+    if re.match(r'(search:)?\.\*$', args[0]):
+        system_ids = []
+        failed_systems = []
+        for system in systems:
+            system_id = self.get_system_id(system)
+            if not system_id:
+                failed_systems.append(system)
+            else:
+                system_ids.append(system_id)
+
+        if failed_systems:
+            logging.warning(_N("Could not find system IDs for: %s"), ", ".join(failed_systems))
+
+        if system_ids:
+            batch_results = self.client.system.getRelevantErrata(self.session, system_ids)
+            errata_set = set()
+            for result in batch_results:
+                for erratum in result.get("errata", []):
+                    # Populate the errata cache so get_erratum_name() works later
+                    advisory_name = erratum.get("advisory_name")
+                    if advisory_name and advisory_name not in self.all_errata:
+                        self.all_errata[advisory_name] = {
+                            "id": erratum.get("id"),
+                            "advisory_name": advisory_name,
+                            "advisory_type": erratum.get("advisory_type"),
+                        }
+                    errata_set.add(advisory_name)
+            errata_list = list(errata_set)
+    else:
+        # allow globbing and searching of errata
+        errata_list = self.expand_errata(args)
 
     if not errata_list or not systems:
         return 1


### PR DESCRIPTION
## What does this PR change?

When using `spacecmd system_applyerrata` and selecting ALL errata, e.g. `spacecmd system_applyerrata <FQDN> *`  or `spacecmd system_applyerrata <FQDN> search:*`, spacecmd would select all errata that exist on MLM, and filter the results in `do_errata_apply` with API call: `affected_systems = self.client.errata.listAffectedSystems(self.session, erratum)`.

If MLM contains a lot of errata, this can result in calling the API thousands of times.

With this change, we pre-filter erratas such that we only select those errata applicable to the system, which potentially significantly reduces the number of API calls.

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/30872
Port(s): https://github.com/SUSE/spacewalk/pull/31457

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
