### PR TITLE
Fix expected channel name in BV micro migration

### DIFF
--- a/testsuite/features/build_validation/migration/migration_slemicro55_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_slemicro55_minion.feature
@@ -23,7 +23,7 @@ Feature: Migrate a SLE Micro 5.5 Salt minion to SL Micro 6.2
     When I choose "SUSE Linux Micro 6.2 x86_64" radio button
     And I click on "Select Channels"
     When I select the channel "Custom Channel for slmicro62_minion"
-    And I select the channel "ManagerTools-SLE-16 for x86_64"
+    And I select the channel "Multi-Linux-ManagerTools-SLE-16 for x86_64 6.2"
     And I check "allowVendorChange"
     And I click on "Schedule Migration"
     Then I should see a "Product Migration - Confirm" text
@@ -46,7 +46,7 @@ Feature: Migrate a SLE Micro 5.5 Salt minion to SL Micro 6.2
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    Then I should see the child channel "ManagerTools-SLE-16 for x86_64" "selected"
+    Then I should see the child channel "Multi-Linux-ManagerTools-SLE-16 for x86_64 6.2" "selected"
 
   Scenario: Detect latest Salt changes on the SLE Micro minion
     When I query latest Salt changes on "slemicro55_minion"


### PR DESCRIPTION
## What does this PR change?

Fixes expected channel name in BV micro migration,



Before:

```
Unable to find xpath "//a[text()='ManagerTools-SLE-16 for x86_64']/preceding-sibling::input[@type='checkbox']" (Capybara::ElementNotFound)
./features/step_definitions/navigation_steps.rb:199:in `/^I select the channel "([^"]*)"$/'
features/build_validation/migration/migration_slemicro55_minion.feature:26:in `I select the channel "ManagerTools-SLE-16 for x86_64"'
```
<img width="2048" height="1909" alt="image" src="https://github.com/user-attachments/assets/0d9e31f9-b8c6-4e5c-a172-c312db019623" />


After:

