### PR TITLE
Testsuite: added a stopper text for check_text? and according minionssh test adjustment

### DIFF
--- a/testsuite/features/secondary/minssh_tunnel.feature
+++ b/testsuite/features/secondary/minssh_tunnel.feature
@@ -21,7 +21,7 @@ Feature: Register a Salt system to be managed via SSH tunnel
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
+    And I wait at most 180 seconds until I see "has been deleted" but "An error occurred during cleanup" text
     Then "ssh_minion" should not be registered
 
   Scenario: Register this minion for push via SSH tunnel
@@ -35,8 +35,8 @@ Feature: Register a Salt system to be managed via SSH tunnel
     And I select the hostname of "proxy" from "proxies" if present
     And I check "manageWithSSH"
     And I click on "Bootstrap"
-    # workaround for bsc#1222108
-    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108 - The bootstrap page on a Salt SSH Minion takes more than 4 minutes to finish
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." but "already exist" text
     And I wait until onboarding is completed for "ssh_minion"
 
   Scenario: The contact method is SSH tunnel on this minion

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -48,6 +48,10 @@ When(/^I wait at most (\d+) seconds until I see "([^"]*)" text$/) do |seconds, t
   raise ScriptError, "Text '#{text}' not found" unless check_text?(text, timeout: seconds.to_i)
 end
 
+When(/^I wait at most (\d+) seconds until I see "([^"]*)" but "([^"]*)" text$/) do |seconds, text, stopper|
+  raise ScriptError, "Text '#{text}' not found or '#{stopper}' appeared" unless check_text?(text, stopper: stopper, timeout: seconds.to_i)
+end
+
 When(/^I wait until I see "([^"]*)" text or "([^"]*)" text(?:, (refreshing the page))?$/) do |text1, text2, refresh_option|
   if refresh_option
     # refreshing the page

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -135,9 +135,10 @@ end
 #
 # @param text1 [String] The first text to check for visibility.
 # @param text2 [String, nil] The second text to check for visibility (optional).
+# @param stoppper [String, nil] The stopper that end the loop if matched (optional).
 # @param timeout [Integer] The maximum time to wait for the text to become visible (default: Capybara.default_max_wait_time).
 # @return [Boolean] Returns true if the text is visible, false otherwise.
-def check_text?(text1, text2: nil, timeout: Capybara.default_max_wait_time)
+def check_text?(text1, text2: nil, stopper: nil, timeout: Capybara.default_max_wait_time)
   # WORKAROUND: Chrome 134+ raises Capybara::ElementNotFound, StaleElementReferenceError, or
   # NoMethodError (CDP response type mismatch) during page navigation, bypassing Capybara's
   # synchronize() retry mechanism. All three are caught and retried. All other exceptions still
@@ -148,6 +149,7 @@ def check_text?(text1, text2: nil, timeout: Capybara.default_max_wait_time)
     begin
       return true if has_text?(text1, wait: 1)
       return true if !text2.nil? && has_text?(text2, wait: 1)
+      return false if !stopper.nil? && has_text?(stopper, wait: 1)
     rescue Capybara::ElementNotFound,
            Selenium::WebDriver::Error::StaleElementReferenceError,
            Selenium::WebDriver::Error::NoSuchElementError,


### PR DESCRIPTION
## What does this PR change?

Adding a stopper text to the check_test? function that ends the function immediatelly. This will cut the unnecessary sleep time in tests. 

minssh_tunnel.feature has been updated accordingly - the tests fail immediatelly when the specific situation accurs - for example bootstrapping already bootstrapped system.

## Testing 

- tested with Multi-Linux Manager 5.1.4 with SLES SSH minion

## Additional info 

Please note that the existing test minssh_tunnel.feature is not fixed by this PR, only the execution time is being cut significantly.