### PR TITLE
Make using beta client tools conditional on existence

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -218,9 +218,10 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I select "SUSE Linux Enterprise Micro 5.2 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Micro 5.2 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Micro 5.2 x86_64"
-    And I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64"
-    And I select "SUSE Multi-Linux Manager Beta Client Tools for SLE Micro 5 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Beta Client Tools for SLE Micro 5 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64" selected
+    When I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64" if present
+    And I select or deselect "SUSE Multi-Linux Manager Beta Client Tools for SLE Micro 5 x86_64 (BETA)" beta client tools
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Linux Enterprise Micro 5.2 x86_64" product has been added
@@ -258,9 +259,10 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I select "SUSE Linux Enterprise Micro 5.3 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Micro 5.3 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Micro 5.3 x86_64"
-    And I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64"
-    And I select "SUSE Multi-Linux Manager Beta Client Tools for SLE Micro 5 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Beta Client Tools for SLE Micro 5 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64" selected
+    When I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64" if present
+    And I select or deselect "SUSE Multi-Linux Manager Beta Client Tools for SLE Micro 5 x86_64 (BETA)" beta client tools
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Linux Enterprise Micro 5.3 x86_64" product has been added
@@ -298,9 +300,10 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I select "SUSE Linux Enterprise Micro 5.4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Micro 5.4 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Micro 5.4 x86_64"
-    And I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64"
-    And I select "SUSE Multi-Linux Manager Beta Client Tools for SLE Micro 5 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Beta Client Tools for SLE Micro 5 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64" selected
+    When I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64" if present
+    And I select or deselect "SUSE Multi-Linux Manager Beta Client Tools for SLE Micro 5 x86_64 (BETA)" beta client tools
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Linux Enterprise Micro 5.4 x86_64" product has been added
@@ -338,9 +341,10 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I select "SUSE Linux Enterprise Micro 5.5 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Micro 5.5 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Micro 5.5 x86_64"
-    And I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64"
-    And I select "SUSE Multi-Linux Manager Beta Client Tools for SLE Micro 5 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Beta Client Tools for SLE Micro 5 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64" selected
+    When I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64" if present
+    And I select or deselect "SUSE Multi-Linux Manager Beta Client Tools for SLE Micro 5 x86_64 (BETA)" beta client tools
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Linux Enterprise Micro 5.5 x86_64" product has been added
@@ -378,9 +382,10 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I select "SUSE Linux Micro 6.0 x86_64" as a product
     Then I should see the "SUSE Linux Micro 6.0 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Micro 6.0 x86_64"
-    And I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SUSE Linux Micro 6 x86_64"
-    And I select "SUSE Multi-Linux Manager Beta Client Tools for SUSE Linux Micro 6 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Beta Client Tools for SUSE Linux Micro 6 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Client Tools for SUSE Linux Micro 6 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Client Tools for SUSE Linux Micro 6 x86_64" selected
+    When I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SUSE Linux Micro 6 x86_64" if present
+    And I select or deselect "SUSE Multi-Linux Manager Beta Client Tools for SUSE Linux Micro 6 x86_64 (BETA)" beta client tools
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Linux Micro 6.0 x86_64" product has been added
@@ -418,9 +423,10 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I select "SUSE Linux Micro 6.1 x86_64" as a product
     Then I should see the "SUSE Linux Micro 6.1 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
-    And I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SUSE Linux Micro 6 x86_64"
-    And I select "SUSE Multi-Linux Manager Beta Client Tools for SUSE Linux Micro 6 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Beta Client Tools for SUSE Linux Micro 6 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Client Tools for SUSE Linux Micro 6 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Client Tools for SUSE Linux Micro 6 x86_64" selected
+    When I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SUSE Linux Micro 6 x86_64" if present
+    And I select or deselect "SUSE Multi-Linux Manager Beta Client Tools for SUSE Linux Micro 6 x86_64 (BETA)" beta client tools
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Linux Micro 6.1 x86_64" product has been added


### PR DESCRIPTION
## What does this PR change?

Make using beta client tools conditional on existence, we already have that for most products, just not Micro ones. We had before hardcoded to look for beta client tools but we have the `beta_enabled` variable already. Before this PR we would have to switch the feature, comment out the lines when we had `beta_enabled = false` but there is no need since we have the conditional steps. Instead of failing if it does not find beta, it prints it and continues. This is now visible because the head now has the released client tools and beta client tools no longer exist, until now we just had them. 

Before:

