### PR TITLE
Avoid reverse lookups from postgresql

### DIFF
--- a/containers/server-helm/README.md
+++ b/containers/server-helm/README.md
@@ -138,7 +138,6 @@ Here is a list of the ports to map:
 
 | Protocol | Port  | Service name | Service port |                                                  |
 | -------- | ----- | ------------ | ------------ | ------------------------------------------------ |
-| TCP      | 5432  | reportdb     | 5432         |                                                  |
 | TCP      | 4505  | salt         | 4505         |                                                  |
 | TCP      | 4506  | salt         | 4506         |                                                  |
 | TCP      | 8001  | taskomatic   | 8001         | Only if installed with `exposeJavaDebug = true`  |
@@ -149,6 +148,16 @@ Here is a list of the ports to map:
 Exposing the `tftp` service has to be done differently due to the way TFTP protocol is working.
 Either use the host network using the `tftp.hostNetwork` value or configure a load balancer for the `tftp` service.
 Note that not all load balancers will work: `serviceLB` implementation is not compatible with TFTP protocol, while MetalLB works.
+
+Exposing the report database externally requires configuring the `reportdb` service as a `NodePort` or `LoadBalancer` (via the `services.reportdb` value).
+
+Be aware of a critical security behavior: external database connections require SSL, whereas internal cluster connections do not.
+However, Traefik ingress TCP routes mask client IPs, causing PostgreSQL to view external traffic as internal.
+
+If you expose the database using a Traefik ingress TCP route and endpoint, you risk allowing clients to establish unencrypted, insecure connections.
+
+The IP range to use for the plain text connections on the database can be configured using the `db.podsCIDR` value.
+Also consider using a `NetworkPolicy` to limit the access to the database to the application namespace and the known external IPs.
 
 ### Ingress vs Gateway API
 

--- a/containers/server-helm/server-helm.changes.cbosdo.pg_lookup
+++ b/containers/server-helm/server-helm.changes.cbosdo.pg_lookup
@@ -1,0 +1,2 @@
+- Remove the postgresql TCP route (bsc#1270038)
+- Add a value to change pods CIDR in the database

--- a/containers/server-helm/templates/db.yaml
+++ b/containers/server-helm/templates/db.yaml
@@ -57,6 +57,8 @@ spec:
                 secretKeyRef:
                   key: password
                   name: reportdb-credentials
+            - name: POD_NETWORK
+              value: {{ .Values.db.podsCIDR | quote }}
           image: {{ include "uyuni.image" (dict "name" "server-postgresql" "global" . "local" .Values.db) }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           name: db

--- a/containers/server-helm/templates/services.yaml
+++ b/containers/server-helm/templates/services.yaml
@@ -52,6 +52,9 @@ spec:
 {{- if eq (default .Values.services.type .Values.services.reportdb.type) "NodePort" }}
       nodePort: {{ .Values.services.reportdb.ports.pgsql }}
 {{- end }}
+{{- if eq (default .Values.services.type .Values.services.reportdb.type) "LoadBalancer" }}
+  externalTrafficPolicy: Local
+{{- end }}
   selector:
     app.kubernetes.io/component: db
     app.kubernetes.io/part-of: uyuni

--- a/containers/server-helm/templates/tcp-routes.yaml
+++ b/containers/server-helm/templates/tcp-routes.yaml
@@ -33,24 +33,6 @@ spec:
       - name: salt
         port: 4506
 {{- end }}
-{{- if and .Values.db.enable (ne (default .Values.services.type .Values.services.reportdb.type) "NodePort") }}
----
-apiVersion: gateway.networking.k8s.io/v1alpha2
-kind: TCPRoute
-metadata:
-  name: reportdb-pgsql
-  namespace: "{{ .Release.Namespace }}"
-  labels:
-    app.kubernetes.io/part-of: uyuni
-spec:
-  parentRefs:
-  - name: {{ $gatewayName }}
-    sectionName: reportdb-pgsql
-  rules:
-    - backendRefs:
-      - name: reportdb
-        port: 5432
-{{- end }}
 {{- if .Values.exposeJavaDebug }}
 {{- if ne (default .Values.services.type .Values.services.taskomatic.type) "NodePort" }}
 ---

--- a/containers/server-helm/templates/traefik-routes.yaml
+++ b/containers/server-helm/templates/traefik-routes.yaml
@@ -27,26 +27,6 @@ spec:
       - /tasko-jmx
       - /tomcat-jmx
       - /saline
-{{- if ne (default .Values.services.type .Values.services.reportdb.type) "NodePort" }}
----
-apiVersion: traefik.io/v1alpha1
-kind: IngressRouteTCP
-metadata:
-  name: reportdb-pgsql-route
-  namespace: "{{ .Release.Namespace }}"
-  labels:
-    app.kubernetes.io/part-of: uyuni
-  annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
-spec:
-  entryPoints:
-    - reportdb-pgsql
-  routes:
-    - match: HostSNI(`*`)
-      services:
-      - name: reportdb
-        port: 5432
-{{- end }}
 {{- if ne (default .Values.services.type .Values.services.salt.type) "NodePort" }}
 ---
 apiVersion: traefik.io/v1alpha1

--- a/containers/server-helm/tests/db_test.yaml
+++ b/containers/server-helm/tests/db_test.yaml
@@ -12,8 +12,11 @@ tests:
           path: metadata.name
           value: db
       - equal:
-          path: spec.template.spec.containers[0].image
+          path: spec.template.spec.containers[?(@.name=="db")].image
           value: registry.opensuse.org/uyuni/server-postgresql:latest
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="db")].env[?(@.name=="POD_NETWORK")].value
+          value: 10.42.0.0/16
 
   - it: should override image when values.images is provided
     set:
