### PR TITLE
Implement native LDAP authentication service layer (Phase 1)

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -32,6 +32,7 @@
         <dependency org="suse" name="cache-api" rev="1.1.1" />
         <dependency org="suse" name="geronimo-jta_1.1_spec" rev="1.2" />
         <dependency org="suse" name="gson" rev="2.8.9" />
+        <dependency org="com.unboundid" name="unboundid-ldapsdk" rev="7.0.4" />
         <dependency org="suse" name="hibernate-c3p0" rev="7.1.6" />
         <dependency org="suse" name="hibernate-models" rev="1.0.1" />
         <dependency org="suse" name="hibernate-core" rev="7.1.6" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -82,6 +82,15 @@ artifacts:
     package: google-gson
     jar: gson\.jar
     repository: Leap
+  # TODO(ldap): UnboundID LDAP SDK (com.unboundid:unboundid-ldapsdk) is used by the native LDAP
+  # authentication feature. The Ant/Ivy CI build resolves it from Maven Central (see ivy-suse.xml),
+  # but the OBS product/RPM build is network-isolated and resolves only packaged artifacts. Before
+  # this feature can be released, an OBS package (e.g. in systemsmanagement:Uyuni:Master or :Other)
+  # must be created and the new third-party dependency approved (licensing). Activate this entry
+  # once that package exists.
+  # - artifact: unboundid-ldapsdk
+  #   package: unboundid-ldapsdk
+  #   repository: Uyuni
   - artifact: hibernate-c3p0
     package: hibernate-c3p0
     jar: hibernate-c3p0

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -102,6 +102,10 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.unboundid</groupId>
+            <artifactId>unboundid-ldapsdk</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-c3p0</artifactId>
         </dependency>

