### PR TITLE
 Refactor activation key, add child channels for client roles and excl…

### DIFF
--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -344,60 +344,22 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
   # Create a key with the base channel for this client
   id = description = "#{client}_key"
   client = 'proxy_nontransactional' if client == 'proxy' && !$is_transactional_server
-  base_channel = BASE_CHANNEL_BY_CLIENT[product][client]
-  base_channel_label = LABEL_BY_BASE_CHANNEL[product][base_channel]
+  client = 'server_nontransactional' if client == 'server' && !$is_transactional_server
+  base_channel_label = LABEL_BY_BASE_CHANNEL[product][BASE_CHANNEL_BY_CLIENT[product][client]]
+
   key = $api_test.activationkey.create(id, description, base_channel_label, 100)
   raise StandardError, 'Error creating activation key via the API' if key.nil?
 
-  $stdout.puts "Activation key #{key} created" unless key.nil?
+  $stdout.puts "Activation key #{key} created"
+  contact_method = client.include?('ssh_minion') ? 'ssh-push' : 'default'
+  success = $api_test.activationkey.details_set?(key, description, base_channel_label, 100, contact_method)
+  raise 'Failed to set activation key details' unless success
 
-  is_sshminion = client.include? 'sshminion'
-  $api_test.activationkey.details_set?(key, description, base_channel_label, 100, is_sshminion ? 'ssh-push' : 'default')
-  entitlements = client.include?('buildhost') ? ['osimage_build_host'] : ''
-  $api_test.activationkey.set_entitlement(key, entitlements) unless entitlements.empty?
+  $api_test.activationkey.set_entitlement(key, ['osimage_build_host']) if client.include?('buildhost')
 
-  # Get the list of child channels for this base channel
-  child_channels = $api_test.channel.software.list_child_channels(base_channel_label)
-
-  # Define which clients trigger which exclusions
-  channel_filters = {
-    /sles15sp6|slemicro55/ => %w[
-      suse-manager-proxy
-      suse-manager-retail-branch-server
-      suse-manager-server
-    ],
-    /sles15sp7|slmicro6[12]/ => %w[
-      suse-multi-linux-manager-proxy
-      suse-multi-linux-manager-retail-branch-server
-      suse-multi-linux-manager-server
-    ]
-  }.freeze
-
-  # Apply the filters to don't have wrong child channels on normal minions
-  channel_filters.each do |pattern, exclusions|
-    child_channels.reject! { |channel| exclusions.any? { |ex| channel.include?(ex) } } if client.match?(pattern)
-  end
-
-  if client.include?('proxy_nontransactional')
-    # The non-transactional proxy for 5.1 and 5.2 is based on the same HostOS SLES15 SP7
-    # we need to determine the proxy version and exclude the channels for the other proxy version.
-    version = product_version_full
-    version_to_exclude =
-      if version&.include?('5.1')
-        '5.2'
-      elsif version&.include?('5.2') || version&.include?('head')
-        '5.1'
-      else
-        nil
-      end
-
-    # Reject the channels containing the version we want to exclude
-    child_channels.reject! { |channel| channel.include?(version_to_exclude) } if version_to_exclude
-  end
-
+  # Attach the child channels appropriate for this client's role
+  child_channels = child_channels_for_activation_key(client, base_channel_label)
   $stdout.puts "Child_channels for #{key}: <#{child_channels}>"
-
-  # Add child channels to the key
   $api_test.activationkey.add_child_channels(key, child_channels)
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -843,6 +843,33 @@ def channel_packages_are_downloaded?(channel_name)
   false
 end
 
