### PR TITLE
Use playwright driver for browser automation, update dependencies

### DIFF
--- a/.github/workflows/acceptance_tests_base.yml
+++ b/.github/workflows/acceptance_tests_base.yml
@@ -39,6 +39,7 @@ jobs:
       java: ${{ steps.filter.outputs.java }}
       web: ${{ steps.filter.outputs.web }}
       testsuite: ${{ steps.filter.outputs.testsuite }}
+      controller_dockerfile: ${{ steps.filter.outputs.controller_dockerfile }}
       not_bv_validation: ${{ steps.bv_filter.outputs.not_build_validation }}
       require_acceptance_tests: ${{ steps.filter.outputs.java == 'true' || steps.filter.outputs.web == 'true' || ( steps.filter.outputs.testsuite == 'true' && steps.bv_filter.outputs.not_build_validation == 'true' ) }}
     steps:
@@ -57,6 +58,8 @@ jobs:
               - 'web/html/src/**'
             testsuite:
               - 'testsuite/**'
+            controller_dockerfile:
+              - 'testsuite/dockerfiles/controller-dev/**'
       - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
         id: bv_filter
         with:
@@ -150,6 +153,13 @@ jobs:
       - name: Create Podman network
         if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/02_setup_network.sh
+
+      - name: Build controller image from current branch
+        if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' && needs.filters.outputs.controller_dockerfile == 'true' }}
+        run: |
+          sudo podman build \
+            -t ghcr.io/${{ env.UYUNI_PROJECT }}/uyuni/ci-test-controller-dev:${{ env.UYUNI_VERSION }} \
+            ./testsuite/dockerfiles/controller-dev/
 
       - name: Start controller, registry and build host
         if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}

--- a/.github/workflows/build_controller_test_container.yml
+++ b/.github/workflows/build_controller_test_container.yml
@@ -3,6 +3,7 @@ name: Controller Test Image
 on:
   push:
     branches:
+      - master
       - qe-develop
     paths:
       - '.github/workflows/build_controller_test_container.yml'

--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -5,6 +5,10 @@ source 'https://rubygems.org'
 
 gem 'bcrypt_pbkdf', '~> 1.1'
 gem 'capybara', '3.40.0'
+gem 'capybara-playwright-driver', '0.5.9'
+# Pinned explicitly (no Gemfile.lock in this repo): the Ruby client shells out to the Node
+# `playwright` driver and MUST match the npm version installed on controllers/dev images (1.60.0).
+gem 'playwright-ruby-client', '1.60.0'
 gem 'cucumber', '10.1.0'
 gem 'ed25519', '~> 1.4'
 gem 'faraday', '~>2.14'
@@ -30,7 +34,6 @@ gem 'redis-client', '~> 0.26'
 gem 'require_all', '~> 3.0'
 gem 'rubocop', '1.82.1'
 gem 'rubocop-ast', '1.49.0'
