### PR TITLE
REVERTED - use temp table for hidden packages in update_needed_cache (bsc#1267912)

### DIFF
--- a/schema/spacewalk/common/views/suseServerAppStreamHiddenPackagesView.sql
+++ b/schema/spacewalk/common/views/suseServerAppStreamHiddenPackagesView.sql
@@ -12,6 +12,8 @@
 -- granted to use or replicate Red Hat trademarks that are incorporated
 -- in this software or its documentation.
 --
+-- Consider converting it to a MATERIALIZED VIEW with an index on
+-- (sid, pid). see bsc#1267912
 CREATE OR REPLACE VIEW suseServerAppStreamHiddenPackagesView AS
 
 -- If a package is part of any appstream,

--- a/schema/spacewalk/postgres/packages/rhn_server.pkb
+++ b/schema/spacewalk/postgres/packages/rhn_server.pkb
@@ -668,38 +668,43 @@ update pg_settings set setting = 'rhn_server,' || setting where name = 'search_p
     begin
       delete from rhnServerNeededCache
         where server_id = server_id_in;
+      create temp table if not exists tmp_hidden_packages on commit drop as
+        select pid from suseServerAppStreamHiddenPackagesView where sid = server_id_in
+        with no data;
+      insert into tmp_hidden_packages
+        select pid from suseServerAppStreamHiddenPackagesView where sid = server_id_in;
+      analyze tmp_hidden_packages;
+      create index on tmp_hidden_packages(pid);
+
       insert into rhnServerNeededCache
              (server_id, errata_id, package_id, channel_id)
-        (
-		   with hidden_packages as materialized (
-              select pid from suseServerAppStreamHiddenPackagesView where sid = server_id_in
-           )
-		   select distinct sp.server_id, x.errata_id, p.id, x.channel_id
-           FROM (SELECT sp_sp.server_id, sp_sp.name_id,
-		        sp_sp.package_arch_id, max(sp_pe.evr) AS max_evr
-                   FROM rhnServerPackage sp_sp
-                   join rhnPackageEvr sp_pe ON sp_pe.id = sp_sp.evr_id
-                  GROUP BY sp_sp.server_id, sp_sp.name_id, sp_sp.package_arch_id) sp
-           join susePackageExcludingPartOfPtf p ON p.name_id = sp.name_id
-           join rhnPackageEvr pe ON pe.id = p.evr_id AND (sp.max_evr).type = (pe.evr).type AND sp.max_evr < pe.evr
-           join rhnPackageUpgradeArchCompat puac
-	            ON puac.package_arch_id = sp.package_arch_id
-		    AND puac.package_upgrade_arch_id = p.package_arch_id
-           join rhnServerChannel sc ON sc.server_id = sp.server_id
-           join rhnChannelPackage cp ON cp.package_id = p.id
-	            AND cp.channel_id = sc.channel_id
-           left join (SELECT ep.errata_id, ce.channel_id, ep.package_id
-                        FROM rhnChannelErrata ce
-                        join rhnErrataPackage ep
-			         ON ep.errata_id = ce.errata_id
-			join rhnServerChannel sc_sc
-			         ON sc_sc.channel_id = ce.channel_id
-		       WHERE sc_sc.server_id = server_id_in) x
-             ON x.channel_id = sc.channel_id AND x.package_id = cp.package_id
-	   left join rhnErrata e on x.errata_id = e.id
-          where sp.server_id = server_id_in
-            and (x.errata_id IS NULL or e.advisory_status != 'retracted') -- packages which are part of a retracted errata should not be installed
-            and NOT EXISTS (SELECT 1 FROM hidden_packages WHERE pid = p.id));
+      select distinct sp.server_id, x.errata_id, p.id, x.channel_id
+        FROM (SELECT sp_sp.server_id, sp_sp.name_id,
+                     sp_sp.package_arch_id, max(sp_pe.evr) AS max_evr
+                FROM rhnServerPackage sp_sp
+                join rhnPackageEvr sp_pe ON sp_pe.id = sp_sp.evr_id
+               GROUP BY sp_sp.server_id, sp_sp.name_id, sp_sp.package_arch_id) sp
+        join susePackageExcludingPartOfPtf p ON p.name_id = sp.name_id
+        join rhnPackageEvr pe ON pe.id = p.evr_id AND (sp.max_evr).type = (pe.evr).type AND sp.max_evr < pe.evr
+        join rhnPackageUpgradeArchCompat puac
+             ON puac.package_arch_id = sp.package_arch_id
+            AND puac.package_upgrade_arch_id = p.package_arch_id
+        join rhnServerChannel sc ON sc.server_id = sp.server_id
+        join rhnChannelPackage cp ON cp.package_id = p.id
+                 AND cp.channel_id = sc.channel_id
+        left join (SELECT ep.errata_id, ce.channel_id, ep.package_id
+                     FROM rhnChannelErrata ce
+                     join rhnErrataPackage ep
+                      ON ep.errata_id = ce.errata_id
+                     join rhnServerChannel sc_sc
+                      ON sc_sc.channel_id = ce.channel_id
+                    WHERE sc_sc.server_id = server_id_in) x
+          ON x.channel_id = sc.channel_id AND x.package_id = cp.package_id
+        left join rhnErrata e on x.errata_id = e.id
+        where sp.server_id = server_id_in
+          and (x.errata_id IS NULL or e.advisory_status != 'retracted')
+          and NOT EXISTS (SELECT 1 FROM tmp_hidden_packages WHERE pid = p.id);
+      drop table tmp_hidden_packages;
 	end$$ language plpgsql;
 -- restore the original setting
 update pg_settings set setting = overlay( setting placing '' from 1 for (length('rhn_server')+1) ) where name = 'search_path';

--- a/schema/spacewalk/susemanager-schema.changes.mbussolotto.tmp_table
+++ b/schema/spacewalk/susemanager-schema.changes.mbussolotto.tmp_table
@@ -1,0 +1,1 @@
+- Use temp table for hidden packages (bsc#1267912)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.13-to-susemanager-schema-5.2.14/300-update-needed-cache-performance.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.13-to-susemanager-schema-5.2.14/300-update-needed-cache-performance.sql
@@ -1,0 +1,58 @@
+--
+-- Copyright (c) 2026 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+-- Replace the MATERIALIZED CTE in update_needed_cache with a temp table
+-- to give the planner accurate row estimates and enable a fast indexed anti-join.
+-- See bsc#1267912 for details.
+create or replace function rhn_server.update_needed_cache(
+    server_id_in in numeric
+) returns void as $$
+    begin
+      delete from rhnServerNeededCache
+        where server_id = server_id_in;
+      create temp table if not exists tmp_hidden_packages on commit drop as
+        select pid from suseServerAppStreamHiddenPackagesView where sid = server_id_in
+        with no data;
+      insert into tmp_hidden_packages
+        select pid from suseServerAppStreamHiddenPackagesView where sid = server_id_in;
+      analyze tmp_hidden_packages;
+      create index on tmp_hidden_packages(pid);
+
+      insert into rhnServerNeededCache
+             (server_id, errata_id, package_id, channel_id)
+      select distinct sp.server_id, x.errata_id, p.id, x.channel_id
+        FROM (SELECT sp_sp.server_id, sp_sp.name_id,
+                     sp_sp.package_arch_id, max(sp_pe.evr) AS max_evr
+                FROM rhnServerPackage sp_sp
+                join rhnPackageEvr sp_pe ON sp_pe.id = sp_sp.evr_id
+               GROUP BY sp_sp.server_id, sp_sp.name_id, sp_sp.package_arch_id) sp
+        join susePackageExcludingPartOfPtf p ON p.name_id = sp.name_id
+        join rhnPackageEvr pe ON pe.id = p.evr_id AND (sp.max_evr).type = (pe.evr).type AND sp.max_evr < pe.evr
+        join rhnPackageUpgradeArchCompat puac
+             ON puac.package_arch_id = sp.package_arch_id
+            AND puac.package_upgrade_arch_id = p.package_arch_id
+        join rhnServerChannel sc ON sc.server_id = sp.server_id
+        join rhnChannelPackage cp ON cp.package_id = p.id
+                 AND cp.channel_id = sc.channel_id
+        left join (SELECT ep.errata_id, ce.channel_id, ep.package_id
+                     FROM rhnChannelErrata ce
+                     join rhnErrataPackage ep
+                      ON ep.errata_id = ce.errata_id
+                     join rhnServerChannel sc_sc
+                      ON sc_sc.channel_id = ce.channel_id
+                    WHERE sc_sc.server_id = server_id_in) x
+          ON x.channel_id = sc.channel_id AND x.package_id = cp.package_id
+        left join rhnErrata e on x.errata_id = e.id
+        where sp.server_id = server_id_in
+          and (x.errata_id IS NULL or e.advisory_status != 'retracted')
+          and NOT EXISTS (SELECT 1 FROM tmp_hidden_packages WHERE pid = p.id);
+      drop table tmp_hidden_packages;
+	end$$ language plpgsql;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

improve performance using temp table.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30908
5.1: https://github.com/SUSE/spacewalk/pull/31087

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!