### PR TITLE
Fix frontend CI React warnings in multiple views

### DIFF
--- a/web/html/src/components/dialog/Dialog.test.tsx
+++ b/web/html/src/components/dialog/Dialog.test.tsx
@@ -1,0 +1,24 @@
+import ReactModal from "react-modal";
+
+import { click, render, screen } from "utils/test-utils";
+
+import { Dialog } from "./Dialog";
+
+describe("Dialog", () => {
+  beforeAll(() => {
+    ReactModal.setAppElement(document.body);
+  });
+
+  test("closes ReactModal without Bootstrap dismiss handling", async () => {
+    const onClose = jest.fn();
+
+    render(<Dialog id="test-dialog" isOpen title="Title" content={<p>Content</p>} onClose={onClose} />);
+
+    const closeButton = screen.getByLabelText("Close");
+    expect(closeButton.getAttribute("data-bs-dismiss")).toBeNull();
+
+    await click(closeButton);
+
+    expect(onClose).toBeCalledTimes(1);
+  });
+});

--- a/web/html/src/components/dialog/Dialog.tsx
+++ b/web/html/src/components/dialog/Dialog.tsx
@@ -22,7 +22,8 @@ export type DialogProps = {
   closableModal?: boolean;
 };
 
-ReactModal.setAppElement(document.body);
+const appElement = document.querySelector<HTMLElement>(".spacewalk-main-column-layout") ?? document.body;
+ReactModal.setAppElement(appElement);
 
 export function Dialog(props: DialogProps) {
   const closableModal = props.closableModal ?? true;
@@ -43,13 +44,7 @@ export function Dialog(props: DialogProps) {
         {!props.hideHeader && (
           <div className="modal-header">
             {closableModal && (
-              <button
-                type="button"
-                className="close"
-                data-bs-dismiss="modal"
-                aria-label="Close"
-                onClick={() => props.onClose?.()}
-              >
+              <button type="button" className="close" aria-label="Close" onClick={() => props.onClose?.()}>
                 <span aria-hidden="true">
                   <i className="fa fa-close"></i>
                 </span>

--- a/web/html/src/components/dialog/util.test.ts
+++ b/web/html/src/components/dialog/util.test.ts
@@ -1,0 +1,73 @@
+import { hideDialog, showDialog } from "./util";
+
+function renderModalTarget(id: string) {
+  document.body.innerHTML = `<div id="${id}" class="modal"></div>`;
+}
+
+function renderNonModalTarget(id: string) {
+  document.body.innerHTML = `<div id="${id}"></div>`;
+}
+
+function mockBootstrapModalPlugin() {
+  const originalModal = (jQuery.fn as any).modal;
+  const modalMock = jest.fn(function (this: JQuery) {
+    return this;
+  });
+
+  (jQuery.fn as any).modal = modalMock;
+
+  return {
+    modalMock,
+    restore: () => {
+      if (originalModal === undefined) {
+        delete (jQuery.fn as any).modal;
+      } else {
+        (jQuery.fn as any).modal = originalModal;
+      }
+    },
+  };
+}
+
+describe("dialog util", () => {
+  let modalMock: jest.Mock;
+  let restoreModalPlugin: () => void;
+
+  beforeEach(() => {
+    const bootstrapModalPlugin = mockBootstrapModalPlugin();
+    modalMock = bootstrapModalPlugin.modalMock;
+    restoreModalPlugin = bootstrapModalPlugin.restore;
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    restoreModalPlugin();
+  });
+
+  test("does not invoke Bootstrap for missing targets", () => {
+    showDialog("missing-dialog");
+    hideDialog("missing-dialog");
+
+    expect(modalMock).not.toBeCalled();
+  });
+
+  test("does not invoke Bootstrap for non-modal targets", () => {
+    renderNonModalTarget("react-modal-dialog");
+
+    showDialog("react-modal-dialog");
+    hideDialog("react-modal-dialog");
+
+    expect(modalMock).not.toBeCalled();
+  });
+
+  test("invokes Bootstrap for modal targets", () => {
+    renderModalTarget("legacy-dialog");
+
+    showDialog("legacy-dialog");
+    expect(modalMock).toBeCalledWith("show");
+
+    modalMock.mockClear();
+    hideDialog("legacy-dialog");
+    expect(modalMock).toBeCalledWith("hide");
+  });
+});

--- a/web/html/src/components/dialog/util.ts
+++ b/web/html/src/components/dialog/util.ts
@@ -1,8 +1,23 @@
+function getBootstrapModal(dialogId: string): JQuery | null {
+  const element = document.getElementById(dialogId);
+
+  if (!element?.classList.contains("modal")) {
+    return null;
+  }
+
+  return jQuery(element);
+}
+
 export function showDialog(dialogId: string) {
   // The base event is "hide.bs.modal", we only want to remove the listener we added so we add a namespace, see https://api.jquery.com/event.namespace/
   const namespacedEventName = "hide.bs.modal.namespace-dialog-util";
+  const bootstrapModal = getBootstrapModal(dialogId);
 
-  const dialog = jQuery("#" + dialogId)
+  if (!bootstrapModal) {
+    return;
+  }
+
+  const dialog = bootstrapModal
     .modal("show")
     // Here and below, these manual handlers offer compatibility between Bootstrap 3 and 5, we can drop these after the migration is complete
     .addClass("show")
@@ -19,5 +34,5 @@ export function showDialog(dialogId: string) {
 }
 
 export function hideDialog(dialogId: string) {
-  jQuery("#" + dialogId).modal("hide");
+  getBootstrapModal(dialogId)?.modal("hide");
 }

--- a/web/html/src/components/messages/messages.tsx
+++ b/web/html/src/components/messages/messages.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, Component } from "react";
+import { type ReactNode, Component, isValidElement } from "react";
 export type Severity = "info" | "success" | "warning" | "error";
 
 export type ServerMessageType = {
@@ -134,8 +134,8 @@ function msg(severityIn: Severity, textIn: ReactNode, listMultiple: boolean, hea
             <>
               {header && <p>{header}</p>}
               <ul>
-                {textIn.map((msg) => (
-                  <li key={msg}>{msg}</li>
+                {textIn.map((msg, index) => (
+                  <li key={isValidElement(msg) && msg.key !== null ? msg.key : index}>{msg}</li>
                 ))}
               </ul>
             </>

--- a/web/html/src/components/table/TableDataHandler.tsx
+++ b/web/html/src/components/table/TableDataHandler.tsx
@@ -358,6 +358,7 @@ export class TableDataHandler extends Component<Props, State> {
     if (!searchField && this.props.onSearch) {
       searchField = <SearchField />;
     }
+    const searchPanelChildren = Children.toArray([searchField, ...(this.props.additionalFilters ?? [])]);
     const isTableHeaderEmpty = !this.props.titleButtons && !searchField && !this.props.additionalFilters;
     const stickyHeader = this.props.stickyHeader;
 
@@ -455,8 +456,7 @@ export class TableDataHandler extends Component<Props, State> {
                     selectable={isSelectable}
                     searchPanelInline={this.props.searchPanelInline}
                   >
-                    {searchField}
-                    {this.props.additionalFilters}
+                    {searchPanelChildren}
                   </SearchPanel>
                   <div className="spacewalk-list-head-addons-extra table-items-per-page-wrapper">
                     {this.renderTitleButtons()}

--- a/web/html/src/components/toastr/toastr.tsx
+++ b/web/html/src/components/toastr/toastr.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode, ReactNodeArray } from "react";
+import { type ReactNode, type ReactNodeArray, forwardRef, useImperativeHandle } from "react";
+
 import { cssTransition, toast, ToastContainer } from "react-toastify";
 
 type OptionalParams = {
@@ -78,7 +79,9 @@ export function showInfoToastr(message: ReactNode, optionalParams: OptionalParam
   show(message, notify);
 }
 
-export const MessagesContainer = (props: MessagesContainerProps) => {
+export const MessagesContainer = forwardRef((props: MessagesContainerProps, ref) => {
+  useImperativeHandle(ref, () => ({}), []);
+
   return (
     <ToastContainer
       className="sticky-container"
@@ -94,4 +97,4 @@ export const MessagesContainer = (props: MessagesContainerProps) => {
       transition={FadeTransition}
     />
   );
-};
+});

--- a/web/html/src/manager/admin/setup/products/products.tsx
+++ b/web/html/src/manager/admin/setup/products/products.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, Component, useEffect, useState } from "react";
+import { type ReactNode, Component, Fragment, useEffect, useState } from "react";
 
 import _partition from "lodash/partition";
 
@@ -17,6 +17,7 @@ import { SearchField } from "components/table/SearchField";
 import { Toggler } from "components/toggler";
 import { DEPRECATED_onClick } from "components/utils";
 
+import { Cancelable } from "utils/functions";
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
 import Network from "utils/network";
 
@@ -95,11 +96,20 @@ class ProductsPageWrapperState {
  */
 class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPageWrapperState> {
   state = new ProductsPageWrapperState();
+  private metadataRequest?: Cancelable;
+  private productsRequest?: Cancelable;
+  private isUnmounted = false;
 
   UNSAFE_componentWillMount() {
     if (!this.state.refreshRunning) {
       this.refreshServerData();
     }
+  }
+
+  componentWillUnmount() {
+    this.isUnmounted = true;
+    this.metadataRequest?.cancel();
+    this.productsRequest?.cancel();
   }
 
   forceStartSccSync = () => {
@@ -112,10 +122,22 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
   };
 
   refreshServerData = () => {
+    if (this.isUnmounted) {
+      return;
+    }
+
     this.setState({ loading: true });
 
-    loadMetadata()
+    this.metadataRequest?.cancel();
+    this.productsRequest?.cancel();
+
+    const metadataRequest = loadMetadata();
+    this.metadataRequest = metadataRequest;
+    metadataRequest
       .then((metadata) => {
+        if (this.isUnmounted || this.metadataRequest !== metadataRequest) {
+          return;
+        }
         this.setState({
           issMaster: metadata.issMaster,
           refreshNeeded: metadata.refreshNeeded,
@@ -140,8 +162,13 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
       })
       .catch(this.handleResponseError);
 
-    reloadData()
+    const productsRequest = reloadData();
+    this.productsRequest = productsRequest;
+    productsRequest
       .then((data) => {
+        if (this.isUnmounted || this.productsRequest !== productsRequest) {
+          return;
+        }
         this.setState({
           serverData: data[_DATA_ROOT_ID],
           loading: false,
@@ -195,6 +222,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
       this.state.selectedItems.map((i) => i.identifier)
     )
       .then((data) => {
+        if (this.isUnmounted) {
+          return;
+        }
         // returned data format is { productId : "error" }. If the value is null or missing the operation succeeded
         const failedProducts = this.state.selectedItems.filter(
           (i) => !DEPRECATED_unsafeEquals(data[i.identifier], null)
@@ -205,9 +235,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
         } else {
           resultMessages = MessagesUtils.warning(
             failedProducts.map((a) => (
-              <>
+              <Fragment key={a.identifier}>
                 {a.label}: {data[a.identifier]}
-              </>
+              </Fragment>
             )),
             true,
             t("The following product installations failed. Please check log files.")
@@ -229,6 +259,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
 
       Network.post("/rhn/manager/admin/setup/products", [id])
         .then((data) => {
+          if (this.isUnmounted) {
+            return;
+          }
           // if the id is not present in the response or it is null, the operation went fine.
           if (DEPRECATED_unsafeEquals(data[id], null)) {
             this.setState((innerPrevState) => ({
@@ -253,6 +286,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
     this.setState({ addingProducts: true, errors: [] });
     Network.post("/rhn/manager/admin/setup/channels/optional", channels)
       .then((data) => {
+        if (this.isUnmounted) {
+          return;
+        }
         // returned data format is { channel : "error" }. If the value is null or missing the operation succeeded
         const failedChannels = channels.filter((c) => !DEPRECATED_unsafeEquals(data[c], null));
         let resultMessages: MessageType[] | null = null;
@@ -261,9 +297,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
         } else {
           resultMessages = MessagesUtils.warning(
             failedChannels.map((c) => (
-              <>
+              <Fragment key={c}>
                 {c}: {data[c]}
-              </>
+              </Fragment>
             )),
             true,
             t('The following channel installations for "{product}" failed. Please check log files.', { product })
@@ -279,7 +315,11 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
       .catch(this.handleResponseError);
   };
 
-  handleResponseError = (jqXHR: JQueryXHR, arg = {}) => {
+  handleResponseError = (jqXHR: JQueryXHR | Error | undefined, arg = {}) => {
+    if (this.isUnmounted || !jqXHR || (!(jqXHR instanceof Error) && jqXHR.status === 0)) {
+      return;
+    }
+
     this.setState((prevState) => {
       const msg = Network.responseErrorMessage(jqXHR, (status, msg) =>
         messageMap[msg] ? t(messageMap[msg], arg) : null

--- a/web/html/src/manager/admin/setup/products/products.tsx
+++ b/web/html/src/manager/admin/setup/products/products.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, Component, useEffect, useState } from "react";
+import { type ReactNode, Component, Fragment, useEffect, useState } from "react";
 
 import _partition from "lodash/partition";
 
@@ -17,6 +17,7 @@ import { SearchField } from "components/table/SearchField";
 import { Toggler } from "components/toggler";
 import { DEPRECATED_onClick } from "components/utils";
 
+import { Cancelable } from "utils/functions";
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
 import Network from "utils/network";
 
@@ -97,11 +98,20 @@ class ProductsPageWrapperState {
  */
 class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPageWrapperState> {
   state = new ProductsPageWrapperState();
+  private metadataRequest?: Cancelable;
+  private productsRequest?: Cancelable;
+  private isUnmounted = false;
 
   UNSAFE_componentWillMount() {
     if (!this.state.refreshRunning) {
       this.refreshServerData();
     }
+  }
+
+  componentWillUnmount() {
+    this.isUnmounted = true;
+    this.metadataRequest?.cancel();
+    this.productsRequest?.cancel();
   }
 
   forceStartSccSync = () => {
@@ -114,10 +124,22 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
   };
 
   refreshServerData = () => {
+    if (this.isUnmounted) {
+      return;
+    }
+
     this.setState({ loading: true });
 
-    loadMetadata()
+    this.metadataRequest?.cancel();
+    this.productsRequest?.cancel();
+
+    const metadataRequest = loadMetadata();
+    this.metadataRequest = metadataRequest;
+    metadataRequest
       .then((metadata) => {
+        if (this.isUnmounted || this.metadataRequest !== metadataRequest) {
+          return;
+        }
         this.setState({
           issMaster: metadata.issMaster,
           refreshNeeded: metadata.refreshNeeded,
@@ -142,8 +164,13 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
       })
       .catch(this.handleResponseError);
 
-    reloadData()
+    const productsRequest = reloadData();
+    this.productsRequest = productsRequest;
+    productsRequest
       .then((data) => {
+        if (this.isUnmounted || this.productsRequest !== productsRequest) {
+          return;
+        }
         this.setState({
           serverData: data[_DATA_ROOT_ID],
           loading: false,
@@ -197,6 +224,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
       this.state.selectedItems.map((i) => i.identifier)
     )
       .then((data) => {
+        if (this.isUnmounted) {
+          return;
+        }
         // returned data format is { productId : "error" }. If the value is null or missing the operation succeeded
         const failedProducts = this.state.selectedItems.filter(
           (i) => !DEPRECATED_unsafeEquals(data[i.identifier], null)
@@ -207,9 +237,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
         } else {
           resultMessages = MessagesUtils.warning(
             failedProducts.map((a) => (
-              <>
+              <Fragment key={a.identifier}>
                 {a.label}: {data[a.identifier]}
-              </>
+              </Fragment>
             )),
             true,
             t("The following product installations failed. Please check log files.")
@@ -231,6 +261,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
 
       Network.post("/rhn/manager/admin/setup/products", [id])
         .then((data) => {
+          if (this.isUnmounted) {
+            return;
+          }
           // if the id is not present in the response or it is null, the operation went fine.
           if (DEPRECATED_unsafeEquals(data[id], null)) {
             this.setState((innerPrevState) => ({
@@ -255,6 +288,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
     this.setState({ addingProducts: true, errors: [] });
     Network.post("/rhn/manager/admin/setup/channels/optional", channels)
       .then((data) => {
+        if (this.isUnmounted) {
+          return;
+        }
         // returned data format is { channel : "error" }. If the value is null or missing the operation succeeded
         const failedChannels = channels.filter((c) => !DEPRECATED_unsafeEquals(data[c], null));
         let resultMessages: MessageType[] | null = null;
@@ -263,9 +299,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
         } else {
           resultMessages = MessagesUtils.warning(
             failedChannels.map((c) => (
-              <>
+              <Fragment key={c}>
                 {c}: {data[c]}
-              </>
+              </Fragment>
             )),
             true,
             t('The following channel installations for "{product}" failed. Please check log files.', { product })
@@ -281,7 +317,11 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
       .catch(this.handleResponseError);
   };
 
-  handleResponseError = (jqXHR: JQueryXHR, arg = {}) => {
+  handleResponseError = (jqXHR: JQueryXHR | Error | undefined, arg = {}) => {
+    if (this.isUnmounted || !jqXHR || (!(jqXHR instanceof Error) && jqXHR.status === 0)) {
+      return;
+    }
+
     this.setState((prevState) => {
       const msg = Network.responseErrorMessage(jqXHR, (status, msg) =>
         messageMap[msg] ? t(messageMap[msg], arg) : null

--- a/web/html/src/manager/shared/websocket/useWebSocket.ts
+++ b/web/html/src/manager/shared/websocket/useWebSocket.ts
@@ -1,22 +1,28 @@
-import { useEffect, useState } from "react";
+import { type Dispatch, type SetStateAction, useEffect, useRef } from "react";
 
 export function useWebSocket(
   errors: string[],
-  setErrors: (...args: any[]) => any,
+  setErrors: Dispatch<SetStateAction<string[]>>,
   property: string,
   callback: (value: any) => void
 ) {
-  const [webSocketErr, setWebSocketErr] = useState(false);
-  const [pageUnloading, setPageUnloading] = useState(false);
+  const callbackRef = useRef(callback);
+  const errorsRef = useRef(errors);
+  const pageUnloadingRef = useRef(false);
+  const webSocketErrRef = useRef(false);
 
-  const onBeforeUnload = () => {
-    setPageUnloading(true);
-  };
+  callbackRef.current = callback;
+  errorsRef.current = errors;
 
   useEffect(() => {
+    let closedByCleanup = false;
     const { port } = window.location;
     const url = `wss://${window.location.hostname}${port ? `:${port}` : ""}/rhn/websocket/notifications`;
     const ws = new WebSocket(url);
+
+    const onBeforeUnload = () => {
+      pageUnloadingRef.current = true;
+    };
 
     ws.onopen = () => {
       // Tell the websocket what we want to hear about
@@ -24,29 +30,38 @@ export function useWebSocket(
     };
 
     ws.onclose = () => {
-      setErrors(
-        (errors || []).concat(
-          !pageUnloading && !webSocketErr ? t("Websocket connection closed. Refresh the page to try again.") : []
-        )
-      );
+      if (!closedByCleanup && !pageUnloadingRef.current && !webSocketErrRef.current) {
+        setErrors((currentErrors) =>
+          (currentErrors || errorsRef.current || []).concat(
+            t("Websocket connection closed. Refresh the page to try again.")
+          )
+        );
+      }
     };
 
     ws.onerror = () => {
-      setErrors([t("Error connecting to server. Refresh the page to try again.")]);
-      setWebSocketErr(true);
+      if (!closedByCleanup) {
+        webSocketErrRef.current = true;
+        setErrors([t("Error connecting to server. Refresh the page to try again.")]);
+      }
     };
 
     ws.onmessage = (e) => {
-      if (typeof e.data === "string") {
+      if (!closedByCleanup && typeof e.data === "string") {
         const data = JSON.parse(e.data);
-        callback(data[property]);
+        callbackRef.current(data[property]);
       }
     };
 
     window.addEventListener("beforeunload", onBeforeUnload);
 
     return () => {
+      closedByCleanup = true;
       window.removeEventListener("beforeunload", onBeforeUnload);
+      ws.onopen = null;
+      ws.onclose = null;
+      ws.onerror = null;
+      ws.onmessage = null;
       ws.close();
     };
   }, [property]);

--- a/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
+++ b/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
@@ -1,11 +1,10 @@
-import { Component } from "react";
+import { Component, Fragment } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 import { productName } from "core/user-preferences";
 
 import { AsyncButton, Button } from "components/buttons";
 import { Dialog } from "components/dialog/Dialog";
-import { ModalLink } from "components/dialog/ModalLink";
 import { Messages, MessageType, Utils as MessagesUtils } from "components/messages/messages";
 import { TopPanel } from "components/panels/TopPanel";
 
@@ -379,19 +378,18 @@ class BootstrapMinions extends Component<Props, State> {
     } else if (this.state.errors.length > 0) {
       alertMessages = MessagesUtils.error(
         this.state.errors.map((error, index) => (
-          <>
+          <Fragment key={`${error.message}-${index}`}>
             {error.message}{" "}
             {this.hasDetails(error) && (
-              <ModalLink
+              <Button
                 id={"error-details-" + index}
                 text={t("Details")}
                 title={t("Show additional details about this error")}
-                target="show-error-details"
-                className="no-padding"
-                onClick={() => this.showErrorDetailsDialog(error)}
+                className="btn-tertiary no-padding"
+                handler={() => this.showErrorDetailsDialog(error)}
               />
             )}
-          </>
+          </Fragment>
         )),
         true,
         t("Unable to bootstrap host. The following errors have happened:")

--- a/web/html/src/manager/systems/ssm/ssm-counter.tsx
+++ b/web/html/src/manager/systems/ssm/ssm-counter.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export function SsmCounter(props: Props) {
   const [count, setCount] = useState(props.count ?? 0);
-  const [errors, setErrors] = useState([]);
+  const [errors, setErrors] = useState<string[]>([]);
   useWebSocket(errors, setErrors, "ssm-count", (value: number) => {
     setCount(value);
   });

--- a/web/spacewalk-web.changes.emaksy.bootstrap-modal
+++ b/web/spacewalk-web.changes.emaksy.bootstrap-modal
@@ -1,0 +1,2 @@
+- Prevent Bootstrap handling for ReactModal and invalid modal
+  targets.

--- a/web/spacewalk-web.changes.emaksy.console-warnings
+++ b/web/spacewalk-web.changes.emaksy.console-warnings
@@ -1,0 +1,1 @@
+- Fix frontend console warnings in products, tables and SSM.


### PR DESCRIPTION
## What does this PR change?

This fixes several frontend CI/browser console issues reproduced in the setup wizard and bootstrap UI:

- Fixed missing React keys in message lists, product/channel failure messages, bootstrap error messages, and table search panel children.
- Fixed `MessagesContainer` ref warning by converting it to `forwardRef`.
- Fixed ReactModal accessibility warning by no longer setting `document.body` as the app element.
- Removed Bootstrap modal dismissal behavior from ReactModal dialogs.
- Replaced bootstrap error `ModalLink` with a React button to avoid Bootstrap/ReactModal interference.
- Guarded products setup async requests and websocket cleanup to avoid state updates after unmount during route changes.

## Routes Checked

- `/rhn/manager/admin/setup/products`
- `/rhn/manager/systems/bootstrap`
- Setup wizard navigation between products/proxy/payg/mirror credentials

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
