### PR TITLE
feat(openapi): migrate preferences.locale handler to OpenAPI contract

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/preferences/locale/PreferencesLocaleHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/preferences/locale/PreferencesLocaleHandler.java
@@ -36,7 +36,7 @@ import java.util.List;
  * @apidoc.namespace preferences.locale
  * @apidoc.doc Provides methods to access and modify user locale information
  */
-public class PreferencesLocaleHandler extends BaseHandler {
+public class PreferencesLocaleHandler extends BaseHandler implements PreferencesLocaleHandlerApi {
 
     /**
      * Set the TimeZone for the given user.

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/preferences/locale/PreferencesLocaleHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/preferences/locale/PreferencesLocaleHandlerApi.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.preferences.locale;
+
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+import com.suse.manager.api.docs.PublicApiEndpoint;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import spark.route.HttpMethod;
+
+/**
+ * API contract for {@link PreferencesLocaleHandler}.
+ */
+@Tag(name = "preferences.locale", description = "Provides methods to access and modify user locale information")
+public interface PreferencesLocaleHandlerApi {
+
+    /**
+     * Set a user's timezone.
+     *
+     * @param loggedInUser current user
+     * @param login the login of the user whose timezone will be changed
+     * @param tzid the timezone ID to set
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set a user's timezone.",
+        requestClass = SetTimeZoneRequest.class,
+        isIntegerResponse = true
+    )
+    int setTimeZone(User loggedInUser, String login, Integer tzid);
+
+    /**
+     * Set a user's locale.
+     *
+     * @param loggedInUser current user
+     * @param login the login of the user whose locale will be changed
+     * @param locale the locale code to set
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set a user's locale.",
+        requestClass = SetLocaleRequest.class,
+        isIntegerResponse = true
+    )
+    int setLocale(User loggedInUser, String login, String locale);
+
+    /**
+     * Returns a list of all understood timezones. Results can be used as input to setTimeZone.
+     *
+     * @return list of all understood timezones
+     */
+    @PublicApiEndpoint
+    @ApiEndpointDoc(
+        summary = "Returns a list of all understood timezones. Results can be used as input to setTimeZone.",
+        method = HttpMethod.get,
+        responseClass = TimeZoneListResponse.class
+    )
+    Object[] listTimeZones();
+
+    /**
+     * Returns a list of all understood locales. Can be used as input to setLocale.
+     *
+     * @return list of all understood locales
+     */
+    @PublicApiEndpoint
+    @ApiEndpointDoc(
+        summary = "Returns a list of all understood locales. Can be used as input to setLocale.",
+        method = HttpMethod.get,
+        responseClass = LocaleListResponse.class,
+        responseDescription = "Locale code."
+    )
+    Object[] listLocales();
+
+    @Schema(name = "SetTimeZoneRequest")
+    @JsonPropertyOrder({"login", "tzid"})
+    interface SetTimeZoneRequest {
+
+        /**
+         * @return the login of the user whose timezone will be changed
+         */
+        @Schema(description = "User's login name.", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLogin();
+
+        /**
+         * @return the timezone ID to set
+         */
+        @Schema(description = "Timezone ID. (from listTimeZones)", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getTzid();
+    }
+
+    @Schema(name = "SetLocaleRequest")
+    @JsonPropertyOrder({"login", "locale"})
+    interface SetLocaleRequest {
+
+        /**
+         * @return the login of the user whose locale will be changed
+         */
+        @Schema(description = "User's login name.", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLogin();
+
+        /**
+         * @return the locale code to set
+         */
+        @Schema(description = "Locale to set. (from listLocales)", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLocale();
+    }
+
+    @Schema(name = "Timezone", description = "timezone")
+    interface RhnTimeZoneDoc {
+
+        /**
+         * @return the unique identifier for the timezone
+         */
+        @Schema(name = "time_zone_id", description = "unique identifier for timezone",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        int getTimeZoneId();
+
+        /**
+         * @return the name as identified by the Olson database
+         */
+        @Schema(name = "olson_name", description = "name as identified by the Olson database",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getOlsonName();
+    }
+
+    @Schema(name = "ApiResponseTimeZoneList")
+    interface TimeZoneListResponse extends ApiResponseWrapper<List<RhnTimeZoneDoc>> { }
+
+    @Schema(name = "ApiResponseLocaleList")
+    interface LocaleListResponse extends ApiResponseWrapper<List<String>> { }
+}

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/preferences/locale/PreferencesLocaleHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/preferences/locale/PreferencesLocaleHandlerApi.java
@@ -122,6 +122,7 @@ public interface PreferencesLocaleHandlerApi {
     }
 
     @Schema(name = "Timezone", description = "timezone")
+    @JsonPropertyOrder({"timeZoneId", "olsonName"})
     interface RhnTimeZoneDoc {
 
         /**

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -17,6 +17,7 @@ package com.suse.manager.api;
 import com.redhat.rhn.frontend.xmlrpc.access.AccessHandler;
 import com.redhat.rhn.frontend.xmlrpc.admin.ssh.AdminSshHandler;
 import com.redhat.rhn.frontend.xmlrpc.api.ApiHandler;
+import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
 import com.redhat.rhn.frontend.xmlrpc.saltkey.SaltKeyHandler;
 
 import com.suse.manager.api.docs.UyuniSwaggerReader;
@@ -104,6 +105,7 @@ public final class OpenApiConfig {
         handlers.put("access", AccessHandler.class);
         handlers.put("admin.ssh", AdminSshHandler.class);
         handlers.put("api", ApiHandler.class);
+        handlers.put("preferences.locale", PreferencesLocaleHandler.class);
         handlers.put("saltkey", SaltKeyHandler.class);
         return handlers;
     }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -308,7 +308,8 @@ public class OpenApiToAsciidocParser {
             Schema<?> propertySchema = prop;
             String propDesc = propertySchema.getDescription() != null ?
                     " - " + propertySchema.getDescription() : "";
-            writer.printf("** [.string]#string#  \"%s\"%s%n", name, propDesc);
+            String propertyType = structPropertyType(propertySchema);
+            writer.printf("** [.%s]#%s#  \"%s\"%s%n", propertyType, propertyType, name, propDesc);
         });
     }
 
@@ -340,6 +341,18 @@ public class OpenApiToAsciidocParser {
 
     private String displayType(Schema<?> schema) {
         return "integer".equals(schema.getType()) ? "int" : schema.getType();
+    }
+
+    private String structPropertyType(Schema<?> schema) {
+        String type = schema.getType();
+        if ("integer".equals(type)) {
+            return "int";
+        }
+        if ("string".equals(type) || "boolean".equals(type) || "number".equals(type)) {
+            return type;
+        }
+        // arrays, objects and $ref types keep the legacy "string" fallback
+        return "string";
     }
 
     private ApiResponse getSuccessResponse(ApiResponses responses) {
@@ -385,7 +398,9 @@ public class OpenApiToAsciidocParser {
                 if (propertySchema.getDescription() != null) {
                     propertyDescription = " - " + propertySchema.getDescription();
                 }
-                writer.printf("%s** [.string]#string#  \"%s\"%s%n", prefix, name, propertyDescription);
+                String propertyType = structPropertyType(propertySchema);
+                writer.printf("%s** [.%s]#%s#  \"%s\"%s%n", prefix, propertyType, propertyType, name,
+                        propertyDescription);
             });
         }
 
@@ -402,7 +417,9 @@ public class OpenApiToAsciidocParser {
                     if (propertySchema.getDescription() != null) {
                         propertyDescription = " - " + propertySchema.getDescription();
                     }
-                    writer.printf("%s** [.string]#string#  \"%s\"%s%n", prefix, name, propertyDescription);
+                    String propertyType = structPropertyType(propertySchema);
+                    writer.printf("%s** [.%s]#%s#  \"%s\"%s%n", prefix, propertyType, propertyType, name,
+                            propertyDescription);
                 });
             }
             else if (isSimpleType(resolvedInner)) {
@@ -410,7 +427,8 @@ public class OpenApiToAsciidocParser {
                 if (resolvedInner.getDescription() != null) {
                     description = " - " + resolvedInner.getDescription();
                 }
-                writer.printf("%s** [.string]#string#%s%n", prefix, description);
+                String innerType = structPropertyType(resolvedInner);
+                writer.printf("%s** [.%s]#%s#%s%n", prefix, innerType, innerType, description);
             }
         }
     }

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/BaseOpenApiTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/BaseOpenApiTest.java
@@ -13,12 +13,11 @@ package com.suse.manager.api.test.contract;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
+import com.redhat.rhn.frontend.xmlrpc.serializer.SerializerFactory;
 
 import com.suse.manager.api.RouteFactory;
 import com.suse.manager.api.docs.UyuniSwaggerReader;
 import com.suse.utils.Json;
-
-import com.google.gson.Gson;
 
 import org.everit.json.schema.loader.SchemaLoader;
 import org.jmock.Expectations;
@@ -429,7 +428,7 @@ public abstract class BaseOpenApiTest {
     }
 
     private void initializeRouteFactory() {
-        this.testableRouteFactory = new RouteFactory(null) {
+        this.testableRouteFactory = new RouteFactory(new SerializerFactory()) {
             @Override
             protected String getSessionKeyFromRequest(Request req) {
                 return "fake-session";
@@ -455,11 +454,6 @@ public abstract class BaseOpenApiTest {
 
             @Override
             protected void rollbackTransactionSafe() {
-            }
-
-            @Override
-            protected Gson initGsonWithSerializers() {
-                return Json.GSON;
             }
         };
     }

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/PreferencesLocaleHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/PreferencesLocaleHandlerContractTest.java
@@ -10,11 +10,12 @@
  */
 package com.suse.manager.api.test.contract;
 
+import com.redhat.rhn.domain.user.RhnTimeZone;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
 
 import org.jmock.Expectations;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -66,12 +67,13 @@ public class PreferencesLocaleHandlerContractTest extends BaseOpenApiTest {
 
     @Test
     public void testListTimeZones() throws Exception {
-        // RhnTimeZone is serialized with camelCase bean names while the documented schema uses the
-        // legacy snake_case (time_zone_id/olson_name), so an empty array is returned here, matching
-        // how the merged access handler tests renamed-field structs.
+        RhnTimeZone timezone = new RhnTimeZone();
+        timezone.setTimeZoneId(5);
+        timezone.setOlsonName("Etc/UTC");
+
         context.checking(new Expectations() {{
             oneOf(handler()).listTimeZones();
-            will(returnValue(new Object[]{}));
+            will(returnValue(new Object[]{timezone}));
         }});
 
         validateApiContract("/preferences.locale/listTimeZones", "GET")

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/PreferencesLocaleHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/PreferencesLocaleHandlerContractTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
+
+import org.jmock.Expectations;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class PreferencesLocaleHandlerContractTest extends BaseOpenApiTest {
+
+    @Override
+    protected String getApiNamespace() {
+        return "preferences.locale";
+    }
+
+    @Override
+    protected Class<PreferencesLocaleHandler> getHandlerClass() {
+        return PreferencesLocaleHandler.class;
+    }
+
+    private PreferencesLocaleHandler handler() {
+        return (PreferencesLocaleHandler) handlerMock;
+    }
+
+    @Test
+    public void testSetTimeZone() throws Exception {
+        var login = "alice";
+        var tzid = 5;
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setTimeZone(with(mockUser), with(login), with(tzid));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/preferences.locale/setTimeZone", "POST")
+                .withBody(Map.of("login", login, "tzid", tzid))
+                .onHandlerMethod("setTimeZone", User.class, String.class, Integer.class);
+    }
+
+    @Test
+    public void testSetLocale() throws Exception {
+        var login = "alice";
+        var locale = "en_US";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setLocale(with(mockUser), with(login), with(locale));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/preferences.locale/setLocale", "POST")
+                .withBody(Map.of("login", login, "locale", locale))
+                .onHandlerMethod("setLocale", User.class, String.class, String.class);
+    }
+
+    @Test
+    public void testListTimeZones() throws Exception {
+        // RhnTimeZone is serialized with camelCase bean names while the documented schema uses the
+        // legacy snake_case (time_zone_id/olson_name), so an empty array is returned here, matching
+        // how the merged access handler tests renamed-field structs.
+        context.checking(new Expectations() {{
+            oneOf(handler()).listTimeZones();
+            will(returnValue(new Object[]{}));
+        }});
+
+        validateApiContract("/preferences.locale/listTimeZones", "GET")
+                .onHandlerMethod("listTimeZones");
+    }
+
+    @Test
+    public void testListLocales() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listLocales();
+            will(returnValue(new Object[]{"en_US"}));
+        }});
+
+        validateApiContract("/preferences.locale/listLocales", "GET")
+                .onHandlerMethod("listLocales");
+    }
+}


### PR DESCRIPTION
## What does this PR change?

Part of GSoC 2026 - OpenAPI migration project (migrating Uyuni API docs from
Javadoc/custom Doclets to OpenAPI/Swagger).

Migrates the `preferences.locale` XML-RPC handler to the OpenAPI contract approach:

- Added `PreferencesLocaleHandlerApi` — the contract interface documenting all 4
  endpoints (`setTimeZone`, `setLocale`, `listTimeZones`, `listLocales`).
- `PreferencesLocaleHandler` now implements the interface (no behavior change).
- Registered the handler in `OpenApiConfig`.
- Added `PreferencesLocaleHandlerContractTest`, validating the generated OpenAPI
  schema against the handler's real responses.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Unit tests were added: `PreferencesLocaleHandlerContractTest` validates the generated
  OpenAPI schema against the handler responses.

- [x] **DONE**

## Links

Tracks: GSoC 2026 OpenAPI migration

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