@@ -23,8 +26,18 @@ tests:
         tag: 5.0.0
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].image
+          path: spec.template.spec.containers[?(@.name=="db")].image
           value: my-custom-registry/db:5.0.0
+      
+  - it: should set pod network if db podsCIDR is provided
+    set:
+      global.fqdn: uyuni.example.com
+      db:
+        podsCIDR: 192.168.15.0/24
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="db")].env[?(@.name=="POD_NETWORK")].value
+          value: 192.168.15.0/24
 
   - it: should not render db deployment if disabled
     set:

--- a/containers/server-helm/tests/db_test.yaml
+++ b/containers/server-helm/tests/db_test.yaml
@@ -12,8 +12,11 @@ tests:
           path: metadata.name
           value: db
       - equal:
-          path: spec.template.spec.containers[0].image
+          path: spec.template.spec.containers[?(@.name=="db")].image
           value: registry.opensuse.org/uyuni/server-postgresql:0.0.0
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="db")].env[?(@.name=="POD_NETWORK")].value
+          value: 10.42.0.0/16
 
   - it: should override image when values.images is provided
     set:
@@ -23,8 +26,18 @@ tests:
         tag: 5.0.0
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].image
+          path: spec.template.spec.containers[?(@.name=="db")].image
           value: my-custom-registry/db:5.0.0
+      
+  - it: should set pod network if db podsCIDR is provided
+    set:
+      global.fqdn: uyuni.example.com
+      db:
+        podsCIDR: 192.168.15.0/24
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="db")].env[?(@.name=="POD_NETWORK")].value
+          value: 192.168.15.0/24
 
   - it: should not render db deployment if disabled
     set:

--- a/containers/server-helm/tests/gateway_test.yaml
+++ b/containers/server-helm/tests/gateway_test.yaml
@@ -38,7 +38,7 @@ tests:
         template: routes.yaml
 
       - hasDocuments:
-          count: 3
+          count: 2
         template: tcp-routes.yaml
 
       - hasDocuments:
@@ -78,7 +78,7 @@ tests:
           matchMany: true
 
       - hasDocuments:
-          count: 6
+          count: 5
         template: tcp-routes.yaml
         documentSelector:
           path: spec.parentRefs[?(@.name=="test-gw")].name
@@ -137,14 +137,6 @@ tests:
           kind: TCPRoute
           apiVersion: gateway.networking.k8s.io/v1alpha2
           name: salt-request
-          namespace: myns
-          any: true
-        template: tcp-routes.yaml
-
-      - containsDocument:
-          kind: TCPRoute
-          apiVersion: gateway.networking.k8s.io/v1alpha2
-          name: reportdb-pgsql
           namespace: myns
           any: true
         template: tcp-routes.yaml

--- a/containers/server-helm/tests/services_test.yaml
+++ b/containers/server-helm/tests/services_test.yaml
@@ -181,6 +181,21 @@ tests:
         documentSelector:
           path: metadata.name
           value: search
+      
+  - it: should add local external traffic policy for LB reportdb
+    set:
+      global.fqdn: uyuni.example.com
+      exposeJavaDebug: true
+      services:
+        reportdb:
+          type: LoadBalancer
+    asserts:
+      - equal:
+          path: spec.externalTrafficPolicy
+          value: Local
+        documentSelector:
+          path: metadata.name
+          value: reportdb
 
   - it: should render services types and annotations with overridden values
     set:

--- a/containers/server-helm/tests/traefik-routes_test.yaml
+++ b/containers/server-helm/tests/traefik-routes_test.yaml
@@ -20,12 +20,6 @@ tests:
         documentSelector:
           path: metadata.name
           value: salt-publish-route
-      - equal:
-          path: spec.routes[0].services[0].port
-          value: 5432
-        documentSelector:
-          path: metadata.name
-          value: reportdb-pgsql-route
       - hasDocuments:
           count: 0
         documentSelector:

--- a/containers/server-helm/values.schema.json
+++ b/containers/server-helm/values.schema.json
@@ -339,6 +339,11 @@
           "description": "Deploy a PostgreSQL instance.",
           "default": true
         },
