### PR TITLE
Do not delete certificates that do not exist (bsc#1268151)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/hub/HubManager.java
+++ b/java/core/src/main/java/com/suse/manager/hub/HubManager.java
@@ -396,6 +396,12 @@ public class HubManager {
 
         hubFactory.remove(peripheral);
         hubFactory.removeAccessTokensFor(peripheral.getFqdn());
+
+        if (StringUtils.isEmpty(peripheral.getRootCa())) {
+            // No root ca is set for this peripheral, skip the certificate deletion
+            return;
+        }
+
         try {
             taskomaticApi.scheduleSingleRootCaCertDelete(IssRole.PERIPHERAL, peripheral.getFqdn());
         }
@@ -438,12 +444,17 @@ public class HubManager {
 
         cleanupSccDeletingHub(hub);
 
+        if (StringUtils.isEmpty(hub.getRootCa())) {
+            // No root ca is set for this hub, skip the certificate deletion
+            return;
+        }
+
         try {
             taskomaticApi.scheduleSingleRootCaCertDelete(IssRole.HUB, hub.getFqdn());
         }
         catch (TaskomaticApiException ex) {
             //if unable to delete ca certificate, just log a warning
-            LOG.warn("Cannot remove ca certificate for peripheral {}", hub.getFqdn());
+            LOG.warn("Cannot remove ca certificate for hub {}", hub.getFqdn());
         }
     }
 

--- a/java/core/src/main/java/com/suse/utils/CertificateUtils.java
+++ b/java/core/src/main/java/com/suse/utils/CertificateUtils.java
@@ -163,7 +163,7 @@ public final class CertificateUtils {
 
             try {
                 if (rootCaCertContent.isEmpty()) {
-                    Files.delete(getCertificateSafePath(fileName));
+                    Files.deleteIfExists(getCertificateSafePath(fileName));
                     LOG.info("CA certificate file: {} successfully removed", fileName);
                 }
                 else {

--- a/java/core/src/test/java/com/suse/manager/hub/HubManagerTest.java
+++ b/java/core/src/test/java/com/suse/manager/hub/HubManagerTest.java
@@ -684,12 +684,50 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
             allowing(internalClient).deregister();
         }});
 
+        mockTaskomaticApi.resetTaskomaticCall();
+        mockTaskomaticApi.setExpectations(0, List.of(), List.of(), null, null, null);
+
         hubManager.deregister(satAdmin, fqdn, IssRole.HUB, false);
 
         assertNull(hubFactory.lookupAccessTokenFor(fqdn));
         assertNull(hubFactory.lookupIssuedToken(fqdn));
         assertTrue(hubFactory.lookupIssHub().isEmpty(), "Failed to remove Hub");
         assertEquals(0, CredentialsFactory.listSCCCredentials().size());
+
+        mockTaskomaticApi.verifyTaskoCall();
+    }
+
+    @Test
+    public void canDeregisterHubAndDeleteRootCA() throws Exception {
+        String fqdn = LOCAL_SERVER_FQDN;
+        IssAccessToken token = createHubRegistration(fqdn, "---- BEGIN ROOT CA ----", null);
+        HubInternalClient internalClient = mock(HubInternalClient.class);
+
+        context().checking(new Expectations() {{
+            allowing(clientFactoryMock).newInternalClient(fqdn, token.getToken(), "---- BEGIN ROOT CA ----");
+            will(returnValue(internalClient));
+
+            allowing(internalClient).deregister();
+        }});
+
+        mockTaskomaticApi.resetTaskomaticCall();
+        mockTaskomaticApi.setExpectations(
+            1,
+            List.of("tasko.scheduleSingleSatBunchRun"),
+            List.of("root-ca-cert-update-bunch"),
+            "hub_local-server.unit-test.local_root_ca.pem",
+            "",
+            null
+        );
+
+        hubManager.deregister(satAdmin, fqdn, IssRole.HUB, false);
+
+        assertNull(hubFactory.lookupAccessTokenFor(fqdn));
+        assertNull(hubFactory.lookupIssuedToken(fqdn));
+        assertTrue(hubFactory.lookupIssHub().isEmpty(), "Failed to remove Hub");
+        assertEquals(0, CredentialsFactory.listSCCCredentials().size());
+
+        mockTaskomaticApi.verifyTaskoCall();
     }
 
     @Test
@@ -716,12 +754,50 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
             allowing(internalClient).deregister();
         }});
 
+        mockTaskomaticApi.resetTaskomaticCall();
+        mockTaskomaticApi.setExpectations(0, List.of(), List.of(), null, null, null);
+
         hubManager.deregister(satAdmin, fqdn, IssRole.PERIPHERAL, false);
 
         assertNull(hubFactory.lookupAccessTokenFor(fqdn));
         assertNull(hubFactory.lookupIssuedToken(fqdn));
         assertTrue(hubFactory.lookupIssPeripheralByFqdn(fqdn).isEmpty(), "Failed to remove Peripheral");
         assertEquals(0, CredentialsFactory.listCredentialsByType(HubSCCCredentials.class).size());
+
+        mockTaskomaticApi.verifyTaskoCall();
+    }
+
+    @Test
+    public void canDeregisterPeripheralAndDeleteRootCa() throws Exception {
+        String fqdn = LOCAL_SERVER_FQDN;
+        IssAccessToken token = createPeripheralRegistration(fqdn, "---- BEGIN ROOT CA ----");
+        HubInternalClient internalClient = mock(HubInternalClient.class);
+
+        context().checking(new Expectations() {{
+            allowing(clientFactoryMock).newInternalClient(fqdn, token.getToken(), "---- BEGIN ROOT CA ----");
+            will(returnValue(internalClient));
+
+            allowing(internalClient).deregister();
+        }});
+
+        mockTaskomaticApi.resetTaskomaticCall();
+        mockTaskomaticApi.setExpectations(
+            1,
+            List.of("tasko.scheduleSingleSatBunchRun"),
+            List.of("root-ca-cert-update-bunch"),
+            "peripheral_local-server.unit-test.local_root_ca.pem",
+            "",
+            null
+        );
+
+        hubManager.deregister(satAdmin, fqdn, IssRole.PERIPHERAL, false);
+
+        assertNull(hubFactory.lookupAccessTokenFor(fqdn));
+        assertNull(hubFactory.lookupIssuedToken(fqdn));
+        assertTrue(hubFactory.lookupIssPeripheralByFqdn(fqdn).isEmpty(), "Failed to remove Peripheral");
+        assertEquals(0, CredentialsFactory.listCredentialsByType(HubSCCCredentials.class).size());
+
+        mockTaskomaticApi.verifyTaskoCall();
     }
 
     @Test

--- a/java/spacewalk-java.changes.mackdk.do-not-delete-non-existing-certificates
+++ b/java/spacewalk-java.changes.mackdk.do-not-delete-non-existing-certificates
@@ -1,0 +1,2 @@
+- Do not attempt to delete a certificate that does not exist
+  (bsc#1268151)


### PR DESCRIPTION
## What does this PR change?

Added a check before invoking `scheduleSingleRootCaCertDelete()` to ensure the peripheral/hub was actually registered with a root CA. Used `Files.deleteIfExists()` in place of `Files.delete()` to avoid an exception during the execution of `CertificateUtils.saveAndUpdateCertificates()`.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bugfix

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Unit tests were added for the `HubManager` change. Adding unit tests for `CertificateUtils` would require a bigger refactoring of the class that might impact the current behaviour and would need further testing.

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30958

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
