### PR TITLE
Make setting of column filters in ListTag idempotent (bsc#1269192)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/list/ColumnFilter.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/list/ColumnFilter.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 
 /**
@@ -57,5 +58,29 @@ public class ColumnFilter extends BaseListFilter {
     public String toString() {
         return new ToStringBuilder(this).append("Column Key", key).
                             append("Attribute", attr).toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ColumnFilter other = (ColumnFilter) obj;
+        return Objects.equals(key, other.key) &&
+               Objects.equals(attr, other.attr);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, attr);
     }
 }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/list/ListTag.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/list/ListTag.java
@@ -30,6 +30,8 @@ import com.redhat.rhn.frontend.taglibs.list.row.RowRenderer;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -67,6 +69,7 @@ public class ListTag extends BodyTagSupport {
             "backward", "forward", "allForward" };
     private static final String HIDDEN_TEXT = "<input type=\"hidden\" " +
                                                 "name=\"%s\" value=\"%s\"/>";
+    private static final Logger LOG = LogManager.getLogger(ListTag.class);
 
     private int columnCount;
     private int pageSize = -1;
@@ -293,8 +296,17 @@ public class ListTag extends BodyTagSupport {
      */
     void setColumnFilter(ListFilter f) throws JspException {
         if (filter != null) {
+            // If the incoming filter is identical to the existing filter,
+            // silently return (idempotent). This handles tag reuse and
+            // exception recovery scenarios where the same filter is registered twice.
+            if (filter.equals(f)) {
+                LOG.debug("Column filter {} already set, skipping duplicate registration", f);
+                return;
+            }
+
+            // Different filters indicate a genuine multi-filter conflict
             String msg = "Cannot set the column filter - [%s], " +
-                        "since the table has been has already assigned a filter - [%s]";
+                        "since the table has already been assigned a filter - [%s]";
 
             throw new JspException(String.format(msg, f,
                     filter));

--- a/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/list/ListTagFilterTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/taglibs/list/ListTagFilterTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.frontend.taglibs.list;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.redhat.rhn.testing.MockObjectTestCase;
+import com.redhat.rhn.testing.TestUtils;
+
+import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.jsp.JspException;
+import jakarta.servlet.jsp.PageContext;
+
+/**
+ * Tests for ListTag column filter behaviour.
+ */
+public class ListTagFilterTest extends MockObjectTestCase {
+
+    /**
+     * Test subclass that exposes private ListTag members via reflection.
+     */
+    static class TesterListTag extends ListTag {
+        public ListFilter getFilter() throws Exception {
+            var field = ListTag.class.getDeclaredField("filter");
+            field.setAccessible(true);
+            return (ListFilter) field.get(this);
+        }
+
+        public void setManipulator(DataSetManipulator m) throws Exception {
+            var field = ListTag.class.getDeclaredField("manip");
+            field.setAccessible(true);
+            field.set(this, m);
+        }
+    }
+
+    private PageContext pageContext;
+    private HttpServletRequest req;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        TestUtils.disableLocalizationLogging();
+
+        req = mock(HttpServletRequest.class);
+        pageContext = mock(PageContext.class);
+
+        // Stub all pageContext interactions that may arise from tag lifecycle
+        // methods (setPageContext, setColumnFilter, release).
+        context().checking(new Expectations() { {
+            allowing(pageContext).getAttribute(with(any(String.class)));
+            will(returnValue(null));
+            allowing(pageContext).removeAttribute(with(any(String.class)));
+            allowing(pageContext).getRequest();
+            will(returnValue(req));
+        } });
+    }
+
+    private TesterListTag createMinimalListTag() throws Exception {
+        TesterListTag testTag = new TesterListTag();
+        testTag.setPageContext(pageContext);
+        testTag.setName("testFilterList");
+
+        DataSetManipulator manipulator = mock(DataSetManipulator.class);
+        context().checking(new Expectations() { {
+            ignoring(manipulator);
+        } });
+        testTag.setManipulator(manipulator);
+
+        return testTag;
+    }
+
+    /**
+     * Registering the same ColumnFilter twice must be a no-op.
+     * Fix for bsc#1269192: JSP containers reuse pooled tag instances, which causes
+     * ColumnTag to call setColumnFilter() again during the ENUMERATE phase on a tag
+     * whose filter field is already set.
+     */
+    @Test
+    public void testSetColumnFilterIdempotentSameFilter() throws Exception {
+        TesterListTag testTag = createMinimalListTag();
+        ColumnFilter filter = new ColumnFilter("actions.jsp.action", "actionName");
+
+        testTag.setColumnFilter(filter);
+        assertEquals(filter, testTag.getFilter(), "Filter should be set after first registration");
+
+        testTag.setColumnFilter(filter);
+        assertEquals(filter, testTag.getFilter(), "Filter should remain unchanged after duplicate registration");
+    }
+
+    /**
+     * Registering a different ColumnFilter on the same tag must still
+     * throw a JspException, preserving the original conflict-detection behaviour.
+     */
+    @Test
+    public void testSetColumnFilterConflictDifferentFilter() throws Exception {
+        TesterListTag testTag = createMinimalListTag();
+        ColumnFilter filter1 = new ColumnFilter("actions.jsp.action", "actionName");
+        ColumnFilter filter2 = new ColumnFilter("actions.jsp.status", "statusName");
+
+        testTag.setColumnFilter(filter1);
+
+        assertThrows(JspException.class, () -> testTag.setColumnFilter(filter2),
+                "Setting a different filter on an already-filtered tag must throw JspException");
+    }
+
+    /**
+     * After release(), the filter field must be null so that a subsequent render
+     * cycle (as happens with pooled tags) can register a fresh filter.
+     */
+    @Test
+    public void testReleaseResetsFilterState() throws Exception {
+        TesterListTag testTag = createMinimalListTag();
+        ColumnFilter filter1 = new ColumnFilter("actions.jsp.action", "actionName");
+
+        testTag.setColumnFilter(filter1);
+        assertEquals(filter1, testTag.getFilter(), "Filter should be set before release");
+
+        testTag.release();
+        assertNull(testTag.getFilter(), "Filter must be null after release");
+
+        ColumnFilter filter2 = new ColumnFilter("actions.jsp.status", "statusName");
+        testTag.setColumnFilter(filter2);
+        assertEquals(filter2, testTag.getFilter(), "New filter should be accepted after release");
+    }
+}

--- a/java/spacewalk-java.changes.cbbayburt.bsc#1269192
+++ b/java/spacewalk-java.changes.cbbayburt.bsc#1269192
@@ -1,0 +1,2 @@
+- Make setting of column filters in ListTag idempotent
+  (bsc#1269192)


### PR DESCRIPTION
When the lifecycle of a JSP list tag is interrupted for any reason, the framework tries to set the same column filter to the tag again. In the current code, this leads to a JspException and ends up with an ISE.

This PR allows setting the same filter multiple times, so it's idempotent and doesn't cause ISEs.

See: [bsc#1269192](https://bugzilla.suse.com/show_bug.cgi?id=1269192)

## GUI diff

No difference.

## Documentation
- No documentation needed: Bugfix

## Test coverage
- Unit tests were added

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31056
Ports: https://github.com/SUSE/spacewalk/pull/31133

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
