### PR TITLE
Fix EOL notifications not working inside containers

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -26,6 +26,9 @@ import org.apache.commons.lang3.StringUtils;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -102,6 +105,7 @@ public class ConfigDefaults {
     public static final String VENDOR_NAME = "java.vendor_name";
     public static final String PRODUCT_VERSION_MGR = "web.version";
     public static final String PRODUCT_VERSION_UYUNI = "web.version.uyuni";
+    public static final String PRODUCT_VERSION_EOL = "web.version.eol";
     public static final String ENTERPRISE_LINUX_NAME = "java.enterprise_linux_name";
     public static final String VENDOR_SERVICE_NAME = "java.vendor_service_name";
 
@@ -822,6 +826,27 @@ public class ConfigDefaults {
             return Config.get().getString(PRODUCT_VERSION_UYUNI);
         }
         return Config.get().getString(PRODUCT_VERSION_MGR);
+    }
+
+    /**
+     * Return the product end of life date, if configured.
+     *
+     * @return the product end of life date, or an empty optional if it is not set or cannot be
+     * parsed as an ISO 8601 date
+     */
+    public Optional<LocalDate> getProductEndOfLifeDate() {
+        String value = Config.get().getString(PRODUCT_VERSION_EOL);
+        if (StringUtils.isBlank(value)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(LocalDate.parse(value, DateTimeFormatter.ISO_LOCAL_DATE));
+        }
+        catch (DateTimeParseException ex) {
+            org.apache.logging.log4j.LogManager.getLogger(ConfigDefaults.class)
+                .warn("Unable to parse {} value '{}' as YYYY-MM-DD; ignoring", PRODUCT_VERSION_EOL, value, ex);
+            return Optional.empty();
+        }
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/taskomatic/task/DailySummary.java
+++ b/java/core/src/main/java/com/redhat/rhn/taskomatic/task/DailySummary.java
@@ -36,7 +36,6 @@ import com.redhat.rhn.frontend.dto.OrgIdWrapper;
 import com.redhat.rhn.frontend.dto.ReportingUser;
 
 import com.suse.cloud.CloudPaygManager;
-import com.suse.manager.maintenance.BaseProductManager;
 import com.suse.manager.utils.MailHelper;
 
 import org.apache.commons.lang3.StringUtils;
@@ -47,6 +46,7 @@ import org.quartz.JobExecutionContext;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.Period;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.HashMap;
@@ -69,7 +69,7 @@ public class DailySummary extends RhnJavaJob {
     private static final String ERRATA_UPDATE = "Errata Update";
     private static final String ERRATA_INDENTION = StringUtils.repeat(" ", ERRATA_SPACER);
 
-    private static final BaseProductManager END_OF_LIFE_MANAGER = new BaseProductManager();
+    private static final Period END_OF_LIFE_NOTIFICATION_PERIOD = Period.ofMonths(6);
     private static final CloudPaygManager CLOUD_PAYG_MANAGER = GlobalInstanceHolder.PAYG_MANAGER;
 
     @Override
@@ -92,22 +92,32 @@ public class DailySummary extends RhnJavaJob {
     }
 
     private void processEndOfLifeNotification() {
-        if (ConfigDefaults.get().isUyuni()) {
-            // No end of life for Uyuni
-            return;
-        }
-
         // Notify only on the first day of the month
         final LocalDate today = LocalDate.now();
         if (today.getDayOfMonth() != 1) {
             return;
         }
 
-        if (END_OF_LIFE_MANAGER.isNotificationPeriod(today)) {
-            NotificationMessage notification = UserNotificationFactory.createNotificationMessage(
-                new EndOfLifePeriod(END_OF_LIFE_MANAGER.getEndOfLifeDate()));
-            UserNotificationFactory.storeNotificationMessageFor(notification, RoleFactory.ORG_ADMIN);
-        }
+        // The product end of life date is only set for products that have an end of life.
+        ConfigDefaults.get().getProductEndOfLifeDate()
+            .filter(endOfLife -> isEndOfLifeNotificationPeriod(endOfLife, today))
+            .ifPresent(endOfLife -> {
+                NotificationMessage notification = UserNotificationFactory.createNotificationMessage(
+                    new EndOfLifePeriod(endOfLife));
+                UserNotificationFactory.storeNotificationMessageFor(notification, RoleFactory.ORG_ADMIN);
+            });
+    }
+
+    /**
+     * Checks whether a given date is inside the period during which we notify about the product
+     * end of life.
+     *
+     * @param endOfLife the product end of life date
+     * @param onDate    the date to check
+     * @return true if onDate is within the notification period before the end of life, or after it
+     */
+    static boolean isEndOfLifeNotificationPeriod(LocalDate endOfLife, LocalDate onDate) {
+        return endOfLife.minus(END_OF_LIFE_NOTIFICATION_PERIOD).isBefore(onDate);
     }
 
     private void  processSubscriptionWarningNotification() {

--- a/java/core/src/main/java/com/suse/manager/maintenance/BaseProductManager.java
+++ b/java/core/src/main/java/com/suse/manager/maintenance/BaseProductManager.java
@@ -24,10 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Path;
-import java.time.LocalDate;
-import java.time.Period;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Optional;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -42,8 +38,6 @@ public class BaseProductManager {
 
     private static final Logger LOGGER = LogManager.getLogger(BaseProductManager.class);
 
-    private static final Period NOTIFICATION_PERIOD = Period.ofMonths(6);
-
     private static final String BASE_PRODUCT_FILE = "/etc/products.d/baseproduct";
 
     private final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
@@ -57,8 +51,6 @@ public class BaseProductManager {
     private final String arch;
 
     private final String summary;
-
-    private final LocalDate endOfLifeDate;
 
     /**
      * Default constructor.
@@ -79,29 +71,9 @@ public class BaseProductManager {
         version = document.map(doc -> extractTextByXPath(doc, "//product/version")).orElse(null);
         arch = document.map(doc -> extractTextByXPath(doc, "//product/arch")).orElse(null);
         summary = document.map(doc -> extractTextByXPath(doc, "//product/summary")).orElse(null);
-        endOfLifeDate = document.map(doc -> extractTextByXPath(doc, "//product/codestream/endoflife"))
-            .map(stringDate -> {
-                try {
-                    return LocalDate.parse(stringDate, DateTimeFormatter.ISO_LOCAL_DATE);
-                }
-                catch (DateTimeParseException ex) {
-                    LOGGER.warn("Unable to parse end of life date {}", stringDate, ex);
-                    return null;
-                }
-            })
-            .orElse(null);
 
-        LOGGER.debug("{} parse result: (name, version, arch, summary, endOfLife) => ({}, {}, {}, {}, {})",
-            baseProductURI, name, version, arch, summary, endOfLifeDate);
-    }
-
-    /**
-     * Checks if a given date is inside the notification period for the specified end of life date
-     * @param date          the date to check
-     * @return true if the given date is in the range we should notify the end of life
-     */
-    public boolean isNotificationPeriod(LocalDate date) {
-        return endOfLifeDate.minus(NOTIFICATION_PERIOD).isBefore(date);
+        LOGGER.debug("{} parse result: (name, version, arch, summary) => ({}, {}, {}, {})",
+            baseProductURI, name, version, arch, summary);
     }
 
     /**
@@ -126,15 +98,6 @@ public class BaseProductManager {
      */
     public String getArch() {
         return arch;
-    }
-
-    /**
-     * Returns the end of life date for this product.
-     *
-     * @return the end of life date of the product, or null if not defined.
-     */
-    public LocalDate getEndOfLifeDate() {
-        return endOfLifeDate;
     }
 
     /**

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/DailySummaryTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/DailySummaryTest.java
@@ -15,7 +15,9 @@
 package com.redhat.rhn.taskomatic.task;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.common.db.datasource.ModeFactory;
 import com.redhat.rhn.common.db.datasource.WriteMode;
@@ -24,6 +26,7 @@ import com.redhat.rhn.testing.UserTestUtils;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,5 +55,19 @@ public class DailySummaryTest extends BaseTestCase {
         assertEquals(1, rows);
         rows = ds.dequeueOrg(oid);
         assertEquals(1, rows);
+    }
+
+    @Test
+    void testIsEndOfLifeNotificationPeriod() {
+        LocalDate today = LocalDate.of(2026, 1, 1);
+
+        // More than 6 months before the end of life -> do not notify yet
+        assertFalse(DailySummary.isEndOfLifeNotificationPeriod(today.plusMonths(7), today));
+        // Within the 6 months notification window -> notify
+        assertTrue(DailySummary.isEndOfLifeNotificationPeriod(today.plusMonths(3), today));
+        // End of life reached today -> notify
+        assertTrue(DailySummary.isEndOfLifeNotificationPeriod(today, today));
+        // Already past the end of life -> notify
+        assertTrue(DailySummary.isEndOfLifeNotificationPeriod(today.minusDays(1), today));
     }
 }

--- a/java/core/src/test/java/com/suse/manager/maintenance/BaseProductManagerTest.java
+++ b/java/core/src/test/java/com/suse/manager/maintenance/BaseProductManagerTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.time.LocalDate;
 import java.util.Objects;
 
 public class BaseProductManagerTest {
@@ -42,8 +41,6 @@ public class BaseProductManagerTest {
         assertEquals("SUSE-Manager-Server", productManager.getName());
         assertEquals("4.3", productManager.getVersion());
         assertEquals("x86_64", productManager.getArch());
-
         assertEquals("SUSE Manager Server 4.3", productManager.getSummary());
-        assertEquals(LocalDate.of(2025, 6, 30), productManager.getEndOfLifeDate());
     }
 }

--- a/java/spacewalk-java.changes.mfriedrich.fix-eol-notification-in-containers
+++ b/java/spacewalk-java.changes.mfriedrich.fix-eol-notification-in-containers
@@ -1,0 +1,1 @@
+- Fix EOL notifications in containers

--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -65,6 +65,10 @@ web.version = 5.2.0
 # for Uyuni
 web.version.uyuni = 2026.08
 
+# the date used to notify administrators when the product is approaching
+# its end of life (YYYY-MM-DD).
+web.version.eol =
+
 web.buildtimestamp = _OBS_BUILD_TIMESTAMP_
 
 # maximum size for a config file

--- a/web/spacewalk-web.changes.mfriedrich.fix-eol-notification-in-containers
+++ b/web/spacewalk-web.changes.mfriedrich.fix-eol-notification-in-containers
@@ -1,0 +1,1 @@
+- Add `web.version.eol` setting to provide an end of life date


### PR DESCRIPTION
## What does this PR change?

This PR fixes the EOL notification not working properly in containers. Previously, it failed because the `/etc/products.d/` is not available inside the container. This is solved by defining the EOL date in the web config. By default (e.g. for Uyuni) the key is not set to a value and is ignored.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): Fixes https://github.com/SUSE/spacewalk/issues/30691
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
