### PR TITLE
Prevent ansible inventory refresh before ansible package is installed

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/manager/system/AnsibleManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/AnsibleManager.java
@@ -158,6 +158,22 @@ public class AnsibleManager extends BaseManager {
      * @throws ValidatorException if the validation fails
      */
     public AnsiblePath createAnsiblePath(String typeLabel, MinionServer minionServer, String path) {
+        return createAnsiblePath(typeLabel, minionServer, path, true);
+    }
+
+    /**
+     * Create and save a new ansible path
+     *
+     * @param typeLabel the type label
+     * @param minionServer the minion server
+     * @param path the path
+     * @param scheduleRefresh whether to schedule an immediate inventory refresh
+     * @return the created and saved AnsiblePath
+     * @throws LookupException if the user does not have permissions or server not found
+     * @throws ValidatorException if the validation fails
+     */
+    public AnsiblePath createAnsiblePath(String typeLabel, MinionServer minionServer,
+            String path, boolean scheduleRefresh) {
         validateAnsiblePath(path, of(typeLabel), empty(), minionServer.getId());
 
         AnsiblePath ansiblePath;
@@ -176,13 +192,16 @@ public class AnsibleManager extends BaseManager {
         ansiblePath = AnsibleFactory.saveAnsiblePath(ansiblePath);
 
         if (type == AnsiblePath.Type.INVENTORY) {
-            // Schedule inventory refresh
-            try {
-                ActionManager.scheduleInventoryRefresh(ansiblePath.getMinionServer(), ansiblePath.getPath().toString());
-            }
-            catch (TaskomaticApiException e) {
-                log.error("Could not schedule Ansible inventory refresh for minion: {}",
-                        ansiblePath.getMinionServer().getMinionId(), e);
+            if (scheduleRefresh) {
+                // Schedule inventory refresh
+                try {
+                    ActionManager.scheduleInventoryRefresh(ansiblePath.getMinionServer(),
+                            ansiblePath.getPath().toString());
+                }
+                catch (TaskomaticApiException e) {
+                    log.error("Could not schedule Ansible inventory refresh for minion: {}",
+                            ansiblePath.getMinionServer().getMinionId(), e);
+                }
             }
 
             // Refresh inotify beacon
@@ -575,7 +594,7 @@ public class AnsibleManager extends BaseManager {
         String inventory = "/etc/ansible/hosts";
         String playbook = "/etc/ansible/playbooks";
         try {
-            createAnsiblePath(AnsiblePath.Type.INVENTORY.getLabel(), minionServer, inventory);
+            createAnsiblePath(AnsiblePath.Type.INVENTORY.getLabel(), minionServer, inventory, false);
         }
         catch (ValidatorException e) {
             log.info(String.format("Inventory path: '%s' already exists. Skipping...", inventory));

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/AnsibleManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/AnsibleManagerTest.java
@@ -16,6 +16,7 @@
 package com.redhat.rhn.manager.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.redhat.rhn.common.hibernate.LookupException;
@@ -72,6 +73,15 @@ class AnsibleManagerTest extends BaseTestCaseWithUser {
         TestUtils.flushSession();
         TestUtils.evict(path);
         assertEquals(path, AnsibleManager.lookupAnsiblePathById(path.getId(), user).get());
+    }
+
+    @Test
+    void testCreateAnsiblePathWithoutRefresh() {
+        MinionServer minion = createAnsibleControlNode(user);
+        AnsiblePath path = ansibleManager.createAnsiblePath("inventory", minion, "/tmp/test-no-refresh", false);
+
+        assertNotNull(path);
+        assertEquals("/tmp/test-no-refresh", path.getPath().toString());
     }
 
     @Test

--- a/java/spacewalk-java.changes.parlt.fix-inventory-refresh
+++ b/java/spacewalk-java.changes.parlt.fix-inventory-refresh
@@ -1,0 +1,2 @@
+- Prevent inventory refresh before ansible package
+  is installed (bsc#1244141)

--- a/susemanager-utils/susemanager-sls/salt/ansible/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/ansible/init.sls
@@ -20,4 +20,13 @@ mgr_ansible_installed:
     - name: "No candidates for Ansible packages available for installation"
   {%- endif %}
 
+{%- if 'ansible.targets' in salt %}
+mgr_ansible_inventory_refresh:
+  module.run:
+    - name: event.send
+    - tag: salt/beacon/{{ grains['id'] }}/inotify//etc/ansible/hosts
+    - onlyif:
+      - test -f /etc/ansible/hosts
+{%- endif %}
+
 {% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.parlt.fix-inventory-refresh
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.parlt.fix-inventory-refresh
@@ -1,0 +1,2 @@
+- Prevent inventory refresh before ansible package
+  is installed (bsc#1244141)


### PR DESCRIPTION
## What does this PR change?

Don't schedule an inventory refresh right after the `Ansible control Node` entitlement is added.
Instead perform the refresh during highstate if ...
a) The ansible package is installed
b) The /etc/ansible/hosts file exists

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **BUGFIX**

- [x] **DONE**

## Test coverage

- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27444 https://github.com/SUSE/spacewalk/issues/27442 https://github.com/SUSE/spacewalk/issues/30564

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
