### PR TITLE
SonarCloud error reduction fix step 20, removal of old TODOs 

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/common/db/datasource/CachedStatement.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/db/datasource/CachedStatement.java
@@ -654,7 +654,7 @@ public class CachedStatement implements Serializable {
                     else {
                         Integer pos = pointers.get(getObject(rs, getColumn()));
                         /*
-                         * TODO: there is a possible bug here. If the elaborator
+                         * OLDTODO: there is a possible bug here. If the elaborator
                          * does not restrict itself to only the current results
                          * (%s thing), then the pos here is null, because the
                          * object might not exist in the map. Decide if this is
@@ -699,7 +699,7 @@ public class CachedStatement implements Serializable {
                     }
                 }
             }
-            // TODO: this is the only place that we care that we are
+            // OLDTODO: this is the only place that we care that we are
             // returning a DataResult object rather than simply a List.
             // Furthermore, this is entirely because of paging in the
             // user interface which should clearly not be done in the

--- a/java/core/src/main/java/com/redhat/rhn/common/filediff/RhnPatchDiffWriter.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/filediff/RhnPatchDiffWriter.java
@@ -51,7 +51,7 @@ public class RhnPatchDiffWriter implements DiffVisitor, DiffWriter {
         diff = new StringBuilder();
 
 
-        String dateString = fromDate.toString(); //TODO: format the date
+        String dateString = fromDate.toString(); //OLDTODO: format the date
         writeHeader(FROM_LABEL, fromPath, dateString);
         dateString = toDate.toString();
         writeHeader(TO_LABEL, toPath, dateString);

--- a/java/core/src/main/java/com/redhat/rhn/common/hibernate/ForceRecreationListType.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/hibernate/ForceRecreationListType.java
@@ -164,7 +164,7 @@ public class ForceRecreationListType implements UserCollectionType {
 
     /**
      * Returns an ArrayList. Not sure what the heck this is here for.
-     * TODO: WHAT IS THIS FOR? 2007-11-8 jesusr
+     * OLDTODO: WHAT IS THIS FOR? 2007-11-8 jesusr
      * @return ArrayList as an Object.
      */
     public Object instantiate() {

--- a/java/core/src/main/java/com/redhat/rhn/common/localization/LocalizationService.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/localization/LocalizationService.java
@@ -358,7 +358,7 @@ public class LocalizationService {
     /**
      * Get localized text for log messages as well as error emails. Determines
      * Locale of running JVM vs using the current Thread or any other User
-     * related Locale information. TODO mmccune Get Locale out of Config or from
+     * related Locale information. OLDTODO mmccune Get Locale out of Config or from
      * the JVM
      * @param messageId The key of the message we are fetching
      * @return String debug message.

--- a/java/core/src/main/java/com/redhat/rhn/common/security/acl/Access.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/security/acl/Access.java
@@ -159,7 +159,7 @@ public class Access extends BaseHandler {
      */
     public boolean aclIs(Map<String, Object> ctx, String[] params) {
         if (params == null || params.length < 1) {
-            // FIXME: need to localize exception text
+            // OLDTODO: need to localize exception text
             throw new IllegalArgumentException("Invalid number of parameters.");
         }
         return Config.get().getBoolean(params[0]);

--- a/java/core/src/main/java/com/redhat/rhn/common/security/acl/Access.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/security/acl/Access.java
@@ -166,7 +166,7 @@ public class Access extends BaseHandler {
     }
 
     /**
-     * TODO: Right now this method calls a small little query
+     * OLDTODO: Right now this method calls a small little query
      * very similar to how the perl code decides this acl.
      * IMO, there is a better way, and we should fix this when
      * we migrate the channels tab.

--- a/java/core/src/main/java/com/redhat/rhn/common/security/acl/SystemAclHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/security/acl/SystemAclHandler.java
@@ -70,7 +70,7 @@ public class SystemAclHandler extends BaseHandler {
     }
 
     /**
-     * TODO: Right now this method calls a small little query
+     * OLDTODO: Right now this method calls a small little query
      * very similar to how the perl code decides this acl.
      * IMO, there is a better way, and we should fix this when
      * we migrate the channels tab.

--- a/java/core/src/main/java/com/redhat/rhn/common/util/StringUtil.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/util/StringUtil.java
@@ -670,7 +670,7 @@ public class StringUtil {
      * Convert an incoming web-string (with \r\n EOL) to a Linux string (with \n
      * as EOL)
      * @param inWebStr string from a web form
-     * @return Linux-EOL'd-string TODO: This shoudl be generalized to handle
+     * @return Linux-EOL'd-string OLDTODO: This shoudl be generalized to handle
      * other kinds of non-Linux EOLs, so we can use it on uploaded files as well
      */
     public static String webToLinux(String inWebStr) {

--- a/java/core/src/main/java/com/redhat/rhn/common/util/manifestfactory/ManifestFactoryBuilder.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/util/manifestfactory/ManifestFactoryBuilder.java
@@ -30,8 +30,8 @@ public interface ManifestFactoryBuilder {
     Object createObject(Map<String, Object> param);
 
     /** get the filename associated with this builder
-     *   TODO: probably should be a URL instead
-     *   TODO: probably going to need to generalize this a bit more, so that
+     *   OLDTODO: probably should be a URL instead
+     *   OLDTODO: probably going to need to generalize this a bit more, so that
      *         we can have different webapps with different manifest files
      * @return String filename used by manifest
     */

--- a/java/core/src/main/java/com/redhat/rhn/common/validator/SchemaParser.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/validator/SchemaParser.java
@@ -135,7 +135,7 @@ public class SchemaParser {
     /**
      * <p>
      *  This will convert an attribute into constraints.
-     *  TODO: make everyone happy: replace this with Digester
+     *  OLDTODO: make everyone happy: replace this with Digester
      * </p>
      *
      * @throws IOException - when parsing errors occur.

--- a/java/core/src/main/java/com/redhat/rhn/common/validator/Validator.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/validator/Validator.java
@@ -133,7 +133,7 @@ public class Validator {
             log.error(errorMessage, e);
             throw new ValidatorException(errorMessage, e);
         }
-        // TODO: Get rid of the toString and determine the type
+        // OLDTODO: Get rid of the toString and determine the type
         String data = (value == null) ? null : value.toString();
 
         ValidatorError validationMessage;

--- a/java/core/src/main/java/com/redhat/rhn/domain/org/Org.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/org/Org.java
@@ -375,7 +375,7 @@ public class Org extends BaseDomainHelper implements SaltConfigurable {
     }
 
     /**
-     * TODO: get rid of Role label and pass in the class Reset channel
+     * OLDTODO: get rid of Role label and pass in the class Reset channel
      * permissions for a user/channel/role combination
      * @param uid User ID to reset
      * @param cid Channel ID
@@ -386,7 +386,7 @@ public class Org extends BaseDomainHelper implements SaltConfigurable {
     }
 
     /**
-     * TODO: get rid of Role label and pass in the class Remove all channel
+     * OLDTODO: get rid of Role label and pass in the class Remove all channel
      * permissions for a user/channel/role combination
      * @param uid User ID to reset
      * @param cid Channel ID

--- a/java/core/src/main/java/com/redhat/rhn/domain/org/OrgFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/org/OrgFactory.java
@@ -94,7 +94,7 @@ public class OrgFactory extends HibernateFactory {
      * @param oid Org Id to delete
      * @param user User who initiated this action
      */
-    // TODO this be probably somewhere else
+    // OLDTODO this be probably somewhere else
     public static void deleteOrgAndDependencies(Long oid, User user) {
         Org org = OrgFactory.lookupById(oid);
         SaltStateGeneratorService.INSTANCE.removeOrg(org);

--- a/java/core/src/main/java/com/redhat/rhn/domain/rhnset/RhnSetFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/rhnset/RhnSetFactory.java
@@ -59,7 +59,7 @@ public class RhnSetFactory extends HibernateFactory {
      * Returns null if no matches found.
      * @param uid Userid of RhnSet
      * @param label Label of RhnSet
-     * @param cleanup TODO
+     * @param cleanup
      * @return the RhnSet which matched the given uid and label.
      */
     public static RhnSet lookupByLabel(Long uid, String label, SetCleanup cleanup) {

--- a/java/core/src/main/java/com/redhat/rhn/domain/server/Server.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/server/Server.java
@@ -476,7 +476,7 @@ public class Server extends BaseDomainHelper implements Identifiable {
         //if we didn't find one, we just haven't created it yet.
         ConfigChannel channel = ConfigurationFactory.createNewLocalChannel(this, cct);
 
-        //TODO: Adding the new channel to the set of local channels should
+        //OLDTODO: Adding the new channel to the set of local channels should
         //happen in the createNewLocalChannel method.  However, the way things
         //are currently set up, I have to work with the member variable, because using
         //accessors and mutators would create an infinite loop.  Fix this setup.

--- a/java/core/src/main/java/com/redhat/rhn/domain/server/VirtualInstance.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/server/VirtualInstance.java
@@ -202,7 +202,7 @@ public class VirtualInstance extends BaseDomainHelper {
      * set the info
      * @param instanceInfo the info
      */
-    // TODO Determine if we need to handle deletion of the info.
+    // OLDTODO Determine if we need to handle deletion of the info.
     // If there are use cases for deleting the VirtualInstanceInfo from a
     // VirtualInstance
     // object, then this method will need to be refactored to handle deletion.

--- a/java/core/src/main/java/com/redhat/rhn/domain/user/UserFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/user/UserFactory.java
@@ -283,7 +283,7 @@ public class UserFactory extends HibernateFactory {
 
     /**
      * Insert a new user.  Invalid to call this when updating a user
-     * TODO: mmccune fill out the other fields in the user object.
+     * OLDTODO: mmccune fill out the other fields in the user object.
      * @param usr The object we are commiting.
      * @param addr The address to add to the User
      * @param orgId Org this new user is a member of
@@ -315,7 +315,7 @@ public class UserFactory extends HibernateFactory {
 
     /**
      * Insert a new user.  Invalid to call this when updating a user
-     * TODO: mmccune fill out the other fields in the user object.
+     * OLDTODO: mmccune fill out the other fields in the user object.
      * @param usr The object we are commiting.
      * @param addr The address to add to the User
      * @param orgId Org this new user is a member of

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/BaseEditAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/BaseEditAction.java
@@ -111,7 +111,7 @@ public abstract class BaseEditAction extends RhnAction {
      * @param opr to process setters on.
      * @param form web form containing values
      * @param request the http servlet request
-     * @return TODO
+     * @return
      */
     protected abstract ValidatorError processCommandSetters(PersistOperation opr,
             DynaActionForm form, HttpServletRequest request);

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
@@ -821,7 +821,6 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
 
     /** {@inheritDoc} */
     public String getListName() {
-        // TODO Auto-generated method stub
         return "trustedOrgList";
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/manage/ErrataHelper.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/manage/ErrataHelper.java
@@ -48,7 +48,7 @@ public class ErrataHelper {
      * Perform a check to see if the user can modify channels, throws an
      *          PermissionException if the user does not have permission
      * @param user the user to check
-     * @param cid TODO
+     * @param cid
      *
      */
     public static void checkPermissions(User user, Long cid) {

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/manage/repo/RepoDetailsAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/manage/repo/RepoDetailsAction.java
@@ -344,7 +344,7 @@ public class RepoDetailsAction extends RhnAction {
 
         try {
             // Add SSL
-            // FIXME: Allow to set multiple SSL sets per custom repo - new page?
+            // OLDTODO: Allow to set multiple SSL sets per custom repo - new page?
             repoCmd.deleteAllSslSets();
             repoCmd.addSslSet(parseIdFromForm(form, SSL_CA_CERT),
                     parseIdFromForm(form, SSL_CLIENT_CERT),

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -836,7 +836,7 @@ public class DownloadFile extends DownloadAction {
         log.debug("Added header Content-Length: {}", size);
         log.debug("Added header Content-Range: bytes {}-{}/{}", start, end, totalSize);
         log.debug("Added header Accept-Ranges: bytes");
-        // TODO: it's a bad idea to read file from filesystem into memory.
+        // OLDTODO: it's a bad idea to read file from filesystem into memory.
         // We have to implement copying from InputStream to OutputStream by chunks in this
         // class instead of using parent execute() (and copy()).
         // New copy() method will take into account Content-Range header in response

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/configuration/channel/BaseCopyToAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/configuration/channel/BaseCopyToAction.java
@@ -188,8 +188,8 @@ public abstract class BaseCopyToAction extends RhnAction {
 
     /**
      * When we tell the user things worked, what's the bean-key?
-     * @param numFiles TODO
-     * @param numChannels TODO
+     * @param numFiles
+     * @param numChannels
      * @return key into I18N system
      */
     public abstract String getSuccessKey(int numFiles, int numChannels);

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/configuration/channel/ChannelOverviewTasks.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/configuration/channel/ChannelOverviewTasks.java
@@ -195,7 +195,7 @@ public class ChannelOverviewTasks extends RhnAction {
     }
 
 
-    // TODO: generalize and move this somewhere it can be used by other
+    // OLDTODO: generalize and move this somewhere it can be used by other
     // action-producers!
     private void makeMessage(int successes, HttpServletRequest request) {
         if (successes > 0) {

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/configuration/sdc/ChannelListUnsubscribeSubmitAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/configuration/sdc/ChannelListUnsubscribeSubmitAction.java
@@ -83,7 +83,7 @@ public class ChannelListUnsubscribeSubmitAction extends
     @Override
     protected void processParamMap(ActionForm form, HttpServletRequest request,
                                    Map<String, Object> params) {
-        // TODO Auto-generated method stub
+        // OLDTODO Auto-generated method stub
 
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/errata/ErrataSearchAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/errata/ErrataSearchAction.java
@@ -326,7 +326,7 @@ public class ErrataSearchAction extends BaseSearchAction {
             LOG.debug("{} records have passed being filtered and will be displayed.", filtered.size());
         }
 
-        // TODO: need to figure out a way to properly sort the
+        // OLDTODO: need to figure out a way to properly sort the
         // errata from a package search. What we get back from the
         // search server is pid, pkg-name in relevant order.
         // What we get back from searchByPackageIds, is an unsorted

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/renderers/setupwizard/ProxySettingsRenderer.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/renderers/setupwizard/ProxySettingsRenderer.java
@@ -54,7 +54,7 @@ public class ProxySettingsRenderer {
             log.debug("Saving proxy settings: {}", settings);
         }
 
-        // TODO: Handle errors
+        // OLDTODO: Handle errors
         ValidatorError[] errors =
                 ProxySettingsManager.storeProxySettings(settings, webUser, request);
         if (errors != null) {

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/ErrataConfirmSetupAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/ErrataConfirmSetupAction.java
@@ -188,7 +188,7 @@ public class ErrataConfirmSetupAction extends RhnAction implements Listable, Mai
         }
         /*
          * Everything is not ok.
-         * TODO: Error page or some other shout-to-user-venue
+         * OLDTODO: Error page or some other shout-to-user-venue
          * What happens if a few ServerActions fail to be scheduled?
          */
         Map<String, Object> params = makeParamMap(request);

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/SystemSearchAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/SystemSearchAction.java
@@ -160,7 +160,7 @@ public class SystemSearchAction extends BaseSearchAction implements Listable<Sys
                  }
              }
 
-            // TODO: Set up combined-form validator
+            // OLDTODO: Set up combined-form validator
 //              errs.add(RhnValidationHelper.validateDynaActionForm(this, daForm))
         addErrors(request, errs);
 

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/SystemSearchHelper.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/SystemSearchHelper.java
@@ -230,7 +230,7 @@ public class SystemSearchHelper {
      * @param searchResults The list of results to process
      * @param viewMode the view mode
      * @return server map
-     * TODO:  Look into a quicker/more efficient implementation.  This appears to
+     * OLDTODO:  Look into a quicker/more efficient implementation.  This appears to
      * work....but I think it can be become quicker.
      */
     protected static Map<Long, Map<String, Object>> getResultMapFromPackagesIndex(User user,

--- a/java/core/src/main/java/com/redhat/rhn/frontend/events/BaseEvent.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/events/BaseEvent.java
@@ -67,7 +67,7 @@ public abstract class BaseEvent {
      * @return return the Users locale or default if not set
      */
     public Locale getUserLocale() {
-        //TODO: when we support translated emails, remove this stub
+        //OLDTODO: when we support translated emails, remove this stub
         //String loc = (getUser() == null) ? null : getUser().getPreferredLocale();
         //return (loc == null) ? LocalizationService.DEFAULT_LOCALE : new Locale(loc);
         return LocalizationService.DEFAULT_LOCALE;

--- a/java/core/src/main/java/com/redhat/rhn/frontend/events/TraceBackEvent.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/events/TraceBackEvent.java
@@ -42,7 +42,7 @@ public class TraceBackEvent extends BaseEvent implements EventMessage {
 
     /**
      * format this message as a string
-     *   TODO mmccune - fill out the email properly with the entire
+     *   OLDTODO mmccune - fill out the email properly with the entire
      *                  request values
      * @return Text of email.
      */

--- a/java/core/src/main/java/com/redhat/rhn/frontend/servlets/LocalizedEnvironmentFilter.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/servlets/LocalizedEnvironmentFilter.java
@@ -56,8 +56,7 @@ public class LocalizedEnvironmentFilter implements Filter {
      */
     @Override
     public void destroy() {
-        // TODO Auto-generated method stub
-
+        //empty
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/frontend/struts/RequestContext.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/struts/RequestContext.java
@@ -207,7 +207,7 @@ public class RequestContext {
      *
      * @return User found.
      */
-    // TODO Write unit tests for getUserFromUIDParameter()
+    // OLDTODO Write unit tests for getUserFromUIDParameter()
     public User getUserFromUIDParameter() {
         Long uid = getParamAsLong(USER_ID);
         return UserManager.lookupUser(getCurrentUser(), uid);
@@ -243,7 +243,7 @@ public class RequestContext {
      * @throws IllegalArgumentException if no server with the ID given in the
      * request can be found
      */
-    // TODO Write unit tests for lookupServer()
+    // OLDTODO Write unit tests for lookupServer()
     public Server lookupServer()
     throws IllegalArgumentException {
         Long serverId = getRequiredParam(SID);
@@ -402,7 +402,7 @@ public class RequestContext {
      * @param required whether this parameter must be present
      * @return the parameter value or null if not required.
      */
-    // TODO Refactor getParam(String, boolean)
+    // OLDTODO Refactor getParam(String, boolean)
     // This method is awkward in that if the required flag is set, an exception may be
     // throw. No exception will be thrown though if the flag is not set. Refactor the
     // method by removing the boolean argument, and adding a new method,
@@ -554,7 +554,7 @@ public class RequestContext {
      * Creates a hashmap with pagination vars added.
      * @return Returns a new hashmap containing the parameters
      */
-    // TODO Write unit tests for makeParamMapWithPagination()
+    // OLDTODO Write unit tests for makeParamMapWithPagination()
     public Map<String, Object> makeParamMapWithPagination() {
         Map<String, Object> params = new HashMap<>();
         String lower = processPagination();

--- a/java/core/src/main/java/com/redhat/rhn/frontend/struts/RhnListDispatchAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/struts/RhnListDispatchAction.java
@@ -101,7 +101,6 @@ public abstract class RhnListDispatchAction extends RhnLookupDispatchAction {
      * @param form the ActionForm
      * @param request HttpServletRequest containing request vars
      * @return Returns Map of parameters
-     * TODO: was private
      */
     protected Map<String, Object> makeParamMap(ActionForm form,
             HttpServletRequest request) {

--- a/java/core/src/main/java/com/redhat/rhn/frontend/struts/StrutsDelegate.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/struts/StrutsDelegate.java
@@ -112,7 +112,7 @@ public class StrutsDelegate {
      * @param msgKey to add
      * @param errors to add too
      */
-    // TODO Write unit tests for addError(String, ActionErrors)
+    // OLDTODO Write unit tests for addError(String, ActionErrors)
     public void addError(String msgKey, ActionErrors errors) {
         addError(errors, msgKey);
     }
@@ -124,7 +124,7 @@ public class StrutsDelegate {
      * @param msgKey to add
      * @param params key params
      */
-    // TODO Write unit tests for addError(String, ActionErrors)
+    // OLDTODO Write unit tests for addError(String, ActionErrors)
     public void addError(ActionErrors errors, String msgKey, Object...params) {
         ActionMessages msg = new ActionMessages();
         msg.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(msgKey,
@@ -172,7 +172,7 @@ public class StrutsDelegate {
      * @param params formatted params for the localized message
      * @param req used to store the message in.
      */
-    // TODO Write unit tests for saveMessage(String, String[], HttpServletRequest)
+    // OLDTODO Write unit tests for saveMessage(String, String[], HttpServletRequest)
     public void saveMessage(String msgKey, String[] params, HttpServletRequest req) {
         if (params == null) {
             params = new String[0];
@@ -188,7 +188,7 @@ public class StrutsDelegate {
      * @param request Request where messages will be saved.
      * @param messages Messages to be saved.
      */
-    // TODO Write unit tests for saveMessages(HttpServletRequest, ActionMessages)
+    // OLDTODO Write unit tests for saveMessages(HttpServletRequest, ActionMessages)
     public void saveMessages(HttpServletRequest request, ActionMessages messages) {
         HttpSession session = request.getSession();
 
@@ -266,7 +266,7 @@ public class StrutsDelegate {
      * @param paramName of the FormFile
      * @return String version of the upload.
      */
-    // TODO Write unit tests for getFormFileString(DynaActionForm, String)
+    // OLDTODO Write unit tests for getFormFileString(DynaActionForm, String)
     public String getFormFileString(DynaActionForm form, String paramName) {
         if (form.getDynaClass().getDynaProperty(paramName) == null) {
             return "";

--- a/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/ColumnTag.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/ColumnTag.java
@@ -106,7 +106,7 @@ public class ColumnTag extends TagSupport {
     /** header colspan attribute **/
     private String headerStyle;
     /**
-     *  TODO: Eliminate this attribute. This is a dirty dirty
+     *  OLDTODO: Eliminate this attribute. This is a dirty dirty
      *  hack to allow the ColumnTag to know whether to use
      *  UnpagedListDisplayTag as its parent or ListDisplayTag
      *  as its parent. When ListDisplayTag is refactored

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
@@ -299,7 +299,7 @@ public class BaseHandler implements XmlRpcInvocationHandler {
      * @throws XmlRpcFault Thrown if we can't find the method asked for
      */
     /*
-     * TODO: Make this method even smarterer.
+     * OLDTODO: Make this method even smarterer.
      *      Currently this finds methods that match the number of parameters and returns
      *          those.
      */

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -2197,7 +2197,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
          // check SSL-certificates parameters
          if (!StringUtils.isEmpty(sslCaCert)) {
              try {
-                 // FIXME: Allow to set multiple SSL sets per custom repo - new API calls?
+                 // OLDTODO: Allow to set multiple SSL sets per custom repo - new API calls?
                  repoCmd.addSslSet(getKeyId(loggedInUser, sslCaCert),
                          getKeyId(loggedInUser, sslCliCert),
                          getKeyId(loggedInUser, sslCliKey));
@@ -2405,7 +2405,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
         // set new SSL Certificates for the repository
         if (!StringUtils.isEmpty(sslCaCert)) {
             try {
-                // FIXME: Allow to set multiple SSL sets per custom repo - new API calls?
+                // OLDTODO: Allow to set multiple SSL sets per custom repo - new API calls?
                 repoEditor.deleteAllSslSets();
                 repoEditor.addSslSet(getKeyId(loggedInUser, sslCaCert),
                         getKeyId(loggedInUser, sslCliCert),
@@ -2825,7 +2825,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
             throw new PermissionCheckFailureException("Only Org Admins can remove repo filters.");
         }
 
-        //TODO is this necessary?
+        //OLDTODO is this necessary?
         lookupContentSourceByLabel(label, loggedInUser.getOrg());
 
         String flag = filterProps.get("flag");

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -423,7 +423,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
      */
     @ReadOnly
     public int isGloballySubscribable(User loggedInUser, String channelLabel) {
-        // TODO: this should return a boolean NOT an int
+        // OLDTODO: this should return a boolean NOT an int
 
         // Make sure the channel exists:
         lookupChannelByLabel(loggedInUser, channelLabel);

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -938,7 +938,7 @@ public class SystemHandler extends BaseHandler {
                 SystemManager.subscribableChannels(server.getId(),
                 loggedInUser.getId(), baseChannel.getId());
 
-        //TODO: This should go away once we teach marquee how to deal with nulls in a list.
+        //OLDTODO: This should go away once we teach marquee how to deal with nulls in a list.
         //      Luckily, this list shouldn't be too long.
         for (Map<String, Object> row : dr) {
             Map<String, Object> channel = new HashMap<>();

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -6819,7 +6819,7 @@ public class SystemHandler extends BaseHandler {
 
         // Set network device information to the server
         for (Map<String, String> map : netDevices) {
-            // FIXME: why do we need this?
+            // OLDTODO: why do we need this?
             CobblerNetworkInterface device = cmd.new CobblerNetworkInterface();
             device.setName(map.get("name"));
             device.setIpaddr(map.get("ip"));

--- a/java/core/src/main/java/com/redhat/rhn/manager/acl/AclManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/acl/AclManager.java
@@ -66,7 +66,7 @@ public class AclManager {
         if (acl == null || "".equals(acl)) {
             return true;
         }
-        // TODO: Lifecycle issue
+        // OLDTODO: Lifecycle issue
         // It's not cool that we're instantiating a new
         // Acl everytime we need to use it. We should register
         // the acl handlers at startup and simply call acl.evalAcl()

--- a/java/core/src/main/java/com/redhat/rhn/manager/audit/CVEAuditManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/audit/CVEAuditManager.java
@@ -185,7 +185,7 @@ public class CVEAuditManager {
      * (given by a list of channel product IDs) and channel tree given by
      * the ID of the parent channel. Will return the base channel as well.
      *
-     * TODO: Merge with {@link DistUpgradeManager#findProductChannels(long, String)}.
+     * OLDTODO: Merge with {@link DistUpgradeManager#findProductChannels(long, String)}.
      *
      * @param channelProductIDs IDs of channel products (rhnChannelProduct rows)
      * @param parentChannelID ID of a parent channel
@@ -596,7 +596,7 @@ public class CVEAuditManager {
     /**
      * Only packageInstalled and channelAssigned can be null on an affected entry.
      * This is because of the result that the SQL query returns.
-     * TODO: This should be refactored either at the query or here, preferably after dropping Oracle support.
+     * OLDTODO: This should be refactored either at the query or here, preferably after dropping Oracle support.
      *
      * This class is a wrapper of a single row extracted by a sql query that contains info about
      *   - a system

--- a/java/core/src/main/java/com/redhat/rhn/manager/configuration/EnableConfigHelper.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/configuration/EnableConfigHelper.java
@@ -63,7 +63,7 @@ public class EnableConfigHelper {
          * The problem we are solving by using RhnSet is remembering what
          * systems ran into what problems across page requests (pagination especially)
          *
-         * TODO: currently any single system will only have one error
+         * OLDTODO: currently any single system will only have one error
          *       condition.  We should probably tell the user multiple
          *       errors if we can.
          */

--- a/java/core/src/main/java/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1962,7 +1962,7 @@ public class ContentSyncManager {
                 Tuple3<Long, Long, Long> ids = new Tuple3<>(rootJson.getId(), productJson.getId(), repoJson.getSCCId());
                 SUSEProduct product = productMap.get(productJson.getId());
                 SUSEProduct root = productMap.get(rootJson.getId());
-                //FIXME: this is not pretty and should be changed if somebody has the time
+                //OLDTODO: this is not pretty and should be changed if somebody has the time
                 Optional<SUSEProduct> parent = parentJson.flatMap(Function.identity())
                         .map(p -> productMap.get(p.getId()));
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/kickstart/IpAddressRange.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/kickstart/IpAddressRange.java
@@ -163,7 +163,7 @@ public class IpAddressRange implements Serializable {
     }
 
     /**
-     * TODO: does anybody use this? Is there any reason for it to exist?
+     * OLDTODO: does anybody use this? Is there any reason for it to exist?
      * @return range in String form
      */
     public String getRange() {

--- a/java/core/src/main/java/com/redhat/rhn/manager/kickstart/KickstartEditCommand.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/kickstart/KickstartEditCommand.java
@@ -335,7 +335,7 @@ public class KickstartEditCommand extends BaseKickstartCommand {
     public String getReleaseUpdate() {
         String retval = null;
 
-        // TODO: Actually fetch this off the kickstartableTree
+        // OLDTODO: Actually fetch this off the kickstartableTree
         // Only can parse the label if its an RHN
         // owned channel
         //if (this.ksdata.getTree().getChannel().getOrg() == null) {

--- a/java/core/src/main/java/com/redhat/rhn/manager/kickstart/KickstartEditPackagesCommand.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/kickstart/KickstartEditPackagesCommand.java
@@ -31,7 +31,6 @@ public class KickstartEditPackagesCommand extends BaseKickstartCommand {
      */
     public KickstartEditPackagesCommand(Long ksidIn, User userIn) {
         super(ksidIn, userIn);
-        // TODO Auto-generated constructor stub
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -693,7 +693,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
                             "kickstart.session.newtokennote", getTargetServer().getName());
         }
         else {
-            // TODO: translate this
+            // OLDTODO: translate this
             note = "Automatically generated activation key.";
         }
 
@@ -719,7 +719,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
         Boolean deployConfig = this.getKsdata().
                 getKickstartDefaults().getCfgManagementFlag();
 
-        // TODO: Proxy logic
+        // OLDTODO: Proxy logic
 
         // Setup the KickstartSession
         kickstartSession.setPackageFetchCount(0L);
@@ -926,7 +926,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
         log.debug("PROFILE_TYPE={}", profileTypeIn);
 
         if (profileTypeIn == null ||
-                profileTypeIn.isEmpty() || // TODO: fix this hack
+                profileTypeIn.isEmpty() || // OLDTODO: fix this hack
                 profileTypeIn.equals(TARGET_PROFILE_TYPE_NONE)) {
             return null;
         }
@@ -979,7 +979,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
         }
 
 
-        // TODO: Compute missing packages and forward user to the missing page
+        // OLDTODO: Compute missing packages and forward user to the missing page
 
         return retval;
     }

--- a/java/core/src/main/java/com/redhat/rhn/manager/kickstart/ProvisionVirtualInstanceCommand.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/kickstart/ProvisionVirtualInstanceCommand.java
@@ -193,7 +193,7 @@ public class ProvisionVirtualInstanceCommand extends KickstartScheduleCommand {
 
         KickstartSession ksSession = getKickstartSession();
         Long sessionId = (ksSession != null) ? ksSession.getId() : null;
-        //TODO -- It feels a little dirty to pass in this & this.getExtraOptions,
+        //OLDTODO -- It feels a little dirty to pass in this & this.getExtraOptions,
         //but I don't know that I understand the implications of making getExtraOptions
         //a public method.
         KickstartGuestAction ksAction = ActionManager.scheduleKickstartGuestAction(this,

--- a/java/core/src/main/java/com/redhat/rhn/manager/org/MigrationManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/org/MigrationManager.java
@@ -198,7 +198,7 @@ public class MigrationManager extends BaseManager {
      * @param server Server to be migrated.
      */
     public static void updateAdminRelationships(Org fromOrg, Org toOrg, Server server) {
-        // TODO: In some scenarios this appears to be somewhat slow, for an org with
+        // OLDTODO: In some scenarios this appears to be somewhat slow, for an org with
         // around a thousand org admins and a dozen or so servers, this can take about a
         // minute to run. Probably a much more efficient way to do this. (i.e. delete
         // from rhnUserServerPerms where server_id = blah. Add a huge number of servers to

--- a/java/core/src/main/java/com/redhat/rhn/manager/profile/ProfileManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/profile/ProfileManager.java
@@ -781,7 +781,7 @@ public class ProfileManager extends BaseManager {
 
         // finally for each channel needed, subscribe the server
         // to that channel. if there's an error throw an exception
-        // TODO: what type of exception
+        // OLDTODO: what type of exception
         // once subscribed, throw away any of the remaining missing
         // packages.
 
@@ -955,7 +955,7 @@ public class ProfileManager extends BaseManager {
 
         // finally for each channel needed, subscribe the server
         // to that channel. if there's an error throw an exception
-        // TODO: what type of exception
+        // OLDTODO: what type of exception
         // once subscribed, throw away any of the remaining missing
         // packages.
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/task/TaskScheduler.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/task/TaskScheduler.java
@@ -99,7 +99,7 @@ public class TaskScheduler {
         List tasks = TaskFactory.getTaskListByChannel(org);
         Date now = new Date();
         /*
-         * TODO: Hopefully when we get to hib3, we can make one update statement to hit
+         * OLDTODO: Hopefully when we get to hib3, we can make one update statement to hit
          * all of the Task objects. As of now, this isn't a big deal since we will
          * realistically only have a few channels per org.
          */

--- a/java/core/src/main/java/com/redhat/rhn/manager/token/ActivationKeyManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/token/ActivationKeyManager.java
@@ -391,7 +391,7 @@ public class ActivationKeyManager {
      * was generated implies that the user credentials have been
      * verified...
      * @param key the key to remove
-     * @param user TODO
+     * @param user
      */
     public void remove(ActivationKey key, User user) {
         changeCobblerProfileKey(key, key.getKey(), "", user);
@@ -426,7 +426,7 @@ public class ActivationKeyManager {
      * and activation key after edit by prepending its org_id to it.
      * @param newKey the key to rename to
      * @param key the key object to be renamed
-     * @param user TODO
+     * @param user
      */
     public void changeKey(String newKey, ActivationKey key, User user) {
         String oldKey = key.getKey();

--- a/java/core/src/main/java/com/redhat/rhn/manager/user/CreateUserCommand.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/user/CreateUserCommand.java
@@ -224,7 +224,7 @@ public class CreateUserCommand {
          * Check for login maximum length
          * Since we are allowing utf8 input, but not supporting it in the db, we need to
          * check the length of the bytes here as well.
-         * TODO: Do better error checking here once the db and code is fully localized and
+         * OLDTODO: Do better error checking here once the db and code is fully localized and
          * we are supporting it on logins
          */
         else if (login.length() > max || login.getBytes().length > max) {

--- a/java/core/src/main/java/com/redhat/rhn/taskomatic/core/SingleShotListener.java
+++ b/java/core/src/main/java/com/redhat/rhn/taskomatic/core/SingleShotListener.java
@@ -81,8 +81,7 @@ public class SingleShotListener implements TriggerListener {
      */
     @Override
     public void triggerMisfired(Trigger trigger) {
-        // TODO Auto-generated method stub
-
+        //empty
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/taskomatic/task/ErrataMailer.java
+++ b/java/core/src/main/java/com/redhat/rhn/taskomatic/task/ErrataMailer.java
@@ -230,7 +230,7 @@ public class ErrataMailer extends RhnJavaJob {
         Object[] args = new Object[2];
 
         //Create the data to show in the table
-        //TODO: I'm just copying over code that was here before, but it
+        //OLDTODO: I'm just copying over code that was here before, but it
         //      seems to me that we should be printing another column to
         //      the table according to the String Resource bundle.
         StringWriter writer = new StringWriter();

--- a/java/core/src/main/java/com/redhat/rhn/taskomatic/task/errata/ErrataQueueWorker.java
+++ b/java/core/src/main/java/com/redhat/rhn/taskomatic/task/errata/ErrataQueueWorker.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * have been moved out to the AutoErrataTask, so it just is basically a gatekeeper
  * that ensures that the yum metadata has been regenerated and that the errata cache
  * has already been updated before scheduling the errata notifications.
- * TODO: consolidate this job with Errata Mailer.
+ * OLDTODO: consolidate this job with Errata Mailer.
  * ErrataQueueWorker
  */
 class ErrataQueueWorker implements QueueWorker {

--- a/java/core/src/main/java/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/core/src/main/java/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -504,7 +504,7 @@ public class HardwareMapper {
             if (zhost == null) {
                 // create a new z/OS host server entry
                 zhost = ServerFactory.createServer();
-                // TODO extract this cpuarch + "-redhat-linux" in some common util
+                // OLDTODO extract this cpuarch + "-redhat-linux" in some common util
                 zhost.setServerArch(ServerFactory
                         .lookupServerArchByLabel(cpuarch + "-redhat-linux"));
                 zhost.setName(name);
@@ -519,7 +519,7 @@ public class HardwareMapper {
                                 "CPU Arch: %s", os, sysvalues.get("Type"), cpuarch));
 
                 zhost.setDigitalServerId(identifier);
-                zhost.setOrg(OrgFactory.getSatelliteOrg()); // TODO clarify this
+                zhost.setOrg(OrgFactory.getSatelliteOrg()); // OLDTODO clarify this
                 zhost.setSecret(RandomStringUtils.random(64, 0, 0, true, true, null, new SecureRandom()));
                 zhost.setAutoUpdate("N");
                 zhost.setContactMethod(ServerFactory
@@ -556,7 +556,7 @@ public class HardwareMapper {
                 hostcpu.setStepping(null);
                 hostcpu.setModel(cpuarch);
                 hostcpu.setVendor(type);
-                zhost.setCpu(hostcpu); // TODO test if this deletes any existing CPU
+                zhost.setCpu(hostcpu); // OLDTODO test if this deletes any existing CPU
                 hostcpu.setServer(zhost);
             }
 
@@ -1035,7 +1035,7 @@ public class HardwareMapper {
                     result = String.format("%s|%s", vendorFromDb, modelFromDb);
                 }
                 else {
-                    // TODO lookup in hwdata
+                    // OLDTODO lookup in hwdata
                     result = String.format("%s|%s", pciVendorDesc, pciDeviceDesc);
                 }
                 break;
@@ -1066,7 +1066,7 @@ public class HardwareMapper {
                 result = String.format("%s|%s", vendorFromDb, modelFromDb);
             }
             else {
-                // TODO lookup in hwdata
+                // OLDTODO lookup in hwdata
                 result = String.format("%s|%s", vendorId, usbDeviceDesc);
             }
         }
@@ -1091,7 +1091,7 @@ public class HardwareMapper {
                 String usbDeviceDesc = p.length > 1 ?
                         String.format("%04x", Integer.parseInt(p[1], 16)) : "";
 
-                // TODO lookup in hwdata
+                // OLDTODO lookup in hwdata
                 result = String.format("%s|%s", usbVendorDesc, usbDeviceDesc);
             }
         }

--- a/java/core/src/main/java/com/suse/manager/utils/MachinePasswordUtils.java
+++ b/java/core/src/main/java/com/suse/manager/utils/MachinePasswordUtils.java
@@ -36,8 +36,8 @@ public class MachinePasswordUtils {
     * @param minionServer minion
     * @return machine password as hash bytes
     */
-   //TODO: move this to a more appropriate place and finalize how the password is generated
-   //TODO: evaluate if plain SHA-256 is appropriate for password hashing
+   //OLDTODO: move this to a more appropriate place and finalize how the password is generated
+   //OLDTODO: evaluate if plain SHA-256 is appropriate for password hashing
    public static byte[] machinePasswordBytes(MinionServer minionServer) {
       try {
          MessageDigest instance = MessageDigest.getInstance("SHA-256");

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/StatesAPI.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/StatesAPI.java
@@ -207,7 +207,7 @@ public class StatesAPI {
         String target = request.queryParams("target");
         String targetLowerCase = target.toLowerCase();
         String serverId = request.queryParams("sid");
-        // TODO add org,group support
+        // OLDTODO add org,group support
 
         // Find matches among this server's current packages states
         MinionServer server = getEntityIfExists(MinionServerFactory.lookupById(Long.valueOf(serverId)));

--- a/java/core/src/main/java/com/suse/manager/webui/services/ConfigChannelSaltManager.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/ConfigChannelSaltManager.java
@@ -151,7 +151,7 @@ public class ConfigChannelSaltManager {
      * @throws IOException in case of an IO error
      */
     private void doGenerateConfigChannelFiles(ConfigChannel channel) throws IOException {
-        // TODO synchronize at file level not on the class instance
+        // OLDTODO synchronize at file level not on the class instance
         if (!(channel.isNormalChannel() || channel.isStateChannel())) {
             LOG.debug("Trying to generate salt files for incompatible channel type (channel: {}). Skipping. " +
                     "(Only 'normal' and 'state' configuration channels are supported.)", channel);

--- a/java/core/src/main/java/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/SaltServerActionService.java
@@ -587,7 +587,7 @@ public class SaltServerActionService {
                     // get Salt calls for this action
                     Map<LocalCall<?>, List<MinionSummary>> actionCalls = callsForAction(actionIn, minions);
 
-                    // TODO how to handle staging jobs?
+                    // OLDTODO how to handle staging jobs?
 
                     // Salt calls for each minion
                     Map<MinionSummary, List<LocalCall<?>>> callsPerMinion =

--- a/java/core/src/main/java/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
@@ -45,7 +45,7 @@ import java.util.Set;
 
 /**
  * Processes data from the matcher to a form that's displayable by the UI.
- * todo consider caching immediate lookup values to maps to improve performance
+ * OLDTODO consider caching immediate lookup values to maps to improve performance
  */
 public class SubscriptionMatchProcessor {
 

--- a/java/core/src/test/java/com/redhat/rhn/common/messaging/MessageQueueTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/messaging/MessageQueueTest.java
@@ -145,7 +145,7 @@ public class MessageQueueTest extends BaseTestCase {
         Thread.sleep(5000);
         // Just need to relinquish control to let the notify happen.
         TestEventMessage me = new TestEventMessage();
-        // TODO: figure out why this breaks on galaga but not on my
+        // OLDTODO: figure out why this breaks on galaga but not on my
         // workstation
         verifyMessageEvent(me, false);
         logger.debug("testStop - end");

--- a/java/core/src/test/java/com/redhat/rhn/domain/rhnpackage/PackageTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/rhnpackage/PackageTest.java
@@ -285,7 +285,7 @@ public class PackageTest extends BaseTestCaseWithUser {
 
     @Test
     public void testIsInChannel() {
-        // TODO make this work on sate
+        // OLDTODO make this work on sate
     }
 
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/ScheduleKickstartWizardTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/ScheduleKickstartWizardTest.java
@@ -245,7 +245,7 @@ public class ScheduleKickstartWizardTest extends RhnMockStrutsTestCase {
         assertEquals(getActualForward(),
                 "/systems/details/kickstart/SessionStatus.do?sid=" + s.getId());
 
-        // TODO Figure out why this is breaking on digdug
+        // OLDTODO Figure out why this is breaking on digdug
         //assertNotNull(KickstartFactory.lookupKickstartSessionByServer(s.getId()));
         if (addProxy && proxy != null) {
             verifyFormValue(ScheduleKickstartWizardAction.PROXY_HOST,

--- a/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/cobbler/CobblerSnippetEditActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/action/kickstart/cobbler/CobblerSnippetEditActionTest.java
@@ -31,7 +31,7 @@ public class CobblerSnippetEditActionTest extends RhnMockStrutsTestCase {
     }
 
     /**
-     * TODO: Right now this blows up with a permission denied.
+     * OLDTODO: Right now this blows up with a permission denied.
 
     @Test
     public void testDelete() throws Exception {

--- a/java/core/src/test/java/com/redhat/rhn/frontend/filter/DepthAwareBean.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/filter/DepthAwareBean.java
@@ -46,7 +46,6 @@ public class DepthAwareBean implements DepthAware {
      */
     @Override
     public long depth() {
-        // TODO Auto-generated method stub
         return depth;
     }
 
@@ -54,7 +53,6 @@ public class DepthAwareBean implements DepthAware {
      * @return the content value
      */
     public String getContent() {
-        // TODO Auto-generated method stub
         return content;
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/security/PxtAuthenticationServiceTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/security/PxtAuthenticationServiceTest.java
@@ -30,7 +30,7 @@ import jakarta.servlet.http.HttpServletResponse;
 /**
  * PxtAuthenticationServiceTest
  */
-// TODO Review Test classes in package to factor out common code
+// OLDTODO Review Test classes in package to factor out common code
 public class PxtAuthenticationServiceTest extends AuthenticationServiceAbstractTestCase {
 
     private class PxtAuthenticationServiceStub extends PxtAuthenticationService {

--- a/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/ColumnTagTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/ColumnTagTest.java
@@ -155,7 +155,7 @@ public class ColumnTagTest extends BaseTestCase {
         ct.setPageContext(mpc);
         tth.assertDoStartTag(Tag.SKIP_BODY);
         tth.assertDoEndTag(Tag.EVAL_BODY_INCLUDE);
-        //TODO: verify if this test is needed, followup with bug 458688
+        //OLDTODO: verify if this test is needed, followup with bug 458688
         RhnMockJspWriter out = (RhnMockJspWriter)tth.getPageContext().getOut();
         String expected = String.format("<th><a class=\"js-spa\" title=\"Sort By This Column\" " +
                         "href=\"?order=desc&sort=sortProp&uid=%d\">**headervalue**</a></th>",

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandlerTest.java
@@ -135,7 +135,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
 
     public void ignoredtestAddRemovePackages() throws Exception {
 
-        // TODO : GET THIS WORKING
+        // OLDTODO : GET THIS WORKING
         Channel channel = ChannelFactoryTest.createTestChannel(admin);
         Package pkg1 = PackageTest.createTestPackage(admin.getOrg());
         Package pkg2 = PackageTest.createTestPackage(admin.getOrg());

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandlerTest.java
@@ -73,7 +73,7 @@ public class PackagesHandlerTest extends BaseHandlerTestCase {
         assertEquals(2, files.length);
 
 
-        //TODO: Once we work out the mappings between packages -> files -> capabilities
+        //OLDTODO: Once we work out the mappings between packages -> files -> capabilities
         //we should do some more exhaustive testing of this method.
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/action/ActionManagerApplyStatesTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/action/ActionManagerApplyStatesTest.java
@@ -77,7 +77,7 @@ public class ActionManagerApplyStatesTest extends BaseTestCaseWithUser {
         assertEquals(ApplyStatesEventMessage.CHANNELS, details.getMods().get(0));
         assertEquals(ApplyStatesEventMessage.PACKAGES, details.getMods().get(1));
 
-        // FIXME: Verifying server actions is a problem because plain SQL is used
+        // OLDTODO: Verifying server actions is a problem because plain SQL is used
         // assertEquals(1, savedAction.getServerActions().size());
     }
 

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/admin/handlers/PaygApiControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/admin/handlers/PaygApiControllerTest.java
@@ -190,7 +190,7 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
         assertEquals("", returnData.getData().getProperties().getBastionKey());
         assertEquals("", returnData.getData().getProperties().getBastionKeyPassword());
 
-        //FIXME check data in the database
+        //OLDTODO check data in the database
 
         context.assertIsSatisfied();
     }


### PR DESCRIPTION
## What does this PR change?

SonarCloud error reduction fix step 20, removing old TODOs

As agreed in the retrospective, all **TODO** tags older than 10 years have been substituted with **OLDTODO** tag, so that they are out of SonarCloud radar, and they can be tracked if necessary. Same for older **FIXME** tags, equally substituted with **OLDTODO**

SonarCloud fix: java:S1135 track uses of TODO tags
SonarCloud fix: java:S1134 track uses of FIXME tags

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s): 
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
