### PR TITLE
Create downgrade scenario so we test patching on fully patched systems

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -8,7 +8,7 @@ Feature: Smoke tests for <client>
   I want to :
   - View the details of the system
   - Install a package via Web UI
-  - Install a patch via Web UI
+  - Install a patch via Web UI (for pre-patched systems: downgrade via zypper first)
   - Remove a package via Web UI
   - Execute a remote command via Web UI
   - Apply a configuration file via Web UI
@@ -64,6 +64,19 @@ Feature: Smoke tests for <client>
     And I should see a "Location" text
     And I should see a "UUID" text
 
+# For pre-patched systems (slmicro60, slmicro62), downgrade curl via zypper first to create a patchable state
+@pre_patched_system_downgrade
+  Scenario: Prepare patch test by downgrading a package via zypper on <client>
+    Given I am on the Systems overview page of this "<client>"
+    When I downgrade "curl libcurl4" via zypper on "<client>"
+    And I reboot the "<client>" if it is a transactional system
+    Given I am on the Systems overview page of this "<client>"
+    When I follow "Software" in the content area
+    And I wait until I see "Upgrade Packages" text
+    And I click on "Update Package List"
+    And I wait until event "Package List Refresh scheduled by" is completed
+    And I wait until zypper reports patches are available on "<client>"
+
 # Patches are available for Ubuntu and Debian, but they are delivered through package updates rather than standalone patch files.
 @skip_for_debian
 @skip_for_amazon2023
@@ -80,6 +93,7 @@ Feature: Smoke tests for <client>
     Then I should see a "1 patch update has been scheduled for" text
     And I wait until event "Patch Update:" is completed
     And I reboot the "<client>" if it is a transactional system
+    Given I am on the Systems overview page of this "<client>"
 
   Scenario: Install a package on the <client>
     Given I am on the Systems overview page of this "<client>"
@@ -95,6 +109,7 @@ Feature: Smoke tests for <client>
     Then I should see a "1 package install has been scheduled for" text
     And I wait until event "Package Install/Upgrade scheduled by <client>" is completed
     And I reboot the "<client>" if it is a transactional system
+    Given I am on the Systems overview page of this "<client>"
 
   Scenario: Remove package from <client>
     When I follow "Software" in the content area
@@ -108,6 +123,7 @@ Feature: Smoke tests for <client>
     Then I should see a "1 package removal has been scheduled" text
     And I wait until event "Package Removal scheduled by <client>" is completed
     And I reboot the "<client>" if it is a transactional system
+    Given I am on the Systems overview page of this "<client>"
 
   Scenario: Run a remote command on <client> minion
     When I follow the left menu "Salt > Remote Commands"
@@ -135,6 +151,7 @@ Feature: Smoke tests for <client>
     And I click on "Update Channel Rankings"
     Then I should see a "Channel Subscriptions successfully changed for" text
     And I reboot the "<client>" if it is a transactional system
+    Given I am on the Systems overview page of this "<client>"
 
 @skip_for_transactional_minion
   Scenario: Reboot the <client> and wait until reboot is completed
@@ -219,6 +236,7 @@ Feature: Smoke tests for <client>
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled by <client>" is completed
     And I reboot the "<client>" if it is a transactional system
+    Given I am on the Systems overview page of this "<client>"
 
 @transactional_minion
   # workaround for SLE Micro and SL Micro minion issue bsc#1209374

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1938,3 +1938,67 @@ When(/^I remove test supportconfig on "([^"]*)"$/) do |host|
   node.run('rm -rf /root/server-supportconfig')
   node.run('rm -rf /root/server-supportconfig.tar.gz')
 end