```bash
Given I am authorized for the "Admin" section00:00:00.277
 When I follow the left menu "Admin > Setup Wizard > Products"00:00:00.215
 And I wait until I do not see "currently running" text00:00:00.083
 And I wait until I do not see "Loading" text00:00:00.650
 And I enter "SUSE Linux Micro 6.1" as the filtered product description00:00:00.457
 And I select "SUSE Linux Micro 6.1 x86_64" as a product00:00:00.059
 Then I should see the "SUSE Linux Micro 6.1 x86_64" selected00:00:00.024
 When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"00:00:00.056
 And I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SUSE Linux Micro 6 x86_64" 00:01:00.000[+ Show Error](https://ci.suse.de/job/manager-head-qe-build-validation/369/Build_20Validation_20report/features/e1f1bed0-3460-48e6-b511-edf7be708f10-synchronize-products-in-the-products-page-of-the-setup-wizard.html#error33-8-error) [+ Screenshot](https://ci.suse.de/job/manager-head-qe-build-validation/369/Build_20Validation_20report/features/e1f1bed0-3460-48e6-b511-edf7be708f10-synchronize-products-in-the-products-page-of-the-setup-wizard.html#info33-8-image)
xpath: //span[contains(text(), 'SUSE Multi-Linux Manager Client Tools for SUSE Linux Micro 6 x86_64')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/i[contains(@class, 'fa-angle-right')] not found (ScriptError)
./features/step_definitions/setup_steps.rb:126:in `rescue in block in (top (required))'
./features/step_definitions/setup_steps.rb:123:in `/^I open the sub-list of the product "(.*?)"((?: if present)?)$/'
features/build_validation/reposync/srv_sync_all_products.feature:421:in `I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SUSE Linux Micro 6 x86_64"'
 And I select "SUSE Multi-Linux Manager Beta Client Tools for SUSE Linux Micro 6 x86_64 (BETA)" as a product0s
 Then I should see the "SUSE Multi-Linux Manager Beta Client Tools for SUSE Linux Micro 6 x86_64 (BETA)" selected0s
 When I click the Add Product button
 ```

 After:
 
 ```bash
 mlm-bv-head-controller:~/spacewalk/testsuite # export BETA_ENABLED=False && cucumber features/build_validation/reposync/srv_sync_all_products.feature:417 --ta
gs @susemanager --tags @slmicro61_minion                                                                                                                      
Using Ruby version: 3.3.11                                                                                                                                    
Initializing a remote node for 'server'.                                                                                                                      
Host 'server' is alive with determined hostname mlm-bv-head-server and FQDN mlm-bv-head-server.mgr.suse.de                                                    
Node: mlm-bv-head-server, OS Version: 15-SP7, Family: sles                                                                                                    
Node: mlm-bv-head-server, OS Version: 15-SP7, Family: sles                                                                                                    
Capybara APP Host: https://mlm-bv-head-server.mgr.suse.de:8888                                                                                                
Activating XML-RPC API                                                                                                                                        
Using the default profile...                                                                                                                                  
# Copyright 2017-2026 SUSE LLC                                                                                                                                
# Licensed under the terms of the MIT license.
Feature: Synchronize products in the products page of the Setup Wizard

  @susemanager @slmicro61_minion
  Scenario: Add SUSE Linux Micro 6.1                                                                                             # features/build_validation/reposync/srv_sync_all_products.feature:417
      This scenario ran at: 2026-06-12 13:22:24 +0200
    Given I am authorized for the "Admin" section                                                                                # features/step_definitions/navigation_steps.rb:486
    When I follow the left menu "Admin > Setup Wizard > Products"                                                                # features/step_definitions/navigation_steps.rb:420
    And I wait until I do not see "currently running" text                                                                       # features/step_definitions/navigation_steps.rb:43
    And I wait until I do not see "Loading" text                                                                                 # features/step_definitions/navigation_steps.rb:43
    And I enter "SUSE Linux Micro 6.1" as the filtered product description                                                       # features/step_definitions/navigation_steps.rb:1000
    And I select "SUSE Linux Micro 6.1 x86_64" as a product                                                                      # features/step_definitions/setup_steps.rb:82
    Then I should see the "SUSE Linux Micro 6.1 x86_64" selected                                                                 # features/step_definitions/setup_steps.rb:141
    When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"                                                        # features/step_definitions/setup_steps.rb:121
    And I select "SUSE Multi-Linux Manager Client Tools for SUSE Linux Micro 6 x86_64" as a product                              # features/step_definitions/setup_steps.rb:82
    Then I should see the "SUSE Multi-Linux Manager Client Tools for SUSE Linux Micro 6 x86_64" selected                         # features/step_definitions/setup_steps.rb:141
    When I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SUSE Linux Micro 6 x86_64" if present     # features/step_definitions/s
etup_steps.rb:121
SUSE Multi-Linux Manager Beta Client Tools for SUSE Linux Micro 6 x86_64 (BETA) beta client tools checkbox not found
    And I select or deselect "SUSE Multi-Linux Manager Beta Client Tools for SUSE Linux Micro 6 x86_64 (BETA)" beta client tools # features/step_definitions/s
etup_steps.rb:88
    When I click the Add Product button                                                                                          # features/step_definitions/s
etup_steps.rb:161
    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text                            # features/step_definitions/n
avigation_steps.rb:39
    And I wait until I see "SUSE Linux Micro 6.1 x86_64" product has been added                                                  # features/step_definitions/s
etup_steps.rb:148
```
 

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): no issue, directly from testsuite review
Port(s): 5.1: https://github.com/SUSE/spacewalk/pull/30962

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
