### PR TITLE
feat(openapi): migrate channel.access handler to OpenAPI contract

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/access/ChannelAccessHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/access/ChannelAccessHandler.java
@@ -33,7 +33,7 @@ import com.suse.manager.api.ReadOnly;
  * @apidoc.namespace channel.access
  * @apidoc.doc Provides methods to retrieve and alter channel access restrictions.
  */
-public class ChannelAccessHandler extends BaseHandler {
+public class ChannelAccessHandler extends BaseHandler implements ChannelAccessHandlerApi {
 
     /**
      * Enable user restrictions for the given channel. If enabled, only

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/access/ChannelAccessHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/access/ChannelAccessHandlerApi.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.channel.access;
+
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import spark.route.HttpMethod;
+
+/**
+ * API contract for {@link ChannelAccessHandler}.
+ */
+@Tag(name = "channel.access", description = "Provides methods to retrieve and alter channel access restrictions.")
+public interface ChannelAccessHandlerApi {
+
+    /**
+     * Enable user restrictions for the given channel. If enabled, only
+     * selected users within the organization may subscribe to the channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel to change
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Enable user restrictions for the given channel. If enabled, only " +
+                  "selected users within the organization may subscribe to the channel.",
+        requestClass = ChannelLabelRequest.class,
+        isIntegerResponse = true
+    )
+    int enableUserRestrictions(User loggedInUser, String channelLabel);
+
+    /**
+     * Disable user restrictions for the given channel. If disabled,
+     * all users within the organization may subscribe to the channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel to change
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Disable user restrictions for the given channel. If disabled, " +
+                  "all users within the organization may subscribe to the channel.",
+        requestClass = ChannelLabelRequest.class,
+        isIntegerResponse = true
+    )
+    int disableUserRestrictions(User loggedInUser, String channelLabel);
+
+    /**
+     * Set organization sharing access control.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel to change
+     * @param access the access value to set (one of 'public', 'private' or 'protected')
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set organization sharing access control.",
+        requestClass = SetOrgSharingRequest.class,
+        isIntegerResponse = true
+    )
+    int setOrgSharing(User loggedInUser, String channelLabel, String access);
+
+    /**
+     * Get organization sharing access control.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel
+     * @return the access value
+     */
+    @ApiEndpointDoc(
+        summary = "Get organization sharing access control.",
+        method = HttpMethod.get,
+        responseClass = OrgSharingResponse.class,
+        responseDescription = "access - The access value (one of the following: 'public', 'private', or 'protected')"
+    )
+    String getOrgSharing(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(
+            name = "channelLabel",
+            description = "label of the channel",
+            in = ParameterIn.QUERY,
+            required = true
+        ) String channelLabel
+    );
+
+    @Schema(name = "ChannelLabelRequest")
+    interface ChannelLabelRequest {
+        /**
+         * @return label of the channel
+         */
+        @Schema(description = "label of the channel", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+    }
+
+    @Schema(name = "SetOrgSharingRequest")
+    @JsonPropertyOrder({"channelLabel", "access"})
+    interface SetOrgSharingRequest {
+        /**
+         * @return label of the channel
+         */
+        @Schema(description = "label of the channel", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return access (one of the following: 'public', 'private' or 'protected')
+         */
+        @Schema(description = "access (one of the following: 'public', 'private' or 'protected')",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAccess();
+    }
+
+    @Schema(name = "ApiResponseOrgSharing")
+    interface OrgSharingResponse extends ApiResponseWrapper<String> { }
+}

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -17,6 +17,7 @@ package com.suse.manager.api;
 import com.redhat.rhn.frontend.xmlrpc.access.AccessHandler;
 import com.redhat.rhn.frontend.xmlrpc.admin.ssh.AdminSshHandler;
 import com.redhat.rhn.frontend.xmlrpc.api.ApiHandler;
+import com.redhat.rhn.frontend.xmlrpc.channel.access.ChannelAccessHandler;
 import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
 import com.redhat.rhn.frontend.xmlrpc.saltkey.SaltKeyHandler;
 
@@ -105,6 +106,7 @@ public final class OpenApiConfig {
         handlers.put("access", AccessHandler.class);
         handlers.put("admin.ssh", AdminSshHandler.class);
         handlers.put("api", ApiHandler.class);
+        handlers.put("channel.access", ChannelAccessHandler.class);
         handlers.put("preferences.locale", PreferencesLocaleHandler.class);
         handlers.put("saltkey", SaltKeyHandler.class);
         return handlers;

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ChannelAccessHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ChannelAccessHandlerContractTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.channel.access.ChannelAccessHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class ChannelAccessHandlerContractTest extends BaseOpenApiTest {
+
+    @Override
+    protected String getApiNamespace() {
+        return "channel.access";
+    }
+
+    @Override
+    protected Class<ChannelAccessHandler> getHandlerClass() {
+        return ChannelAccessHandler.class;
+    }
+
+    private ChannelAccessHandler handler() {
+        return (ChannelAccessHandler) handlerMock;
+    }
+
+    @Test
+    public void testEnableUserRestrictions() throws Exception {
+        var channelLabel = "test-channel";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).enableUserRestrictions(with(mockUser), with(channelLabel));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.access/enableUserRestrictions", "POST")
+                .withBody(Map.of("channelLabel", channelLabel))
+                .onHandlerMethod("enableUserRestrictions", User.class, String.class);
+    }
+
+    @Test
+    public void testDisableUserRestrictions() throws Exception {
+        var channelLabel = "test-channel";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).disableUserRestrictions(with(mockUser), with(channelLabel));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.access/disableUserRestrictions", "POST")
+                .withBody(Map.of("channelLabel", channelLabel))
+                .onHandlerMethod("disableUserRestrictions", User.class, String.class);
+    }
+
+    @Test
+    public void testSetOrgSharing() throws Exception {
+        var channelLabel = "test-channel";
+        var access = "public";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setOrgSharing(with(mockUser), with(channelLabel), with(access));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.access/setOrgSharing", "POST")
+                .withBody(Map.of("channelLabel", channelLabel, "access", access))
+                .onHandlerMethod("setOrgSharing", User.class, String.class, String.class);
+    }
+
+    @Test
+    public void testGetOrgSharing() throws Exception {
+        var channelLabel = "test-channel";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).getOrgSharing(with(mockUser), with(channelLabel));
+            will(returnValue("public"));
+        }});
+
+        validateApiContract("/channel.access/getOrgSharing", "GET")
+                .withParams(Map.of("channelLabel", new String[]{channelLabel}))
+                .onHandlerMethod("getOrgSharing", User.class, String.class);
+    }
+}


### PR DESCRIPTION
## What does this PR change?

Part of GSoC 2026 - OpenAPI migration project (migrating Uyuni API docs from
Javadoc/custom Doclets to OpenAPI/Swagger).

Migrates the `channel.access` XML-RPC handler to the OpenAPI contract approach.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Unit tests were added: `ChannelAccessHandlerContractTest` validates the generated
  OpenAPI schema against the handler responses.

- [x] **DONE**

## Links

Tracks: GSoC 2026 OpenAPI migration

- [x] **DONE**

## Changelogs

- [x] No changelog needed