+        "podsCIDR": {
+          "type": "string",
+          "description": "Network IP range to allow plain text connections from, usually the cluster pods CIDR",
+          "default": "10.42.0.0/16"
+        },
         "internal": { "ref": "#/definitions/dbConnectionConfig" },
         "report": { "ref": "#/definitions/dbConnectionConfig" }
       }

--- a/containers/server-helm/values.schema.json
+++ b/containers/server-helm/values.schema.json
@@ -340,6 +340,11 @@
           "description": "Deploy a PostgreSQL instance.",
           "default": true
         },
+        "podsCIDR": {
+          "type": "string",
+          "description": "Network IP range to allow plain text connections from, usually the cluster pods CIDR",
+          "default": "10.42.0.0/16"
+        },
         "internal": { "ref": "#/definitions/dbConnectionConfig" },
         "report": { "ref": "#/definitions/dbConnectionConfig" }
       }

--- a/containers/server-helm/values.yaml
+++ b/containers/server-helm/values.yaml
@@ -284,6 +284,10 @@ db:
   # WARNING: using a third party database is not tested and supported for now.
   enable: true
 
+  # Network IP range to allow plain text connections from, usually the cluster pods CIDR
+  # The default has been adjusted with rke2's pods CIDR default.
+  podsCIDR: 10.42.0.0/16
+
   # Configuration of the internal database connection
   # WARNING: Only taken into account if db is disabled
   internal:

--- a/containers/server-helm/values.yaml
+++ b/containers/server-helm/values.yaml
@@ -285,6 +285,10 @@ db:
   # WARNING: using a third party database is not tested and supported for now.
   enable: true
 
+  # Network IP range to allow plain text connections from, usually the cluster pods CIDR
+  # The default has been adjusted with rke2's pods CIDR default.
+  podsCIDR: 10.42.0.0/16
+
   # Configuration of the internal database connection
   # WARNING: Only taken into account if db is disabled
   internal:

--- a/containers/server-postgresql-image/root/docker-entrypoint-upgdb.d/01-pg_hba.sh
+++ b/containers/server-postgresql-image/root/docker-entrypoint-upgdb.d/01-pg_hba.sh
@@ -14,16 +14,8 @@ PG_HBA_CHANGED=""
 if [ -f "$NAMESPACE_FILE" ] ; then
     # kubernetes
     NAMESPACE=$(<"$NAMESPACE_FILE")
-
-    # reverse lookup does nor work during initialization, we must check also IP
-    POD_IP=$(getent hosts $(cat /etc/hostname) 2>/dev/null | sed 's/[[:space:]].*//')
-    POD_NETWORK=$(echo "${POD_IP:-10.42.0.0}" | cut -d. -f1,2).0.0/16
-    INTERNAL_ACCESS="$POD_NETWORK .$NAMESPACE.svc.cluster.local"
-
-    # handle external access via traefik
-    # it matches the IP so it must be rejected explicitly, by domain
-    EXTERNAL_RULES="hostssl reportdb all .kube-system.svc.cluster.local scram-sha-256
-host all all .kube-system.svc.cluster.local reject"
+    INTERNAL_ACCESS="$POD_NETWORK"
+    EXTERNAL_RULES=""
 else
     # podman
     INTERNAL_ACCESS="uyuni-server uyuni-server-attestation-0 uyuni-server-attestation-1 uyuni-server-attestation-2 uyuni-server-attestation-3"

--- a/containers/server-postgresql-image/server-postgresql-image.changes.cbosdo.pg_lookup
+++ b/containers/server-postgresql-image/server-postgresql-image.changes.cbosdo.pg_lookup
@@ -1,0 +1,2 @@
+- Avoid reverse lookups from postgresql (bsc#1270038)
+- Use the POD_NETWORK variable as the CIDR for plain connections


### PR DESCRIPTION
## What does this PR change?

If FQDNs are used in `pg_hba.conf`, postgresql will reverse lookup the IPs to see if it matches those rules. On Kubernetes, the IP of the client is the one of the pod and coredns cannot reverse look it up (only services IPs).

The solution is to not use the FQDNS to filter out the connections in the Kubernetes cluster. The only drawback is that the reportdb service now needs to be either a NodePort or a LoadBalancer with this config: `externalTrafficPolicy: Local`. The traefik IngressRouteTCP masks the real external client IP and postgresql believes it's from within the cluster. bsc#1270038

## End-User Impact & Release Notes

Release notes snippet:

```
On Kubernetes installations, the database no longer relies on reverse lookup of FQDNs to give access to the internal pods without SSL.
This means that accessing the report database from the outside requires the `reportdb` service to be either of `NodePort` or `LoadBalancer` type.
```

- [x] **DONE**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pull/5057)

- [x] **DONE**

## Test coverage
- No tests: postgresql init script

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31100
Port(s): https://github.com/SUSE/spacewalk/pull/31787

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
