### PR TITLE
K8S supportconfig enhancements

### DIFF
--- a/containers/mlm-supportconfig/kubectl-mlm_supportconfig
+++ b/containers/mlm-supportconfig/kubectl-mlm_supportconfig
@@ -225,7 +225,11 @@ collect_rancher_on_node() {
     dst="${WORK}/nodes/$(basename "$debug_pod_tarball")"
     if kubectl cp -n "$NS" "${debug_pod}:${debug_pod_tarball}" "$dst" 2>/dev/null; then
         kubectl exec -n "$NS" "$debug_pod" -- rm -f "$debug_pod_tarball" >/dev/null 2>&1 || true
-        record "$label" "OK ($(basename "$dst"))"
+        pushd $(dirname $dst)
+        tar xf $dst
+        rm -f $dst
+        popd
+        record "$label" "OK ($(basename "${dst%%.tar.gz}"))"
     else
         warn "kubectl cp from ${debug_pod} failed"
         record "$label" "PARTIAL (copy failed)"
@@ -333,11 +337,12 @@ collect_pod_data() {
         done
     fi
 
-    if kubectl logs -n "$NS" "$pod" --all-containers --timestamps --prefix=true > "${dst_dir}/logs.txt" 2>/dev/null; then
+    if kubectl logs -n "$NS" "$pod" --all-containers --timestamps --prefix=true > "${dst_dir}/logs.txt" 2>${dst_dir}/stderr; then
         record "logs:${pod}" "OK"
     else
-        rm -f "${dst_dir}/logs.txt"
-        record "logs:${pod}" "SKIPPED (no read permission or no logs)"
+        err=$(cat ${dst_dir}/stderr)
+        rm -f ${dst_dir}/stderr
+        record "logs:${pod}" "ERROR ($err)"
     fi
 
     # Logs (previous)


### PR DESCRIPTION
## What does this PR change?

Add the logs of the pods even in case of error: the kubectl logs command fails if one of the containers is still in initialization state. This should prevent us from getting logs from the other containers.

Unpack the rancher log-collector tarball: it's way easier to work with the tree.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: supportconfig internal change

- [x] **DONE**

## Test coverage
- No tests: supportconfig change

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
