### PR TITLE
Fix ace editor error when switching between normal and state url

### DIFF
--- a/web/html/javascript/spacewalk-essentials.js
+++ b/web/html/javascript/spacewalk-essentials.js
@@ -226,6 +226,15 @@ function onDocumentReadyAutoBootstrapGrid() {
  * shows a select box to choose it.
  */
 function setupTextareaEditor(textarea, mode) {
+  // Some legacy JSP fragments include the editor setup even when the
+  // matching textarea is not rendered for the current form type.
+  if (!textarea || textarea.length === 0) {
+    return;
+  }
+
+  const currentTextareaValue = textarea.val();
+  const textareaValue = typeof currentTextareaValue === "string" ? currentTextareaValue : "";
+
   // if textarea is not shown, the height will be negative,
   // so we set the height of the editor in the popup to the 70% of the window height
   var tH = textarea.height() > 0 ? textarea.height() : (jQuery(window).height()  * 0.7);
@@ -241,7 +250,7 @@ function setupTextareaEditor(textarea, mode) {
   textarea.hide();
 
   var editor = ace.edit(editDiv[0]);
-  editor.getSession().setValue(textarea.val());
+  editor.getSession().setValue(textareaValue);
   editor.getSession().setOptions({ tabSize: 4, useSoftTabs: true });
 
   editor.setTheme("ace/theme/xcode");

--- a/web/spacewalk-web.changes.emaksy.ace-editor
+++ b/web/spacewalk-web.changes.emaksy.ace-editor
@@ -1,0 +1,1 @@
+- Avoid Ace editor crashes when optional textareas are missing.


### PR DESCRIPTION
## What does this PR change?

This PR fixes the Ace editor console error that happens when legacy editor setup runs on pages where the expected contents textarea is not rendered.

The shared setupTextareaEditor() helper now skips initialization when no textarea target exists, and ensures Ace only receives a string value when initializing the editor session.

This prevents errors like: TypeError: Cannot read properties of undefined (reading 'match')


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:
https://uyuni.server.vm/rhn/configuration/ChannelCreate.do?editing=true&type=normal
<img width="2488" height="1801" alt="image" src="https://github.com/user-attachments/assets/6835a334-0508-4b81-9f4a-d284ede0766e" />


After:
https://localhost:8080/rhn/configuration/ChannelCreate.do?editing=true&type=normal
<img width="2488" height="1801" alt="image" src="https://github.com/user-attachments/assets/ba225a75-b456-4c45-be0c-950f1d757e36" />

Note: the remaining error was fixed here https://github.com/uyuni-project/uyuni/pull/12206

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/30314


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