-gem 'selenium-webdriver', '4.39'
 gem 'simplecov', '~> 0.22'
 gem 'syntax', '~> 1.2'
 gem 'websocket', '~> 1.2'

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -13,6 +13,18 @@ Apart from Cucumber, the test suite relies on a number of [software components](
 
 You can run the Uyuni test suite with [sumaform](https://github.com/uyuni-project/sumaform/blob/master/README_TESTING.md#running-the-testsuite).
 
+## Browser automation (Playwright)
+
+The UI scenarios are driven by **Playwright** through the
+[`capybara-playwright-driver`](https://github.com/YusukeIwaki/capybara-playwright-driver) gem (replacing the previous
+Selenium / `chromedriver` backend). The Cucumber features and the Capybara DSL are unchanged — only the driver behind
+Capybara changed. Each parallel worker auto-spawns its own headless Chromium via the Node.js `playwright` package; there
+is no Selenium and no separate browser server.
+
+This means the controller needs the Node.js `playwright` CLI and a Playwright-managed Chromium installed alongside Ruby.
+See [Playwright controller setup](documentation/playwright-controller-setup.md) for the exact dependencies and how they
+are provisioned with Salt.
+
 ## Core features, idempotency and tests order
 
 The tests (features) mentioned in the YAML files inside the [run_sets](https://github.com/uyuni-project/uyuni/tree/master/testsuite/run_sets)

--- a/testsuite/dockerfiles/controller-dev/Dockerfile
+++ b/testsuite/dockerfiles/controller-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.6@sha256:b084d6e29d975ce9123fd52bd201ac020628797f2772e9171ef76f33cc92d591
+FROM docker.io/opensuse/leap:15.6@sha256:b084d6e29d975ce9123fd52bd201ac020628797f2772e9171ef76f33cc92d591
 # Ruby 3 devel repos
 RUN zypper -n ar -f --no-gpgcheck http://download.opensuse.org/repositories/devel:/languages:/ruby/15.6/ ruby_devel
 RUN zypper -n ar -f --no-gpgcheck http://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/15.6/ rubey_devel_extensions
@@ -25,7 +25,6 @@ RUN zypper ref -f && \
       mozilla-nss-tools \
       postgresql14-devel \
       chromium \
-      chromedriver \
       libgbm-devel \
       npm \
       openssh-server \
@@ -54,6 +53,15 @@ RUN update-alternatives --set ri /usr/bin/ri.ruby.ruby3.3
 RUN ruby -v
 RUN gem env
 
-# TODO: Adjust the URL/branch before merging!
-RUN curl https://raw.githubusercontent.com/uyuni-project/uyuni/master/testsuite/Gemfile -o Gemfile && bundle.ruby3.3 install --verbose && rm Gemfile
+# Playwright CLI + Chromium for the Capybara Playwright driver.
+# NOTE: no --with-deps — Playwright only supports apt/dnf for OS deps, not zypper.
+# The distro `chromium` package (installed above) provides the required shared libraries.
+# Keep PLAYWRIGHT_VERSION aligned with the `playwright-ruby-client` gem pin in testsuite/Gemfile.
+ARG PLAYWRIGHT_VERSION=1.60.0
+RUN npm install -g playwright@${PLAYWRIGHT_VERSION} && \
+    playwright install chromium
+ENV PLAYWRIGHT_CLI_EXECUTABLE_PATH=/usr/local/bin/playwright
+
+ARG GEMFILE_BRANCH=master
+RUN curl https://raw.githubusercontent.com/uyuni-project/uyuni/${GEMFILE_BRANCH}/testsuite/Gemfile -o Gemfile && bundle.ruby3.3 install --verbose && rm Gemfile
 RUN gem list

--- a/testsuite/documentation/playwright-controller-setup.md
+++ b/testsuite/documentation/playwright-controller-setup.md
@@ -1,0 +1,86 @@
+# Playwright controller setup
+
+The UI part of the test suite is driven by [Playwright](https://playwright.dev/) through the
+[`capybara-playwright-driver`](https://github.com/YusukeIwaki/capybara-playwright-driver) gem. This replaces the old
+Selenium / `chromedriver` stack. This document lists what the **controller** (the machine that runs `cucumber` /
+`parallel_cucumber`) needs, and the openSUSE-specific gotchas.
+
+## What changed vs. Selenium
+
+| Before (Selenium) | After (Playwright) |
+| --- | --- |
+| `selenium-webdriver` gem | `capybara-playwright-driver` gem (pulls `playwright-ruby-client`) |
+| distro `chromedriver` package | **none** — Playwright talks CDP directly |
+| distro `chromium` used by chromedriver | distro `chromium` kept **only for its shared libraries**; the browser actually launched is the Playwright-managed Chromium |
+| nothing from npm | Node.js `playwright` package (the CLI + Node driver) |
+
+The Cucumber features, step definitions and Capybara DSL are unchanged. Each `parallel_cucumber` worker auto-spawns its
+own headless Chromium — same per-worker model as chromedriver before, so no separate browser server is needed.
+
+## Pinned versions
+
+These three must stay aligned:
+
+| Component | Version | Why |
+| --- | --- | --- |
+| `capybara-playwright-driver` (gem) | `0.5.9` | declared in `testsuite/Gemfile` |
+| `playwright-ruby-client` (gem) | `1.60.0` | **explicitly pinned** in `testsuite/Gemfile`. The repo commits no `Gemfile.lock`, so an explicit pin is required to stop Bundler resolving a newer client than the installed Node driver |
+| `playwright` (npm) | `1.60.0` | **must equal** the `playwright-ruby-client` version — the Ruby client shells out to this exact Node driver |
+
+If you bump the gem, bump the npm package to the matching version.
+
+## Dependencies to install on the controller
+
+1. **Ruby 3.3 + build deps** — already provisioned for the suite (`ruby3.3`, `ruby3.3-devel`, `gcc`, `make`, …).
+2. **The gems** — `bundle install` against `testsuite/Gemfile` installs `capybara-playwright-driver` (and drops
+   `selenium-webdriver`). No change to how gems are installed.
+3. **Node.js + npm** — package `npm-default` (already used by the suite for the HTML reporter).
+4. **Playwright CLI (Node)** — `npm install -g playwright@1.60.0`. Installs the CLI to the global npm prefix
+   (`/usr/local/bin/playwright` on openSUSE Leap).
+5. **A Playwright-managed Chromium** — `playwright install chromium`. Downloads a CDP-matched Chromium build into
+   `~/.cache/ms-playwright` (i.e. `/root/.cache/ms-playwright` when the suite runs as `root`).
+6. **Chromium shared libraries** — keep the distro `chromium` package installed. It is *not* the browser Playwright
+   launches, but it pulls the shared libraries (libgbm, NSS, fonts, …) that the Playwright Chromium needs. Combined
+   with the suite's existing `cantarell-fonts`, `mozilla-nss-tools` and `ca-certificates-mozilla`, this satisfies the
+   runtime deps.
+
+### ⚠️ openSUSE gotcha — do NOT use `--with-deps`
+
+Playwright's `playwright install --with-deps` only knows how to install OS libraries on **apt** (Debian/Ubuntu) and
+**dnf/yum** (RHEL family). On **openSUSE / zypper it is unsupported** and will fail or do nothing useful. Therefore on
+the controller:
+
+```bash
+playwright install chromium        # ✅ download the browser only
+# playwright install --with-deps chromium   # ❌ do NOT — no zypper support
+```
+
+The OS libraries come from the distro `chromium` package (kept) instead.
+
+## Environment variables
+
+| Variable | Value | Purpose |
+| --- | --- | --- |
+| `PLAYWRIGHT_CLI_EXECUTABLE_PATH` | `/usr/local/bin/playwright` | tells `playwright-ruby-client` where the Node CLI is. Set in three places for robustness: the `controller/bashrc` template (the shells the suite runs in), `/etc/profile.d/playwright.sh` (login shells, via the SLS), and a hard-coded default in `features/support/env.rb`. |
+| `PLAYWRIGHT_BROWSERS_PATH` | *(unset — default)* | only needed if the suite runs as a non-`root` user and the browser cache lives elsewhere. Default `~/.cache/ms-playwright` is fine for `root`. |
+
+## Quick verification on the controller
+
+```bash
+playwright --version                       # -> Version 1.60.0
+ls ~/.cache/ms-playwright                   # -> chromium-XXXX directory present
+ruby -e 'require "capybara/playwright"; puts "gem ok"'   # from the testsuite dir, after bundle install
+```
+
+## How it is provisioned
+
+The real controllers are provisioned with Salt, in the SUSE CI / sumaform Salt tree (outside this
+repository). The controller state installs the dependencies listed above, in short:
+
+1. keep the distro `chromium` package; remove `chromedriver` (Selenium-only);
+2. install the Node driver globally: `npm install -g playwright@1.60.0`;
+3. download the browser: `playwright install chromium` (never `--with-deps` on openSUSE — see above);
+4. export `PLAYWRIGHT_CLI_EXECUTABLE_PATH=/usr/local/bin/playwright`.
+
+The `capybara-playwright-driver` and `playwright-ruby-client` gems are pulled in automatically by the
+existing `bundle install` step against `testsuite/Gemfile`.

--- a/testsuite/documentation/software-components.md
+++ b/testsuite/documentation/software-components.md
@@ -57,8 +57,12 @@ In order to enable this feature, you need to set the `QUALITY_INTELLIGENCE` envi
 
 * [`capybara`](https://github.com/teamcapybara/capybara) simulates user interaction with a web interface.
 It can rely on different drivers for different web browsers.
-* [`selenium-webdriver`](https://github.com/SeleniumHQ/selenium) is for automating web applications for testing purposes.
-We use `chromedriver` as driver, which offers access to the `Google Chrome` web browser run in headless mode.
+* [`capybara-playwright-driver`](https://github.com/YusukeIwaki/capybara-playwright-driver) is the Capybara driver we
+use to automate the browser. It wraps [`playwright-ruby-client`](https://github.com/YusukeIwaki/playwright-ruby-client)
+and drives a headless `Chromium` through [Playwright](https://playwright.dev/). One Chromium instance is auto-spawned
+per parallel worker (no Selenium, no chromedriver, no separate browser server).
+Playwright requires the Node.js `playwright` package and a Playwright-managed Chromium on the controller — see the
+controller setup notes in `documentation/playwright-controller-setup.md`.
 
 ### Standard Ruby Library
 

--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -1,6 +1,7 @@
 # Copyright 2017-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@long_running
 Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: Refresh SCC

--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -106,7 +106,7 @@ Feature: Action chains on Salt minions
     And I follow "Action Chain Channel"
     And I follow "List/Remove Files"
     And I follow "/etc/action-chain.cnf"
-    And I follow "Download File"
+    And I download the file by following "Download File"
     And I wait until file "/tmp/downloads/action-chain.cnf" exists on "localhost"
     Then file "/tmp/downloads/action-chain.cnf" should contain "Testchain=YES_PLEASE" on "localhost"
 

--- a/testsuite/features/secondary/srv_cobbler_profile.feature
+++ b/testsuite/features/secondary/srv_cobbler_profile.feature
@@ -56,7 +56,7 @@ Feature: Edit Cobbler profiles
     And I enter "ise_ui_test=ISE_UI_TEST" as "variables"
     And I click on "Update Variables"
     And I refresh the page
-    Then I should see a "ISE_UI_TEST" text
+    Then I should see "ise_ui_test=ISE_UI_TEST" in field identified by "variables"
 
   ## XML-RPC API tests
   Scenario: Create a Cobbler distribution via the UI in the XML-RPC context

--- a/testsuite/features/secondary/srv_users.feature
+++ b/testsuite/features/secondary/srv_users.feature
@@ -34,6 +34,7 @@ Feature: Manage users
     And I enter "galaxy-noise@localhost" as "email"
     And I click on "Create Login"
     Then I should see a "Account user1 created, login information sent to galaxy-noise@localhost" text
+    When I filter "user1" username
     And I should see a "user1" link
     And I should see a "normal user" text
 
@@ -44,6 +45,7 @@ Feature: Manage users
   Scenario: Access user details
     Given I am authorized for the "Admin" section
     When I follow the left menu "Users > User List > Active"
+    And I filter "user1" username
     And I follow "user1"
     Then I should see a "User Details" text
     And I should see a "Delete User" link
@@ -67,6 +69,7 @@ Feature: Manage users
 @susemanager
   Scenario: Add roles
     When I follow the left menu "Users > User List > Active"
+    And I filter "user1" username
     And I follow "user1"
     When the "role_satellite_admin" checkbox should be disabled
     And I check "role_system_group_admin"
@@ -91,6 +94,7 @@ Feature: Manage users
 @uyuni
   Scenario: Add roles
     When I follow the left menu "Users > User List > Active"
+    And I filter "user1" username
     And I follow "user1"
     When the "role_satellite_admin" checkbox should be disabled
     And I check "role_system_group_admin"
@@ -166,10 +170,12 @@ Feature: Manage users
 
   Scenario: Verify user list
     When I follow the left menu "Users > User List > Active"
+    And I filter "user1" username
     Then table row for "user1" should contain "Organization Administrator"
 
   Scenario: Fail to deactivate organization administrator
     When I follow the left menu "Users > User List > Active"
+    And I filter "user1" username
     And I follow "user1"
     When I follow "Deactivate User"
     Then I should see a "This action will deactivate this user. This user will no longer be able to log in or perform actions unless it is reactivated." text
@@ -180,6 +186,7 @@ Feature: Manage users
 
   Scenario: Remove role
     When I follow the left menu "Users > User List > Active"
+    And I filter "user1" username
     And I follow "user1"
     When I uncheck "role_org_admin"
     And I click on "Update"
@@ -192,6 +199,7 @@ Feature: Manage users
 
   Scenario: Deactivate ordinary user
     When I follow the left menu "Users > User List > Active"
+    And I filter "user1" username
     And I follow "user1"
     Then I should see "role_org_admin" as unchecked
     When I follow "Deactivate User"
@@ -203,6 +211,7 @@ Feature: Manage users
     Then I should see a "Deactivated Users" text
     And I should see a "user1" link
     When I follow "All"
+    And I filter "user1" username
     Then I should see a "user1" link
 
 @susemanager
@@ -235,12 +244,14 @@ Feature: Manage users
 
   Scenario: Delete user
     When I follow the left menu "Users > User List > Active"
+    And I filter "user1" username
     And I follow "user1"
     When I follow "Delete User"
     Then I should see a "Confirm User Deletion" text
     And I should see a "This will delete this user permanently." text
     When I click on "Delete User"
     Then I should see a "Active Users" text
+    And I filter "user1" username
     And I should not see a "user1" link
 
   Scenario: Display the CSV separator preference

--- a/testsuite/features/step_definitions/content_lifecycle_steps.rb
+++ b/testsuite/features/step_definitions/content_lifecycle_steps.rb
@@ -51,19 +51,26 @@ When(/^I add the "([^"]*)" channel to sources$/) do |channel|
 end
 
 When(/^I click the "([^"]*)" item (.*?) button$/) do |name, action|
-  button =
+  icon_class =
     case action
-    when /details/ then 'i[contains(@class, \'fa-list\')]'
-    when /edit/ then 'i[contains(@class, \'fa-edit\')]'
-    when /delete/ then 'i[contains(@class, \'fa-trash\')]'
+    when /details/ then 'fa-list'
+    when /edit/ then 'fa-edit'
+    when /delete/ then 'fa-trash'
     else raise ScriptError, "Unknown element with description '#{action}'"
     end
 
-  td_element = find(:xpath, "//td[contains(text(), '#{name}')]")
-  raise ScriptError, "xpath: #{name} item not found" unless td_element
+  xpath = "//tr[td[contains(text(), '#{name}')]]//button[i[contains(@class, '#{icon_class}')]]"
 
-  button_element = td_element.find(:xpath, "./ancestor::tr/td/button/#{button} | ./ancestor::tr/td/div/button/#{button}")
-  raise ScriptError, "xpath: #{action} button not found" unless button_element.click
+  attempts = 0
+  begin
+    find(:xpath, xpath).click
+  rescue Playwright::Error => e
+    raise unless e.message.include?('not attached to the DOM')
+
+    attempts += 1
+    retry if attempts < 3
+    raise
+  end
 end
 
 When(/^I click the "([^"]*)" item (.*?) button if exists$/) do |name, action|
@@ -121,7 +128,12 @@ When(/^I add "([^"]*)" calendar file as url$/) do |file|
   get_target('server').run("chmod 644 #{dest}")
   url = "https://#{get_target('server').full_hostname}/pub/" + file
   log "URL: #{url}"
-  step %(I enter "#{url}" as "calendar-data-text")
+  # Playwright's locator.fill waits for the element to be visible, attached, and editable
+  # before typing -- this handles any React async initialization of the field without a
+  # separate has_field? guard (which has proved unreliable with the Playwright driver).
+  page.driver.with_playwright_page do |pw_page|
+    pw_page.locator('#calendar-data-text').fill(url)
+  end
 end
 
 When(/^I deploy testing playbooks and inventory files to "([^"]*)"$/) do |host|

--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -13,7 +13,7 @@ Given(/^I pick "([^"]*)" as date$/) do |desired_date|
   value = Date.parse(desired_date)
   date_input = find('input[data-testid="date-picker"]')
   date_input.click
-  # TODO: Switch this over to .clear once we update Selenium
+  # TODO: Evaluate switching this over to .clear now that the Playwright driver is in use
   date_input.send_keys [:control, 'a'], :backspace, value.strftime('%Y-%m-%d'), :enter
 end
 
@@ -76,12 +76,12 @@ When(/^I schedule action to (\d+) minutes from now$/) do |minutes|
 
   date_input = find('input[data-testid="date-picker"]')
   date_input.click
-  # TODO: Switch this over to .clear once we update Selenium
+  # TODO: Evaluate switching this over to .clear now that the Playwright driver is in use
   date_input.send_keys [:control, 'a'], :backspace, action_date, :enter
 
   time_input = find('input[data-testid="time-picker"]')
   time_input.click
-  # TODO: Switch this over to .clear once we update Selenium
+  # TODO: Evaluate switching this over to .clear now that the Playwright driver is in use
   time_input.send_keys [:control, 'a'], :backspace, action_time, :enter
 end
 

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1115,7 +1115,7 @@ end
 # Test if a radio button is checked
 #
 Then(/^radio button "([^"]*)" should be checked$/) do |arg1|
-  raise ScriptError, "#{arg1} is unchecked" unless has_checked_field?(arg1)
+  raise ScriptError, "#{arg1} is unchecked" unless has_checked_field?(arg1, disabled: :all)
 end
 
 #

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -167,12 +167,19 @@ Then(/^I wait until I see the (VNC|spice) graphical console$/) do |type|
 end
 
 When(/^I switch to last opened window$/) do
-  page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
+  # Playwright registers new tab handles asynchronously after a target="_blank" click.
+  # Poll briefly so windows.last is the new tab, not the current one.
+  repeat_until_timeout(message: 'No new window was opened', timeout: 10) do
+    break if windows.count > 1
+
+    sleep 0.3
+  end
+  switch_to_window(windows.last)
 end
 
 When(/^I close the last opened window$/) do
-  page.driver.browser.close
-  page.driver.browser.switch_to.window(page.driver.browser.window_handles.first)
+  current_window.close
+  switch_to_window(windows.first)
 end
 
 #
@@ -309,14 +316,18 @@ end
 
 # Go back in the browser history
 When(/^I go back$/) do
-  page.driver.go_back
+  page.go_back
 end
 
 #
-# Click on a button
+# Click on a button or a link styled as a button (e.g. <a class="btn">)
 #
 When(/^I click on "([^"]*)"$/) do |text|
-  click_button_and_wait(text, match: :first)
+  begin
+    click_button_and_wait(text, match: :first)
+  rescue Capybara::ElementNotFound
+    click_link_and_wait(text, match: :first, force: true)
+  end
 end
 
 #
@@ -335,8 +346,8 @@ end
 # Click on a button which appears inside of <div> with
 # the given "id"
 When(/^I click on "([^"]*)" in element "([^"]*)"$/) do |text, element_id|
-  within(:xpath, "//div[@id=\"#{element_id}\"]") do
-    click_button_and_wait(text, match: :first)
+  page.driver.with_playwright_page do |pw_page|
+    pw_page.locator("##{element_id} button:visible", hasText: text).first.click(force: true)
   end
 end
 
@@ -344,7 +355,7 @@ end
 # Click on a button and confirm in alert box
 When(/^I click on "([^"]*)" and confirm$/) do |text|
   begin
-    accept_alert do
+    accept_alert(wait: Capybara.default_max_wait_time) do
       step %(I click on "#{text}")
     end
   rescue Capybara::ModalNotFound
@@ -355,7 +366,7 @@ end
 # Click on a button and confirm in alert box
 When(/^I click on "([^"]*)" and confirm alert box$/) do |text|
   begin
