### PR TITLE
Check the user rights on systems and groups in the formulas API

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/formula/FormulaHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/formula/FormulaHandler.java
@@ -177,6 +177,7 @@ public class FormulaHandler extends BaseHandler {
             List<String> formulas) throws IOFaultException {
         try {
             ServerGroup group = ServerGroupFactory.lookupById(systemGroupId.longValue());
+            FormulaUtil.ensureUserHasPermissionsOnServerGroup(loggedInUser, group);
             FormulaFactory.saveGroupFormulas(group, formulas);
             List<String> minions = group.getServers().stream()
                     .map(Server::asMinionServer)

--- a/java/core/src/main/java/com/redhat/rhn/manager/formula/FormulaManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/formula/FormulaManager.java
@@ -329,6 +329,9 @@ public class FormulaManager {
     public List<FormulaData> getCombinedFormulaDataForSystems(User user, List<Long> systemIDs,
             String formulaName) {
         List<MinionServer> minions = MinionServerFactory.findMinionsByServerIds(systemIDs);
+        for (MinionServer minion : minions) {
+            FormulaUtil.ensureUserHasPermissionsOnServer(user, minion);
+        }
 
         Map<Long, List<SystemGroupID>> managedGroupsPerServer =
                 this.serverGroupFactory.lookupManagedSystemGroupsForSystems(systemIDs);

--- a/java/spacewalk-java.changes.cbosdo.bsc1269253
+++ b/java/spacewalk-java.changes.cbosdo.bsc1269253
@@ -1,0 +1,1 @@
+- Check access rights on two formula API calls (bsc#1269253)


### PR DESCRIPTION
## What does this PR change?

The getCombinedFormulaDataByServerId and setFormulasOfGroup APIs now check the user permissions (bsc#1269253)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: API permission checks

- [x] **DONE**

## Links

Issue(s): 
Port(s): https://github.com/SUSE/spacewalk/pull/31062 https://github.com/SUSE/spacewalk/pull/31065

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
