### PR TITLE
Fix the issues related to remedtion apply (bsc#1270049)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/controllers/ScapAuditController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/ScapAuditController.java
@@ -1728,8 +1728,12 @@ public class ScapAuditController {
      */
     private Action createBashRemediationAction(ApplyRemediationJson body, User user, Server server) {
         final long scriptTimeout = 300L;
+        String script = body.getRemediationContent();
+        if (!script.stripLeading().startsWith("#!")) {
+            script = "#!/bin/bash\n" + script;
+        }
         ScriptActionDetails scriptDetails = ActionFactory.createScriptActionDetails(
-                "root", "root", scriptTimeout, body.getRemediationContent());
+                "root", "root", scriptTimeout, script);
         ScriptRunAction action = (ScriptRunAction) ActionFactory.createAction(ActionFactory.TYPE_SCRIPT_RUN);
         action.setName(REMEDIATION_ACTION_PREFIX + body.getRuleIdentifier());
         action.setOrg(user.getOrg());

--- a/java/spacewalk-java.changes.abid.bsc-1270049
+++ b/java/spacewalk-java.changes.abid.bsc-1270049
@@ -1,0 +1,1 @@
+- Ensure SCAP bash remediation run under bash, not sh (bsc#1270049)

--- a/susemanager-utils/susemanager-sls/scap/xccdf-resume.xslt.in
+++ b/susemanager-utils/susemanager-sls/scap/xccdf-resume.xslt.in
@@ -82,9 +82,21 @@ Authors:
     <!-- Fix element template -->
     <xsl:template match="cdf1:fix | cdf2:fix">
         <remediation>
-            <xsl:value-of select="text()"/>
+            <xsl:apply-templates mode="fix-content"/>
         </remediation>
-    </xsl:template>    
+    </xsl:template>
+
+    <xsl:template match="text()" mode="fix-content">
+        <xsl:value-of select="."/>
+    </xsl:template>
+
+    <xsl:template match="cdf1:sub | cdf2:sub" mode="fix-content">
+        <xsl:variable name="subId" select="@idref"/>
+        <xsl:value-of select="//*[local-name()='Value' and @id=$subId]/*[local-name()='value' and not(@selector)]"/>
+    </xsl:template>
+
+    <xsl:template match="*" mode="fix-content"/>
+
     <xsl:template match="cdf1:TestResult | cdf2:TestResult">
         <TestResult>
             <xsl:copy-of select="@id"/>

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.abid.bsc-1270049
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.abid.bsc-1270049
@@ -1,0 +1,1 @@
+- Fix SCAP remediation truncation at <sub> element (bsc#1270049)


### PR DESCRIPTION
## What does this PR change?

This PR fixes two issue.

1. Ensure SCAP bash remediations run under bash, not sh. Some XCCDF fix scripts use bash-specific features (readarray, process
substitution) but Salt's cmd.script falls back to /bin/sh when no shebang is present, causing syntax errors at runtime. 

2. Fix SCAP remediation truncation at `<sub>` element boundaries. xsl:value-of select="text()" only captures the first text node, causing scripts to be silently truncated where XCCDF `<sub>` elements appear (e.g. value substitutions like `sysctl_*_value='<sub .../>').`

This was recently introduced change in upstream and that'S why we din't catch it before.



## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: It was a backend bug, nothing to document

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): # https://bugzilla.suse.com/show_bug.cgi?id=1270049
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