-    accept_confirm do
+    accept_confirm(wait: Capybara.default_max_wait_time) do
       click_button(text)
     end
   rescue Capybara::ModalNotFound
@@ -624,10 +635,18 @@ Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd
     capybara_register_driver
     Capybara.reset_sessions!
   ensure
-    visit Capybara.app_host
+    begin
+      visit Capybara.app_host
+    rescue Playwright::Error => e
+      # net::ERR_ABORTED can fire when SUMA's SSE/streaming connection collides with a new
+      # page navigation. Wait briefly for connections to settle and retry once.
+      warn "Navigation to #{Capybara.app_host} aborted (#{e.message.lines.first.chomp}) — retrying once"
+      sleep 1
+      visit Capybara.app_host
+    end
   end
   begin
-    next if all(:xpath, "//header//span[text()='#{$current_user}']", wait: 0).any?
+    next if all(:xpath, "//header//span[text()='#{$current_user}']", wait: IMMEDIATE_WAIT).any?
   rescue NoMethodError, Capybara::NotSupportedByDriverError
     # driver is not ready yet after session reset, proceed to full login
   end
@@ -940,24 +959,18 @@ When(/^I click on the clear SSM button$/) do
 end
 
 When(/^I click on the filter button$/) do
-  find_and_wait_click('button.spacewalk-button-filter').click
+  page.driver.with_playwright_page { |pw_page| pw_page.locator('button.spacewalk-button-filter').click }
   raise ScriptError, "Filter was not applied: 'filtered' text did not appear" unless check_text?('filtered', timeout: 20)
 end
 
 Then(/^I click on the filter button until page does not contain "([^"]*)" text$/) do |text|
