### PR TITLE
Change default OS image

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -46,7 +46,7 @@ $context = {}
 
 # Other global variables
 $pxeboot_mac = ENV.fetch('PXEBOOT_MAC', nil)
-$pxeboot_image = ENV.fetch('PXEBOOT_IMAGE', nil) || 'sles15sp3o'
+$pxeboot_image = ENV.fetch('PXEBOOT_IMAGE', nil) || 'sles15sp7o'
 $sle15sp6_terminal_mac = ENV.fetch('SLE15SP6_TERMINAL_MAC', nil)
 $sle15sp7_terminal_mac = ENV.fetch('SLE15SP7_TERMINAL_MAC', nil)
 $private_net = ENV.fetch('PRIVATENET', nil) if ENV['PRIVATENET']


### PR DESCRIPTION
## What does this PR change?

Modernize default OS image from SLES 15 SP3 to SLES 15 SP7.

Normally, this default value is not used because sumaform does its job. However, during manual tests, this might happen.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes.

- [x] **DONE**


## Test coverage

Cucumber tests were refined.

- [x] **DONE**


## Links

Port(s):
 * 5.1: https://github.com/SUSE/spacewalk/pull/31025
 * 5.0: https://github.com/SUSE/spacewalk/pull/31027
 * 4.3: https://github.com/SUSE/spacewalk/pull/31028

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
