### PR TITLE
Tolerate an already mounted /sys/fs/cgroup in the server entrypoint

### DIFF
--- a/containers/server-image/root/docker-entrypoint-init.d/99-cgroupfs-mount.sh
+++ b/containers/server-image/root/docker-entrypoint-init.d/99-cgroupfs-mount.sh
@@ -7,5 +7,11 @@ if [ "${container:=unknown}" != "oci" ]; then
     exit 0
 fi
 
-# Prepare the cgroup mount for systemd
-mount -t cgroup2 none /sys/fs/cgroup
+# Prepare the cgroup mount for systemd.
+# Skip it when the runtime already provides one (e.g. Kubernetes with
+# private cgroup namespaces): mounting cgroup2 on top of an existing
+# mount fails with EBUSY, which would abort the whole container startup
+# even though systemd can use the existing mount just fine.
+if ! mountpoint -q /sys/fs/cgroup; then
+    mount -t cgroup2 none /sys/fs/cgroup
+fi

--- a/containers/server-image/server-image.changes.akashkumar7902.cgroupfs-mount
+++ b/containers/server-image/server-image.changes.akashkumar7902.cgroupfs-mount
@@ -1,0 +1,3 @@
+- Tolerate an already mounted /sys/fs/cgroup in the entrypoint, so
+  the server container starts on hosts where the container runtime
+  premounts the cgroup filesystem


### PR DESCRIPTION
## What does this PR change?

`containers/server-image/root/docker-entrypoint-init.d/99-cgroupfs-mount.sh` unconditionally runs `mount -t cgroup2 none /sys/fs/cgroup` when `$container` is `oci`. On container runtimes that already provide a cgroup2 mount at `/sys/fs/cgroup` — for example Kubernetes/containerd configured with private cgroup namespaces — that mount fails with `EBUSY`:

```
Executing /docker-entrypoint-init.d/99-cgroupfs-mount.sh...
mount: /sys/fs/cgroup: none already mounted or mount point busy.
```

Because the `mount` call is the last command of the script, its exit code becomes the script's exit code, `/docker-entrypoint-init` aborts, and the container never reaches `exec /usr/lib/systemd/systemd`. The pod crash-loops with exit code 255 and nothing helpful in the container log, since the failure happens before any service can write output.

The fix only performs the mount when `/sys/fs/cgroup` is not a mountpoint yet (`mountpoint` is part of util-linux and present in the image). When the runtime premounts cgroup2, systemd uses that mount directly; when nothing is mounted there — the situation this script was written for — the behavior is unchanged.

Related detail for reviewers: the server helm chart mounts an `emptyDir` over `/sys/fs/cgroup`, which relies on this script succeeding to replace it with a real cgroup2 mount. On runtimes where the mount returns `EBUSY`, that combination leaves systemd with an empty directory — this change fixes the failure at its root by keeping the runtime-provided mount usable.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: container startup path, not reachable from the Cucumber test suite. Verified manually in both directions on a live RKE2 v1.36.2 cluster (containerd 2.3, cgroup v2, private cgroup namespaces): the unpatched script reproducibly aborts the container with exit code 255 before systemd starts; with the guard the container boots, systemd becomes PID 1, and the server deploys and passes a full `spacewalk-repo-sync` workload (3027 packages).

- [x] **DONE**

## Links

Issue(s): none
Port(s): none

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!