### PR TITLE
feat(openapi): migrate saltkey handler to OpenAPI contract

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
@@ -30,7 +30,7 @@ import java.util.List;
  * @apidoc.namespace saltkey
  * @apidoc.doc Provides methods to manage salt keys
  */
-public class SaltKeyHandler extends BaseHandler {
+public class SaltKeyHandler extends BaseHandler implements SaltKeyHandlerApi {
 
     private final SaltKeyUtils saltKeyUtils;
 

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandlerApi.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.saltkey;
+
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+
+import java.util.List;
+
+import io.swagger.models.HttpMethod;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * API contract for {@link SaltKeyHandler}.
+ */
+@Tag(name = "saltkey", description = "Provides methods to manage salt keys")
+public interface SaltKeyHandlerApi {
+
+    /**
+     * Lists the accepted salt keys.
+     *
+     * @param loggedInUser current user
+     * @return the accepted salt key list
+     */
+    @ApiEndpointDoc(
+        summary = "List accepted salt keys",
+        method = HttpMethod.GET,
+        responseClass = SaltKeyListResponse.class
+    )
+    List<String> acceptedList(User loggedInUser);
+
+    /**
+     * Lists the pending salt keys.
+     *
+     * @param loggedInUser current user
+     * @return the pending salt key list
+     */
+    @ApiEndpointDoc(
+        summary = "List pending salt keys",
+        method = HttpMethod.GET,
+        responseClass = SaltKeyListResponse.class
+    )
+    List<String> pendingList(User loggedInUser);
+
+    /**
+     * Lists the rejected salt keys.
+     *
+     * @param loggedInUser current user
+     * @return the rejected salt key list
+     */
+    @ApiEndpointDoc(
+        summary = "List of rejected salt keys",
+        method = HttpMethod.GET,
+        responseClass = SaltKeyListResponse.class
+    )
+    List<String> rejectedList(User loggedInUser);
+
+    /**
+     * Lists the denied salt keys.
+     *
+     * @param loggedInUser current user
+     * @return the denied salt key list
+     */
+    @ApiEndpointDoc(
+        summary = "List of denied salt keys",
+        method = HttpMethod.GET,
+        responseClass = SaltKeyListResponse.class
+    )
+    List<String> deniedList(User loggedInUser);
+
+    /**
+     * Accepts a minion key.
+     *
+     * @param loggedInUser current user
+     * @param minionId the key identifier (minionId)
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Accept a minion key",
+        requestClass = SaltKeyActionRequest.class,
+        isIntegerResponse = true
+    )
+    int accept(User loggedInUser, String minionId);
+
+    /**
+     * Rejects a minion key.
+     *
+     * @param loggedInUser current user
+     * @param minionId the key identifier (minionId)
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Reject a minion key",
+        requestClass = SaltKeyActionRequest.class,
+        isIntegerResponse = true
+    )
+    int reject(User loggedInUser, String minionId);
+
+    /**
+     * Deletes a minion key.
+     *
+     * @param loggedInUser current user
+     * @param minionId the key identifier (minionId)
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Delete a minion key",
+        requestClass = SaltKeyActionRequest.class,
+        isIntegerResponse = true
+    )
+    int delete(User loggedInUser, String minionId);
+
+    @Schema(name = "SaltKeyActionRequest")
+    interface SaltKeyActionRequest {
+
+        /**
+         * @return the key identifier (minionId)
+         */
+        @Schema(description = "the key identifier (minionId)", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getMinionId();
+    }
+
+    @Schema(name = "ApiResponseSaltKeyList")
+    interface SaltKeyListResponse extends ApiResponseWrapper<List<String>> { }
+}

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandlerApi.java
@@ -36,7 +36,8 @@ public interface SaltKeyHandlerApi {
     @ApiEndpointDoc(
         summary = "List accepted salt keys",
         method = HttpMethod.GET,
-        responseClass = SaltKeyListResponse.class
+        responseClass = SaltKeyListResponse.class,
+        responseDescription = "Accepted salt key list"
     )
     List<String> acceptedList(User loggedInUser);
 
@@ -49,7 +50,8 @@ public interface SaltKeyHandlerApi {
     @ApiEndpointDoc(
         summary = "List pending salt keys",
         method = HttpMethod.GET,
-        responseClass = SaltKeyListResponse.class
+        responseClass = SaltKeyListResponse.class,
+        responseDescription = "Pending salt key list"
     )
     List<String> pendingList(User loggedInUser);
 
@@ -62,7 +64,8 @@ public interface SaltKeyHandlerApi {
     @ApiEndpointDoc(
         summary = "List of rejected salt keys",
         method = HttpMethod.GET,
-        responseClass = SaltKeyListResponse.class
+        responseClass = SaltKeyListResponse.class,
+        responseDescription = "Rejected salt key list"
     )
     List<String> rejectedList(User loggedInUser);
 
@@ -75,7 +78,8 @@ public interface SaltKeyHandlerApi {
     @ApiEndpointDoc(
         summary = "List of denied salt keys",
         method = HttpMethod.GET,
-        responseClass = SaltKeyListResponse.class
+        responseClass = SaltKeyListResponse.class,
+        responseDescription = "Denied salt key list"
     )
     List<String> deniedList(User loggedInUser);
 

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -16,6 +16,7 @@ package com.suse.manager.api;
 
 import com.redhat.rhn.frontend.xmlrpc.access.AccessHandler;
 import com.redhat.rhn.frontend.xmlrpc.api.ApiHandler;
+import com.redhat.rhn.frontend.xmlrpc.saltkey.SaltKeyHandler;
 
 import com.suse.manager.api.docs.UyuniSwaggerReader;
 
@@ -99,7 +100,8 @@ public final class OpenApiConfig {
     public static Map<String, Class<?>> getHandlerClasses() {
         return Map.of(
             "access", AccessHandler.class,
-            "api", ApiHandler.class
+            "api", ApiHandler.class,
+            "saltkey", SaltKeyHandler.class
         );
     }
 }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -223,66 +223,96 @@ public class OpenApiToAsciidocParser {
         if (jsonContent == null || jsonContent.getSchema() == null) {
             return;
         }
-        Schema<?> schema = jsonContent.getSchema();
-        if (schema.get$ref() != null) {
-            schema = resolveSchema(schema.get$ref());
-        }
+        Schema<?> schema = resolveSchemaReference(jsonContent.getSchema());
         String refName = "";
 
         if (schema.getProperties() != null && schema.getProperties().containsKey("result")) {
             Schema<?> resultSchema = (Schema<?>) schema.getProperties().get("result");
             refName = extractRefName(resultSchema.get$ref());
-            schema = resultSchema.get$ref() != null ? resolveSchema(resultSchema.get$ref()) : resultSchema;
+            schema = resolveSchemaReference(resultSchema);
         }
 
         if ("array".equals(schema.getType()) && schema.getItems() != null) {
-            Schema<?> itemSchema = schema.getItems();
-            Schema<?> resolved = itemSchema.get$ref() != null ? resolveSchema(itemSchema.get$ref()) : itemSchema;
-            String itemRefName = itemSchema.get$ref() != null ? extractRefName(itemSchema.get$ref()) : "";
-
-            if (resolved != null && isSimpleType(resolved)) {
-                String itemType = "integer".equals(resolved.getType()) ? "int" : resolved.getType();
-                String label = Optional.ofNullable(successResponse.getDescription())
-                        .filter(d -> !d.isBlank())
-                        .orElse("");
-                if (!label.isEmpty()) {
-                    writer.printf("* [.array]#%s array#  %s%n", itemType, label);
-                    return;
-                }
-                writer.println("* [.array]#array# :");
-                writer.printf("    * [.%s]#%s#%n", itemType, itemType);
-            }
-            else {
-                writer.println("* [.array]#array# :");
-                writer.printf("    * [.struct]#struct#  %s%n", itemRefName);
-                if (resolved != null && resolved.getProperties() != null) {
-                    resolved.getProperties().forEach((name, prop) -> {
-                        Schema<?> propertySchema = prop;
-                        String propDesc = propertySchema.getDescription() != null ?
-                                " - " + propertySchema.getDescription() : "";
-                        writer.printf("** [.string]#string#  \"%s\"%s%n", name, propDesc);
-                    });
-                }
-            }
-            writer.println();
+            writeArrayReturn(writer, schema, successResponse);
             return;
         }
 
         if (isSimpleType(schema)) {
-            String type = schema.getType();
-            String label = Optional.ofNullable(successResponse.getDescription())
-                    .filter(d -> !d.isBlank())
-                    .orElseGet(() -> operation.getOperationId()
-                            .replace("get", "")
-                            .replaceAll("([a-z])([A-Z])", "$1 $2")
-                            .toLowerCase().trim());
-
-            String displayType = "integer".equals(type) ? "int" : type;
-            writer.printf("* [.%s]#%s#  %s%n ", displayType, displayType, label);
+            writeSimpleReturn(writer, schema, successResponse, operation);
             return;
         }
 
         printStruct(writer, schema, 0, refName);
+    }
+
+    private void writeArrayReturn(PrintWriter writer, Schema<?> schema, ApiResponse successResponse) {
+        Schema<?> itemSchema = schema.getItems();
+        Schema<?> resolved = resolveSchemaReference(itemSchema);
+        String itemRefName = itemSchema.get$ref() != null ? extractRefName(itemSchema.get$ref()) : "";
+
+        if (resolved != null && isSimpleType(resolved)) {
+            writeSimpleArrayReturn(writer, resolved, successResponse);
+            return;
+        }
+
+        writer.println("* [.array]#array# :");
+        writer.printf("    * [.struct]#struct#  %s%n", itemRefName);
+        printArrayStructProperties(writer, resolved);
+        writer.println();
+    }
+
+    private void writeSimpleArrayReturn(PrintWriter writer, Schema<?> resolved, ApiResponse successResponse) {
+        String itemType = displayType(resolved);
+        String label = responseDescription(successResponse);
+        if (!label.isEmpty()) {
+            writer.printf("* [.array]#%s array#  %s%n", itemType, label);
+            return;
+        }
+        writer.println("* [.array]#array# :");
+        writer.printf("    * [.%s]#%s#%n", itemType, itemType);
+        writer.println();
+    }
+
+    private void printArrayStructProperties(PrintWriter writer, Schema<?> resolved) {
+        if (resolved == null || resolved.getProperties() == null) {
+            return;
+        }
+        resolved.getProperties().forEach((name, prop) -> {
+            Schema<?> propertySchema = prop;
+            String propDesc = propertySchema.getDescription() != null ?
+                    " - " + propertySchema.getDescription() : "";
+            writer.printf("** [.string]#string#  \"%s\"%s%n", name, propDesc);
+        });
+    }
+
+    private void writeSimpleReturn(PrintWriter writer, Schema<?> schema,
+                                   ApiResponse successResponse, Operation operation) {
+        String displayType = displayType(schema);
+        String label = Optional.of(responseDescription(successResponse))
+                .filter(d -> !d.isBlank())
+                .orElseGet(() -> operation.getOperationId()
+                        .replace("get", "")
+                        .replaceAll("([a-z])([A-Z])", "$1 $2")
+                        .toLowerCase().trim());
+
+        writer.printf("* [.%s]#%s#  %s%n ", displayType, displayType, label);
+    }
+
+    private Schema<?> resolveSchemaReference(Schema<?> schema) {
+        if (schema == null || schema.get$ref() == null) {
+            return schema;
+        }
+        return resolveSchema(schema.get$ref());
+    }
+
+    private String responseDescription(ApiResponse response) {
+        return Optional.ofNullable(response.getDescription())
+                .filter(d -> !d.isBlank())
+                .orElse("");
+    }
+
+    private String displayType(Schema<?> schema) {
+        return "integer".equals(schema.getType()) ? "int" : schema.getType();
     }
 
     private ApiResponse getSuccessResponse(ApiResponses responses) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -240,12 +240,20 @@ public class OpenApiToAsciidocParser {
             Schema<?> resolved = itemSchema.get$ref() != null ? resolveSchema(itemSchema.get$ref()) : itemSchema;
             String itemRefName = itemSchema.get$ref() != null ? extractRefName(itemSchema.get$ref()) : "";
 
-            writer.println("* [.array]#array# :");
             if (resolved != null && isSimpleType(resolved)) {
                 String itemType = "integer".equals(resolved.getType()) ? "int" : resolved.getType();
+                String label = Optional.ofNullable(successResponse.getDescription())
+                        .filter(d -> !d.isBlank())
+                        .orElse("");
+                if (!label.isEmpty()) {
+                    writer.printf("* [.array]#%s array#  %s%n", itemType, label);
+                    return;
+                }
+                writer.println("* [.array]#array# :");
                 writer.printf("    * [.%s]#%s#%n", itemType, itemType);
             }
             else {
+                writer.println("* [.array]#array# :");
                 writer.printf("    * [.struct]#struct#  %s%n", itemRefName);
                 if (resolved != null && resolved.getProperties() != null) {
                     resolved.getProperties().forEach((name, prop) -> {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -185,12 +185,11 @@ public class OpenApiToDocBookParser {
         }
 
         Map<String, Schema<?>> allProps = getAllPossibleProperties(op);
-        for (Map.Entry<String, Schema<?>> e : allProps.entrySet()) {
-            String name = e.getKey();
-            if (!activeParams.contains(name)) {
+        for (String name : activeParams) {
+            Schema<?> schema = allProps.get(name);
+            if (schema == null) {
                 continue;
             }
-            Schema<?> schema = e.getValue();
             String type = formatType(schema);
             String desc = findDescription(schema);
             params.add(new ParamDoc(type, name, desc));
@@ -271,6 +270,11 @@ public class OpenApiToDocBookParser {
             Schema<?> item = schema.getItems();
             Schema<?> resolvedItem = item.get$ref() != null ?
                     resolveSchema(item.get$ref()) : item;
+            if (resolvedItem != null && isSimpleType(resolvedItem) && label != null && !label.isBlank()) {
+                String itemType = "integer".equals(resolvedItem.getType()) ? "int" : resolvedItem.getType();
+                return String.format("<listitem><para>array(%s) %s</para></listitem>",
+                        escapeXml(itemType), escapeXml(label));
+            }
             String itemLabel = item.get$ref() != null ? extractRefName(item.get$ref()) : "";
             StringBuilder sb = new StringBuilder();
             sb.append("<listitem>\n");

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -256,56 +256,82 @@ public class OpenApiToDocBookParser {
         if (schema == null) {
             return "<listitem><para></para></listitem>";
         }
-        if (schema.getProperties() != null && schema.getProperties().containsKey("result")) {
-            Object resultProp = schema.getProperties().get("result");
-            if (resultProp instanceof Schema<?> resultSchema) {
-                String innerLabel = resultSchema.get$ref() != null ?
-                        extractRefName(resultSchema.get$ref()) : label;
-                Schema<?> resolved = resultSchema.get$ref() != null ?
-                        resolveSchema(resultSchema.get$ref()) : resultSchema;
-                return renderReturnSchema(resolved, innerLabel);
-            }
+        Schema<?> resultSchema = getResultSchema(schema);
+        if (resultSchema != null) {
+            return renderReturnSchema(resolveSchemaReference(resultSchema), getResultLabel(resultSchema, label));
         }
         if ("array".equals(schema.getType()) && schema.getItems() != null) {
-            Schema<?> item = schema.getItems();
-            Schema<?> resolvedItem = item.get$ref() != null ?
-                    resolveSchema(item.get$ref()) : item;
-            if (resolvedItem != null && isSimpleType(resolvedItem) && label != null && !label.isBlank()) {
-                String itemType = "integer".equals(resolvedItem.getType()) ? "int" : resolvedItem.getType();
-                return String.format("<listitem><para>array(%s) %s</para></listitem>",
-                        escapeXml(itemType), escapeXml(label));
-            }
-            String itemLabel = item.get$ref() != null ? extractRefName(item.get$ref()) : "";
-            StringBuilder sb = new StringBuilder();
-            sb.append("<listitem>\n");
-            sb.append("  <para>array</para>\n");
-            sb.append("  <itemizedlist spacing=\"compact\">\n");
-            sb.append(indentLines(renderReturnSchema(resolvedItem, itemLabel), 4));
-            sb.append("\n  </itemizedlist>\n");
-            sb.append("</listitem>");
-            return sb.toString();
+            return renderArrayReturn(schema, label);
         }
         if (isSimpleType(schema)) {
-            String type = "integer".equals(schema.getType()) ? "int" : schema.getType();
-            String text = (label == null || label.isBlank()) ? type : type + " - " + label;
-            return String.format("<listitem><para>%s</para></listitem>", escapeXml(text));
+            return renderSimpleReturn(schema, label);
         }
         if (schema.getAdditionalProperties() instanceof Schema<?> inner) {
-            Schema<?> resolvedInner = inner.get$ref() != null ?
-                    resolveSchema(inner.get$ref()) : inner;
-            String innerLabel;
-            if (inner.get$ref() != null) {
-                innerLabel = extractRefName(inner.get$ref());
-            }
-            else if (label.isEmpty()) {
-                innerLabel = "namespace";
-            }
-            else {
-                innerLabel = label;
-            }
-            return renderReturnSchema(resolvedInner, innerLabel.isEmpty() ? "namespace" : innerLabel);
+            return renderAdditionalPropertiesReturn(inner, label);
         }
         return renderStructList(schema, label);
+    }
+
+    private Schema<?> getResultSchema(Schema<?> schema) {
+        if (schema.getProperties() == null || !schema.getProperties().containsKey("result")) {
+            return null;
+        }
+        Object resultProp = schema.getProperties().get("result");
+        return resultProp instanceof Schema<?> resultSchema ? resultSchema : null;
+    }
+
+    private String getResultLabel(Schema<?> resultSchema, String label) {
+        return resultSchema.get$ref() != null ? extractRefName(resultSchema.get$ref()) : label;
+    }
+
+    private String renderArrayReturn(Schema<?> schema, String label) {
+        Schema<?> item = schema.getItems();
+        Schema<?> resolvedItem = resolveSchemaReference(item);
+        if (resolvedItem != null && isSimpleType(resolvedItem) && label != null && !label.isBlank()) {
+            String itemType = formatSimpleType(resolvedItem);
+            return String.format("<listitem><para>array(%s) %s</para></listitem>",
+                    escapeXml(itemType), escapeXml(label));
+        }
+
+        String itemLabel = item.get$ref() != null ? extractRefName(item.get$ref()) : "";
+        StringBuilder sb = new StringBuilder();
+        sb.append("<listitem>\n");
+        sb.append("  <para>array</para>\n");
+        sb.append("  <itemizedlist spacing=\"compact\">\n");
+        sb.append(indentLines(renderReturnSchema(resolvedItem, itemLabel), 4));
+        sb.append("\n  </itemizedlist>\n");
+        sb.append("</listitem>");
+        return sb.toString();
+    }
+
+    private String renderSimpleReturn(Schema<?> schema, String label) {
+        String type = formatSimpleType(schema);
+        String text = (label == null || label.isBlank()) ? type : type + " - " + label;
+        return String.format("<listitem><para>%s</para></listitem>", escapeXml(text));
+    }
+
+    private String renderAdditionalPropertiesReturn(Schema<?> inner, String label) {
+        Schema<?> resolvedInner = resolveSchemaReference(inner);
+        String innerLabel = getAdditionalPropertiesLabel(inner, label);
+        return renderReturnSchema(resolvedInner, innerLabel.isEmpty() ? "namespace" : innerLabel);
+    }
+
+    private String getAdditionalPropertiesLabel(Schema<?> inner, String label) {
+        if (inner.get$ref() != null) {
+            return extractRefName(inner.get$ref());
+        }
+        if (label.isEmpty()) {
+            return "namespace";
+        }
+        return label;
+    }
+
+    private Schema<?> resolveSchemaReference(Schema<?> schema) {
+        return schema.get$ref() != null ? resolveSchema(schema.get$ref()) : schema;
+    }
+
+    private String formatSimpleType(Schema<?> schema) {
+        return "integer".equals(schema.getType()) ? "int" : schema.getType();
     }
 
     private String renderStructList(Schema<?> schema, String label) {

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/SaltKeyHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/SaltKeyHandlerContractTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.saltkey.SaltKeyHandler;
+
+import org.jmock.Expectations;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class SaltKeyHandlerContractTest extends BaseOpenApiTest {
+
+    @Override
+    protected String getApiNamespace() {
+        return "saltkey";
+    }
+
+    @Override
+    protected Class<SaltKeyHandler> getHandlerClass() {
+        return SaltKeyHandler.class;
+    }
+
+    private SaltKeyHandler handler() {
+        return (SaltKeyHandler) handlerMock;
+    }
+
+    @Test
+    public void testAcceptedList() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).acceptedList(with(mockUser));
+            will(returnValue(List.of("minion1", "minion2")));
+        }});
+
+        validateApiContract("/saltkey/acceptedList", "GET")
+                .onHandlerMethod("acceptedList");
+    }
+
+    @Test
+    public void testPendingList() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).pendingList(with(mockUser));
+            will(returnValue(List.of("minion1")));
+        }});
+
+        validateApiContract("/saltkey/pendingList", "GET")
+                .onHandlerMethod("pendingList");
+    }
+
+    @Test
+    public void testRejectedList() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).rejectedList(with(mockUser));
+            will(returnValue(List.of()));
+        }});
+
+        validateApiContract("/saltkey/rejectedList", "GET")
+                .onHandlerMethod("rejectedList");
+    }
+
+    @Test
+    public void testDeniedList() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).deniedList(with(mockUser));
+            will(returnValue(List.of()));
+        }});
+
+        validateApiContract("/saltkey/deniedList", "GET")
+                .onHandlerMethod("deniedList");
+    }
+
+    @Test
+    public void testAccept() throws Exception {
+        var minionId = "minion-1";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).accept(with(mockUser), with(minionId));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/saltkey/accept", "POST")
+                .withBody(Map.of("minionId", minionId))
+                .onHandlerMethod("accept", User.class, String.class);
+    }
+
+    @Test
+    public void testReject() throws Exception {
+        var minionId = "minion-2";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).reject(with(mockUser), with(minionId));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/saltkey/reject", "POST")
+                .withBody(Map.of("minionId", minionId))
+                .onHandlerMethod("reject", User.class, String.class);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        var minionId = "minion-3";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).delete(with(mockUser), with(minionId));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/saltkey/delete", "POST")
+                .withBody(Map.of("minionId", minionId))
+                .onHandlerMethod("delete", User.class, String.class);
+    }
+}