+# Return the child channels an activation key should carry for the given client,
+# excluding the proxy/server channels that don't belong to the client's role.
+def child_channels_for_activation_key(client, base_channel_label)
+  child_channels = $api_test.channel.software.list_child_channels(base_channel_label)
+
+  role = ACTIVATION_KEY_ROLE_BY_CLIENT.fetch(client, :minion)
+  excluded_tokens =
+    ACTIVATION_KEY_EXCLUDED_CATEGORIES_BY_ROLE[role]
+    .flat_map { |category| ACTIVATION_KEY_CHANNEL_CATEGORIES[category] }
+  child_channels.reject! { |channel| excluded_tokens.any? { |token| channel.include?(token) } }
+
+  # A non-transactional proxy/server (5.1 and 5.2) shares the SLES15 SP7 HostOS, so the
+  # other MLM version's channels show up too - drop them.
+  if client.include?('nontransactional')
+    version = product_version_full
+    version_to_exclude =
+      if version&.include?('5.1')
+        '5.2'
+      elsif version&.include?('5.2') || version&.include?('head')
+        '5.1'
+      end
+    child_channels.reject! { |channel| channel.include?(version_to_exclude) } if version_to_exclude
+  end
+
+  child_channels
+end
+
 # Determines whether a channel is synchronized on the server.
 #
 # @param channel [String] The name of the channel to check.

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -254,6 +254,8 @@ BASE_CHANNEL_BY_CLIENT = {
     'proxy' => 'SL-Micro-6.2-Pool for x86_64',
     'proxy_container' => 'SL-Micro-6.2-Pool for x86_64',
     'proxy_nontransactional' => 'SLE-Product-SLES15-SP7-Pool for x86_64',
+    'server' => 'SL-Micro-6.2-Pool for x86_64',
+    'server_nontransactional' => 'SLE-Product-SLES15-SP7-Pool for x86_64',
     'sle_minion' => 'SLE-Product-SLES15-SP7-Pool for x86_64',
     'sshminion' => 'SLE-Product-SLES15-SP7-Pool for x86_64',
     'rhlike_minion' => 'RHEL8-Pool for x86_64',
@@ -495,6 +497,39 @@ LABEL_BY_BASE_CHANNEL = {
     'openSUSE Leap 15.6 (aarch64)' => 'opensuse_leap15_6-aarch64',
     'openSUSE Leap 16.0 (aarch64)' => 'opensuse_leap16_0-aarch64'
   }
+}.freeze
+
+# Maps an activation-key client to its deployment role. Anything not listed
+# (minions, monitoring_server, terminals, buildhosts) defaults to :minion.
+ACTIVATION_KEY_ROLE_BY_CLIENT = {
+  'proxy' => :proxy,
+  'proxy_container' => :proxy,
+  'proxy_nontransactional' => :proxy,
+  'server' => :server,
+  'server_nontransactional' => :server
+}.freeze
+
+# Channel-label substrings grouped by the role that owns them. Retail branch
+# server is a proxy-type role, so it lives in :proxy.
+ACTIVATION_KEY_CHANNEL_CATEGORIES = {
+  proxy: %w[
+    suse-manager-proxy
+    suse-multi-linux-manager-proxy
+    suse-manager-retail-branch-server
+    suse-multi-linux-manager-retail-branch-server
+    custom_channel_proxy
+  ],
+  server: %w[
+    suse-manager-server
+    suse-multi-linux-manager-server
+  ]
+}.freeze
+
+# Channel categories each role must NOT carry on its activation key.
+ACTIVATION_KEY_EXCLUDED_CATEGORIES_BY_ROLE = {
+  minion: %i[proxy server],
+  proxy: %i[server],
+  server: %i[proxy]
 }.freeze
 
 # Used for creating bootstrap repositories
@@ -1152,6 +1187,15 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
       %w[
         suse-multi-linux-manager-retail-branch-server-sle-5.2-pool-x86_64-sp7
         suse-multi-linux-manager-retail-branch-server-sle-5.2-updates-x86_64-sp7
+      ],
+    'suse-multi-linux-manager-server-52' =>
+      %w[
+        suse-multi-linux-manager-server-5.2-x86_64
+      ],
+    'suse-multi-linux-manager-server-52-sp7' =>
+      %w[
+        suse-multi-linux-manager-server-sle-5.2-pool-x86_64-sp7
+        suse-multi-linux-manager-server-sle-5.2-updates-x86_64-sp7
       ]
   },
   'Uyuni' => {
@@ -1812,6 +1856,9 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'suse-multi-linux-manager-retail-branch-server-sle-5.1-updates-x86_64-sp7' => 60, # for sles15sp7
   'suse-multi-linux-manager-retail-branch-server-sle-5.2-pool-x86_64-sp7' => 60, # for sles15sp7
   'suse-multi-linux-manager-retail-branch-server-sle-5.2-updates-x86_64-sp7' => 60, # for sles15sp7
+  'suse-multi-linux-manager-server-5.2-x86_64' => 60, # for slmicro6.2
+  'suse-multi-linux-manager-server-sle-5.2-pool-x86_64-sp7' => 60, # for sles15sp7
+  'suse-multi-linux-manager-server-sle-5.2-updates-x86_64-sp7' => 60, # for sles15sp7
   'suse-microos-5.2-devel-uyuni-client-x86_64' => 120,
   'suse-microos-5.2-pool-x86_64' => 120,
   'suse-microos-5.2-updates-x86_64' => 660,


### PR DESCRIPTION
…ude non-transactional proxy/server channels.

## What does this PR change?

 => Role-based activation key channels + hub server support

### What

Refactor When I create an activation key including custom channels for "<client>" via API to attach child channels by client role instead of by OS-version name match, and add SUSE Multi-Linux Manager server (hub) support.

### Why

The old filter keyed on an OS-version regex (/sle15sp7|slmicro6[12]/), so role detection was wrong: monitoring_server and proxy* clients skipped the filter and inherited proxy/server channels they shouldn't have. There was also no hub server client.

### Changes

- Role-based filtering (now in constants): minion/monitoring → no proxy & no server; proxy
→ keeps proxy + retail-branch-server, drops server; server → keeps server, drops proxy.
- New constants in constants.rb: ACTIVATION_KEY_ROLE_BY_CLIENT, ACTIVATION_KEY_CHANNEL_CATEGORIES, ACTIVATION_KEY_EXCLUDED_CATEGORIES_BY_ROLE.
- New child_channels_for_activation_key helper in commonlib.rb; step cut from ~60 to ~17 lines.
- Hub server support: server/server_nontransactional base channels, server sync-group +
timeout constants, and two @server reposync scenarios mirroring the proxy setup.
- nontransactional version-exclusion generalized to proxy and server.

Note

The SL Micro 6.2 server channel label suse-multi-linux-manager-server-5.2-x86_64 is inferred; drop the …-server-52 group, its timeout, and the @transactional_server scenariofor SP7-only if it doesn't exist.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): 
  - 5.2: https://github.com/SUSE/spacewalk/pull/31611
  - 5.1: https://github.com/SUSE/spacewalk/pull/31612

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!