### PR TITLE
Skip rhel10 exporters that will never exist

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -199,6 +199,7 @@ Feature: Smoke tests for <client>
     Then I should see a "Formula saved" text
 
 @skip_for_transactional_minion
+@skip_for_rhel10_like
   Scenario: Enable Prometheus Apache and Postgres exporter formula on the <client>
     Given I am on the Systems overview page of this "<client>"
     When I follow "Formulas" in the content area
@@ -230,6 +231,7 @@ Feature: Smoke tests for <client>
     And I visit "Prometheus node exporter" endpoint of this "<client>"
 
 @skip_for_transactional_minion
+@skip_for_rhel10_like
   Scenario: Visit Apache and Postgres monitoring endpoint on the <client>
     When I wait until "apache" exporter service is active on "<client>"
     And I visit "Prometheus apache exporter" endpoint of this "<client>"

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -699,6 +699,11 @@ Before('@skip_for_transactional_minion') do |scenario|
   skip_this_scenario if scenario.location.file.include?('slemicro') || scenario.location.file.include?('slmicro')
 end
 
+Before('@skip_for_rhel10_like') do |scenario|
+  rhel10_minion_tags = %w[@alma10_minion @alma10_ssh_minion @oracle10_minion @oracle10_ssh_minion @rocky10_minion @rocky10_ssh_minion]
+  skip_this_scenario if rhel10_minion_tags.any? { |tag| scenario.source_tag_names.include?(tag) }
+end
+
 # do some tests only if we have SCC credentials
 Before('@scc_credentials') do
   skip_this_scenario unless $scc_credentials


### PR DESCRIPTION
## What does this PR change?