+
+# Patch test preparation steps
+
+When(/^I downgrade "([^"]*)" via zypper on "([^"]*)"$/) do |packages, host|
+  node = get_target(host)
+
+  # Split packages in case multiple are provided (e.g., "curl libcurl4")
+  package_list = packages.split
+  first_package = package_list.first
+
+  # Get currently installed version to exclude from downgrade candidates
+  current_version, _code = node.run("rpm -q #{first_package} --qf '%{VERSION}-%{RELEASE}'", check_errors: false)
+
+  # Get list of available older versions for the first package
+  versions_output, _code = node.run("zypper se -s #{first_package} 2>/dev/null | grep '^v  '", check_errors: false)
+
+  # Extract versions - match exact package name in column 2, get version from column 4
+  matching_lines =
+    versions_output.lines.select do |line|
+      cols = line.split('|')
+      next false if cols.length < 4
+      cols[1].strip == first_package
+    end
+
+  available_versions = matching_lines
+    .map { |line| line.split('|')[3].strip }
+    .uniq
+    .reject { |v| v == current_version.strip }
+    .sort
+    .reverse
+
+  raise "No older versions available for #{first_package} on #{host}" if available_versions.empty?
+
+  target_version = available_versions.first
+  log "Downgrading #{packages} from #{current_version.strip} to version: #{target_version}"
+
+  # Build package list with versions using = separator for both transactional and regular systems
+  packages_with_versions = package_list.map { |pkg| "#{pkg}=#{target_version}" }.join(' ')
+
+  if transactional_system?(host)
+    cmd = "transactional-update --no-selfupdate --non-interactive --continue pkg install --oldpackage #{packages_with_versions}"
+    output, _code = node.run(cmd, timeout: 300, check_errors: true)
+    raise "Failed to downgrade #{packages} on #{host}" unless output.include?('to downgrade')
+  else
+    cmd = "zypper install --no-confirm --oldpackage #{packages_with_versions}"
+    node.run(cmd, timeout: 300, check_errors: true)
+  end
+end
+
+When(/^I wait until zypper reports patches are available on "([^"]*)"$/) do |host|
+  node = get_target(host)
+
+  repeat_until_timeout(timeout: 120, message: "Patches did not appear on #{host}") do
+    output, _code = node.run("zypper list-patches 2>/dev/null | grep -c 'patch needed'", check_errors: false)
+    patch_count = output.strip.to_i
+    log "Patches available: #{patch_count}" if patch_count.positive?
+    break if patch_count.positive?
+
+    sleep 3
+  end
+
+  output, _code = node.run("zypper list-patches", check_errors: false)
+  raise "No patches appeared after downgrade on #{host}" unless output.include?('patch needed')
+end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -2007,3 +2007,67 @@ When(/^I remove test supportconfig on "([^"]*)"$/) do |host|
   node.run('rm -rf /root/server-supportconfig')
   node.run('rm -rf /root/server-supportconfig.tar.gz')
 end