+  # Use a Playwright locator instead of Capybara's find() so the button is re-resolved from the
+  # DOM on every click iteration. After the list re-renders the old DOM node is detached, but a
+  # locator picks up the new one automatically -- no StaleElementReference or DOM-detachment errors.
   repeat_until_timeout(message: "'#{text}' still found") do
     break unless check_text?(text)
 
-    begin
-      find('button.spacewalk-button-filter').click
-      check_text?('is filtered')
-    rescue Capybara::ElementNotFound,
-           Selenium::WebDriver::Error::StaleElementReferenceError,
-           Selenium::WebDriver::Error::NoSuchElementError,
-           NoMethodError
-
-      # page mid-navigation, retry
-    end
+    page.driver.with_playwright_page { |pw_page| pw_page.locator('button.spacewalk-button-filter').click }
   end
 end
 
@@ -965,16 +978,7 @@ Then(/^I click on the filter button until page does contain "([^"]*)" text$/) do
   repeat_until_timeout(message: "'#{text}' was not found") do
     break if check_text?(text)
 
-    begin
-      find('button.spacewalk-button-filter').click
-      check_text?('is filtered')
-    rescue Capybara::ElementNotFound,
-           Selenium::WebDriver::Error::StaleElementReferenceError,
-           Selenium::WebDriver::Error::NoSuchElementError,
-           NoMethodError
-
-      # page mid-navigation, retry
-    end
+    page.driver.with_playwright_page { |pw_page| pw_page.locator('button.spacewalk-button-filter').click }
   end
 end
 
@@ -1015,6 +1019,11 @@ end
 
 When(/^I enter "([^"]*)" as the filtered formula name$/) do |input|
   find('input[placeholder=\'Filter by formula name\']').set(input)
+end
+
+When(/^I filter "([^"]*)" username$/) do |input|
+  find('input[placeholder=\'Filter by Username: \']').set(input)
+  step 'I click on the filter button'
 end
 
 When(/^I enter the package for "([^"]*)" as the filtered package name$/) do |host|
@@ -1180,12 +1189,7 @@ When(/^I click on "([^"]*)" in "([^"]*)" modal$/) do |btn, title|
   # We wait until the element is not shown, because
   # the fade out animation might still be in progress
   repeat_until_timeout(message: "The #{title} modal dialog is still present") do
-    begin
-      break if has_no_xpath?(path, wait: 1)
-    rescue Selenium::WebDriver::Error::StaleElementReferenceError
-      # We need to consider the case that after obtaining the element it is detached from the page document
-      break
-    end
+    break if has_no_xpath?(path, wait: 1)
   end
 end
 
@@ -1246,7 +1250,21 @@ When(/^I enter the controller hostname as the redfish server address$/) do
 end
 
 When(/^I clear browser cookies$/) do
-  page.driver.browser.manage.delete_all_cookies
+  page.driver.with_playwright_page { |pw_page| pw_page.context.clear_cookies }
+end
+
+# Click a link that triggers a browser download and persist it to /tmp/downloads.
+# Playwright has no "default download directory" (unlike the old Selenium Chrome preference).
+# Best practice: drop to the native Playwright page and trigger the click inside expect_download
+# with a native locator. Mixing Capybara DSL inside the download wait is a known flakiness source.
+When(/^I download the file by following "([^"]*)"$/) do |link|
+  # capybara-playwright-driver's built-in on('download') handler auto-saves every download to
+  # Capybara.save_path (set to /tmp/downloads in env.rb). Just trigger it; the following
+  # "wait until file ... exists" step confirms completion. Manually waiting/saving here as well
+  # double-handles the same Download object and is a known flakiness/hang source.
+  page.driver.with_playwright_page do |pw_page|
+    pw_page.get_by_role('link', name: link).click
+  end
 end
 
 When(/^I close the modal dialog$/) do
@@ -1254,13 +1272,7 @@ When(/^I close the modal dialog$/) do
 end
 
 When(/^I refresh the page$/) do
-  begin
-    accept_prompt do
-      execute_script 'window.location.reload()'
-    end
-  rescue Capybara::ModalNotFound
-    # ignored
-  end
+  refresh_page
 end
 
 When(/^I make a list of the existing systems$/) do
@@ -1306,12 +1318,12 @@ end
 When(/^I click on the search button$/) do
   click_button_and_wait('Search', match: :first)
   # after a search reindex, the UI will show a "Could not connect to search server" followed by a false "No matches found" for a while
-  if has_text?('Could not connect to search server.', wait: 0)
+  if has_text?('Could not connect to search server.', wait: IMMEDIATE_WAIT)
     repeat_until_timeout(message: 'Could not perform a successful search after reindexation', timeout: 10) do
