### PR TITLE
Fix bootstrap modal backdrop

### DIFF
--- a/web/html/src/components/dialog/Dialog.test.tsx
+++ b/web/html/src/components/dialog/Dialog.test.tsx
@@ -1,0 +1,24 @@
+import ReactModal from "react-modal";
+
+import { click, render, screen } from "utils/test-utils";
+
+import { Dialog } from "./Dialog";
+
+describe("Dialog", () => {
+  beforeAll(() => {
+    ReactModal.setAppElement(document.body);
+  });
+
+  test("closes ReactModal without Bootstrap dismiss handling", async () => {
+    const onClose = jest.fn();
+
+    render(<Dialog id="test-dialog" isOpen title="Title" content={<p>Content</p>} onClose={onClose} />);
+
+    const closeButton = screen.getByLabelText("Close");
+    expect(closeButton.getAttribute("data-bs-dismiss")).toBeNull();
+
+    await click(closeButton);
+
+    expect(onClose).toBeCalledTimes(1);
+  });
+});

--- a/web/html/src/components/dialog/Dialog.tsx
+++ b/web/html/src/components/dialog/Dialog.tsx
@@ -22,7 +22,11 @@ export type DialogProps = {
   closableModal?: boolean;
 };
 
-ReactModal.setAppElement(document.body);
+const appElement = document.querySelectorAll("header.navbar-pf, .spacewalk-main-column-layout");
+if (appElement.length > 0) {
+  const setAppElement = ReactModal.setAppElement as (appElement: HTMLElement | NodeList) => void;
+  setAppElement(appElement);
+}
 
 export function Dialog(props: DialogProps) {
   const closableModal = props.closableModal ?? true;
@@ -43,13 +47,7 @@ export function Dialog(props: DialogProps) {
         {!props.hideHeader && (
           <div className="modal-header">
             {closableModal && (
-              <button
-                type="button"
-                className="close"
-                data-bs-dismiss="modal"
-                aria-label="Close"
-                onClick={() => props.onClose?.()}
-              >
+              <button type="button" className="close" aria-label="Close" onClick={() => props.onClose?.()}>
                 <span aria-hidden="true">
                   <i className="fa fa-close"></i>
                 </span>

--- a/web/html/src/components/dialog/Dialog.tsx
+++ b/web/html/src/components/dialog/Dialog.tsx
@@ -22,11 +22,8 @@ export type DialogProps = {
   closableModal?: boolean;
 };
 
-const appElement = document.querySelectorAll("header.navbar-pf, .spacewalk-main-column-layout");
-if (appElement.length > 0) {
-  const setAppElement = ReactModal.setAppElement as (appElement: HTMLElement | NodeList) => void;
-  setAppElement(appElement);
-}
+const appElement = document.querySelector<HTMLElement>(".spacewalk-main-column-layout") ?? document.body;
+ReactModal.setAppElement(appElement);
 
 export function Dialog(props: DialogProps) {
   const closableModal = props.closableModal ?? true;

--- a/web/html/src/components/dialog/util.test.ts
+++ b/web/html/src/components/dialog/util.test.ts
@@ -1,0 +1,52 @@
+import { hideDialog, showDialog } from "./util";
+
+describe("dialog util", () => {
+  let originalModal: unknown;
+  let modalMock: jest.Mock;
+
+  beforeEach(() => {
+    originalModal = (jQuery.fn as any).modal;
+    modalMock = jest.fn(function (this: JQuery) {
+      return this;
+    });
+    (jQuery.fn as any).modal = modalMock;
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+
+    if (originalModal === undefined) {
+      delete (jQuery.fn as any).modal;
+    } else {
+      (jQuery.fn as any).modal = originalModal;
+    }
+  });
+
+  test("does not invoke Bootstrap for missing targets", () => {
+    showDialog("missing-dialog");
+    hideDialog("missing-dialog");
+
+    expect(modalMock).not.toBeCalled();
+  });
+
+  test("does not invoke Bootstrap for non-modal targets", () => {
+    document.body.innerHTML = '<div id="react-modal-dialog"></div>';
+
+    showDialog("react-modal-dialog");
+    hideDialog("react-modal-dialog");
+
+    expect(modalMock).not.toBeCalled();
+  });
+
+  test("invokes Bootstrap for modal targets", () => {
+    document.body.innerHTML = '<div id="legacy-dialog" class="modal"></div>';
+
+    showDialog("legacy-dialog");
+    expect(modalMock).toBeCalledWith("show");
+
+    modalMock.mockClear();
+    hideDialog("legacy-dialog");
+    expect(modalMock).toBeCalledWith("hide");
+  });
+});

--- a/web/html/src/components/dialog/util.test.ts
+++ b/web/html/src/components/dialog/util.test.ts
@@ -1,26 +1,47 @@
 import { hideDialog, showDialog } from "./util";
 
+function renderModalTarget(id: string) {
+  document.body.innerHTML = `<div id="${id}" class="modal"></div>`;
+}
+
+function renderNonModalTarget(id: string) {
+  document.body.innerHTML = `<div id="${id}"></div>`;
+}
+
+function mockBootstrapModalPlugin() {
+  const originalModal = (jQuery.fn as any).modal;
+  const modalMock = jest.fn(function (this: JQuery) {
+    return this;
+  });
+
+  (jQuery.fn as any).modal = modalMock;
+
+  return {
+    modalMock,
+    restore: () => {
+      if (originalModal === undefined) {
+        delete (jQuery.fn as any).modal;
+      } else {
+        (jQuery.fn as any).modal = originalModal;
+      }
+    },
+  };
+}
+
 describe("dialog util", () => {
-  let originalModal: unknown;
   let modalMock: jest.Mock;
+  let restoreModalPlugin: () => void;
 
   beforeEach(() => {
-    originalModal = (jQuery.fn as any).modal;
-    modalMock = jest.fn(function (this: JQuery) {
-      return this;
-    });
-    (jQuery.fn as any).modal = modalMock;
+    const bootstrapModalPlugin = mockBootstrapModalPlugin();
+    modalMock = bootstrapModalPlugin.modalMock;
+    restoreModalPlugin = bootstrapModalPlugin.restore;
     document.body.innerHTML = "";
   });
 
   afterEach(() => {
     document.body.innerHTML = "";
-
-    if (originalModal === undefined) {
-      delete (jQuery.fn as any).modal;
-    } else {
-      (jQuery.fn as any).modal = originalModal;
-    }
+    restoreModalPlugin();
   });
 
   test("does not invoke Bootstrap for missing targets", () => {
@@ -31,7 +52,7 @@ describe("dialog util", () => {
   });
 
   test("does not invoke Bootstrap for non-modal targets", () => {
-    document.body.innerHTML = '<div id="react-modal-dialog"></div>';
+    renderNonModalTarget("react-modal-dialog");
 
     showDialog("react-modal-dialog");
     hideDialog("react-modal-dialog");
@@ -40,7 +61,7 @@ describe("dialog util", () => {
   });
 
   test("invokes Bootstrap for modal targets", () => {
-    document.body.innerHTML = '<div id="legacy-dialog" class="modal"></div>';
+    renderModalTarget("legacy-dialog");
 
     showDialog("legacy-dialog");
     expect(modalMock).toBeCalledWith("show");

--- a/web/html/src/components/dialog/util.ts
+++ b/web/html/src/components/dialog/util.ts
@@ -1,8 +1,23 @@
+function getBootstrapModal(dialogId: string): JQuery | null {
+  const element = document.getElementById(dialogId);
+
+  if (!element?.classList.contains("modal")) {
+    return null;
+  }
+
+  return jQuery(element);
+}
+
 export function showDialog(dialogId: string) {
   // The base event is "hide.bs.modal", we only want to remove the listener we added so we add a namespace, see https://api.jquery.com/event.namespace/
   const namespacedEventName = "hide.bs.modal.namespace-dialog-util";
+  const bootstrapModal = getBootstrapModal(dialogId);
 
-  const dialog = jQuery("#" + dialogId)
+  if (!bootstrapModal) {
+    return;
+  }
+
+  const dialog = bootstrapModal
     .modal("show")
     // Here and below, these manual handlers offer compatibility between Bootstrap 3 and 5, we can drop these after the migration is complete
     .addClass("show")
@@ -19,5 +34,5 @@ export function showDialog(dialogId: string) {
 }
 
 export function hideDialog(dialogId: string) {
-  jQuery("#" + dialogId).modal("hide");
+  getBootstrapModal(dialogId)?.modal("hide");
 }

--- a/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
+++ b/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
@@ -1,11 +1,10 @@
-import { Component } from "react";
+import { Component, Fragment } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 import { productName } from "core/user-preferences";
 
 import { AsyncButton, Button } from "components/buttons";
 import { Dialog } from "components/dialog/Dialog";
-import { ModalLink } from "components/dialog/ModalLink";
 import { Messages, MessageType, Utils as MessagesUtils } from "components/messages/messages";
 import { TopPanel } from "components/panels/TopPanel";
 
@@ -379,19 +378,18 @@ class BootstrapMinions extends Component<Props, State> {
     } else if (this.state.errors.length > 0) {
       alertMessages = MessagesUtils.error(
         this.state.errors.map((error, index) => (
-          <>
+          <Fragment key={`${error.message}-${index}`}>
             {error.message}{" "}
             {this.hasDetails(error) && (
-              <ModalLink
+              <Button
                 id={"error-details-" + index}
                 text={t("Details")}
                 title={t("Show additional details about this error")}
-                target="show-error-details"
-                className="no-padding"
-                onClick={() => this.showErrorDetailsDialog(error)}
+                className="btn-tertiary no-padding"
+                handler={() => this.showErrorDetailsDialog(error)}
               />
             )}
-          </>
+          </Fragment>
         )),
         true,
         t("Unable to bootstrap host. The following errors have happened:")

--- a/web/spacewalk-web.changes.emaksy.bootstrap-modal
+++ b/web/spacewalk-web.changes.emaksy.bootstrap-modal
@@ -1,0 +1,2 @@
+- Prevent Bootstrap modal handling for ReactModal dialogs and invalid
+  modal targets.

--- a/web/spacewalk-web.changes.emaksy.bootstrap-modal
+++ b/web/spacewalk-web.changes.emaksy.bootstrap-modal
@@ -1,2 +1,2 @@
-- Prevent Bootstrap modal handling for ReactModal dialogs and invalid
-  modal targets.
+- Prevent Bootstrap handling for ReactModal and invalid modal
+  targets.


### PR DESCRIPTION
## What does this PR change?

This PR fixes the Bootstrap modal backdrop error caused by mixing ReactModal dialogs with legacy Bootstrap/jQuery modal handling.
It removes Bootstrap dismiss handling from the ReactModal close button, guards the legacy showDialog() / hideDialog() helpers so Bootstrap is only called for real .modal targets, and updates the bootstrap minions error details action to open through React state instead of ModalLink.

It also adds regression tests for:
- ReactModal close behavior without data-bs-dismiss
- missing modal targets
- non-Bootstrap modal targets
- valid legacy Bootstrap modal targets

This prevents errors like:
``` 
TypeError: Cannot read properties of undefined (reading 'backdrop')
```

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff


Before:
https://uyuni.server.vm/rhn/manager/admin/setup/products

<img width="3392" height="534" alt="image" src="https://github.com/user-attachments/assets/972f1bd7-7048-4925-a461-ec5fe25aea42" />

onClose of the modal:
<img width="3392" height="705" alt="image" src="https://github.com/user-attachments/assets/d3a37b5a-741f-4255-80c5-216bf19a3780" />

https://uyuni.server.vm/rhn/manager/systems/bootstrap
<img width="3372" height="928" alt="image" src="https://github.com/user-attachments/assets/dbbf41e3-1059-42f5-b928-7ed49e47d935" />

<img width="3368" height="1238" alt="image" src="https://github.com/user-attachments/assets/9c70b6f4-63a5-4518-b27f-a87cc9756c43" />



After:
https://localhost:8080/rhn/manager/admin/setup/products

<img width="3372" height="928" alt="image" src="https://github.com/user-attachments/assets/a797c95e-b105-4380-a809-df685ab41dd3" />

onClose of the modal:
<img width="3372" height="928" alt="image" src="https://github.com/user-attachments/assets/a7b3d24b-7cb0-4759-94f8-b22623e45319" />

https://localhost:8080/rhn/manager/systems/bootstrap

<img width="3372" height="928" alt="image" src="https://github.com/user-attachments/assets/2594bfb7-0650-4d68-b0ff-5df7f1ae85fd" />

<img width="3385" height="1173" alt="image" src="https://github.com/user-attachments/assets/6f3afe83-434b-4e92-bbcc-4e013a723598" />



- [ x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Unit tests were added


- [ x] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/30314
Port(s): # **add downstream PR(s), if any**

- [x ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
