### PR TITLE
Support parsing of uname_test and fallback CPE derivation in OVAL sync

### DIFF
--- a/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
+++ b/java/core/src/main/java/com/suse/oval/parser/OvalParser.java
@@ -64,7 +64,7 @@ import javax.xml.stream.events.XMLEvent;
 public class OvalParser {
 
     private static final Logger LOG = LogManager.getLogger(OvalParser.class);
-    private static final List<String> TEST_TYPES = List.of("rpminfo_test", "dpkginfo_test");
+    private static final List<String> TEST_TYPES = List.of("rpminfo_test", "dpkginfo_test", "uname_test");
     private static final List<String> OBJECT_TYPES = List.of("rpminfo_object", "dpkginfo_object");
     private static final List<String> STATE_TYPES = List.of("rpminfo_state", "dpkginfo_state");
 
@@ -401,6 +401,9 @@ public class OvalParser {
                 }
                 else if (element.equals("dpkginfo_test_test")) {
                     tests.add(parseTestType(nextEvent.asStartElement(), reader, PackageType.DEB));
+                }
+                else if (element.equals("uname_test")) {
+                    tests.add(parseTestType(nextEvent.asStartElement(), reader, PackageType.RPM));
                 }
             }
 

--- a/java/core/src/main/java/com/suse/oval/vulnerablepkgextractor/SUSEVulnerablePackageExtractor.java
+++ b/java/core/src/main/java/com/suse/oval/vulnerablepkgextractor/SUSEVulnerablePackageExtractor.java
@@ -126,7 +126,7 @@ public class SUSEVulnerablePackageExtractor extends CriteriaTreeBasedExtractor {
 
             ProductVulnerablePackages vulnerableProduct = new ProductVulnerablePackages();
             vulnerableProduct.setSingleCve(definition.getSingleCve().orElseThrow());
-            vulnerableProduct.setProductCpe(deriveCpe(productTest).asString());
+            vulnerableProduct.setProductCpe(deriveCpe(productCriterion, productTest).asString());
             vulnerableProduct.setProductUserFriendlyName(productUserFriendlyName);
             vulnerableProduct.setVulnerablePackages(vulnerablePackages);
 
@@ -168,7 +168,7 @@ public class SUSEVulnerablePackageExtractor extends CriteriaTreeBasedExtractor {
                         comment.startsWith("openSUSE Leap"));
     }
 
-    private Cpe deriveCpe(TestType productTest) {
+    private Cpe deriveCpe(CriterionType productCriterion, TestType productTest) {
         OsFamily osProduct = definition.getOsFamily();
         if (osProduct == OsFamily.LEAP) {
             return deriveOpenSUSELeapCpe();
@@ -180,8 +180,50 @@ public class SUSEVulnerablePackageExtractor extends CriteriaTreeBasedExtractor {
             return deriveSUSELibertyCpe();
         }
         else {
-            return deriveFromProductOVALTest(productTest);
+            try {
+                return deriveFromProductOVALTest(productTest);
+            }
+            catch (IllegalStateException e) {
+                return deriveFromProductCriterionComment(productCriterion);
+            }
         }
+    }
+
+    private Cpe deriveFromProductCriterionComment(CriterionType productCriterion) {
+        String comment = productCriterion.getComment();
+        String commentLower = comment.toLowerCase();
+
+        String productPart = "sles";
+        if (commentLower.contains("desktop")) {
+            productPart = "sled";
+        }
+        else if (commentLower.contains("suse linux enterprise server")) {
+            productPart = "sles";
+        }
+        else if (commentLower.contains("suse linux enterprise desktop")) {
+            productPart = "sled";
+        }
+
+        String versionPart = "12";
+        Pattern versionPattern = Pattern.compile("\\b(12|15|16)\\b");
+        Matcher versionMatcher = versionPattern.matcher(comment);
+        if (versionMatcher.find()) {
+            versionPart = versionMatcher.group(1);
+        }
+
+        String updatePart = null;
+        Pattern spPattern = Pattern.compile("sp(\\d+)", Pattern.CASE_INSENSITIVE);
+        Matcher spMatcher = spPattern.matcher(comment);
+        if (spMatcher.find()) {
+            updatePart = "sp" + spMatcher.group(1);
+        }
+
+        return new CpeBuilder()
+                .withVendor("suse")
+                .withProduct(productPart)
+                .withVersion(versionPart)
+                .withUpdate(updatePart)
+                .build();
     }
 
     private Cpe deriveSUSELibertyCpe() {

--- a/java/spacewalk-java.changes.parlt.fix-oval-uname-test-parsing
+++ b/java/spacewalk-java.changes.parlt.fix-oval-uname-test-parsing
@@ -1,0 +1,2 @@
+- Support parsing of uname_test and dynamic fallback CPE
+  derivation in OVAL sync (bsc#1269038)


### PR DESCRIPTION
## What does this PR change?

Oval data sync for SLE 12 was failing since our oval parser didn't support the `uname_test` oval test type.
Some additional logic is needed to derive the product CPE from this type to ensure vulnerabilities are parsed correctly.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **BUGFIX**

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **BUGFIX**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31052

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
