### PR TITLE
Implement use of JUnit5 extensions for test needing a User

### DIFF
--- a/java/core/src/test/java/com/redhat/rhn/common/messaging/MessageQueueTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/messaging/MessageQueueTest.java
@@ -21,16 +21,22 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.testing.RhnBaseTestCase;
+import com.redhat.rhn.testing.UserForTest;
+import com.redhat.rhn.testing.UserForTestCaseExtension;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(UserForTestCaseExtension.class)
 public class MessageQueueTest extends RhnBaseTestCase {
 
     private static Logger logger = LogManager.getLogger(MessageQueueTest.class);
+
+    @UserForTest
     protected User user;
 
     @BeforeEach
@@ -44,7 +50,7 @@ public class MessageQueueTest extends RhnBaseTestCase {
         logger.debug("setUp - end");
     }
 
-        @AfterEach
+    @AfterEach
     public void tearDown() throws Exception {
         logger.debug("tearDown - start");
         TestAction.deRegisterAction();
@@ -65,7 +71,6 @@ public class MessageQueueTest extends RhnBaseTestCase {
         assertTrue(me.getMessageReceived());
         logger.debug("testPublish - end");
     }
-
 
     @Test
     public void testMultiThreadedPublish() throws Exception {

--- a/java/core/src/test/java/com/redhat/rhn/testing/BaseTestCaseWithUser.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/BaseTestCaseWithUser.java
@@ -19,17 +19,19 @@ import com.redhat.rhn.domain.kickstart.KickstartDataTest;
 import com.redhat.rhn.domain.user.User;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Basic test class with a User
  */
+@ExtendWith(UserForTestCaseExtension.class)
 public abstract class BaseTestCaseWithUser extends RhnBaseTestCase {
 
+    @UserForTest(useClassNameForOrg = true)
     protected User user;
 
     @BeforeEach
     public void setUpBaseTestCaseWithUser() throws Exception {
-        user = UserTestUtils.createUser(this);
         KickstartDataTest.setupTestConfiguration(user);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
@@ -19,12 +19,15 @@ import com.redhat.rhn.domain.kickstart.KickstartDataTest;
 import com.redhat.rhn.domain.user.User;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Basic test class with a User
  */
+@ExtendWith(UserForTestCaseExtension.class)
 public abstract class JMockBaseTestCaseWithUser extends RhnJmockBaseTestCase {
 
+    @UserForTest
     protected User user;
 
     /**
@@ -34,7 +37,6 @@ public abstract class JMockBaseTestCaseWithUser extends RhnJmockBaseTestCase {
      */
     @BeforeEach
     public void setUpJMockBaseTestCaseWithUser() throws Exception {
-        user = UserTestUtils.createUser();
         KickstartDataTest.setupTestConfiguration(user);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/testing/RhnMockStrutsTestCase.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/RhnMockStrutsTestCase.java
@@ -46,11 +46,13 @@ import java.util.TimeZone;
  * Struts Actions use a User.
  */
 @ExtendWith(SaltTestCaseExtension.class)
+@ExtendWith(UserForTestCaseExtension.class)
 public class RhnMockStrutsTestCase extends BaseStrutsTestCase {
 
     @SaltTestRootPath
     protected Path tmpSaltRoot;
 
+    @UserForTest(userName = TestStatics.TEST_USER, orgName = TestStatics.TEST_ORG)
     protected User user;
 
     /**
@@ -65,7 +67,6 @@ public class RhnMockStrutsTestCase extends BaseStrutsTestCase {
 
         request.setServerName("localhost");
         request.setMethod("GET");
-        user = UserTestUtils.createUser(TestStatics.TEST_USER, TestStatics.TEST_ORG);
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         addRequestParameter(RequestContext.USER_ID, user.getId().toString());
         WebSession s = requestContext.getWebSession();

--- a/java/core/src/test/java/com/redhat/rhn/testing/UserForTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/UserForTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.testing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserForTest {
+    boolean useClassNameForOrg() default false;
+    String userName() default "";
+    String orgName() default "";
+}

--- a/java/core/src/test/java/com/redhat/rhn/testing/UserForTestCaseExtension.java
+++ b/java/core/src/test/java/com/redhat/rhn/testing/UserForTestCaseExtension.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.testing;
+
+import com.redhat.rhn.domain.user.User;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.reflect.Field;
+
+public class UserForTestCaseExtension extends TestCaseExtension implements BeforeEachCallback, AfterEachCallback {
+    protected User temporaryUser;
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContextIn) throws Exception {
+        extendAnnotatedValue(extensionContextIn, UserForTest.class, null, User.class);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContextIn) throws Exception {
+        //empty
+    }
+
+    @Override
+    protected void setInstanceField(Field field, Object instance, Object extensionObjectValue)
+            throws IllegalAccessException {
+        UserForTest annotation = field.getAnnotation(UserForTest.class);
+        boolean useUserName = StringUtils.isNotEmpty(annotation.userName());
+        boolean useOrgName = StringUtils.isNotEmpty(annotation.orgName());
+        boolean useClassNameForOrg = annotation.useClassNameForOrg();
+
+        if (useClassNameForOrg && (useUserName || useOrgName)) {
+            throw new IllegalStateException("Annotation param useClassNameForOrg must be used alone");
+        }
+
+        if (useUserName != useOrgName) {
+            throw new IllegalStateException("Annotation params userName and orgName must be used together");
+        }
+
+        if (useClassNameForOrg) {
+            temporaryUser = UserTestUtils.createUser(instance);
+        }
+        else if (useUserName && useOrgName) {
+            temporaryUser = UserTestUtils.createUser(annotation.userName(), annotation.orgName());
+        }
+        else {
+            temporaryUser = UserTestUtils.createUser();
+        }
+
+        field.set(instance, temporaryUser);
+    }
+}


### PR DESCRIPTION
## What does this PR change?

Implement use of JUnit5 extensions for test needing a User

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/29207
Port(s): 
- [x ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