Skip rhel10 exporters that will never exist. We will only have node exporter, not apache or postgres. Verified with Marina and Abid [here](https://suse.slack.com/archives/C02DDLYLFMX/p1781606274011119?thread_ts=1779542837.000699&cid=C02DDLYLFMX)

partial revert of https://github.com/uyuni-project/uyuni/commit/72c8d91f624d69ea26ced6b5f6a83ac0aac41e5b


Before:

```
[2026-06-15T23:22:14.910Z] Failing Scenarios:
[2026-06-15T23:22:14.910Z] cucumber features/build_validation/smoke_tests/alma10_ssh_minion_smoke_tests.feature:213 # Scenario: Apply highstate for the Prometheus exporters on the alma10_ssh_minion
[2026-06-15T23:22:14.910Z] cucumber features/build_validation/smoke_tests/alma10_ssh_minion_smoke_tests.feature:233 # Scenario: Visit Apache and Postgres monitoring endpoint on the alma10_ssh_minion
```

After:

```
  Scenario: Enable Prometheus Node exporter formula on the alma10_ssh_minion                 # features/build_validation/smoke_tests/alma10_ssh_minion_smoke_tests.feature:185
      This scenario ran at: 2026-06-16 19:36:18 +0200
    Given I am on the Systems overview page of this "alma10_ssh_minion"                      # features/step_definitions/navigation_steps.rb:500
    When I follow "Formulas" in the content area                                             # features/step_definitions/navigation_steps.rb:380
    And I wait until I see "Salt Formulas" text                                              # features/step_definitions/navigation_steps.rb:39
    And I check the "prometheus-exporters" formula                                           # features/step_definitions/salt_steps.rb:303
    And I click on "Save"                                                                    # features/step_definitions/navigation_steps.rb:314
    Then I wait until I see "Formula saved" text                                             # features/step_definitions/navigation_steps.rb:39
    # Configure Prometheus exporter formula
    When I follow "Prometheus Exporters" in the content area                                 # features/step_definitions/navigation_steps.rb:380
    And I wait until I see "configure Prometheus exporters" text                             # features/step_definitions/navigation_steps.rb:39
    And I click on "Expand All Sections"                                                     # features/step_definitions/navigation_steps.rb:314
    And I should see a "Enable and configure Prometheus exporters for managed systems." text # features/step_definitions/navigation_steps.rb:696
    And I check "node" exporter                                                              # features/step_definitions/navigation_steps.rb:1198
    And I click on "Save"                                                                    # features/step_definitions/navigation_steps.rb:314
    Then I should see a "Formula saved" text                                                 # features/step_definitions/navigation_steps.rb:696
      This scenario took: 2 seconds

  @skip_for_transactional_minion @skip_for_rhel10plus
  Scenario: Enable Prometheus Apache and Postgres exporter formula on the alma10_ssh_minion  # features/build_validation/smoke_tests/alma10_ssh_minion_smoke_tests.feature:203
      This scenario ran at: 2026-06-16 19:36:20 +0200
    Given I am on the Systems overview page of this "alma10_ssh_minion"                      # features/step_definitions/navigation_steps.rb:500
    When I follow "Formulas" in the content area                                             # features/step_definitions/navigation_steps.rb:380
    When I follow "Prometheus Exporters" in the content area                                 # features/step_definitions/navigation_steps.rb:380
    And I click on "Expand All Sections"                                                     # features/step_definitions/navigation_steps.rb:314
    And I should see a "Enable and configure Prometheus exporters for managed systems." text # features/step_definitions/navigation_steps.rb:696
    And I check "apache" exporter                                                            # features/step_definitions/navigation_steps.rb:1198
    And I check "postgres" exporter                                                          # features/step_definitions/navigation_steps.rb:1198
    And I click on "Save"                                                                    # features/step_definitions/navigation_steps.rb:314
    Then I should see a "Formula saved" text                                                 # features/step_definitions/navigation_steps.rb:696
      This scenario took: 0 seconds
  Scenario: Apply highstate for the Prometheus exporters on the alma10_ssh_minion        # features/build_validation/smoke_tests/alma10_ssh_minion_smoke_tests.feature:214
      This scenario ran at: 2026-06-16 19:36:20 +0200
    Given I am on the Systems overview page of this "alma10_ssh_minion"                  # features/step_definitions/navigation_steps.rb:500
    When I follow "States" in the content area                                           # features/step_definitions/navigation_steps.rb:380
    And I wait until I see "Apply Highstate" text                                        # features/step_definitions/navigation_steps.rb:39
    And I click on "Apply Highstate"                                                     # features/step_definitions/navigation_steps.rb:314
    Then I should see a "Applying the highstate has been scheduled." text                # features/step_definitions/navigation_steps.rb:696
    And I wait until event "Apply highstate scheduled by alma10_ssh_minion" is completed # features/step_definitions/common_steps.rb:150
    And I reboot the "alma10_ssh_minion" if it is a transactional system                 # features/step_definitions/command_steps.rb:1662
      This scenario took: 40 seconds

  # workaround for SLE Micro and SL Micro minion issue bsc#1209374
  @transactional_minion
  Scenario: Enable and start Prometheus Node Exporter service                          # features/build_validation/smoke_tests/alma10_ssh_minion_smoke_tests.feature:225
      This scenario ran at: 2026-06-16 19:37:00 +0200
    And I start the "prometheus-node_exporter.service" service on "alma10_ssh_minion"  # features/step_definitions/command_steps.rb:743
    And I enable the "prometheus-node_exporter.service" service on "alma10_ssh_minion" # features/step_definitions/command_steps.rb:743
      This scenario took: 0 seconds

  Scenario: Visit Node monitoring endpoint on the alma10_ssh_minion             # features/build_validation/smoke_tests/alma10_ssh_minion_smoke_tests.feature:229
      This scenario ran at: 2026-06-16 19:37:00 +0200
    When I wait until "node" exporter service is active on "alma10_ssh_minion"  # features/step_definitions/command_steps.rb:323
    And I visit "Prometheus node exporter" endpoint of this "alma10_ssh_minion" # features/step_definitions/navigation_steps.rb:1208
      This scenario took: 0 seconds

  @skip_for_transactional_minion @skip_for_rhel10plus
  Scenario: Visit Apache and Postgres monitoring endpoint on the alma10_ssh_minion  # features/build_validation/smoke_tests/alma10_ssh_minion_smoke_tests.feature:235
      This scenario ran at: 2026-06-16 19:37:00 +0200
    When I wait until "apache" exporter service is active on "alma10_ssh_minion"    # features/step_definitions/command_steps.rb:323
    And I visit "Prometheus apache exporter" endpoint of this "alma10_ssh_minion"   # features/step_definitions/navigation_steps.rb:1208
    And I wait until "postgres" exporter service is active on "alma10_ssh_minion"   # features/step_definitions/command_steps.rb:323
    And I visit "Prometheus postgres exporter" endpoint of this "alma10_ssh_minion" # features/step_definitions/navigation_steps.rb:1208
      This scenario took: 0 seconds

  @monitoring_server
  Scenario: The data from alma10_ssh_minion appear on Grafana dashboard # features/build_validation/smoke_tests/alma10_ssh_minion_smoke_tests.feature:242
      This scenario ran at: 2026-06-16 19:37:00 +0200
Initializing a remote node for 'monitoring_server'.
Node: mlm-bv-head-monitoring, OS Version: 15-SP7, Family: sles
Node: mlm-bv-head-monitoring, OS Version: 15-SP7, Family: sles
    When I visit the grafana dashboards of this "monitoring_server"     # features/step_definitions/navigation_steps.rb:1367
    And I wait until I do not see "Loading Grafana" text                # features/step_definitions/navigation_steps.rb:43
    When I follow "Client Systems"                                      # features/step_definitions/navigation_steps.rb:365
    When I enter "alma10_ssh_minion" hostname on grafana's host field   # features/step_definitions/navigation_steps.rb:1320
    And I wait until I do not see "No data" text                        # features/step_definitions/navigation_steps.rb:43
    Then I should see "alma10_ssh_minion" hostname                      # features/step_definitions/navigation_steps.rb:709
      This scenario took: 34 seconds

21 scenarios (3 skipped, 18 passed)
172 steps (15 skipped, 157 passed)
11m23.899s
```



## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): no issue, directly from the testsuite review
Port(s): 

5.1: https://github.com/SUSE/spacewalk/pull/30974

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