### PR DESCRIPTION
## What does this PR change?

Part of GSoC 2026 - OpenAPI migration project (migrating Uyuni API docs from
Javadoc/custom Doclets to OpenAPI/Swagger).

Migrates the `saltkey` XML-RPC handler to the OpenAPI contract approach:

- Added `SaltKeyHandlerApi` — the contract interface documenting all 7 saltkey
  endpoints (`acceptedList`, `pendingList`, `rejectedList`, `deniedList`,
  `accept`, `reject`, `delete`).
- `SaltKeyHandler` now implements the interface (no behavior change).
- Registered the handler in `OpenApiConfig`.
- Added `SaltKeyHandlerContractTest`, validating the generated OpenAPI schema
  against the handler's real responses.

Verified the generated AsciiDoc and DocBook are functionally equivalent to the
legacy Doclet output (same methods, HTTP verbs, parameters and return types),
and the contract tests pass (7/7).

**Question for review:** for the primitive-array returns (`List<String>`), the
new output keeps the return type (array of string) but drops the legacy
free-text label (e.g. `array(string) Accepted salt key list` → `array` →
`string`). This is a limitation of the already-merged parser (no description
slot for primitive-array items), not specific to this handler. Is the current
behavior acceptable, or should the parser render a label for primitive arrays?

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Unit tests were added: `SaltKeyHandlerContractTest` validates the generated
  OpenAPI schema against the handler responses.

- [x] **DONE**

## Links

Tracks: GSoC 2026 OpenAPI migration

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
