### PR TITLE
testsuite: adjust Leap 16.0 oss repo URL according to minima mirror

### DIFF
--- a/testsuite/features/secondary/srv_salt_git_pillar.feature
+++ b/testsuite/features/secondary/srv_salt_git_pillar.feature
@@ -14,7 +14,7 @@ Feature: Salt master integration with Git pillar
 
   @uyuni
   Scenario: Pre-requisite: Enabling repositories for installing git-core
-    When I add repository "repo-oss" with url "http://minima-mirror-ci-bv.mgr.suse.de/distribution/leap/16.0/repo/oss/" on "server" without error control
+    When I add repository "repo-oss" with url "http://minima-mirror-ci-bv.mgr.suse.de/distribution/leap/16.0/repo/oss/x86_64/" on "server" without error control
 
   Scenario: Preparing Git pillar configuration for Salt master
     When I setup a git_pillar environment on the Salt master


### PR DESCRIPTION
## What does this PR change?

Since openSUSE Leap 16.0, there was a change in the repository structure that makes `repodata` to be available inside each "arch" directory in the repo. For compatibility, the old `repodata` was also kept outside of each "arch" directories.

The problem is that, our minima mirrors, does not synchronize the old `repodata` directory and moves in favor of the new structure where `repodata` lives inside the specific arch directory.

So, in order to avoid failures on Git Pillar testsuite scenarios, we make the URL of the `oss` repo to contain the "arch" as part of its URL, so we avoid current failures due metadata being missing.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
