### PR TITLE
Use postgresql run dir instead of plain /run

### DIFF
--- a/containers/server-postgresql-image/root/usr/bin/healthcheck.sh
+++ b/containers/server-postgresql-image/root/usr/bin/healthcheck.sh
@@ -9,12 +9,14 @@ PGPORT=${POSTGRES_PORT:-5432}
 # Get current disk usage percentage
 DISK_USAGE=$(df --output=pcent /var/lib/pgsql/data | tail -1 | tr -d '%')
 
+UPGRADE_IN_PROGRESS="/run/postgresql/upgrade_in_progress"
+
 if [ "$DISK_USAGE" -gt "$THRESHOLD" ]; then
     echo "Healthcheck failed: Disk usage is at ${DISK_USAGE}%, which exceeds the ${THRESHOLD}% threshold."
     exit 1
 fi
 
-if [ -f "/run/upgrade_in_progress" ]; then
+if [ -f "$UPGRADE_IN_PROGRESS" ]; then
     echo "Healthcheck failed: Database upgrade is currently in progress."
     exit 1
 fi

--- a/containers/server-postgresql-image/root/uyuni-entrypoint.sh
+++ b/containers/server-postgresql-image/root/uyuni-entrypoint.sh
@@ -19,7 +19,7 @@ UPSTREAM_ENTRYPOINT="/usr/local/bin/docker-entrypoint.sh"
 IMAGE_REF_FILE="/etc/uyuni-image-ref"
 PGDATA="${PGDATA:-/var/lib/pgsql/data}"
 UPGRADE_HOOKS_DIR="/docker-entrypoint-upgdb.d"
-UPGRADE_IN_PROGRESS="/run/upgrade_in_progress"
+UPGRADE_IN_PROGRESS="/run/postgresql/upgrade_in_progress"
 
 log() {
     echo "[ENTRYPOINT] $*" >&2


### PR DESCRIPTION
We drop priviledges before running scripts and postgres user cannot write to the /run directly.

## What does this PR change?

Fixes https://github.com/uyuni-project/uyuni/pull/12160

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