-      break unless has_text?('Could not connect to search server.', wait: 0) || has_text?('No matches found', wait: 0)
+      break unless has_text?('Could not connect to search server.', wait: IMMEDIATE_WAIT) || has_text?('No matches found', wait: IMMEDIATE_WAIT)
 
       sleep 1
-      click_button('Search', match: :first, wait: false)
+      click_button('Search', match: :first, wait: IMMEDIATE_WAIT)
     end
   end
 end

--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -371,28 +371,26 @@ When(/^I select the child channel "([^"]*)"$/) do |target_channel|
 end
 
 Then(/^I should see "([^"]*)" "([^"]*)" for the "([^"]*)" channel$/) do |target_radio, target_status, target_channel|
-  xpath = "//a[contains(text(), '#{target_channel}')]"
-  channel_id = find(:xpath, xpath)['href'].split('?')[1].split('=')[1]
+  channel_link = find(:xpath, "//a[contains(text(), '#{target_channel}')]")
+  channel_id = channel_link['href'].split('?')[1].split('=')[1]
 
-  case target_radio
-  when 'No change'
-    xpath = "//input[@type='radio' and @name='ch_action_#{channel_id}' and @value='NO_CHANGE']"
-  when 'Subscribe'
-    xpath = "//input[@type='radio' and @name='ch_action_#{channel_id}' and @value='SUBSCRIBE']"
-  when 'Unsubscribe'
-    xpath = "//input[@type='radio' and @name='ch_action_#{channel_id}' and @value='UNSUBSCRIBE']"
-  else
-    log "Target Radio #{target_radio} not supported"
-  end
+  radio_value =
+    case target_radio
+    when 'No change' then 'NO_CHANGE'
+    when 'Subscribe' then 'SUBSCRIBE'
+    when 'Unsubscribe' then 'UNSUBSCRIBE'
+    else raise ScriptError, "Target Radio '#{target_radio}' not supported"
+    end
 
-  case target_status
-  when 'selected'
-    raise ScriptError, "xpath: #{xpath} is not selected" if find(:xpath, xpath)['checked'].nil?
-  when 'unselected'
-    raise ScriptError, "xpath: #{xpath} is selected" unless find(:xpath, xpath)['checked'].nil?
-  else
-    log "Target status #{target_status} not supported"
-  end
+  checked =
+    case target_status
+    when 'selected' then true
+    when 'unselected' then false
+    else raise ScriptError, "Target status '#{target_status}' not supported"
+    end
+
+  raise ScriptError, "Radio '#{target_radio}' for channel '#{target_channel}' is not #{target_status}" unless
+    has_field?(type: 'radio', name: "ch_action_#{channel_id}", with: radio_value, checked: checked)
 end
 
 Then(/^the notification badge and the table should count the same amount of messages$/) do

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -176,12 +176,34 @@ end
 
 # This Ruby function refreshes the current page and handles any modal not found errors.
 def refresh_page
+  # A bare reload usually fires no JS prompt, so bound the wait: the Playwright driver passes
+  # this straight to the modal future and value!(nil) would otherwise block forever.
+  accept_prompt(wait: Capybara.default_max_wait_time) do
+    execute_script 'window.location.reload()'
+  end
+rescue Capybara::ModalNotFound
+  # no beforeunload dialog appeared - page reloaded normally
+end
+
+#
+# Waits for any page transition triggered by a preceding click to complete.
+# Handles both Senna SPA transitions (.senna-loading) and hard navigations.
+#
+def wait_for_page_transition
+  # Grace period: both the Senna loading class and a hard navigation are set up
+  # asynchronously after the click (e.g. React fires an API call before bouncing
+  # window.location). Without this, both checks below pass vacuously against the
+  # old, already-loaded page.
+  sleep 0.3
   begin
-    accept_prompt do
-      execute_script 'window.location.reload()'
-    end
-  rescue Capybara::ModalNotFound
-    # ignored
+    warn 'Timeout: Waiting AJAX transition' unless has_no_css?('.senna-loading', wait: 20)
+  rescue StandardError => e
+    $stdout.puts e.message # context may be destroyed mid-check by a hard navigation
+  end
+  begin
+    page.driver.with_playwright_page { |pw_page| pw_page.wait_for_load_state(state: 'load', timeout: 30_000) }
+  rescue Playwright::Error
+    # No navigation occurred, or the page is already loaded -- acceptable
   end
 end
 
@@ -191,26 +213,33 @@ end
 # @param locator [String] (optional) The locator for the button element.
 # @param options [Hash] (optional) Additional options for the click_button method.
 def click_button_and_wait(locator = nil, **options)
-  click_button(locator, **options)
   begin
-    warn 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 20)
-  rescue StandardError => e
-    $stdout.puts e.message # Skip errors related to .senna-loading element
+    click_button(locator, **options)
+  rescue Playwright::Error => e
+    raise unless e.message.include?('Timeout') && locator
+
+    warn "click_button_and_wait: Playwright action timeout for '#{locator}' -- waiting for page load to complete"
+    page.driver.with_playwright_page { |pw_page| pw_page.wait_for_load_state(state: 'load', timeout: 60_000) }
   end
+  wait_for_page_transition
 end
 
 #
 # Clicks on a link and waits for any AJAX transition to complete.
 #
 # @param locator [String, nil] The locator for the link to click.
+# @param force [Boolean] When true, uses Playwright force-click (bypasses overlay/actionability
+#   checks). Useful for <a> elements styled as buttons where the standard click is intercepted.
 # @param options [Hash] Additional options for the click action.
-def click_link_and_wait(locator = nil, **options)
-  click_link(locator, **options)
-  begin
-    warn 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 20)
-  rescue StandardError => e
-    $stdout.puts e.message # Skip errors related to .senna-loading element
+def click_link_and_wait(locator = nil, force: false, **options)
+  if force && locator
+    page.driver.with_playwright_page do |pw_page|
+      pw_page.get_by_role('link', name: locator, exact: false).first.click(force: true)
+    end
+  else
+    click_link(locator, **options)
   end
+  wait_for_page_transition
 end
 
 #
@@ -227,14 +256,19 @@ def click_link_or_button_and_wait(locator = nil, **options)
   end
 end
 
-# Capybara Node Element extension to override click method, clicking and then waiting for ajax transition
+# Capybara Node Element extension to override click method,
+# clicking and then waiting for the Senna SPA transition to complete
 module CapybaraNodeElementExtension
   def click
     super
+    # Senna adds .senna-loading asynchronously after the click.
+    # Wait a short moment for it to appear (it may legitimately never
+    # appear for non-navigating clicks), then wait for it to be gone.
+    has_css?('.senna-loading', wait: 1)
     begin
       warn 'Timeout: Waiting AJAX transition (click link)' unless has_no_css?('.senna-loading', wait: 20)
     rescue StandardError => e
-      $stdout.puts e.message # Skip errors related to .senna-loading element
+      $stdout.puts e.message
     end
   end
 end

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -135,30 +135,19 @@ end
 #
 # @param text1 [String] The first text to check for visibility.
 # @param text2 [String, nil] The second text to check for visibility (optional).
-# @param stoppper [String, nil] The stopper that end the loop if matched (optional).
 # @param timeout [Integer] The maximum time to wait for the text to become visible (default: Capybara.default_max_wait_time).
 # @return [Boolean] Returns true if the text is visible, false otherwise.
