### PR TITLE
Do not edit pg_hba.conf with uyuni-postgres-config script (bsc#1267980)

### DIFF
--- a/containers/server-postgresql-image/root/docker-entrypoint-initdb.d/uyuni-postgres-config.sh
+++ b/containers/server-postgresql-image/root/docker-entrypoint-initdb.d/uyuni-postgres-config.sh
@@ -105,11 +105,3 @@ mkdir -p /var/lib/pgsql/data/postgresql.conf.d
 postgres_reconfig "include_dir" "'postgresql.conf.d'"
 
 echo "postgresql.conf updated"
-
-cat > "$HBA_FILE" <<EOT
-local all all trust
-local replication all trust
-host all all all scram-sha-256
-EOT
-
-echo "pg_hba.conf updated"

--- a/containers/server-postgresql-image/server-postgresql-image.changes.mbussolotto.single_pg_hba_conf
+++ b/containers/server-postgresql-image/server-postgresql-image.changes.mbussolotto.single_pg_hba_conf
@@ -1,0 +1,1 @@
+- Edit pg_hba only in one script (bsc#1267980).


### PR DESCRIPTION
## What does this PR change?

Do not edit pg_hba.conf with uyuni-postgres-config script (bsc#1267980).

Everything should be done `01-pg_hba.sh`.

This was causing problems during upgrade from single container version, since `mgradm` called `uyuni-postgres-config` after init.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30928

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
