### PR TITLE
 Fix hubsync package download checksum lookup (bsc#1270040)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/DownloadController.java
@@ -555,7 +555,12 @@ public class DownloadController {
         }
         PkgInfo p = new PkgInfo(name, epoch, version, release, arch);
         // path is getPackage/<org>/<checksum>/filename
-        if (parts.size() == 9 && parts.get(5).equals("getPackage")) {
+        // hubsync routes have 10 parts (getPackage at index 6), non-hubsync have 9 (index 5)
+        if (parts.size() == 10 && parts.get(6).equals("getPackage")) {
+            p.setOrgId(parts.get(7));
+            p.setChecksum(parts.get(8));
+        }
+        else if (parts.size() == 9 && parts.get(5).equals("getPackage")) {
             p.setOrgId(parts.get(6));
             p.setChecksum(parts.get(7));
         }

--- a/java/spacewalk-java.changes.kwalter.bsc1270040
+++ b/java/spacewalk-java.changes.kwalter.bsc1270040
@@ -1,0 +1,1 @@
+- Fix hubsync package download checksum lookup (bsc#1270040)


### PR DESCRIPTION
## What does this PR change?

fixes an issue with hubsync urls not using the checksum for the package lookup.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31105


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
