### PR TITLE
Use for debian repositories default checksum type sha256

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
@@ -479,7 +479,8 @@ class ContentSource:
                 self.authtoken = query
 
     def get_md_checksum_type(self):
-        pass
+        # all supported Debian OSes should support sha256 already
+        return "sha256"
 
     def get_products(self):
         # No products

--- a/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
@@ -177,15 +177,13 @@ class DebRepo:
             if "/" not in suite:
                 if arch is None:
                     rhnSQL.initDB()
-                    h = rhnSQL.prepare(
-                        """
+                    h = rhnSQL.prepare("""
                                        SELECT ca.label AS arch_label
                                        FROM rhnChannel AS c
                                        LEFT JOIN rhnChannelArch AS ca
                                            ON c.channel_arch_id = ca.id
                                        WHERE c.label = :channel_label
-                                       """
-                    )
+                                       """)
                     h.execute(channel_label=channel_label)
                     row = h.fetchone_dict()
                     if row and "arch_label" in row:
@@ -254,7 +252,7 @@ class DebRepo:
         Returns proxies dict for requests with python-requests.
         """
         if self.proxy:
-            (_, netloc, _, _, _) = urlparse.urlsplit(self.proxy)
+            _, netloc, _, _, _ = urlparse.urlsplit(self.proxy)
             proxies = {"http": "http://" + netloc, "https": "http://" + netloc}
             if self.proxy_username and self.proxy_password:
                 proxies = {
@@ -474,7 +472,7 @@ class ContentSource:
 
             # keep authtokens for mirroring
             # pylint: disable-next=invalid-name,unused-variable
-            (_scheme, _netloc, _path, query, _fragid) = urlparse.urlsplit(url)
+            _scheme, _netloc, _path, query, _fragid = urlparse.urlsplit(url)
             if query:
                 self.authtoken = query
 

--- a/python/spacewalk/spacewalk-backend.changes.mcalmer.deb-chksum-type
+++ b/python/spacewalk/spacewalk-backend.changes.mcalmer.deb-chksum-type
@@ -1,0 +1,1 @@
+- Use sha256 as the default checksum type for Debian repositories


### PR DESCRIPTION
## What does this PR change?

Currently we use `sha1` as default checksum type for all repos. With repomd we read the used checksum type of the source repository and change the channel checksum type to use the same.

For debian repos we just keep to use the default.
With newer debian/ubuntu versions we might see that `sha1` get removed and it is insecure anyway.
So we change the default for Debian/Ubuntu now to `sha256` which is hopefully supported by all Uyuni supported OSes already. 

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/31438

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
