### PR TITLE
Fix recursive loop in rhn_rpm.py in case of missing hdr attribute.

### DIFF
--- a/python/uyuni/common/rhn_rpm.py
+++ b/python/uyuni/common/rhn_rpm.py
@@ -102,7 +102,12 @@ class RPM_Header:
         del self.hdr[name]
 
     def __getattr__(self, name):
-        item = getattr(self.hdr, name)
+        try:
+            hdr = object.__getattribute__(self, "hdr")
+        except AttributeError:
+            raise AttributeError(name)
+
+        item = getattr(hdr, name)
         if isinstance(item, bytes):
             item = sstr(item)
         elif isinstance(item, list):

--- a/python/uyuni/common/rhn_rpm.py
+++ b/python/uyuni/common/rhn_rpm.py
@@ -104,8 +104,8 @@ class RPM_Header:
     def __getattr__(self, name):
         try:
             hdr = object.__getattribute__(self, "hdr")
-        except AttributeError:
-            raise AttributeError(name)
+        except AttributeError as exc:
+            raise AttributeError(name) from exc
 
         item = getattr(hdr, name)
         if isinstance(item, bytes):

--- a/python/uyuni/uyuni-common-libs.changes.sbluhm.fix-recursive-rhn_rpm
+++ b/python/uyuni/uyuni-common-libs.changes.sbluhm.fix-recursive-rhn_rpm
@@ -1,0 +1,1 @@
+- Fix recursive loop in case of missing hdr attribute.


### PR DESCRIPTION
## What does this PR change?

Added protection to the RPM_Header.__getattr__ class in rhn_rpm.py to avoid a recurring loop when the hdr attribute is accessed without it being defined.

Example:
```
# python3
>>> from uyuni.common.rhn_rpm import RPM_Header
>>> obj = RPM_Header.__new__(RPM_Header)
>>> obj.hdr
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/site-packages/uyuni/common/rhn_rpm.py", line 105, in __getattr__
    item = getattr(self.hdr, name)
  File "/usr/lib/python3.6/site-packages/uyuni/common/rhn_rpm.py", line 105, in __getattr__
    item = getattr(self.hdr, name)
  File "/usr/lib/python3.6/site-packages/uyuni/common/rhn_rpm.py", line 105, in __getattr__
    item = getattr(self.hdr, name)
  [Previous line repeated 330 more times]
RecursionError: maximum recursion depth exceeded while calling a Python object


```
## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
