### PR TITLE
Fix stale ListTag filter state

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/list/ListTag.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/list/ListTag.java
@@ -834,6 +834,9 @@ public class ListTag extends BodyTagSupport {
      */
     @Override
     public int doStartTag() throws JspException {
+        // Reset filter first so that a tag reused from the pool after a previous
+        // failed request (where doEndTag/release was never called) starts clean.
+        filter = null;
         verifyEnvironment();
         addDecorator(decoratorName);
         setupPageData();


### PR DESCRIPTION
## What does this PR change?

It fixes stale `ListTag` filter state when a JSP tag instance is reused from the pool after a failed request.

If a previous request fails before `doEndTag()`/`release()` is called, the filter field may remain set in the pooled `ListTag` instance. On the next request, `setColumnFilter()` fails because it detects that a filter is already assigned.

This change resets the filter field at the beginning of `doStartTag()`, ensuring each new tag execution starts with a clean filter state.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31056

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