-def check_text?(text1, text2: nil, stopper: nil, timeout: Capybara.default_max_wait_time)
-  # WORKAROUND: Chrome 134+ raises Capybara::ElementNotFound, StaleElementReferenceError, or
-  # NoMethodError (CDP response type mismatch) during page navigation, bypassing Capybara's
-  # synchronize() retry mechanism. All three are caught and retried. All other exceptions still
-  # propagate. Uses a plain Time.now loop instead of repeat_until_timeout / Timeout.timeout to
-  # avoid interrupting WebDriver mid-call, which corrupts the Selenium session.
-  deadline = Time.now + timeout
-  while Time.now < deadline
-    begin
-      return true if has_text?(text1, wait: 1)
-      return true if !text2.nil? && has_text?(text2, wait: 1)
-      return false if !stopper.nil? && has_text?(stopper, wait: 1)
-    rescue Capybara::ElementNotFound,
-           Selenium::WebDriver::Error::StaleElementReferenceError,
-           Selenium::WebDriver::Error::NoSuchElementError,
-           NoMethodError
-
-      # page mid-navigation, let it settle and retry
-      sleep 2
-    end
-  end
+def check_text?(text1, text2: nil, timeout: Capybara.default_max_wait_time)
+  # Rely on Capybara's (Playwright-backed) native auto-waiting instead of a hand-rolled
+  # polling loop: has_text? already polls the page until the text appears or `wait` elapses.
+  # When two candidates are given, OR them into a single Regexp so the whole `timeout` budget
+  # is shared across both instead of being spent sequentially on each one (the old loop waited
+  # 1s on text1 before ever looking at text2). Capybara.default_normalize_ws collapses
+  # whitespace for us. Regexp.union escapes both strings, so regex metacharacters stay literal.
+  pattern = text2.nil? ? text1 : Regexp.union(text1, text2)
+  has_text?(pattern, wait: timeout)
+rescue Capybara::ElementNotFound, NoMethodError
+  # Page was mid-navigation / driver transiently unusable: treat as "not found".
   false
 end
 

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -13,7 +13,7 @@ require 'cucumber'
 require 'minitest/autorun'
 require 'minitest/unit'
 require 'securerandom'
-require 'selenium-webdriver'
+require 'capybara/playwright'
 require 'multi_test'
 require 'set'
 require 'timeout'
@@ -58,8 +58,6 @@ $no_auth_registry = ENV.fetch('NO_AUTH_REGISTRY', nil) if ENV['NO_AUTH_REGISTRY'
 $auth_registry = ENV.fetch('AUTH_REGISTRY', nil) if ENV['AUTH_REGISTRY']
 $current_user = 'admin'
 $current_password = 'admin'
-$chromium_dev_tools = ENV.fetch('REMOTE_DEBUG', false)
-$chromium_dev_port = 9222 + ENV['TEST_ENV_NUMBER'].to_i
 $use_salt_bundle = ENV.fetch('USE_SALT_BUNDLE', true)
 
 # maximal wait before giving up
@@ -68,6 +66,18 @@ $stdout.sync = true
 STARTTIME = Time.new.to_i
 Capybara.default_max_wait_time = ENV['CAPYBARA_TIMEOUT'] ? ENV['CAPYBARA_TIMEOUT'].to_i : 10
 DEFAULT_TIMEOUT = ENV['DEFAULT_TIMEOUT'] ? ENV['DEFAULT_TIMEOUT'].to_i : 250
+# Layer 3 per-scenario watchdog ceiling (see the Around hook below). Backstop against hangs that
+# Ruby's Timeout.timeout cannot interrupt (e.g. a blocked Playwright pipe call).
+# Regular scenarios are expected to finish well under 30 min; default the ceiling to 40 min.
+SCENARIO_HARD_LIMIT = ENV['SCENARIO_HARD_LIMIT'] ? ENV['SCENARIO_HARD_LIMIT'].to_i : 2400
+# Scenarios tagged @long_running (e.g. "Synchronize products" in the Setup Wizard: ~40 min in CI,
+# up to ~13 h in BV) use this instead. It is 0 (watchdog disabled, rely on the external Layer 4
+# job timeout) unless explicitly set, so set it per pipeline: e.g. 3600 in CI, 50400 in BV.
+LONG_SCENARIO_HARD_LIMIT = ENV.fetch('LONG_SCENARIO_HARD_LIMIT', '0').to_i
+# Small positive wait for "is it there right now" existence gates. capybara-playwright-driver does
+# NOT support wait: 0 / wait: false: it requires wait > 0, and a 0 maps to Playwright's "disable
+# timeout" which means wait forever. Never use wait: 0 with the Playwright driver - use this instead.
+IMMEDIATE_WAIT = ENV['IMMEDIATE_WAIT'] ? ENV['IMMEDIATE_WAIT'].to_i : 1
 $is_cloud_provider = ENV['PROVIDER'].include? 'aws'
 $is_gh_validation = ENV['PROVIDER'].include? 'podman'
 $is_containerized_server = %w[k3s podman].include? ENV.fetch('CONTAINER_RUNTIME', '')
@@ -89,58 +99,47 @@ end
 # Fix a problem with minitest and cucumber options passed through rake
 MultiTest.disable_autorun
 
-# WORKAROUND: Chrome 134+ raises UnknownError ("Node with given id does not belong to the document")
-# via CDP when a full page navigation invalidates DOM node references mid-wait.
-# Capybara's synchronize() only retries on errors in invalid_element_errors, which does not include
-# UnknownError, so the error surfaces as a hard crash. Extending the driver makes it retryable.
-module CapybaraUnknownErrorRetry
-  # Adds UnknownError to the list of errors that Capybara retries on during synchronize().
-  # Chrome 134+ raises UnknownError via CDP when a page navigation invalidates DOM node references.
-  def invalid_element_errors
-    super | [Selenium::WebDriver::Error::UnknownError]
-  end
-end
-
-# register chromedriver in headless mode
+# register the Playwright driver (Chromium, headless unless debug)
 def capybara_register_driver
-  Capybara.register_driver :selenium_chrome_headless do |app|
-    # WORKAROUND failure at Scenario: Test IPMI functions: increase from 60 s to 180 s
-    client = Selenium::WebDriver::Remote::Http::Default.new(open_timeout: 30, read_timeout: 240)
-    chrome_options = Selenium::WebDriver::Chrome::Options.new(
+  Capybara.register_driver :playwright do |app|
+    Capybara::Playwright::Driver.new(
+      app,
+      browser_type: :chromium,
+      headless: !$debug_mode,
+      playwright_cli_executable_path: ENV.fetch('PLAYWRIGHT_CLI_EXECUTABLE_PATH', '/usr/local/bin/playwright'),
       args: %w[
         --disable-dev-shm-usage
         --ignore-certificate-errors
-        --window-size=2048,2048
-        --js-flags=--max-old-space-size=2048
         --no-sandbox
         --disable-notifications
+        --window-size=2048,2048
+        --js-flags=--max-old-space-size=2048
         --log-level=3
-      ]
+      ],
+      ignoreHTTPSErrors: true,
+      acceptDownloads: true,
+      viewport: { width: 2048, height: 2048 },
+      # Hard browser-context bounds so a wedged action/navigation can never hang the run
+      # indefinitely (the old Selenium driver enforced this via Http::Default read_timeout: 240).
+      # NOTE: capybara-playwright-driver expects these in SECONDS and multiplies by 1000 internally.
+      default_timeout: Capybara.default_max_wait_time,
+      default_navigation_timeout: 240
     )
-    chrome_options.args << '--headless=new' unless $debug_mode
-    chrome_options.args << "--remote-debugging-port=#{$chromium_dev_port}" if $chromium_dev_tools
-    chrome_options.add_argument("--user-data-dir=/tmp/chrome_profile_#{Process.pid}_#{Time.now.to_i}") if $is_cloud_provider
-
-    chrome_options.add_preference('prompt_for_download', false)
-    chrome_options.add_preference('download.default_directory', '/tmp/downloads')
-    chrome_options.add_preference('unhandledPromptBehavior', 'accept')
-    chrome_options.add_preference('unexpectedAlertBehaviour', 'accept')
-
-    # WORKAROUND: Chrome 134+ raises UnknownError ("Node with given id does not belong to the document")
-    driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options, http_client: client)
-    driver.extend(CapybaraUnknownErrorRetry)
-    driver
   end
 end
 