```gherkin
mlm-bv-head-controller:~/spacewalk/testsuite # cucumber features/build_validation/migration/migration_slemicro55_minion.feature                                                               
Using Ruby version: 3.3.11                                                                                                                                                                    
Initializing a remote node for 'server'.                                                                                                                                                      
Host 'server' is alive with determined hostname mlm-bv-head-server and FQDN mlm-bv-head-server.mgr.suse.de                                                                                    
Node: mlm-bv-head-server, OS Version: 15-SP7, Family: sles                                                                                                                                    
Node: mlm-bv-head-server, OS Version: 15-SP7, Family: sles                                                                                                                                    
Capybara APP Host: https://mlm-bv-head-server.mgr.suse.de:8888                                                                                                                                
Activating XML-RPC API                                                                                                                                                                        
Using the default profile...                                                                                                                                                                  
# Copyright (c) 2025-2026 SUSE LLC                                                                                                                                                            
# Licensed under the terms of the MIT license.                                                                                                                                                
# SL Micro 6.2 is reposynched even if there is no SL Micro 6.2 minion deployed                                                                                                                
@slemicro55_minion                                                                                                                                                                            
Feature: Migrate a SLE Micro 5.5 Salt minion to SL Micro 6.2                                                                                                                                  
                                                                                                                                                                                              
  Scenario: Log in as admin user                  # features/build_validation/migration/migration_slemicro55_minion.feature:8                                                                 
      This scenario ran at: 2026-06-16 17:59:59 +0200                                                                                                                                         
    Given I am authorized for the "Admin" section # features/step_definitions/navigation_steps.rb:486                                                                                         
      This scenario took: 12 seconds                                                                                                                                                          
                                                                                                                                                                                              
  Scenario: Prerequisite: update OS zypper to the latest version # features/build_validation/migration/migration_slemicro55_minion.feature:11                                                 
      This scenario ran at: 2026-06-16 18:00:11 +0200                                                                                                                                         
Initializing a remote node for 'slemicro55_minion'.                                                                                                                                           
Node: mlm-bv-head-slemicro55-minion, OS Version: 5.5, Family: sle-micro                                                                                                                       
Node: mlm-bv-head-slemicro55-minion, OS Version: 5.5, Family: sle-micro                                                                                                                       
    When I upgrade "zypper" on "slemicro55_minion" using the API # features/step_definitions/command_steps.rb:1876
      This scenario took: 151 seconds

  Scenario: Prerequisite: Reboot the slemicro 5.5 after updating zypper                 # features/build_validation/migration/migration_slemicro55_minion.feature:14
      This scenario ran at: 2026-06-16 18:02:42 +0200
reboot returned status code = 0.
Output:
''
Unable to reach the SSH server at mlm-bv-head-slemicro55-minion.mgr.suse.de:22
Node mlm-bv-head-slemicro55-minion is offline.
Unable to reach the SSH server at mlm-bv-head-slemicro55-minion.mgr.suse.de:22
Unable to reach the SSH server at mlm-bv-head-slemicro55-minion.mgr.suse.de:22
SSH operation timed out after 1 seconds.
SSH operation timed out after 1 seconds.
SSH operation timed out after 1 seconds.
SSH operation timed out after 1 seconds.
Node mlm-bv-head-slemicro55-minion is online.
    When I reboot the "slemicro55_minion" host through SSH, waiting until it comes back # features/step_definitions/command_steps.rb:1642
      This scenario took: 23 seconds

  Scenario: Migrate this minion to SL Micro 6.2                               # features/build_validation/migration/migration_slemicro55_minion.feature:17
      This scenario ran at: 2026-06-16 18:03:05 +0200
    Given I am on the Systems overview page of this "slemicro55_minion"       # features/step_definitions/navigation_steps.rb:500
    When I follow "Software" in the content area                              # features/step_definitions/navigation_steps.rb:380
    And I follow "Product Migration" in the content area                      # features/step_definitions/navigation_steps.rb:380
    And I wait until I see "Target Products:" text, refreshing the page       # features/step_definitions/navigation_steps.rb:66
    And I wait until I see "SUSE Linux Micro 6.2 x86_64" text                 # features/step_definitions/navigation_steps.rb:39
    When I choose "SUSE Linux Micro 6.2 x86_64" radio button                  # features/step_definitions/navigation_steps.rb:229
    And I click on "Select Channels"                                          # features/step_definitions/navigation_steps.rb:314
    When I select the channel "Custom Channel for slmicro62_minion"           # features/step_definitions/navigation_steps.rb:198
    And I select the channel "Multi-Linux-ManagerTools-SLE-16 for x86_64 6.2" # features/step_definitions/navigation_steps.rb:198
    And I check "allowVendorChange"                                           # features/step_definitions/navigation_steps.rb:177
    And I click on "Schedule Migration"                                       # features/step_definitions/navigation_steps.rb:314
    Then I should see a "Product Migration - Confirm" text                    # features/step_definitions/navigation_steps.rb:696
    When I click on "Confirm"                                                 # features/step_definitions/navigation_steps.rb:314
    Then I should see a "This system is scheduled to be migrated to" text     # features/step_definitions/navigation_steps.rb:696
      This scenario took: 11 seconds

  Scenario: Check the migration is successful for this minion                        # features/build_validation/migration/migration_slemicro55_minion.feature:33
      This scenario ran at: 2026-06-16 18:03:16 +0200
    Given I am on the Systems overview page of this "slemicro55_minion"              # features/step_definitions/navigation_steps.rb:500
    When I follow "Events"                                                           # features/step_definitions/navigation_steps.rb:365
    And I follow "History"                                                           # features/step_definitions/navigation_steps.rb:365
    And I wait at most 600 seconds until event "Product Migration" is completed      # features/step_definitions/common_steps.rb:173
      2026-06-16 18:05:56 +0200 Still waiting for action to complete...
    And I wait until event "Package List Refresh" is completed                       # features/step_definitions/common_steps.rb:150
    And I reboot the "slemicro55_minion" minion through the web UI                   # features/step_definitions/command_steps.rb:1649
      2026-06-16 18:11:14 +0200 Still waiting for action to complete...
    And I follow "Details" in the content area                                       # features/step_definitions/navigation_steps.rb:380
    Then I wait until I see "SUSE Linux Micro 6.2 x86_64" text, refreshing the page  # features/step_definitions/navigation_steps.rb:66
    And vendor change should be enabled for product migration on "slemicro55_minion" # features/step_definitions/command_steps.rb:284
      This scenario took: 556 seconds

  Scenario: Verify the SLE Micro minion is subscribed to SL Micro 6.2 child channels                # features/build_validation/migration/migration_slemicro55_minion.feature:44
      This scenario ran at: 2026-06-16 18:12:32 +0200
    Given I am on the Systems overview page of this "slemicro55_minion"                             # features/step_definitions/navigation_steps.rb:500
    When I follow "Software" in the content area                                                    # features/step_definitions/navigation_steps.rb:380
    And I follow "Software Channels" in the content area                                            # features/step_definitions/navigation_steps.rb:380
    And I wait until I do not see "Loading..." text                                                 # features/step_definitions/navigation_steps.rb:43
    Then I should see the child channel "Multi-Linux-ManagerTools-SLE-16 for x86_64 6.2" "selected" # features/step_definitions/setup_steps.rb:329
      This scenario took: 2 seconds

  Scenario: Detect latest Salt changes on the SLE Micro minion # features/build_validation/migration/migration_slemicro55_minion.feature:51
      This scenario ran at: 2026-06-16 18:12:34 +0200
    When I query latest Salt changes on "slemicro55_minion"    # features/step_definitions/command_steps.rb:255
      * Tue Mar 17 2026 vzhestkov@suse.com
      - Backport security patch for Salt vendored tornado (bsc#1259554):
        * CVE-2026-31958: Add limits on multipart form data parsing
      - Added:
        * backport-of-the-cve-2026-31958-fix-bsc-1259554.patch
       
      * Fri Mar 13 2026 vzhestkov@suse.com
      - Add x86_64_v2 as a possible rpm package architecture
      - Make users with backslash working for salt-ssh (bsc#1254629)
      - Fix ansible.playbooks extra-vars quoting (bsc#1257831)
      - Fix virtualenv call in test helper to use proper python version
      - Added:
        * add-x86_64_v2-as-a-possible-rpm-package-architecture.patch
        * make-users-with-backslash-working-for-salt-ssh-bsc-1.patch
        * fix-ansible.playbooks-extra-vars-quoting-bsc-1257831.patch
      This scenario took: 0 seconds

  Scenario: Check events history for failures on the SLE Micro minion   # features/build_validation/migration/migration_slemicro55_minion.feature:54
      This scenario ran at: 2026-06-16 18:12:34 +0200
    Given I am on the Systems overview page of this "slemicro55_minion" # features/step_definitions/navigation_steps.rb:500
    Then I check for failed events on history event page                # features/step_definitions/setup_steps.rb:461
      This scenario took: 361 seconds

8 scenarios (8 passed)
34 steps (34 passed)
18m36.412s
```

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): no issue, directly from BV review
Port(s): 
5.1: has already the correct name, it uses 6.1 which has "ManagerTools-SL-Micro-6.1 for x86_64"

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