+
+# Patch test preparation steps
+
+When(/^I downgrade "([^"]*)" via zypper on "([^"]*)"$/) do |packages, host|
+  node = get_target(host)
+
+  # Split packages in case multiple are provided (e.g., "curl libcurl4")
+  package_list = packages.split
+  first_package = package_list.first
+
+  # Get currently installed version to exclude from downgrade candidates
+  current_version, _code = node.run("rpm -q #{first_package} --qf '%{VERSION}-%{RELEASE}'", check_errors: false)
+
+  # Get list of available older versions for the first package
+  versions_output, _code = node.run("zypper se -s #{first_package} 2>/dev/null | grep '^v  '", check_errors: false)
+
+  # Extract versions - match exact package name in column 2, get version from column 4
+  matching_lines =
+    versions_output.lines.select do |line|
+      cols = line.split('|')
+      next false if cols.length < 4
+      cols[1].strip == first_package
+    end
+
+  available_versions = matching_lines
+                       .map { |line| line.split('|')[3].strip }
+                       .uniq
+                       .reject { |v| v == current_version.strip }
+                       .sort
+                       .reverse
+
+  raise "No older versions available for #{first_package} on #{host}" if available_versions.empty?
+
+  target_version = available_versions.first
+  log "Downgrading #{packages} from #{current_version.strip} to version: #{target_version}"
+
+  # Build package list with versions using = separator for both transactional and regular systems
+  packages_with_versions = package_list.map { |pkg| "#{pkg}=#{target_version}" }.join(' ')
+
+  if transactional_system?(host)
+    cmd = "transactional-update --no-selfupdate --non-interactive --continue pkg install --oldpackage #{packages_with_versions}"
+    output, _code = node.run(cmd, timeout: 300, check_errors: true)
+    raise "Failed to downgrade #{packages} on #{host}" unless output.include?('to downgrade')
+  else
+    cmd = "zypper install --no-confirm --oldpackage #{packages_with_versions}"
+    node.run(cmd, timeout: 300, check_errors: true)
+  end
+end
+
+When(/^I wait until zypper reports patches are available on "([^"]*)"$/) do |host|
+  node = get_target(host)
+
+  repeat_until_timeout(timeout: 120, message: "Patches did not appear on #{host}") do
+    output, _code = node.run("zypper list-patches 2>/dev/null | grep -c 'patch needed'", check_errors: false)
+    patch_count = output.strip.to_i
+    log "Patches available: #{patch_count}" if patch_count.positive?
+    break if patch_count.positive?
+
+    sleep 3
+  end
+
+  output, _code = node.run("zypper list-patches", check_errors: false)
+  raise "No patches appeared after downgrade on #{host}" unless output.include?('patch needed')
+end

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -649,6 +649,12 @@ Before('@slmicro62_ssh_minion') do
   skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['slmicro62_ssh_minion']
 end
 
+Before('@pre_patched_system_downgrade') do
+  pre_patched_systems = %w[slmicro60_minion slmicro60_ssh_minion slmicro62_minion slmicro62_ssh_minion]
+  current_system_env = pre_patched_systems.find { |sys| ENV.key? ENV_VAR_BY_HOST[sys] }
+  skip_this_scenario unless current_system_env
+end
+
 Before('@sle15sp6_buildhost') do
   skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['sle15sp6_buildhost']
 end

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -761,6 +761,12 @@ Before('@slmicro62_sshminion') do
   skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['slmicro62_sshminion']
 end
 
+Before('@pre_patched_system_downgrade') do
+  pre_patched_systems = %w[slmicro60_minion slmicro60_sshminion slmicro62_minion slmicro62_sshminion]
+  current_system_env = pre_patched_systems.find { |sys| ENV.key? ENV_VAR_BY_HOST[sys] }
+  skip_this_scenario unless current_system_env
+end
+
 Before('@sles15sp6_buildhost') do
   skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['sles15sp6_buildhost']
 end


### PR DESCRIPTION
## What does this PR change?

Adds a preparation scenario to the build validation smoke tests that downgrades `curl` and `libcurl4` via zypper, so a patch is available to install on systems that ship fully patched.

The patch installation scenario needs at least one relevant patch. SL Micro images are rebuilt often and every available patch is applied at build time, so a freshly provisioned SL Micro 6.0 or 6.2 minion has nothing left to install and the scenario fails. The new scenario is tagged `@pre_patched_system_downgrade` and only runs for slmicro60 and slmicro62: it downgrades the package, reboots on transactional systems, refreshes the package list and waits until zypper reports patches again. Everywhere else the tag does not match, the scenario is skipped, and the patch installation scenario runs against the real patches as before. Two step definitions back it, `I downgrade "..." via zypper on "..."` and `I wait until zypper reports patches are available on "..."`.

Each scenario that reboots a transactional system now ends by returning to the system overview page, so the next scenario starts from a known page.

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): no issue, directly from testsuite review

Ports:
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31903
Manager-5.1: https://github.com/SUSE/spacewalk/pull/31904

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
