### PR TITLE
Use 5.2 proxy when base OS is SLES

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -875,7 +875,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (BETA)" as the filtered product description
+    And I enter "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64" as the filtered product description
     Then I should see the "SUSE Linux Micro 6.2 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Micro 6.2 x86_64"
     And I select "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (BETA)" as a product
@@ -894,22 +894,22 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @susemanager
 @proxy
 @skip_if_transactional_server
-  Scenario: Add SUSE Multi-Linux Manager Proxy Extension 5.1 on top of SUSE Linux Enterprise Server 15 SP7
+  Scenario: Add SUSE Multi-Linux Manager Proxy Extension 5.2 on top of SUSE Linux Enterprise Server 15 SP7
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Multi-Linux Manager Proxy Extension for SLE 5.1 x86_64" as the filtered product description
+    And I enter "SUSE Multi-Linux Manager Proxy Extension for SLE 5.2 x86_64" as the filtered product description
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP7 x86_64"
     And I open the sub-list of the product "Basesystem Module 15 SP7 x86_64"
     And I select "Containers Module 15 SP7 x86_64" as a product
     Then I should see the "Containers Module 15 SP7 x86_64" selected
     When I open the sub-list of the product "Containers Module 15 SP7 x86_64"
-    And I select "SUSE Multi-Linux Manager Proxy Extension for SLE 5.1 x86_64" as a product
-    Then I should see the "SUSE Multi-Linux Manager Proxy Extension for SLE 5.1 x86_64" selected
+    And I select "SUSE Multi-Linux Manager Proxy Extension for SLE 5.2 x86_64 (BETA)" as a product
+    Then I should see the "SUSE Multi-Linux Manager Proxy Extension for SLE 5.2 x86_64 (BETA)" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-51-sp7" have finished
+    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-52-sp7" have finished
 
 @susemanager
 @proxy
@@ -932,20 +932,20 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @susemanager
 @proxy
 @skip_if_transactional_server
-  Scenario: Add SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 on top of SUSE Linux Enterprise Server 15 SP7
+  Scenario: Add SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 on top of SUSE Linux Enterprise Server 15 SP7
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Multi-Linux Manager Proxy Extension for SLE 5.1 x86_64" as the filtered product description
+    And I enter "SUSE Multi-Linux Manager Proxy Extension for SLE 5.2 x86_64" as the filtered product description
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP7 x86_64"
     And I open the sub-list of the product "Basesystem Module 15 SP7 x86_64"
     And I open the sub-list of the product "Containers Module 15 SP7 x86_64"
-    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension for SLE 5.1 x86_64" as a product
-    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension for SLE 5.1 x86_64" selected
+    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension for SLE 5.2 x86_64 (BETA)" as a product
+    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension for SLE 5.2 x86_64 (BETA)" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until all synchronized channels for "suse-multi-linux-manager-retail-branch-server-51-sp7" have finished
+    And I wait until all synchronized channels for "suse-multi-linux-manager-retail-branch-server-52-sp7" have finished
 
 # There are no channels for Retail under Uyuni
 

--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -143,8 +143,8 @@ Feature: Update activation keys
     And I wait for child channels to appear
     And I include the recommended child channels
     And I wait until "ManagerTools-SLE15-Pool for x86_64 SP7" has been checked
-    And I check "SUSE-Manager-Proxy-5.1-Pool for x86_64"
-    And I check "SUSE-Manager-Proxy-5.1-Updates for x86_64"
+    And I check "SUSE-Multi-Linux-Manager-Proxy-SLE-5.2-Pool for x86_64 SP7"
+    And I check "SUSE-Multi-Linux-Manager-Proxy-SLE-5.2-Updates for x86_64 SP7"
     And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2025 SUSE LLC
+# Copyright (c) 2015-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scc_credentials
@@ -30,8 +30,8 @@ Feature: List available channels and enable them
   Scenario: List all products for SUSE Multi-Linux Manager
     When I execute mgr-sync "list products --expand"
     Then I should get "[ ] SUSE Linux Enterprise Server 15 SP7 x86_64"
-    And I should get "  [ ] SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64"
-    And I should get "  [ ] SUSE Multi-Linux Manager Proxy Extension for SLE 5.1 x86_64"
+    And I should get "  [ ] SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64"
+    And I should get "  [ ] SUSE Multi-Linux Manager Proxy Extension for SLE 5.2 x86_64"
     And I should get "  [ ] (R) SUSE Multi-Linux Manager Client Tools for SUSE Liberty Linux 7, RHEL and clones 7 x86_64"
     And I should get "  [ ] (R) SUSE Multi-Linux Manager Client Tools for SLE 15 x86_64"
 

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -171,19 +171,19 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @proxy
 @susemanager
 @skip_if_transactional_server
-  Scenario: Add SUSE MLM Proxy Extension 5.1 with SLES 15 SP7 as base OS
+  Scenario: Add SUSE MLM Proxy Extension 5.2 with SLES 15 SP7 as base OS
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
     And I enter "SUSE Linux Enterprise Server 15 SP7" as the filtered product description
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP7 x86_64"
-    And I select "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" as a product
-    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" selected
+    And I select "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (BETA)" as a product
+    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (BETA)" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" product has been added
-    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-51-sp7" have finished
+    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (BETA)" product has been added
+    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-52-sp7" have finished
 
 @proxy
 @susemanager
@@ -206,19 +206,19 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @proxy
 @susemanager
 @skip_if_transactional_server
-  Scenario: Add SUSE MLM Retail Branch Server Extension 5.1 with SLES 15 SP7 as base OS
+  Scenario: Add SUSE MLM Retail Branch Server Extension 5.2 with SLES 15 SP7 as base OS
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
     And I enter "SUSE Linux Enterprise Server 15 SP7" as the filtered product description
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP7 x86_64"
-    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" as a product
-    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" selected
+    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64 (BETA)" as a product
+    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64 (BETA)" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" product has been added
-    And I wait until all synchronized channels for "suma-retail-branch-server-extension-51-sp7" have finished
+    And I wait until I see "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64 (BETA)" product has been added
+    And I wait until all synchronized channels for "suma-retail-branch-server-extension-52-sp7" have finished
 
 @scc_credentials
 @susemanager


### PR DESCRIPTION
## What does this PR change?

Follow-up of https://github.com/uyuni-project/uyuni/pull/11407

We could not use SCC proxy 5.2 for a long time because it was not ready in SCC.

Now we can.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes.

- [x] **DONE**


## Test coverage

Unit tests were refined.

- [x] **DONE**


## Links

No ports, HEAD only !

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