--- a/java/core/src/main/java/com/suse/manager/ldap/DefaultLdapServiceFactory.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/DefaultLdapServiceFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+/**
+ * Default {@link LdapServiceFactory} producing UnboundID-backed services.
+ */
+public class DefaultLdapServiceFactory implements LdapServiceFactory {
+
+    private final LdapConnectionFactory connectionFactory;
+
+    /**
+     * Creates a factory using the default connection factory.
+     */
+    public DefaultLdapServiceFactory() {
+        this(new LdapConnectionFactory());
+    }
+
+    /**
+     * Creates a factory using a custom connection factory. Mainly useful for tests that point the
+     * service at an in-memory directory server.
+     *
+     * @param connectionFactoryIn the connection factory to use
+     */
+    public DefaultLdapServiceFactory(LdapConnectionFactory connectionFactoryIn) {
+        this.connectionFactory = connectionFactoryIn;
+    }
+
+    @Override
+    public LdapAuthenticationService getInstance(LdapServerConfig configIn) {
+        return new UnboundIdLdapAuthenticationService(configIn, connectionFactory);
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapAuthenticationService.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapAuthenticationService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import java.util.Optional;
+
+/**
+ * Authenticates a user against a single directory server and resolves the profile attributes
+ * and external group labels needed by the login layer.
+ *
+ * <p>The service performs the directory work only; it does not touch the Uyuni database, create
+ * accounts, or assign roles. Those steps belong to the login orchestration layer.</p>
+ */
+public interface LdapAuthenticationService {
+
+    /**
+     * Attempts to authenticate the given credentials using the bind/search/bind sequence.
+     *
+     * <p>An empty result means the credentials were rejected (unknown user, ambiguous match,
+     * empty or wrong password). An {@link LdapException} means the directory could not be
+     * consulted (unreachable host, failed service bind, malformed filter). Callers should treat
+     * both as a failed login for the user while logging the exception details for the
+     * administrator.</p>
+     *
+     * @param login the user-supplied login name
+     * @param password the user-supplied password
+     * @return the authenticated user on success, or empty if the credentials were rejected
+     * @throws LdapException if the directory cannot be consulted because of an infrastructure
+     *                       or configuration problem
+     */
+    Optional<LdapUser> authenticate(String login, String password) throws LdapException;
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapAuthenticationService.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapAuthenticationService.java
@@ -26,7 +26,7 @@ public interface LdapAuthenticationService {
      * Attempts to authenticate the given credentials using the bind/search/bind sequence.
      *
      * <p>An empty result means the credentials were rejected (unknown user, ambiguous match,
-     * empty or wrong password). An {@link LdapException} means the directory could not be
+     * empty or wrong password). An {@link LdapServiceException} means the directory could not be
      * consulted (unreachable host, failed service bind, malformed filter). Callers should treat
      * both as a failed login for the user while logging the exception details for the
      * administrator.</p>
@@ -34,8 +34,8 @@ public interface LdapAuthenticationService {
      * @param login the user-supplied login name
      * @param password the user-supplied password
      * @return the authenticated user on success, or empty if the credentials were rejected
-     * @throws LdapException if the directory cannot be consulted because of an infrastructure
+     * @throws LdapServiceException if the directory cannot be consulted because of an infrastructure
      *                       or configuration problem
      */
-    Optional<LdapUser> authenticate(String login, String password) throws LdapException;
+    Optional<LdapUser> authenticate(String login, String password) throws LdapServiceException;
 }

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapConnectionFactory.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapConnectionFactory.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import com.unboundid.ldap.sdk.LDAPConnection;
+import com.unboundid.ldap.sdk.LDAPConnectionOptions;
+import com.unboundid.ldap.sdk.LDAPConnectionPool;
+import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.SimpleBindRequest;
+import com.unboundid.util.ssl.SSLUtil;
+
+import java.security.GeneralSecurityException;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * Creates the LDAP connections used by {@link UnboundIdLdapAuthenticationService}.
+ *
+ * <p>This class is the seam that lets the service be exercised against an in-memory directory
+ * server in tests: tests subclass it and override {@link #socketFactory(LdapServerConfig)} (or the
+ * connection factory wiring) so no real TLS material or network access is required.</p>
+ *
+ * <p>Supports {@link LdapTransport#PLAIN} and {@link LdapTransport#LDAPS}. Custom trust material
+ * (administrator-uploaded directory CA certificates) and StartTLS are not supported yet; until
+ * then a secure transport relies on the JVM default trust store.</p>
+ */
+public class LdapConnectionFactory {
+
+    private static final int INITIAL_POOL_CONNECTIONS = 1;
+    private static final int MAX_POOL_CONNECTIONS = 4;
+
+    /**
+     * Builds the {@link LDAPConnectionOptions} (timeouts, follow-referrals policy) for a server.
+     *
+     * @param config the server configuration
+     * @return connection options derived from the configuration
+     */
+    protected LDAPConnectionOptions connectionOptions(LdapServerConfig config) {
+        LDAPConnectionOptions options = new LDAPConnectionOptions();
+        options.setConnectTimeoutMillis(config.getConnectTimeoutMillis());
+        options.setResponseTimeoutMillis(config.getResponseTimeoutMillis());
+        options.setFollowReferrals(false);
+        return options;
+    }
+
+    /**
+     * Returns the socket factory used to reach the directory, or {@code null} for a plain
+     * (cleartext) connection.
+     *
+     * @param config the server configuration
+     * @return a socket factory for secure transports, or {@code null} for {@link LdapTransport#PLAIN}
+     * @throws LdapException if a TLS socket factory cannot be created
+     */
+    protected SocketFactory socketFactory(LdapServerConfig config) throws LdapException {
+        if (config.getTransport() == LdapTransport.PLAIN) {
+            return null;
+        }
+        if (config.getTransport() == LdapTransport.STARTTLS) {
+            throw new LdapException("StartTLS is not supported yet; use LDAPS or PLAIN");
+        }
+        try {
+            // Until custom CA trust is wired in, rely on the JVM default trust store.
+            SSLUtil sslUtil = new SSLUtil();
+            SSLSocketFactory factory = sslUtil.createSSLSocketFactory();
+            return factory;
+        }
+        catch (GeneralSecurityException e) {
+            throw new LdapException("Unable to initialize TLS for LDAPS connection", e);
+        }
+    }
+
+    /**
+     * Opens a single, unauthenticated connection. Used for the credential bind so that the
+     * pooled service connections keep their service-account identity.
+     *
+     * @param config the server configuration
+     * @return a new open connection
+     * @throws LdapException if the connection cannot be established
+     */
+    public LDAPConnection openConnection(LdapServerConfig config) throws LdapException {
+        try {
+            SocketFactory factory = socketFactory(config);
+            LDAPConnectionOptions options = connectionOptions(config);
+            if (factory == null) {
+                return new LDAPConnection(options, config.getHost(), config.getPort());
+            }
+            return new LDAPConnection(factory, options, config.getHost(), config.getPort());
+        }
+        catch (LDAPException e) {
+            throw new LdapException("Unable to connect to LDAP server " + config.getHost(), e);
+        }
+    }
+
+    /**
+     * Creates a connection pool bound as the configured service account (or anonymous when
+     * explicitly allowed). The pool is used for user and group searches.
+     *
+     * @param config the server configuration
+     * @return a ready connection pool the caller must close
+     * @throws LdapException if the connection or service bind fails
+     */
+    public LDAPConnectionPool createServicePool(LdapServerConfig config) throws LdapException {
+        LDAPConnection connection = openConnection(config);
+        try {
+            if (config.getBindDn().isPresent()) {
+                connection.bind(new SimpleBindRequest(config.getBindDn().get(),
+                        config.getBindPassword().orElse("")));
+            }
+            return new LDAPConnectionPool(connection, INITIAL_POOL_CONNECTIONS, MAX_POOL_CONNECTIONS);
+        }
+        catch (LDAPException e) {
+            connection.close();
+            throw new LdapException("Service-account bind failed for LDAP server " + config.getHost(), e);
+        }
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapConnectionFactory.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapConnectionFactory.java
@@ -21,7 +21,6 @@ import com.unboundid.util.ssl.SSLUtil;
 import java.security.GeneralSecurityException;
 
 import javax.net.SocketFactory;
-import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Creates the LDAP connections used by {@link UnboundIdLdapAuthenticationService}.
@@ -70,9 +69,7 @@ public class LdapConnectionFactory {
         }
         try {
             // Until custom CA trust is wired in, rely on the JVM default trust store.
-            SSLUtil sslUtil = new SSLUtil();
-            SSLSocketFactory factory = sslUtil.createSSLSocketFactory();
-            return factory;
+            return new SSLUtil().createSSLSocketFactory();
         }
         catch (GeneralSecurityException e) {
             throw new LdapException("Unable to initialize TLS for LDAPS connection", e);
@@ -112,8 +109,9 @@ public class LdapConnectionFactory {
     public LDAPConnectionPool createServicePool(LdapServerConfig config) throws LdapException {
         LDAPConnection connection = openConnection(config);
         try {
-            if (config.getBindDn().isPresent()) {
-                connection.bind(new SimpleBindRequest(config.getBindDn().get(),
+            var bindDn = config.getBindDn();
+            if (bindDn.isPresent()) {
+                connection.bind(new SimpleBindRequest(bindDn.get(),
                         config.getBindPassword().orElse("")));
             }
             return new LDAPConnectionPool(connection, INITIAL_POOL_CONNECTIONS, MAX_POOL_CONNECTIONS);

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapConnectionFactory.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapConnectionFactory.java
@@ -58,21 +58,21 @@ public class LdapConnectionFactory {
      *
      * @param config the server configuration
      * @return a socket factory for secure transports, or {@code null} for {@link LdapTransport#PLAIN}
-     * @throws LdapException if a TLS socket factory cannot be created
+     * @throws LdapServiceException if a TLS socket factory cannot be created
      */
-    protected SocketFactory socketFactory(LdapServerConfig config) throws LdapException {
+    protected SocketFactory socketFactory(LdapServerConfig config) throws LdapServiceException {
         if (config.getTransport() == LdapTransport.PLAIN) {
             return null;
         }
         if (config.getTransport() == LdapTransport.STARTTLS) {
-            throw new LdapException("StartTLS is not supported yet; use LDAPS or PLAIN");
+            throw new LdapServiceException("StartTLS is not supported yet; use LDAPS or PLAIN");
         }
         try {
             // Until custom CA trust is wired in, rely on the JVM default trust store.
             return new SSLUtil().createSSLSocketFactory();
         }
         catch (GeneralSecurityException e) {
-            throw new LdapException("Unable to initialize TLS for LDAPS connection", e);
+            throw new LdapServiceException("Unable to initialize TLS for LDAPS connection", e);
         }
     }
 
@@ -82,9 +82,9 @@ public class LdapConnectionFactory {
      *
      * @param config the server configuration
      * @return a new open connection
-     * @throws LdapException if the connection cannot be established
+     * @throws LdapServiceException if the connection cannot be established
      */
-    public LDAPConnection openConnection(LdapServerConfig config) throws LdapException {
+    public LDAPConnection openConnection(LdapServerConfig config) throws LdapServiceException {
         try {
             SocketFactory factory = socketFactory(config);
             LDAPConnectionOptions options = connectionOptions(config);
@@ -94,7 +94,7 @@ public class LdapConnectionFactory {
             return new LDAPConnection(factory, options, config.getHost(), config.getPort());
         }
         catch (LDAPException e) {
-            throw new LdapException("Unable to connect to LDAP server " + config.getHost(), e);
+            throw new LdapServiceException("Unable to connect to LDAP server " + config.getHost(), e);
         }
     }
 
@@ -104,9 +104,9 @@ public class LdapConnectionFactory {
      *
      * @param config the server configuration
      * @return a ready connection pool the caller must close
-     * @throws LdapException if the connection or service bind fails
+     * @throws LdapServiceException if the connection or service bind fails
      */
-    public LDAPConnectionPool createServicePool(LdapServerConfig config) throws LdapException {
+    public LDAPConnectionPool createServicePool(LdapServerConfig config) throws LdapServiceException {
         LDAPConnection connection = openConnection(config);
         try {
             var bindDn = config.getBindDn();
@@ -118,7 +118,7 @@ public class LdapConnectionFactory {
         }
         catch (LDAPException e) {
             connection.close();
-            throw new LdapException("Service-account bind failed for LDAP server " + config.getHost(), e);
+            throw new LdapServiceException("Service-account bind failed for LDAP server " + config.getHost(), e);
         }
     }
 }

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapException.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+/**
+ * Raised when an LDAP operation cannot be completed because of an infrastructure or
+ * configuration problem, for example the directory is unreachable, the service account
+ * bind fails, or a configured filter is malformed.
+ *
+ * <p>This is deliberately distinct from an authentication <em>decision</em>: a user who
+ * simply supplied the wrong password, or who does not exist in the directory, is reported
+ * as an empty result by {@link LdapAuthenticationService#authenticate(String, String)}
+ * rather than by throwing. Callers should log the details of this exception for the
+ * administrator while presenting only a generic message to the end user.</p>
+ */
+public class LdapException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Builds an instance with the given message.
+     *
+     * @param messageIn human readable description of the failure
+     */
+    public LdapException(String messageIn) {
+        super(messageIn);
+    }
+
+    /**
+     * Builds an instance with the given message and cause.
+     *
+     * @param messageIn human readable description of the failure
+     * @param causeIn the underlying cause
+     */
+    public LdapException(String messageIn, Exception causeIn) {
+        super(messageIn, causeIn);
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapFilters.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapFilters.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import com.unboundid.ldap.sdk.Filter;
+import com.unboundid.ldap.sdk.LDAPException;
+
+/**
+ * Builds search filters from administrator-supplied templates.
+ *
+ * <p>The only supported placeholders are {@code {login}} (the user-supplied login name) and
+ * {@code {userDn}} (the resolved user entry DN). Every substituted value is escaped with
+ * {@link Filter#encodeValue(String)} <em>before</em> it is inserted into the template, so that
+ * untrusted input can never alter the structure of the resulting filter (LDAP injection).</p>
+ */
+public final class LdapFilters {
+
+    /** Placeholder replaced by the escaped, user-supplied login name. */
+    public static final String LOGIN_PLACEHOLDER = "{login}";
+
+    /** Placeholder replaced by the escaped DN of the resolved user entry. */
+    public static final String USER_DN_PLACEHOLDER = "{userDn}";
+
+    private LdapFilters() {
+    }
+
+    /**
+     * Builds a user search filter by substituting the escaped login into the template.
+     *
+     * @param template the filter template, must contain {@value #LOGIN_PLACEHOLDER}
+     * @param login the user-supplied login name
+     * @return a parsed, injection-safe {@link Filter}
+     * @throws LdapException if the template is missing the placeholder or is not a valid filter
+     */
+    public static Filter userFilter(String template, String login) throws LdapException {
+        return buildFilter(template, LOGIN_PLACEHOLDER, login, "user");
+    }
+
+    /**
+     * Builds a group search filter by substituting the escaped user DN into the template.
+     *
+     * @param template the filter template, must contain {@value #USER_DN_PLACEHOLDER}
+     * @param userDn the DN of the resolved user entry
+     * @return a parsed, injection-safe {@link Filter}
+     * @throws LdapException if the template is missing the placeholder or is not a valid filter
+     */
+    public static Filter groupFilter(String template, String userDn) throws LdapException {
+        return buildFilter(template, USER_DN_PLACEHOLDER, userDn, "group");
+    }
+
+    private static Filter buildFilter(String template, String placeholder, String rawValue, String kind)
+            throws LdapException {
+        if (template == null || !template.contains(placeholder)) {
+            throw new LdapException(
+                    "The " + kind + " filter template must contain the " + placeholder + " placeholder");
+        }
+        if (rawValue == null || rawValue.isEmpty()) {
+            throw new LdapException("Refusing to build a " + kind + " filter from an empty value");
+        }
+        String escaped = Filter.encodeValue(rawValue);
+        String filterString = template.replace(placeholder, escaped);
+        try {
+            return Filter.create(filterString);
+        }
+        catch (LDAPException e) {
+            throw new LdapException("Configured " + kind + " filter is not a valid LDAP filter", e);
+        }
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapFilters.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapFilters.java
@@ -39,9 +39,9 @@ public final class LdapFilters {
      * @param template the filter template, must contain {@value #LOGIN_PLACEHOLDER}
      * @param login the user-supplied login name
      * @return a parsed, injection-safe {@link Filter}
-     * @throws LdapException if the template is missing the placeholder or is not a valid filter
+     * @throws LdapServiceException if the template is missing the placeholder or is not a valid filter
      */
-    public static Filter userFilter(String template, String login) throws LdapException {
+    public static Filter userFilter(String template, String login) throws LdapServiceException {
         return buildFilter(template, LOGIN_PLACEHOLDER, login, "user");
     }
 
@@ -51,20 +51,20 @@ public final class LdapFilters {
      * @param template the filter template, must contain {@value #USER_DN_PLACEHOLDER}
      * @param userDn the DN of the resolved user entry
      * @return a parsed, injection-safe {@link Filter}
-     * @throws LdapException if the template is missing the placeholder or is not a valid filter
+     * @throws LdapServiceException if the template is missing the placeholder or is not a valid filter
      */
-    public static Filter groupFilter(String template, String userDn) throws LdapException {
+    public static Filter groupFilter(String template, String userDn) throws LdapServiceException {
         return buildFilter(template, USER_DN_PLACEHOLDER, userDn, "group");
     }
 
     private static Filter buildFilter(String template, String placeholder, String rawValue, String kind)
-            throws LdapException {
+            throws LdapServiceException {
         if (template == null || !template.contains(placeholder)) {
-            throw new LdapException(
+            throw new LdapServiceException(
                     "The " + kind + " filter template must contain the " + placeholder + " placeholder");
         }
         if (rawValue == null || rawValue.isEmpty()) {
-            throw new LdapException("Refusing to build a " + kind + " filter from an empty value");
+            throw new LdapServiceException("Refusing to build a " + kind + " filter from an empty value");
         }
         String escaped = Filter.encodeValue(rawValue);
         String filterString = template.replace(placeholder, escaped);
@@ -72,7 +72,7 @@ public final class LdapFilters {
             return Filter.create(filterString);
         }
         catch (LDAPException e) {
-            throw new LdapException("Configured " + kind + " filter is not a valid LDAP filter", e);
+            throw new LdapServiceException("Configured " + kind + " filter is not a valid LDAP filter", e);
         }
     }
 }

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapServerConfig.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapServerConfig.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable connection and search configuration for a single directory server.
+ *
+ * <p>Callers build these instances in code until persisted LDAP server records (and bind
+ * credentials from {@code suseCredentials}) are available.</p>
+ *
+ * <p>Defaults for search filters and attribute names come from the chosen {@link LdapServerType}
+ * and can each be overridden through the {@link Builder}.</p>
+ */
+public final class LdapServerConfig {
+
+    private final LdapServerType serverType;
+    private final String host;
+    private final int port;
+    private final LdapTransport transport;
+
+    private final String bindDn;
+    private final String bindPassword;
+    private final boolean allowAnonymousBind;
+
+    private final String userBaseDn;
+    private final String userFilter;
+    private final String loginAttribute;
+
+    private final String groupBaseDn;
+    private final String groupFilter;
+    private final String groupNameAttribute;
+
+    private final String firstNameAttribute;
+    private final String lastNameAttribute;
+    private final String emailAttribute;
+
+    private final int connectTimeoutMillis;
+    private final int responseTimeoutMillis;
+
+    private LdapServerConfig(Builder builder) {
+        this.serverType = builder.serverType;
+        this.host = builder.host;
+        this.port = builder.port;
+        this.transport = builder.transport;
+        this.bindDn = builder.bindDn;
+        this.bindPassword = builder.bindPassword;
+        this.allowAnonymousBind = builder.allowAnonymousBind;
+        this.userBaseDn = builder.userBaseDn;
+        this.userFilter = builder.userFilter;
+        this.loginAttribute = builder.loginAttribute;
+        this.groupBaseDn = builder.groupBaseDn;
+        this.groupFilter = builder.groupFilter;
+        this.groupNameAttribute = builder.groupNameAttribute;
+        this.firstNameAttribute = builder.firstNameAttribute;
+        this.lastNameAttribute = builder.lastNameAttribute;
+        this.emailAttribute = builder.emailAttribute;
+        this.connectTimeoutMillis = builder.connectTimeoutMillis;
+        this.responseTimeoutMillis = builder.responseTimeoutMillis;
+    }
+
+    /**
+     * Starts a new builder for the given server type, host and user base DN.
+     *
+     * @param serverTypeIn the directory flavor, supplies the default filters and attributes
+     * @param hostIn the directory host name or address
+     * @param userBaseDnIn the base DN under which user entries are searched
+     * @return a builder pre-populated with the defaults of the server type
+     */
+    public static Builder builder(LdapServerType serverTypeIn, String hostIn, String userBaseDnIn) {
+        return new Builder(serverTypeIn, hostIn, userBaseDnIn);
+    }
+
+    /**
+     * @return the directory flavor
+     */
+    public LdapServerType getServerType() {
+        return serverType;
+    }
+
+    /**
+     * @return the directory host name or address
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * @return the directory TCP port
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * @return the transport security mode
+     */
+    public LdapTransport getTransport() {
+        return transport;
+    }
+
+    /**
+     * @return the service-account bind DN, empty for an anonymous bind
+     */
+    public Optional<String> getBindDn() {
+        return Optional.ofNullable(bindDn);
+    }
+
+    /**
+     * @return the service-account bind password, empty for an anonymous bind
+     */
+    public Optional<String> getBindPassword() {
+        return Optional.ofNullable(bindPassword);
+    }
+
+    /**
+     * @return {@code true} if an anonymous service bind is explicitly permitted
+     */
+    public boolean isAllowAnonymousBind() {
+        return allowAnonymousBind;
+    }
+
+    /**
+     * @return the base DN under which user entries are searched
+     */
+    public String getUserBaseDn() {
+        return userBaseDn;
+    }
+
+    /**
+     * @return the user search filter template (contains the {@code {login}} placeholder)
+     */
+    public String getUserFilter() {
+        return userFilter;
+    }
+
+    /**
+     * @return the attribute carrying the normalized login name
+     */
+    public String getLoginAttribute() {
+        return loginAttribute;
+    }
+
+    /**
+     * @return the base DN under which group entries are searched
+     */
+    public String getGroupBaseDn() {
+        return groupBaseDn;
+    }
+
+    /**
+     * @return the group search filter template (contains the {@code {userDn}} placeholder)
+     */
+    public String getGroupFilter() {
+        return groupFilter;
+    }
+
+    /**
+     * @return the attribute carrying a group's external label
+     */
+    public String getGroupNameAttribute() {
+        return groupNameAttribute;
+    }
+
+    /**
+     * @return the attribute carrying the user's first (given) name
+     */
+    public String getFirstNameAttribute() {
+        return firstNameAttribute;
+    }
+
+    /**
+     * @return the attribute carrying the user's last (family) name
+     */
+    public String getLastNameAttribute() {
+        return lastNameAttribute;
+    }
+
+    /**
+     * @return the attribute carrying the user's e-mail address
+     */
+    public String getEmailAttribute() {
+        return emailAttribute;
+    }
+
+    /**
+     * @return the TCP connect timeout in milliseconds
+     */
+    public int getConnectTimeoutMillis() {
+        return connectTimeoutMillis;
+    }
+
+    /**
+     * @return the per-operation response timeout in milliseconds
+     */
+    public int getResponseTimeoutMillis() {
+        return responseTimeoutMillis;
+    }
+
+    /**
+     * Fluent builder for {@link LdapServerConfig}. Optional values default to those of the
+     * configured {@link LdapServerType}; timeouts default to ten seconds.
+     */
+    public static final class Builder {
+
+        private static final int DEFAULT_TIMEOUT_MILLIS = 10_000;
+
+        private final LdapServerType serverType;
+        private final String host;
+        private final String userBaseDn;
+
+        private int port;
+        private LdapTransport transport = LdapTransport.LDAPS;
+        private String bindDn;
+        private String bindPassword;
+        private boolean allowAnonymousBind;
+        private String userFilter;
+        private String loginAttribute;
+        private String groupBaseDn;
+        private String groupFilter;
+        private String groupNameAttribute;
+        private String firstNameAttribute;
+        private String lastNameAttribute;
+        private String emailAttribute;
+        private int connectTimeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+        private int responseTimeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+
+        private Builder(LdapServerType serverTypeIn, String hostIn, String userBaseDnIn) {
+            this.serverType = Objects.requireNonNull(serverTypeIn, "serverType must not be null");
+            this.host = Objects.requireNonNull(hostIn, "host must not be null");
+            this.userBaseDn = Objects.requireNonNull(userBaseDnIn, "userBaseDn must not be null");
+            this.port = transport.getDefaultPort();
+            this.userFilter = serverTypeIn.getDefaultUserFilter();
+            this.loginAttribute = serverTypeIn.getDefaultLoginAttribute();
+            this.groupBaseDn = userBaseDnIn;
+            this.groupFilter = serverTypeIn.getDefaultGroupFilter();
+            this.groupNameAttribute = serverTypeIn.getDefaultGroupNameAttribute();
+            this.firstNameAttribute = serverTypeIn.getDefaultFirstNameAttribute();
+            this.lastNameAttribute = serverTypeIn.getDefaultLastNameAttribute();
+            this.emailAttribute = serverTypeIn.getDefaultEmailAttribute();
+        }
+
+        /**
+         * @param portIn the directory TCP port
+         * @return this builder
+         */
+        public Builder port(int portIn) {
+            this.port = portIn;
+            return this;
+        }
+
+        /**
+         * Sets the transport mode. Also updates the port to that transport's default unless a
+         * non-zero port has already been set explicitly.
+         *
+         * @param transportIn the transport security mode
+         * @return this builder
+         */
+        public Builder transport(LdapTransport transportIn) {
+            this.transport = Objects.requireNonNull(transportIn, "transport must not be null");
+            if (this.port <= 0) {
+                this.port = transportIn.getDefaultPort();
+            }
+            return this;
+        }
+
+        /**
+         * Configures a service-account (authenticated) bind.
+         *
+         * @param bindDnIn the service-account DN
+         * @param bindPasswordIn the service-account password
+         * @return this builder
+         */
+        public Builder bind(String bindDnIn, String bindPasswordIn) {
+            this.bindDn = bindDnIn;
+            this.bindPassword = bindPasswordIn;
+            this.allowAnonymousBind = false;
+            return this;
+        }
+
+        /**
+         * Explicitly permits an anonymous service bind (no service-account credentials).
+         *
+         * @return this builder
+         */
+        public Builder anonymousBind() {
+            this.bindDn = null;
+            this.bindPassword = null;
+            this.allowAnonymousBind = true;
+            return this;
+        }
+
+        /**
+         * @param userFilterIn the user search filter template (must contain {@code {login}})
+         * @return this builder
+         */
+        public Builder userFilter(String userFilterIn) {
+            this.userFilter = userFilterIn;
+            return this;
+        }
+
+        /**
+         * @param loginAttributeIn the attribute carrying the normalized login name
+         * @return this builder
+         */
+        public Builder loginAttribute(String loginAttributeIn) {
+            this.loginAttribute = loginAttributeIn;
+            return this;
+        }
+
+        /**
+         * @param groupBaseDnIn the base DN under which group entries are searched
+         * @return this builder
+         */
+        public Builder groupBaseDn(String groupBaseDnIn) {
+            this.groupBaseDn = groupBaseDnIn;
+            return this;
+        }
+
+        /**
+         * @param groupFilterIn the group search filter template (must contain {@code {userDn}})
+         * @return this builder
+         */
+        public Builder groupFilter(String groupFilterIn) {
+            this.groupFilter = groupFilterIn;
+            return this;
+        }
+
+        /**
+         * @param groupNameAttributeIn the attribute carrying a group's external label
+         * @return this builder
+         */
+        public Builder groupNameAttribute(String groupNameAttributeIn) {
+            this.groupNameAttribute = groupNameAttributeIn;
+            return this;
+        }
+
+        /**
+         * Overrides the profile attribute names read from the user entry.
+         *
+         * @param firstNameAttributeIn first-name attribute
+         * @param lastNameAttributeIn last-name attribute
+         * @param emailAttributeIn e-mail attribute
+         * @return this builder
+         */
+        public Builder profileAttributes(String firstNameAttributeIn, String lastNameAttributeIn,
+                                         String emailAttributeIn) {
+            this.firstNameAttribute = firstNameAttributeIn;
+            this.lastNameAttribute = lastNameAttributeIn;
+            this.emailAttribute = emailAttributeIn;
+            return this;
+        }
+
+        /**
+         * @param connectTimeoutMillisIn TCP connect timeout in milliseconds
+         * @return this builder
+         */
+        public Builder connectTimeoutMillis(int connectTimeoutMillisIn) {
+            this.connectTimeoutMillis = connectTimeoutMillisIn;
+            return this;
+        }
+
+        /**
+         * @param responseTimeoutMillisIn per-operation response timeout in milliseconds
+         * @return this builder
+         */
+        public Builder responseTimeoutMillis(int responseTimeoutMillisIn) {
+            this.responseTimeoutMillis = responseTimeoutMillisIn;
+            return this;
+        }
+
+        /**
+         * Validates and builds the immutable configuration.
+         *
+         * @return a new {@link LdapServerConfig}
+         * @throws IllegalStateException if the bind configuration is inconsistent
+         */
+        public LdapServerConfig build() {
+            if (port <= 0) {
+                port = transport.getDefaultPort();
+            }
+            boolean hasBindDn = bindDn != null && !bindDn.isBlank();
+            if (!hasBindDn && !allowAnonymousBind) {
+                throw new IllegalStateException(
+                        "A service-account bind DN is required unless anonymous bind is explicitly allowed");
+            }
+            if (hasBindDn && (bindPassword == null || bindPassword.isEmpty())) {
+                throw new IllegalStateException("A bind password is required when a bind DN is set");
+            }
+            return new LdapServerConfig(this);
+        }
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapServerConfig.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapServerConfig.java
@@ -240,7 +240,10 @@ public final class LdapServerConfig {
             this.serverType = Objects.requireNonNull(serverTypeIn, "serverType must not be null");
             this.host = Objects.requireNonNull(hostIn, "host must not be null");
             this.userBaseDn = Objects.requireNonNull(userBaseDnIn, "userBaseDn must not be null");
-            this.port = transport.getDefaultPort();
+            // Leave the port unset (0) so it can follow the transport's default until either the
+            // transport or an explicit port is chosen; build() resolves a still-unset port to the
+            // transport default.
+            this.port = 0;
             this.userFilter = serverTypeIn.getDefaultUserFilter();
             this.loginAttribute = serverTypeIn.getDefaultLoginAttribute();
             this.groupBaseDn = userBaseDnIn;

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapServerType.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapServerType.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+/**
+ * Well-known directory server flavors. Each value supplies sensible default search filters
+ * and attribute names so an administrator only has to override values that differ from the
+ * defaults for their directory.
+ *
+ * <p>Filter templates use two placeholders that {@link LdapFilters} substitutes at search time:
+ * {@code {login}} for the supplied user name and {@code {userDn}} for the resolved user entry DN.
+ * Placeholder values are always LDAP-escaped before substitution.</p>
+ */
+public enum LdapServerType {
+
+    /** Microsoft Active Directory. */
+    ACTIVE_DIRECTORY(
+            "(&(objectClass=user)(sAMAccountName={login}))",
+            "sAMAccountName",
+            "(&(objectClass=group)(member={userDn}))",
+            "cn",
+            "givenName",
+            "sn",
+            "mail"),
+
+    /** FreeIPA / Red Hat Identity Management (389 Directory Server based). */
+    FREE_IPA(
+            "(&(objectClass=person)(uid={login}))",
+            "uid",
+            "(&(objectClass=groupOfNames)(member={userDn}))",
+            "cn",
+            "givenName",
+            "sn",
+            "mail"),
+
+    /** Generic OpenLDAP using inetOrgPerson and groupOfNames. */
+    OPEN_LDAP(
+            "(&(objectClass=inetOrgPerson)(uid={login}))",
+            "uid",
+            "(&(objectClass=groupOfNames)(member={userDn}))",
+            "cn",
+            "givenName",
+            "sn",
+            "mail");
+
+    private final String defaultUserFilter;
+    private final String defaultLoginAttribute;
+    private final String defaultGroupFilter;
+    private final String defaultGroupNameAttribute;
+    private final String defaultFirstNameAttribute;
+    private final String defaultLastNameAttribute;
+    private final String defaultEmailAttribute;
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    LdapServerType(String userFilterIn, String loginAttributeIn, String groupFilterIn,
+                   String groupNameAttributeIn, String firstNameAttributeIn, String lastNameAttributeIn,
+                   String emailAttributeIn) {
+        this.defaultUserFilter = userFilterIn;
+        this.defaultLoginAttribute = loginAttributeIn;
+        this.defaultGroupFilter = groupFilterIn;
+        this.defaultGroupNameAttribute = groupNameAttributeIn;
+        this.defaultFirstNameAttribute = firstNameAttributeIn;
+        this.defaultLastNameAttribute = lastNameAttributeIn;
+        this.defaultEmailAttribute = emailAttributeIn;
+    }
+
+    /**
+     * @return default user search filter template (contains the {@code {login}} placeholder)
+     */
+    public String getDefaultUserFilter() {
+        return defaultUserFilter;
+    }
+
+    /**
+     * @return default attribute carrying the normalized login name
+     */
+    public String getDefaultLoginAttribute() {
+        return defaultLoginAttribute;
+    }
+
+    /**
+     * @return default group search filter template (contains the {@code {userDn}} placeholder)
+     */
+    public String getDefaultGroupFilter() {
+        return defaultGroupFilter;
+    }
+
+    /**
+     * @return default attribute carrying a group's external label
+     */
+    public String getDefaultGroupNameAttribute() {
+        return defaultGroupNameAttribute;
+    }
+
+    /**
+     * @return default attribute carrying the user's first (given) name
+     */
+    public String getDefaultFirstNameAttribute() {
+        return defaultFirstNameAttribute;
+    }
+
+    /**
+     * @return default attribute carrying the user's last (family) name
+     */
+    public String getDefaultLastNameAttribute() {
+        return defaultLastNameAttribute;
+    }
+
+    /**
+     * @return default attribute carrying the user's e-mail address
+     */
+    public String getDefaultEmailAttribute() {
+        return defaultEmailAttribute;
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapServiceException.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapServiceException.java
@@ -16,13 +16,17 @@ package com.suse.manager.ldap;
  * configuration problem, for example the directory is unreachable, the service account
  * bind fails, or a configured filter is malformed.
  *
+ * <p>Named {@code LdapServiceException} (not {@code LdapException}) to avoid confusion with
+ * UnboundID's {@code com.unboundid.ldap.sdk.LDAPException}, which is used internally as the
+ * SDK-level cause.</p>
+ *
  * <p>This is deliberately distinct from an authentication <em>decision</em>: a user who
  * simply supplied the wrong password, or who does not exist in the directory, is reported
  * as an empty result by {@link LdapAuthenticationService#authenticate(String, String)}
  * rather than by throwing. Callers should log the details of this exception for the
  * administrator while presenting only a generic message to the end user.</p>
  */
-public class LdapException extends Exception {
+public class LdapServiceException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
@@ -31,7 +35,7 @@ public class LdapException extends Exception {
      *
      * @param messageIn human readable description of the failure
      */
-    public LdapException(String messageIn) {
+    public LdapServiceException(String messageIn) {
         super(messageIn);
     }
 
@@ -41,7 +45,7 @@ public class LdapException extends Exception {
      * @param messageIn human readable description of the failure
      * @param causeIn the underlying cause
      */
-    public LdapException(String messageIn, Exception causeIn) {
+    public LdapServiceException(String messageIn, Exception causeIn) {
         super(messageIn, causeIn);
     }
 }

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapServiceFactory.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapServiceFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+/**
+ * Creates {@link LdapAuthenticationService} instances for a given server configuration.
+ */
+public interface LdapServiceFactory {
+
+    /**
+     * Creates a service that authenticates against the given directory server.
+     *
+     * @param configIn the directory server configuration
+     * @return a ready-to-use authentication service
+     */
+    LdapAuthenticationService getInstance(LdapServerConfig configIn);
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapTransport.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapTransport.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+/**
+ * Transport security mode used to reach a directory server.
+ */
+public enum LdapTransport {
+
+    /** Plain, unencrypted LDAP (typically port 389). For test and trusted-network use only. */
+    PLAIN(389, false),
+
+    /** LDAP over TLS, negotiated at connection time (LDAPS, typically port 636). */
+    LDAPS(636, true),
+
+    /** Plain LDAP upgraded to TLS via the StartTLS extended operation (typically port 389). */
+    STARTTLS(389, true);
+
+    private final int defaultPort;
+    private final boolean secure;
+
+    LdapTransport(int defaultPortIn, boolean secureIn) {
+        this.defaultPort = defaultPortIn;
+        this.secure = secureIn;
+    }
+
+    /**
+     * @return the default TCP port commonly associated with this transport
+     */
+    public int getDefaultPort() {
+        return defaultPort;
+    }
+
+    /**
+     * @return {@code true} if this transport encrypts traffic to the directory
+     */
+    public boolean isSecure() {
+        return secure;
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapUser.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapUser.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable description of a directory user that has successfully authenticated, together
+ * with the profile attributes and external group labels resolved during the bind/search/bind
+ * sequence.
+ *
+ * <p>This object intentionally carries no Uyuni domain types. It is the contract handed back
+ * to the login layer, which is responsible for just-in-time provisioning and for mapping
+ * {@link #groupLabels()} to Uyuni roles.</p>
+ *
+ * @param login the normalized login name as read from the configured login attribute
+ * @param distinguishedName the full DN of the authenticated entry
+ * @param firstName the user's first (given) name, may be {@code null}
+ * @param lastName the user's last (family) name, may be {@code null}
+ * @param email the user's e-mail address, may be {@code null}
+ * @param groupLabels the external group labels the user belongs to, never {@code null}
+ */
+public record LdapUser(
+        String login,
+        String distinguishedName,
+        String firstName,
+        String lastName,
+        String email,
+        List<String> groupLabels) {
+
+    public LdapUser {
+        Objects.requireNonNull(login, "login must not be null");
+        Objects.requireNonNull(distinguishedName, "distinguishedName must not be null");
+        groupLabels = groupLabels == null ? List.of() : List.copyOf(groupLabels);
+    }
+
+    /**
+     * @return the first name wrapped in an {@link Optional}
+     */
+    public Optional<String> firstNameOpt() {
+        return Optional.ofNullable(firstName);
+    }
+
+    /**
+     * @return the last name wrapped in an {@link Optional}
+     */
+    public Optional<String> lastNameOpt() {
+        return Optional.ofNullable(lastName);
+    }
+
+    /**
+     * @return the e-mail address wrapped in an {@link Optional}
+     */
+    public Optional<String> emailOpt() {
+        return Optional.ofNullable(email);
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapUser.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapUser.java
@@ -39,6 +39,10 @@ public record LdapUser(
         String email,
         List<String> groupLabels) {
 
+    /**
+     * Canonical constructor. Requires a login and a distinguished name, and defensively copies the
+     * group labels (treating {@code null} as an empty, immutable list).
+     */
     public LdapUser {
         Objects.requireNonNull(login, "login must not be null");
         Objects.requireNonNull(distinguishedName, "distinguishedName must not be null");

--- a/java/core/src/main/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationService.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationService.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import com.unboundid.ldap.sdk.Filter;
+import com.unboundid.ldap.sdk.LDAPConnection;
+import com.unboundid.ldap.sdk.LDAPConnectionPool;
+import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.ResultCode;
+import com.unboundid.ldap.sdk.SearchResult;
+import com.unboundid.ldap.sdk.SearchResultEntry;
+import com.unboundid.ldap.sdk.SearchScope;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@link LdapAuthenticationService} backed by the UnboundID LDAP SDK.
+ *
+ * <p>Implements the standard bind/search/bind sequence:</p>
+ * <ol>
+ *   <li>Bind a pooled connection as the service account (or anonymously, when allowed).</li>
+ *   <li>Search for the user under the base DN with the configured filter, requiring exactly one
+ *       match.</li>
+ *   <li>Reject an empty supplied password outright, then bind as the discovered user DN with the
+ *       supplied password on a separate connection.</li>
+ *   <li>Resolve the user's group memberships and normalize them to the configured label
+ *       attribute.</li>
+ *   <li>Return the login, profile attributes, and group labels.</li>
+ * </ol>
+ *
+ * <p>User input is never concatenated into a filter; see {@link LdapFilters}.</p>
+ */
+public class UnboundIdLdapAuthenticationService implements LdapAuthenticationService {
+
+    private static final Logger LOG = LogManager.getLogger(UnboundIdLdapAuthenticationService.class);
+
+    private final LdapServerConfig config;
+    private final LdapConnectionFactory connectionFactory;
+
+    /**
+     * @param configIn the server this service authenticates against
+     * @param connectionFactoryIn the factory used to open connections and the search pool
+     */
+    public UnboundIdLdapAuthenticationService(LdapServerConfig configIn,
+                                              LdapConnectionFactory connectionFactoryIn) {
+        this.config = configIn;
+        this.connectionFactory = connectionFactoryIn;
+    }
+
+    @Override
+    public Optional<LdapUser> authenticate(String login, String password) throws LdapException {
+        if (login == null || login.isBlank()) {
+            LOG.debug("Rejecting LDAP authentication with an empty login");
+            return Optional.empty();
+        }
+        // Reject an empty password before any bind. Many directories treat a bind with a valid
+        // DN and an empty password as a successful unauthenticated bind, which must never happen.
+        if (password == null || password.isEmpty()) {
+            LOG.debug("Rejecting LDAP authentication for [{}] because the password is empty", login);
+            return Optional.empty();
+        }
+
+        try (LDAPConnectionPool pool = connectionFactory.createServicePool(config)) {
+            SearchResultEntry entry = findUser(pool, login);
+            if (entry == null) {
+                LOG.info("LDAP authentication failed for [{}]: no matching directory entry", login);
+                return Optional.empty();
+            }
+
+            if (!credentialBindSucceeds(entry.getDN(), password)) {
+                LOG.info("LDAP authentication failed for [{}]: credential bind rejected", login);
+                return Optional.empty();
+            }
+
+            List<String> groups = findGroups(pool, entry.getDN(), login);
+            LdapUser user = toUser(login, entry, groups);
+            LOG.info("LDAP authentication succeeded for [{}] with {} group label(s)", login, groups.size());
+            return Optional.of(user);
+        }
+    }
+
+    private SearchResultEntry findUser(LDAPConnectionPool pool, String login) throws LdapException {
+        Filter filter = LdapFilters.userFilter(config.getUserFilter(), login);
+        try {
+            SearchResult result = pool.search(config.getUserBaseDn(), SearchScope.SUB, filter,
+                    config.getLoginAttribute(), config.getFirstNameAttribute(),
+                    config.getLastNameAttribute(), config.getEmailAttribute());
+            int count = result.getEntryCount();
+            if (count > 1) {
+                LOG.warn("LDAP authentication failed for [{}]: ambiguous user search (base DN={}, filter={}, "
+                        + "matched {} entries)", login, config.getUserBaseDn(), filter, count);
+                return null;
+            }
+            return count == 1 ? result.getSearchEntries().get(0) : null;
+        }
+        catch (LDAPException e) {
+            throw new LdapException("User search failed for [" + login + "]", e);
+        }
+    }
+
+    private boolean credentialBindSucceeds(String userDn, String password) {
+        LDAPConnection connection = null;
+        try {
+            connection = connectionFactory.openConnection(config);
+            ResultCode code = connection.bind(userDn, password).getResultCode();
+            return ResultCode.SUCCESS.equals(code);
+        }
+        catch (LDAPException e) {
+            // Wrong password (and similar) surface here as a normal, expected rejection.
+            return false;
+        }
+        catch (LdapException e) {
+            LOG.warn("Could not open a connection for the credential bind of [{}]", userDn, e);
+            return false;
+        }
+        finally {
+            if (connection != null) {
+                connection.close();
+            }
+        }
+    }
+
+    private List<String> findGroups(LDAPConnectionPool pool, String userDn, String login) {
+        Filter filter;
+        try {
+            filter = LdapFilters.groupFilter(config.getGroupFilter(), userDn);
+        }
+        catch (LdapException e) {
+            LOG.warn("LDAP group lookup skipped for [{}]: invalid group filter (user DN={})", login, userDn, e);
+            return List.of();
+        }
+        try {
+            SearchResult result = pool.search(config.getGroupBaseDn(), SearchScope.SUB, filter,
+                    config.getGroupNameAttribute());
+            List<String> labels = new ArrayList<>();
+            for (SearchResultEntry entry : result.getSearchEntries()) {
+                String label = entry.getAttributeValue(config.getGroupNameAttribute());
+                if (label != null && !label.isBlank()) {
+                    labels.add(label);
+                }
+            }
+            labels.sort(Comparator.naturalOrder());
+            return labels;
+        }
+        catch (LDAPException e) {
+            LOG.warn("LDAP group lookup failed for [{}] (base DN={}, filter={}): {}",
+                    login, config.getGroupBaseDn(), filter, e.getMessage(), e);
+            return List.of();
+        }
+    }
+
+    private LdapUser toUser(String login, SearchResultEntry entry, List<String> groups) {
+        String normalizedLogin = Optional.ofNullable(entry.getAttributeValue(config.getLoginAttribute()))
+                .filter(value -> !value.isBlank())
+                .orElse(login);
+        return new LdapUser(
+                normalizedLogin,
+                entry.getDN(),
+                entry.getAttributeValue(config.getFirstNameAttribute()),
+                entry.getAttributeValue(config.getLastNameAttribute()),
+                entry.getAttributeValue(config.getEmailAttribute()),
+                groups);
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationService.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationService.java
@@ -102,8 +102,8 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
                     config.getLastNameAttribute(), config.getEmailAttribute());
             int count = result.getEntryCount();
             if (count > 1) {
-                LOG.warn("LDAP authentication failed for [{}]: ambiguous user search (base DN={}, filter={}, "
-                        + "matched {} entries)", login, config.getUserBaseDn(), filter, count);
+                LOG.warn("LDAP authentication failed for [{}]: ambiguous user search (base DN={}, filter={}, " +
+                        "matched {} entries)", login, config.getUserBaseDn(), filter, count);
                 return null;
             }
             return count == 1 ? result.getSearchEntries().get(0) : null;
@@ -113,7 +113,7 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
         }
     }
 
-    private boolean credentialBindSucceeds(String userDn, String password) {
+    private boolean credentialBindSucceeds(String userDn, String password) throws LdapException {
         LDAPConnection connection = null;
         try {
             connection = connectionFactory.openConnection(config);
@@ -121,12 +121,14 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
             return ResultCode.SUCCESS.equals(code);
         }
         catch (LDAPException e) {
-            // Wrong password (and similar) surface here as a normal, expected rejection.
-            return false;
-        }
-        catch (LdapException e) {
-            LOG.warn("Could not open a connection for the credential bind of [{}]", userDn, e);
-            return false;
+            if (ResultCode.INVALID_CREDENTIALS.equals(e.getResultCode())) {
+                // A wrong password is a normal, expected authentication rejection.
+                return false;
+            }
+            // Any other result code (server unreachable, timeout, TLS failure, etc.) is an
+            // infrastructure problem the caller must be able to tell apart from a wrong password,
+            // so it is surfaced as an LdapException rather than silently reported as a failed login.
+            throw new LdapException("Credential bind failed for [" + userDn + "]", e);
         }
         finally {
             if (connection != null) {

--- a/java/core/src/main/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationService.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationService.java
@@ -63,7 +63,7 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
     }
 
     @Override
-    public Optional<LdapUser> authenticate(String login, String password) throws LdapException {
+    public Optional<LdapUser> authenticate(String login, String password) throws LdapServiceException {
         if (login == null || login.isBlank()) {
             LOG.debug("Rejecting LDAP authentication with an empty login");
             return Optional.empty();
@@ -94,7 +94,7 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
         }
     }
 
-    private SearchResultEntry findUser(LDAPConnectionPool pool, String login) throws LdapException {
+    private SearchResultEntry findUser(LDAPConnectionPool pool, String login) throws LdapServiceException {
         Filter filter = LdapFilters.userFilter(config.getUserFilter(), login);
         try {
             SearchResult result = pool.search(config.getUserBaseDn(), SearchScope.SUB, filter,
@@ -109,11 +109,11 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
             return count == 1 ? result.getSearchEntries().get(0) : null;
         }
         catch (LDAPException e) {
-            throw new LdapException("User search failed for [" + login + "]", e);
+            throw new LdapServiceException("User search failed for [" + login + "]", e);
         }
     }
 
-    private boolean credentialBindSucceeds(String userDn, String password) throws LdapException {
+    private boolean credentialBindSucceeds(String userDn, String password) throws LdapServiceException {
         LDAPConnection connection = null;
         try {
             connection = connectionFactory.openConnection(config);
@@ -127,8 +127,8 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
             }
             // Any other result code (server unreachable, timeout, TLS failure, etc.) is an
             // infrastructure problem the caller must be able to tell apart from a wrong password,
-            // so it is surfaced as an LdapException rather than silently reported as a failed login.
-            throw new LdapException("Credential bind failed for [" + userDn + "]", e);
+            // so it is surfaced as an LdapServiceException rather than silently reported as a failed login.
+            throw new LdapServiceException("Credential bind failed for [" + userDn + "]", e);
         }
         finally {
             if (connection != null) {
@@ -142,7 +142,7 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
         try {
             filter = LdapFilters.groupFilter(config.getGroupFilter(), userDn);
         }
-        catch (LdapException e) {
+        catch (LdapServiceException e) {
             LOG.warn("LDAP group lookup skipped for [{}]: invalid group filter (user DN={})", login, userDn, e);
             return List.of();
         }

--- a/java/core/src/test/java/com/suse/manager/ldap/LdapFiltersTest.java
+++ b/java/core/src/test/java/com/suse/manager/ldap/LdapFiltersTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.unboundid.ldap.sdk.Filter;
+
+import org.junit.jupiter.api.Test;
+
+public class LdapFiltersTest {
+
+    @Test
+    public void buildsUserFilterFromTemplate() throws Exception {
+        Filter filter = LdapFilters.userFilter("(&(objectClass=inetOrgPerson)(uid={login}))", "alice");
+        assertEquals("(&(objectClass=inetOrgPerson)(uid=alice))", filter.toString());
+    }
+
+    @Test
+    public void buildsGroupFilterFromTemplate() throws Exception {
+        Filter filter = LdapFilters.groupFilter("(&(objectClass=groupOfNames)(member={userDn}))",
+                "uid=alice,ou=users,dc=uyuni,dc=test");
+        assertEquals("(&(objectClass=groupOfNames)(member=uid=alice,ou=users,dc=uyuni,dc=test))",
+                filter.toString());
+    }
+
+    @Test
+    public void escapesSpecialCharactersToPreventInjection() throws Exception {
+        Filter filter = LdapFilters.userFilter("(uid={login})", "a)(uid=*");
+        // The asterisk and parentheses must be escaped so the supplied value cannot widen the
+        // filter into a wildcard or inject extra clauses.
+        String rendered = filter.toString();
+        assertTrue(rendered.contains("\\2a"), "asterisk should be escaped: " + rendered);
+        assertTrue(rendered.contains("\\28") || rendered.contains("\\29"),
+                "parentheses should be escaped: " + rendered);
+        assertEquals("(uid=a\\29\\28uid=\\2a)", rendered);
+    }
+
+    @Test
+    public void rejectsTemplateWithoutPlaceholder() {
+        assertThrows(LdapException.class, () -> LdapFilters.userFilter("(uid=fixed)", "alice"));
+    }
+
+    @Test
+    public void rejectsEmptyValue() {
+        assertThrows(LdapException.class, () -> LdapFilters.userFilter("(uid={login})", ""));
+        assertThrows(LdapException.class, () -> LdapFilters.groupFilter("(member={userDn})", null));
+    }
+
+    @Test
+    public void rejectsMalformedTemplate() {
+        assertThrows(LdapException.class, () -> LdapFilters.userFilter("(&(uid={login})", "alice"));
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/ldap/LdapFiltersTest.java
+++ b/java/core/src/test/java/com/suse/manager/ldap/LdapFiltersTest.java
@@ -49,17 +49,17 @@ public class LdapFiltersTest {
 
     @Test
     public void rejectsTemplateWithoutPlaceholder() {
-        assertThrows(LdapException.class, () -> LdapFilters.userFilter("(uid=fixed)", "alice"));
+        assertThrows(LdapServiceException.class, () -> LdapFilters.userFilter("(uid=fixed)", "alice"));
     }
 
     @Test
     public void rejectsEmptyValue() {
-        assertThrows(LdapException.class, () -> LdapFilters.userFilter("(uid={login})", ""));
-        assertThrows(LdapException.class, () -> LdapFilters.groupFilter("(member={userDn})", null));
+        assertThrows(LdapServiceException.class, () -> LdapFilters.userFilter("(uid={login})", ""));
+        assertThrows(LdapServiceException.class, () -> LdapFilters.groupFilter("(member={userDn})", null));
     }
 
     @Test
     public void rejectsMalformedTemplate() {
-        assertThrows(LdapException.class, () -> LdapFilters.userFilter("(&(uid={login})", "alice"));
+        assertThrows(LdapServiceException.class, () -> LdapFilters.userFilter("(&(uid={login})", "alice"));
     }
 }

--- a/java/core/src/test/java/com/suse/manager/ldap/LdapServerConfigTest.java
+++ b/java/core/src/test/java/com/suse/manager/ldap/LdapServerConfigTest.java
@@ -48,6 +48,33 @@ public class LdapServerConfigTest {
     }
 
     @Test
+    public void transportSwitchUpdatesPortWhenNoExplicitPortIsSet() {
+        // Regression: selecting PLAIN without an explicit port must use the PLAIN default (389),
+        // not remain on the LDAPS default (636).
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "ldap.example.com", "ou=users,dc=example,dc=com")
+                .transport(LdapTransport.PLAIN)
+                .anonymousBind()
+                .build();
+
+        assertEquals(LdapTransport.PLAIN, config.getTransport());
+        assertEquals(389, config.getPort());
+    }
+
+    @Test
+    public void explicitPortSurvivesLaterTransportChange() {
+        // An explicitly chosen port must win even if the transport is set afterwards.
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "ldap.example.com", "ou=users,dc=example,dc=com")
+                .port(1636)
+                .transport(LdapTransport.PLAIN)
+                .anonymousBind()
+                .build();
+
+        assertEquals(1636, config.getPort());
+    }
+
+    @Test
     public void overridesAreHonored() {
         LdapServerConfig config = LdapServerConfig
                 .builder(LdapServerType.OPEN_LDAP, "ldap.example.com", "ou=users,dc=example,dc=com")

--- a/java/core/src/test/java/com/suse/manager/ldap/LdapServerConfigTest.java
+++ b/java/core/src/test/java/com/suse/manager/ldap/LdapServerConfigTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class LdapServerConfigTest {
+
+    @Test
+    public void appliesServerTypeDefaults() {
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.ACTIVE_DIRECTORY, "ad.example.com", "OU=Users,DC=example,DC=com")
+                .bind("CN=reader,DC=example,DC=com", "secret")
+                .build();
+
+        assertEquals("sAMAccountName", config.getLoginAttribute());
+        assertEquals("(&(objectClass=user)(sAMAccountName={login}))", config.getUserFilter());
+        assertEquals("cn", config.getGroupNameAttribute());
+        assertEquals("givenName", config.getFirstNameAttribute());
+        // group base DN defaults to the user base DN until overridden
+        assertEquals("OU=Users,DC=example,DC=com", config.getGroupBaseDn());
+    }
+
+    @Test
+    public void ldapsIsTheDefaultTransportWithItsDefaultPort() {
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.FREE_IPA, "ipa.example.com", "dc=example,dc=com")
+                .bind("uid=reader,dc=example,dc=com", "secret")
+                .build();
+
+        assertEquals(LdapTransport.LDAPS, config.getTransport());
+        assertEquals(636, config.getPort());
+        assertTrue(config.getTransport().isSecure());
+    }
+
+    @Test
+    public void overridesAreHonored() {
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "ldap.example.com", "ou=users,dc=example,dc=com")
+                .transport(LdapTransport.PLAIN)
+                .port(1389)
+                .bind("cn=admin,dc=example,dc=com", "admin")
+                .groupBaseDn("ou=groups,dc=example,dc=com")
+                .userFilter("(&(objectClass=posixAccount)(uid={login}))")
+                .build();
+
+        assertEquals(1389, config.getPort());
+        assertEquals(LdapTransport.PLAIN, config.getTransport());
+        assertFalse(config.getTransport().isSecure());
+        assertEquals("ou=groups,dc=example,dc=com", config.getGroupBaseDn());
+        assertEquals("(&(objectClass=posixAccount)(uid={login}))", config.getUserFilter());
+    }
+
+    @Test
+    public void anonymousBindIsAllowedWhenExplicit() {
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "ldap.example.com", "ou=users,dc=example,dc=com")
+                .anonymousBind()
+                .build();
+
+        assertTrue(config.isAllowAnonymousBind());
+        assertTrue(config.getBindDn().isEmpty());
+    }
+
+    @Test
+    public void rejectsMissingBindWithoutExplicitAnonymous() {
+        LdapServerConfig.Builder builder = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "ldap.example.com", "ou=users,dc=example,dc=com");
+        assertThrows(IllegalStateException.class, builder::build);
+    }
+
+    @Test
+    public void rejectsBindDnWithoutPassword() {
+        LdapServerConfig.Builder builder = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "ldap.example.com", "ou=users,dc=example,dc=com")
+                .bind("cn=admin,dc=example,dc=com", "");
+        assertThrows(IllegalStateException.class, builder::build);
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationServiceTest.java
+++ b/java/core/src/test/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationServiceTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.unboundid.ldap.listener.InMemoryDirectoryServer;
+import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Integration test exercising the full bind/search/bind pipeline against an embedded
+ * {@link InMemoryDirectoryServer}. The directory is seeded with the same entries as the
+ * {@code tooling/dev-ldap} fixture so the test needs no external server or container.
+ */
+public class UnboundIdLdapAuthenticationServiceTest {
+
+    private static final String BASE_DN = "dc=uyuni,dc=test";
+    private static final String USERS_DN = "ou=users,dc=uyuni,dc=test";
+    private static final String GROUPS_DN = "ou=groups,dc=uyuni,dc=test";
+    private static final String ADMIN_DN = "cn=admin,dc=uyuni,dc=test";
+    private static final String ADMIN_PASSWORD = "admin";
+
+    private InMemoryDirectoryServer directory;
+
+    @BeforeEach
+    public void startDirectory() throws Exception {
+        InMemoryDirectoryServerConfig dsConfig = new InMemoryDirectoryServerConfig(BASE_DN);
+        dsConfig.addAdditionalBindCredentials(ADMIN_DN, ADMIN_PASSWORD);
+        directory = new InMemoryDirectoryServer(dsConfig);
+        seed();
+        directory.startListening();
+    }
+
+    @AfterEach
+    public void stopDirectory() {
+        if (directory != null) {
+            directory.shutDown(true);
+        }
+    }
+
+    private void seed() throws Exception {
+        directory.add("dn: " + BASE_DN, "objectClass: top", "objectClass: domain", "dc: uyuni");
+        directory.add("dn: " + USERS_DN, "objectClass: organizationalUnit", "ou: users");
+        directory.add("dn: " + GROUPS_DN, "objectClass: organizationalUnit", "ou: groups");
+
+        directory.add(
+                "dn: uid=alice," + USERS_DN,
+                "objectClass: inetOrgPerson",
+                "cn: Alice Anderson",
+                "givenName: Alice",
+                "sn: Anderson",
+                "uid: alice",
+                "mail: alice@uyuni.test",
+                "userPassword: alice123");
+        directory.add(
+                "dn: uid=bob," + USERS_DN,
+                "objectClass: inetOrgPerson",
+                "cn: Bob Brown",
+                "givenName: Bob",
+                "sn: Brown",
+                "uid: bob",
+                "mail: bob@uyuni.test",
+                "userPassword: bob123");
+
+        directory.add(
+                "dn: cn=uyuni-admins," + GROUPS_DN,
+                "objectClass: groupOfNames",
+                "cn: uyuni-admins",
+                "member: uid=alice," + USERS_DN);
+        directory.add(
+                "dn: cn=uyuni-users," + GROUPS_DN,
+                "objectClass: groupOfNames",
+                "cn: uyuni-users",
+                "member: uid=alice," + USERS_DN,
+                "member: uid=bob," + USERS_DN);
+    }
+
+    private LdapAuthenticationService service() {
+        return service(ADMIN_DN, ADMIN_PASSWORD);
+    }
+
+    private LdapAuthenticationService service(String bindDn, String bindPassword) {
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "127.0.0.1", USERS_DN)
+                .transport(LdapTransport.PLAIN)
+                .port(directory.getListenPort())
+                .bind(bindDn, bindPassword)
+                .groupBaseDn(GROUPS_DN)
+                .build();
+        return new DefaultLdapServiceFactory().getInstance(config);
+    }
+
+    @Test
+    public void authenticatesUserAndResolvesAllGroups() throws Exception {
+        Optional<LdapUser> result = service().authenticate("alice", "alice123");
+
+        assertTrue(result.isPresent());
+        LdapUser user = result.get();
+        assertEquals("alice", user.login());
+        assertEquals("uid=alice," + USERS_DN, user.distinguishedName());
+        assertEquals("Alice", user.firstName());
+        assertEquals("Anderson", user.lastName());
+        assertEquals("alice@uyuni.test", user.email());
+        assertEquals(List.of("uyuni-admins", "uyuni-users"), user.groupLabels());
+    }
+
+    @Test
+    public void authenticatesUserWithSubsetOfGroups() throws Exception {
+        Optional<LdapUser> result = service().authenticate("bob", "bob123");
+
+        assertTrue(result.isPresent());
+        assertEquals(List.of("uyuni-users"), result.get().groupLabels());
+    }
+
+    @Test
+    public void rejectsWrongPassword() throws Exception {
+        assertTrue(service().authenticate("alice", "wrong-password").isEmpty());
+    }
+
+    @Test
+    public void rejectsUnknownUser() throws Exception {
+        assertTrue(service().authenticate("carol", "whatever").isEmpty());
+    }
+
+    @Test
+    public void rejectsEmptyPasswordWithoutBinding() throws Exception {
+        // A valid DN with an empty password must never be treated as a successful bind.
+        assertTrue(service().authenticate("alice", "").isEmpty());
+    }
+
+    @Test
+    public void rejectsNullCredentials() throws Exception {
+        assertTrue(service().authenticate(null, "x").isEmpty());
+        assertTrue(service().authenticate("alice", null).isEmpty());
+    }
+
+    @Test
+    public void failedServiceBindRaisesLdapException() {
+        LdapAuthenticationService service = service(ADMIN_DN, "wrong-service-password");
+        assertThrows(LdapException.class, () -> service.authenticate("alice", "alice123"));
+    }
+
+    @Test
+    public void rejectsAmbiguousUserSearch() throws Exception {
+        directory.add(
+                "dn: uid=alice-dup," + USERS_DN,
+                "objectClass: inetOrgPerson",
+                "cn: Alice Duplicate",
+                "givenName: Alice",
+                "sn: Duplicate",
+                "uid: alice",
+                "mail: alice-dup@uyuni.test",
+                "userPassword: alice123");
+
+        assertTrue(service().authenticate("alice", "alice123").isEmpty());
+    }
+
+    @Test
+    public void authenticatesWhenGroupLookupFails() throws Exception {
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "127.0.0.1", USERS_DN)
+                .transport(LdapTransport.PLAIN)
+                .port(directory.getListenPort())
+                .bind(ADMIN_DN, ADMIN_PASSWORD)
+                .groupBaseDn("ou=missing," + BASE_DN)
+                .build();
+        LdapAuthenticationService brokenGroupService = new DefaultLdapServiceFactory().getInstance(config);
+
+        Optional<LdapUser> result = brokenGroupService.authenticate("alice", "alice123");
+
+        assertTrue(result.isPresent());
+        assertEquals("alice", result.get().login());
+        assertTrue(result.get().groupLabels().isEmpty());
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationServiceTest.java
+++ b/java/core/src/test/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationServiceTest.java
@@ -153,9 +153,9 @@ public class UnboundIdLdapAuthenticationServiceTest {
     }
 
     @Test
-    public void failedServiceBindRaisesLdapException() {
+    public void failedServiceBindRaisesLdapServiceException() {
         LdapAuthenticationService service = service(ADMIN_DN, "wrong-service-password");
-        assertThrows(LdapException.class, () -> service.authenticate("alice", "alice123"));
+        assertThrows(LdapServiceException.class, () -> service.authenticate("alice", "alice123"));
     }
 
     @Test

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -310,6 +310,11 @@
                 <version>2.8.9</version>
             </dependency>
             <dependency>
+                <groupId>com.unboundid</groupId>
+                <artifactId>unboundid-ldapsdk</artifactId>
+                <version>7.0.4</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hibernate.orm</groupId>
                 <artifactId>hibernate-c3p0</artifactId>
                 <version>7.1.6.Final</version>


### PR DESCRIPTION
## What does this PR change?

Implements **Phase 1** of the native LDAP authentication work described in RFC #116 and the GSoC project proposal (#255).

This PR adds a standalone Java LDAP service layer in `com.suse.manager.ldap`. It does **not** wire login, add database schema, or change the UI—those are deferred to later phases.

**Included:**
- `LdapServiceFactory` / `DefaultLdapServiceFactory` (mirrors `PamServiceFactory`)
- `LdapAuthenticationService` + `UnboundIdLdapAuthenticationService` implementing the bind/search/bind authentication flow and group resolution
- Configuration/value types: `LdapServerConfig`, `LdapServerType`, `LdapTransport`, `LdapUser`, `LdapFilters`, `LdapException`
- Unit and integration tests using an in-memory OpenLDAP-shaped fixture
- UnboundID LDAP SDK 7.0.4 added to the Maven and Ivy build configuration

**Deferred:**
- `LoginController` / `LoginHelper` wiring
- `auth_type` schema
- JIT provisioning
- LDAP group → Uyuni role mapping
- Admin UI

---

## Codespace

N/A

---

## GUI diff

No user-visible changes.

- [x] **DONE**

---

## Documentation

- [x] No documentation needed (internal backend changes only).

- [x] **DONE**

---

## Test coverage

- [x] Unit and integration tests were added.

Run locally:

```bash
cd java/core
mvn test -Dtest='LdapFiltersTest,LdapServerConfigTest,UnboundIdLdapAuthenticationServiceTest' -DskipTests=false
```

- [x] **DONE**

---

## Links

- RFC: https://github.com/uyuni-project/uyuni-rfc/pull/116
- GSoC Project: https://github.com/openSUSE/mentoring/issues/255

- [x] **DONE**

---

## Changelogs

- [x] No changelog needed (internal backend only; no user-visible behavior change yet)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"