-# register chromedriver headless mode
+# register the Playwright driver
 $capybara_driver = capybara_register_driver
-Selenium::WebDriver.logger.level = :error
-Capybara.default_driver = :selenium_chrome_headless
-Capybara.javascript_driver = :selenium_chrome_headless
+Capybara.default_driver = :playwright
+Capybara.javascript_driver = :playwright
 Capybara.default_normalize_ws = true
 Capybara.enable_aria_label = true
 Capybara.automatic_label_click = true
+# capybara-playwright-driver registers a mandatory on('download') handler that does
+# FileUtils.mkdir_p(Capybara.save_path) on EVERY download. If save_path is nil this raises a
+# TypeError inside the Playwright dispatch thread, breaking the connection so the run hangs forever
+# on the first download. Setting it both fixes that and gives the driver a directory to auto-save to.
+Capybara.save_path = ENV.fetch('DOWNLOAD_DIR', '/tmp/downloads')
 Capybara.app_host = "https://#{ENV.fetch('SERVER', nil)}"
 Capybara.server_port = 8888 + ENV['TEST_ENV_NUMBER'].to_i
 $stdout.puts "Capybara APP Host: #{Capybara.app_host}:#{Capybara.server_port}"
@@ -168,27 +167,18 @@ After do |scenario|
   log "This scenario took: #{current_epoch - @scenario_start_time} seconds"
   if scenario.failed?
     begin
-      if scenario.exception.is_a?(Selenium::WebDriver::Error::WebDriverError)
-        log "Caught web driver error: #{scenario.exception.message}"
-        Capybara.current_session.driver.quit
-        visit Capybara.app_host
-        log 'Web driver has been restarted'
-      else
-        # web_session_is_active? can raise WebDriverError if the session went stale
-        # after a long-running step (e.g. bootstrap timeout). Rescue it so the After
-        # hook does not fail and swallow the screenshot opportunity.
-        session_active =
-          begin
-            web_session_is_active?
-          rescue Selenium::WebDriver::Error::WebDriverError => e
-            log "WebDriver session went stale when checking for active session: #{e.message}"
-            false
-          end
-        if session_active
-          handle_screenshot_and_relog(scenario, current_epoch)
-        else
-          warn 'There is no active web session; unable to take a screenshot or relog.'
+      # web_session_is_active? can raise if the session went stale after a long step.
+      session_active =
+        begin
+          web_session_is_active?
+        rescue StandardError => e
+          log "Web session went stale when checking for active session: #{e.message}"
+          false
         end
+      if session_active
+        handle_screenshot_and_relog(scenario, current_epoch)
+      else
+        warn 'There is no active web session; unable to take a screenshot or relog.'
       end
     ensure
       print_server_logs
@@ -208,13 +198,9 @@ end
 def web_session_is_active?
   return false unless capybara_session_created?
 
-  page.has_selector?('header', wait: 0) || page.has_selector?('#username-field', wait: 0)
-rescue Capybara::ElementNotFound,
-       Selenium::WebDriver::Error::StaleElementReferenceError,
-       Selenium::WebDriver::Error::NoSuchElementError,
-       NoMethodError
-
-  # Chrome 134+ CDP type mismatch during page navigation - page is not in a usable state
+  page.has_selector?('header', wait: IMMEDIATE_WAIT) || page.has_selector?('#username-field', wait: IMMEDIATE_WAIT)
+rescue Capybara::ElementNotFound, NoMethodError
+  # the page is mid-navigation and not in a usable state
   false
 end
 
@@ -225,7 +211,7 @@ def handle_screenshot_and_relog(scenario, current_epoch)
   path = "#{screenshot_dir}/#{scenario.name.tr(' ./', '_')}.png"
   begin
     click_details_if_present
-    page.driver.browser.save_screenshot(path)
+    page.driver.with_playwright_page { |pw_page| pw_page.screenshot(path: path) }
     attach path, 'image/png'
     # Attach additional information
     attach "#{Time.at(@scenario_start_time).strftime('%H:%M:%S:%L')} - #{Time.at(current_epoch).strftime('%H:%M:%S:%L')} | Current URL: #{current_url}", 'text/plain'
@@ -238,7 +224,7 @@ end
 
 # Try to get the minion details when on minion page
 def click_details_if_present
-  return unless page.has_content?('Bootstrap Minions', wait: 0) && page.has_content?('Details', wait: 0)
+  return unless page.has_content?('Bootstrap Minions', wait: IMMEDIATE_WAIT) && page.has_content?('Details', wait: IMMEDIATE_WAIT)
 
   begin
     click_button('Details')
@@ -310,13 +296,84 @@ end
 AfterStep do
   next unless capybara_session_created?
 
-  log 'Timeout: Waiting AJAX transition' if has_css?('.senna-loading', wait: 0) && !has_no_css?('.senna-loading', wait: 30)
+  # has_no_css? returns immediately when the spinner is absent (the common case) and otherwise polls
+  # until it disappears, so this both replaces the old wait: 0 gate and adds ~no per-step overhead.
+  log 'Timeout: Waiting AJAX transition' unless has_no_css?('.senna-loading', wait: 30)
 end
 
 Before do
   current_time = Time.new
   @scenario_start_time = current_time.to_i
   log "This scenario ran at: #{current_time}\n"
+end
+
+# Recursively SIGKILL every descendant process of the given PID (the Playwright Node server and the
+# whole Chromium process tree). Scoped to our own descendants so parallel workers - which run in
+# separate Ruby processes - are never affected. Killed depth-first so we enumerate grandchildren
+# before their parent can reparent them.
+def kill_descendant_processes(root_pid)
+  children = `pgrep -P #{root_pid} 2>/dev/null`.split.map(&:to_i)
+  children.each do |child_pid|
+    kill_descendant_processes(child_pid)
+    begin
+      Process.kill('KILL', child_pid)
+    rescue Errno::ESRCH, Errno::EPERM
+      # already gone, or not ours to kill
+    end
+  end
+end
+
+# Unblock a wedged scenario by SIGKILLing our browser subprocess tree (the Playwright Node server
+# and Chromium). This is the ONLY reliable unblock: a thread blocked inside the Playwright pipe never
+# returns to the Ruby interpreter, and a graceful driver.quit issued from here would itself block on
+# the gem's connection mutex that the wedged main thread still holds (observed: the watchdog parked
+# in futex_wait, the browser never died, the run hung past its deadline). Severing the pipe makes the
+# reader hit EOF, so the main thread's pending call raises, the scenario fails, and Capybara rebuilds
+# a fresh browser for the next scenario. We deliberately do NOT call driver.quit - it can re-wedge.
+def unblock_wedged_browser
+  kill_descendant_processes(Process.pid)
+end
+
+# Layer 3 watchdog: a hard per-scenario ceiling that survives hangs which neither Ruby's
+# Timeout.timeout nor a graceful driver.quit can interrupt. A thread blocked inside the Playwright
+# pipe never returns to the Ruby interpreter, so it cannot be interrupted in-process; the only
+# reliable unblock is killing the browser process at the OS level (see unblock_wedged_browser). A
+# monitor thread enforces the deadline and SIGKILLs the browser subtree, so the scenario fails and
+# the run continues instead of hanging for hours. NOTE: this is best-effort - the guaranteed backstop
+# is an external job-level activity timeout (Jenkins `timeout(activity: true)`), because no in-process
+# mechanism can fully guarantee interrupting a native pipe wait.
+Around do |scenario, block|
+  limit =
+    if scenario.source_tag_names.include?('@long_running')
+      LONG_SCENARIO_HARD_LIMIT
+    else
+      SCENARIO_HARD_LIMIT
+    end
+
+  # limit <= 0 disables the watchdog (e.g. @long_running with no LONG_SCENARIO_HARD_LIMIT set, such
+  # as a 13 h product sync in BV); the external job wall-clock remains the backstop in that case.
+  if limit <= 0
+    block.call
+    next
+  end
+
+  finished = false
+  watchdog =
+    Thread.new do
+      sleep limit
+      next if finished
+
+      warn "WATCHDOG: scenario '#{scenario.name}' exceeded its hard limit of #{limit}s - " \
+           'tearing down the browser session to unblock the run'
+      unblock_wedged_browser
+    end
+
+  begin
+    block.call
+  ensure
+    finished = true
+    watchdog.kill
+  end
 end
 
 Before('@skip') do

