### PR TITLE
Do not hardcode any repository in MLM charts

### DIFF
--- a/containers/proxy-helm/proxy-helm.changes.cbosdo.chart-repo
+++ b/containers/proxy-helm/proxy-helm.changes.cbosdo.chart-repo
@@ -1,0 +1,1 @@
+- Error out if the repository is not set (bsc#1269667)

--- a/containers/proxy-helm/templates/_helpers.tpl
+++ b/containers/proxy-helm/templates/_helpers.tpl
@@ -1,15 +1,3 @@
-{{- define "deployment.container.image" -}}
-{{- $imageName := .name -}}
-{{- $uri := (printf "%s/%s:%s" .global.Values.repository $imageName .global.Values.version) | default .global.Chart.AppVersion -}}
-{{- if .global.Values.images -}}
-{{- $image := (get .global.Values.images $imageName) -}}
-{{- if $image -}}
-{{- $uri = $image -}}
-{{- end -}}
-{{- end -}}
-{{- $uri -}}
-{{- end -}}
-
 {{/* uyuni.image computes the image URL out of the global registry and tag as well as overridden values. */}}
 {{/*   "name", the image name */}}
 {{/*   "global", the root object */}}
@@ -19,7 +7,7 @@
 {{- if .local.tag -}}
 {{- $tag = .local.tag -}}
 {{- end -}}
-{{- $uri := (printf "%s/%s:%s" .global.Values.repository .name $tag) -}}
+{{- $uri := (printf "%s/%s:%s" (required "The repository value is required!" .global.Values.repository) .name $tag) -}}
 {{- if .local.image -}}
 {{- $uri = (printf "%s:%s" .local.image $tag) -}}
 {{- end -}}

--- a/containers/proxy-helm/tests/deployment_test.yaml
+++ b/containers/proxy-helm/tests/deployment_test.yaml
@@ -184,3 +184,18 @@ tests:
       - equal:
           path: spec.template.spec.imagePullSecrets[0].name
           value: "my-registry-key"
+
+  - it: should fail to render if the repository value is not set
+    set:
+      global.config: |
+        max_cache_size_mb: 2048
+        server: parent.example.org
+        proxy_fqdn: proxy.example.org
+        email: foo@example.org
+        log_level: 2
+      global.httpd: "httpd_content: test httpd"
+      global.ssh: "ssh_content: test ssh"
+      repository: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "The repository value is required!"

--- a/containers/proxy-helm/values.schema.json
+++ b/containers/proxy-helm/values.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Uyuni Proxy Helm Chart Values",
   "type": "object",
-  "required": ["global"],
+  "required": ["global", "repository"],
   "properties": {
     "repository": {
       "type": "string",

--- a/containers/server-helm/server-helm.changes.cbosdo.chart-repo
+++ b/containers/server-helm/server-helm.changes.cbosdo.chart-repo
@@ -1,0 +1,1 @@
+- Error out if the repository is not set (bsc#1269667)

--- a/containers/server-helm/templates/_helpers.tpl
+++ b/containers/server-helm/templates/_helpers.tpl
@@ -7,7 +7,7 @@
 {{- if .local.tag -}}
 {{- $tag = .local.tag -}}
 {{- end -}}
-{{- $uri := (printf "%s/%s:%s" .global.Values.repository .name $tag) -}}
+{{- $uri := (printf "%s/%s:%s" (required "The repository value is required!" .global.Values.repository) .name $tag) -}}
 {{- if .local.image -}}
 {{- $uri = (printf "%s:%s" .local.image $tag) -}}
 {{- end -}}

--- a/containers/server-helm/tests/deployment_test.yaml
+++ b/containers/server-helm/tests/deployment_test.yaml
@@ -92,3 +92,11 @@ tests:
                 key: password
                 name: myscccreds
                 optional: false
+
+  - it: should fail to render if the repository value is not set
+    set:
+      global.fqdn: uyuni.example.com
+      repository: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "The repository value is required!"

--- a/containers/server-helm/values.schema.json
+++ b/containers/server-helm/values.schema.json
@@ -3,7 +3,8 @@
   "title": "Values",
   "type": "object",
   "required": [
-    "global"
+    "global",
+    "repository"
   ],
   "properties": {
     "repository": {

--- a/rel-eng/chart_push.sh
+++ b/rel-eng/chart_push.sh
@@ -40,7 +40,7 @@ if [ -f "${SRPM_PKG_DIR}/Chart.yaml" ]; then
         CHART_TAR=$(ls ${SRPM_PKG_DIR}/*.tar)
         mkdir ${SRPM_PKG_DIR}/tar
         tar xf $CHART_TAR -C ${SRPM_PKG_DIR}/tar
-        sed "s/^repository: .\+$/repository: registry.suse.com\/suse\/multi-linux-manager\/${VERSION}/" -i ${SRPM_PKG_DIR}/tar/values.yaml
+        sed "s/^repository: .\+$/repository: /" -i ${SRPM_PKG_DIR}/tar/values.yaml
         tar cf $CHART_TAR -C ${SRPM_PKG_DIR}/tar --sort=name --mtime="@0" --owner=0 --group=0 --numeric-owner --pax-option="delete=atime,delete=ctime" .
         rm -rf ${SRPM_PKG_DIR}/tar
         NAME="suse\/multi-linux-manager\/${VERSION}\/${NAME}"


### PR DESCRIPTION
## What does this PR change?

Container images URLs contain the target architecture in their path for MLM. The helm chart cannot hard code any of them as it would be too confusing. The solution is to set no default repository value and nicely fail if it is missing. bsc#1269667

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)
- https://github.com/SUSE/spacewalk/issues/31075

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31076
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
