### PR TITLE
Fix inventory refresh triggering from unrelated inotify events

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/action/ansible/InventoryAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/ansible/InventoryAction.java
@@ -10,6 +10,7 @@
  */
 package com.redhat.rhn.domain.action.ansible;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -32,6 +33,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.logging.log4j.LogManager;
@@ -104,11 +106,18 @@ public class InventoryAction extends Action {
      */
     @Override
     public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        String inventoryPath = details.getInventoryPath();
+        if (StringUtils.isBlank(inventoryPath)) {
+            return emptyMap();
+        }
         return singletonMap(executeInventoryActionCall(), minionSummaries);
     }
 
     private LocalCall<?> executeInventoryActionCall() {
         String inventoryPath = details.getInventoryPath();
+        if (StringUtils.isBlank(inventoryPath)) {
+            return null;
+        }
 
         return new LocalCall<>(SaltParameters.ANSIBLE_INVENTORIES, empty(), of(Map.of("inventory", inventoryPath)),
                 new TypeToken<>() { });
@@ -126,6 +135,11 @@ public class InventoryAction extends Action {
             return;
         }
         String inventoryPath = details.getInventoryPath();
+        if (StringUtils.isBlank(inventoryPath)) {
+            serverAction.setStatusFailed();
+            serverAction.setResultMsg("Inventory path is null or empty");
+            return;
+        }
         if (serverAction.isStatusCompleted()) {
             try {
                 Set<String> inventorySystems = AnsibleManager.parseInventoryAndGetHostnames(

--- a/java/core/src/main/java/com/redhat/rhn/domain/action/ansible/InventoryActionDetails.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/ansible/InventoryActionDetails.java
@@ -36,7 +36,7 @@ public class InventoryActionDetails extends BaseDomainHelper {
     @SequenceGenerator(name = "act_inventory_seq", sequenceName = "rhn_act_inventory_id_seq", allocationSize = 1)
     private Long id;
 
-    @Column(name = "inventory_path")
+    @Column(name = "inventory_path", nullable = false)
     private String inventoryPath;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/java/core/src/main/java/com/suse/manager/reactor/SaltReactor.java
+++ b/java/core/src/main/java/com/suse/manager/reactor/SaltReactor.java
@@ -19,6 +19,7 @@ import static java.util.stream.Stream.of;
 
 import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.common.messaging.MessageQueue;
+import com.redhat.rhn.domain.server.AnsibleFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.manager.action.ActionManager;
@@ -66,6 +67,7 @@ import com.suse.salt.netapi.event.EventStream;
 import com.suse.salt.netapi.event.JobReturnEvent;
 import com.suse.salt.netapi.event.MinionStartEvent;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -307,15 +309,28 @@ public class SaltReactor {
             );
         }
         else if (beaconEvent.getBeacon().equals("inotify")) {
+            String path = beaconEvent.getAdditional();
+            if (StringUtils.isBlank(path)) {
+                LOG.debug("Received inotify beacon event with empty path string for minion '{}'",
+                    beaconEvent.getMinionId());
+                return empty();
+            }
+
             Optional<MinionServer> minion = MinionServerFactory.findByMinionId(beaconEvent.getMinionId());
             minion.ifPresent(m -> {
-                // Schedule retrieval of minions from changed inventory
-                try {
-                    ActionManager.scheduleInventoryRefresh(m, beaconEvent.getAdditional());
+                if (AnsibleFactory.lookupAnsibleInventoryPath(m.getId(), path).isPresent()) {
+                    // Schedule retrieval of minions from changed inventory
+                    try {
+                        ActionManager.scheduleInventoryRefresh(m, path);
+                    }
+                    catch (TaskomaticApiException e) {
+                        LOG.error("Could not schedule Ansible inventory refresh for minion: {}",
+                                m.getMinionId(), e);
+                    }
                 }
-                catch (TaskomaticApiException e) {
-                    LOG.error("Could not schedule Ansible inventory refresh for minion: {}",
-                            m.getMinionId(), e);
+                else {
+                    LOG.warn("Inventory path '{}' is not configured in suseAnsiblePath for minion '{}'",
+                            path, m.getMinionId());
                 }
             });
         }

--- a/java/spacewalk-java.changes.parlt.fix-inotify-inventory-refresh
+++ b/java/spacewalk-java.changes.parlt.fix-inotify-inventory-refresh
@@ -1,0 +1,2 @@
+- Fix inventory refresh triggering from unrelated
+  inotify events (bsc#1268309)

--- a/schema/spacewalk/common/tables/rhnActionInventory.sql
+++ b/schema/spacewalk/common/tables/rhnActionInventory.sql
@@ -17,7 +17,7 @@ CREATE TABLE rhnActionInventory
                             CONSTRAINT rhn_action_inventory_aid_fk
                                 REFERENCES rhnAction (id)
                                 ON DELETE CASCADE,
-    inventory_path      VARCHAR(1024),
+    inventory_path      VARCHAR(1024) NOT NULL,
     created             TIMESTAMPTZ
                             DEFAULT (current_timestamp) NOT NULL,
     modified            TIMESTAMPTZ

--- a/schema/spacewalk/susemanager-schema.changes.parlt.fix-inotify-inventory-refresh
+++ b/schema/spacewalk/susemanager-schema.changes.parlt.fix-inotify-inventory-refresh
@@ -1,0 +1,2 @@
+- Make inventory path not nullable in
+  rhnActionInventory (bsc#1268309)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.12-to-susemanager-schema-5.2.13/002-alter-rhnactioninventory-not-null.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.12-to-susemanager-schema-5.2.13/002-alter-rhnactioninventory-not-null.sql
@@ -1,0 +1,14 @@
+--
+-- Copyright (c) 2026 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+DELETE FROM rhnAction WHERE id IN (SELECT action_id FROM rhnActionInventory WHERE inventory_path IS NULL);
+
+ALTER TABLE rhnActionInventory ALTER COLUMN inventory_path SET NOT NULL;


### PR DESCRIPTION
## What does this PR change?

Performs a check if an inotify event picked up by `SaltReactor.java` is actually associated with an inventory configured for that minion instead of immediately scheduling an inventory refresh.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **Bugfix**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30976

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