--- a/testsuite/podman_runner/03_run_controller_and_registry_and_buildhost.sh
+++ b/testsuite/podman_runner/03_run_controller_and_registry_and_buildhost.sh
@@ -6,7 +6,7 @@ echo buildhostproductuuid > /tmp/buildhost_product_uuid
 
 AUTH_REGISTRY_USER=$(echo "$AUTH_REGISTRY_CREDENTIALS"| cut -d\| -f1)
 AUTH_REGISTRY_PASSWD=$(echo "$AUTH_REGISTRY_CREDENTIALS" | cut -d\| -f2)
-sudo -i podman run --pull newer --rm -d --network network -v /tmp/testing:/tmp --name controller -h controller -v ${src_dir}/testsuite:/testsuite ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-controller-dev:$UYUNI_VERSION
+sudo -i podman run --pull missing --rm -d --network network -v /tmp/testing:/tmp --name controller -h controller -v ${src_dir}/testsuite:/testsuite ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-controller-dev:$UYUNI_VERSION
 cat <<EOF | sudo -i podman exec -i controller bash --login -c 'cat > /etc/profile.local'
 # Generated /etc/profile.local for testsuite environment
 export SCC_CREDENTIALS="test|test"


### PR DESCRIPTION
## What does this PR change?

Replaces the Selenium / ChromeDriver browser automation backend with [Playwright](https://playwright.dev/) via the
  [`capybara-playwright-driver`](https://github.com/YusukeIwaki/capybara-playwright-driver) gem. The Cucumber features and the Capybara DSL are unchanged — only the driver behind Capybara changed.

### What was replaced and why

  | Before (Selenium) | After (Playwright) |
  |---|---|
  | `selenium-webdriver` gem | `capybara-playwright-driver` + `playwright-ruby-client` gems |
  | distro `chromedriver` package | none — Playwright talks Chrome DevTools Protocol directly |
  | Selenium `Chrome::Options` driver registration | `Capybara::Playwright::Driver` registration |
  | Hand-rolled `StaleElementReferenceError` / `UnknownError` retry loops | Playwright's native auto-waiting and locator re-resolution |
  | `wait: 0` existence gates | `IMMEDIATE_WAIT = 1` constant (Playwright treats `wait: 0` as "wait forever") |
  | `page.driver.browser.switch_to.window(...)` | `switch_to_window(windows.last)` |
  | `page.driver.browser.manage.delete_all_cookies` | `pw_page.context.clear_cookies` |
  | `page.driver.browser.save_screenshot(path)` | `pw_page.screenshot(path: path)` |
  | Selenium-specific `UnknownError` monkey-patch (`CapybaraUnknownErrorRetry`) | removed |
  | Download via Capybara link follow + Selenium Chrome `download.default_directory` pref | `I download the file by following "…"` step using Playwright `get_by_role` + `acceptDownloads:  true` |

### Infrastructure changes

  - `testsuite/Gemfile`: adds `capybara-playwright-driver 0.5.9` and  `playwright-ruby-client 1.60.0` (explicitly pinned — no `Gemfile.lock`),  removes `selenium-webdriver`.
  - `testsuite/dockerfiles/controller-dev/Dockerfile`: removes `chromedriver`,  installs Node.js Playwright CLI (`npm install -g playwright@1.60.0`) and  downloads a Playwright-managed Chromium (`playwright install chromium`).  The distro `chromium` package is kept for its shared libraries.
  - Provisioning of real controllers is done via Salt (outside this repo); see `testsuite/documentation/playwright-controller-setup.md` for details.

### Key implementation notes

  - **`IMMEDIATE_WAIT`** — `capybara-playwright-driver` maps `wait: 0` to  Playwright's "no timeout" (wait forever). All `wait: 0` / `wait: false`  gates replaced with `IMMEDIATE_WAIT = 1`.
  - **Scenario watchdog** — a new `Around` hook spawns a monitor thread per  scenario. If the scenario exceeds `SCENARIO_HARD_LIMIT` (default 40 min),  it SIGKILLs the Playwright Node process tree so the run unblocks instead
    of hanging. Scenarios tagged `@long_running` use `LONG_SCENARIO_HARD_LIMIT`
  - **Filter button loop** — both "until page does/does not contain" loops  switch from Capybara `find()` (raises `StaleElementReferenceError` after  React re-renders) to a Playwright locator that re-resolves from the DOM on
    every iteration.
  - **`check_text?`** — replaces a hand-rolled polling loop (workaround for  Chrome 134+ `StaleElementReferenceError`) with a single `has_text?` call  against a `Regexp.union` pattern, sharing the full timeout budget across  both candidate strings.
  - **`click_button_and_wait`** — catches Playwright action timeouts on slow JSP pages (e.g. Cobbler form submit > 11 s) and waits for the page load to complete instead of re-clicking.
  - **Cobbler feature** — `I should see a "ISE_UI_TEST" text` replaced with  `I should see "ise_ui_test=ISE_UI_TEST" in field identified by "variables"`:  the variable is set in the variables textarea, not rendered as visible page  text in the Playwright-driven Chromium.

### Extra implementation related to gh

  - testsuite/Gemfile — replaces selenium-webdriver with playwright-ruby-client and capybara-playwright-driver
  - testsuite/dockerfiles/controller-dev/Dockerfile — installs the Playwright CLI and its Chromium binary via npm
  - testsuite/features/ — updates step definitions and support files to use the Playwright Capybara driver
  - .github/workflows/acceptance_tests_base.yml — adds a step that builds the controller image from the current branch when testsuite/dockerfiles/controller-dev/ has changed, so the
  Playwright binary is available during CI
  - .github/workflows/build_controller_test_container.yml — adds master as a trigger branch so the published ci-test-controller-dev:master image on GHCR is automatically rebuilt after
  merge; future PRs that do not touch the Dockerfile will skip the inline build step
  - testsuite/podman_runner/03_run_controller_and_registry_and_buildhost.sh — changes --pull newer to --pull missing for the controller container so the locally-built image is used when
  present instead of being overwritten by the GHCR pull

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).


- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29248
Port(s):
 - 5.1: https://github.com/SUSE/spacewalk/pull/31053
 - 4.3: https://github.com/SUSE/spacewalk/pull/31153

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
