### PR TITLE
feat(openapi): migrate pinnedsubscription handler to OpenAPI contract

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/subscriptionmatching/PinnedSubscriptionHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/subscriptionmatching/PinnedSubscriptionHandler.java
@@ -35,7 +35,7 @@ import java.util.List;
  * @apidoc.namespace subscriptionmatching.pinnedsubscription
  * @apidoc.doc Provides the namespace for operations on Pinned Subscriptions
  */
-public class PinnedSubscriptionHandler extends BaseHandler {
+public class PinnedSubscriptionHandler extends BaseHandler implements PinnedSubscriptionHandlerApi {
 
     /**
      * Lists all Pinned Subscriptions

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/subscriptionmatching/PinnedSubscriptionHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/subscriptionmatching/PinnedSubscriptionHandlerApi.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.subscriptionmatching;
+
+import com.redhat.rhn.domain.server.PinnedSubscription;
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * API contract for {@link PinnedSubscriptionHandler}.
+ */
+@Tag(name = "subscriptionmatching.pinnedsubscription",
+     description = "Provides the namespace for operations on Pinned Subscriptions")
+public interface PinnedSubscriptionHandlerApi {
+
+    /**
+     * Lists all pinned subscriptions.
+     *
+     * @param loggedInUser the current user
+     * @return the list of pinned subscriptions
+     */
+    @ApiEndpointDoc(
+        summary = "Lists all PinnedSubscriptions",
+        responseClass = PinnedSubscriptionListResponse.class
+    )
+    List<PinnedSubscription> list(User loggedInUser);
+
+    /**
+     * Creates a pinned subscription based on the given subscription and system.
+     *
+     * @param loggedInUser the current user
+     * @param subscriptionId the id of the subscription
+     * @param sid the id of the system
+     * @return the created pinned subscription
+     */
+    @ApiEndpointDoc(
+        summary = "Creates a Pinned Subscription based on given subscription and system",
+        requestClass = CreatePinnedSubscriptionRequest.class,
+        responseClass = PinnedSubscriptionResponse.class
+    )
+    PinnedSubscription create(User loggedInUser, Integer subscriptionId, Integer sid);
+
+    /**
+     * Deletes the pinned subscription with the given id.
+     *
+     * @param loggedInUser the current user
+     * @param subscriptionId the id of the pinned subscription to delete
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Deletes Pinned Subscription with given id",
+        requestClass = DeletePinnedSubscriptionRequest.class,
+        isIntegerResponse = true
+    )
+    int delete(User loggedInUser, Integer subscriptionId);
+
+    @Schema(name = "CreatePinnedSubscriptionRequest")
+    @JsonPropertyOrder({"subscriptionId", "sid"})
+    interface CreatePinnedSubscriptionRequest {
+
+        /**
+         * @return the id of the subscription
+         */
+        @Schema(description = "Subscription ID", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getSubscriptionId();
+
+        /**
+         * @return the id of the system
+         */
+        @Schema(description = "System ID", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getSid();
+    }
+
+    @Schema(name = "DeletePinnedSubscriptionRequest")
+    interface DeletePinnedSubscriptionRequest {
+
+        /**
+         * @return the id of the pinned subscription to delete
+         */
+        @Schema(description = "Pinned Subscription ID", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getSubscriptionId();
+    }
+
+    @Schema(name = "PinnedSubscription", description = "pinned subscription")
+    @JsonPropertyOrder({"id", "subscriptionId", "systemId"})
+    interface PinnedSubscriptionDoc {
+
+        /**
+         * @return the pinned subscription id
+         */
+        @Schema(description = "pinned subscription id", requiredMode = Schema.RequiredMode.REQUIRED)
+        Long getId();
+
+        /**
+         * @return the subscription id
+         */
+        @Schema(name = "subscription_id", description = "subscription id",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Long getSubscriptionId();
+
+        /**
+         * @return the system id
+         */
+        @Schema(name = "system_id", description = "system id",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Long getSystemId();
+    }
+
+    @Schema(name = "ApiResponsePinnedSubscription")
+    interface PinnedSubscriptionResponse extends ApiResponseWrapper<PinnedSubscriptionDoc> { }
+
+    @Schema(name = "ApiResponsePinnedSubscriptionList")
+    interface PinnedSubscriptionListResponse extends ApiResponseWrapper<List<PinnedSubscriptionDoc>> { }
+}

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.frontend.xmlrpc.api.ApiHandler;
 import com.redhat.rhn.frontend.xmlrpc.channel.access.ChannelAccessHandler;
 import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
 import com.redhat.rhn.frontend.xmlrpc.saltkey.SaltKeyHandler;
+import com.redhat.rhn.frontend.xmlrpc.subscriptionmatching.PinnedSubscriptionHandler;
 
 import com.suse.manager.api.docs.UyuniSwaggerReader;
 
@@ -109,6 +110,7 @@ public final class OpenApiConfig {
         handlers.put("channel.access", ChannelAccessHandler.class);
         handlers.put("preferences.locale", PreferencesLocaleHandler.class);
         handlers.put("saltkey", SaltKeyHandler.class);
+        handlers.put("subscriptionmatching.pinnedsubscription", PinnedSubscriptionHandler.class);
         return handlers;
     }
 }

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/PinnedSubscriptionHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/PinnedSubscriptionHandlerContractTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.server.PinnedSubscription;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.subscriptionmatching.PinnedSubscriptionHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class PinnedSubscriptionHandlerContractTest extends BaseOpenApiTest {
+
+    @Override
+    protected String getApiNamespace() {
+        return "subscriptionmatching.pinnedsubscription";
+    }
+
+    @Override
+    protected Class<PinnedSubscriptionHandler> getHandlerClass() {
+        return PinnedSubscriptionHandler.class;
+    }
+
+    private PinnedSubscriptionHandler handler() {
+        return (PinnedSubscriptionHandler) handlerMock;
+    }
+
+    private PinnedSubscription pinnedSubscription() {
+        PinnedSubscription pin = new PinnedSubscription();
+        pin.setId(1L);
+        pin.setSubscriptionId(10L);
+        pin.setSystemId(1000L);
+        return pin;
+    }
+
+    @Test
+    public void testList() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).list(with(mockUser));
+            will(returnValue(List.of(pinnedSubscription())));
+        }});
+
+        validateApiContract("/subscriptionmatching.pinnedsubscription/list", "POST")
+                .onHandlerMethod("list", User.class);
+    }
+
+    @Test
+    public void testCreate() throws Exception {
+        Integer subscriptionId = 10;
+        Integer sid = 1000;
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).create(with(mockUser), with(subscriptionId), with(sid));
+            will(returnValue(pinnedSubscription()));
+        }});
+
+        validateApiContract("/subscriptionmatching.pinnedsubscription/create", "POST")
+                .withBody(Map.of("subscriptionId", subscriptionId, "sid", sid))
+                .onHandlerMethod("create", User.class, Integer.class, Integer.class);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        Integer subscriptionId = 1;
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).delete(with(mockUser), with(subscriptionId));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/subscriptionmatching.pinnedsubscription/delete", "POST")
+                .withBody(Map.of("subscriptionId", subscriptionId))
+                .onHandlerMethod("delete", User.class, Integer.class);
+    }
+}


### PR DESCRIPTION

Migrates the `subscriptionmatching.pinnedsubscription` XML-RPC handler to the OpenAPI
contract approach (`list`, `create`, `delete`).

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Unit tests were added: `PinnedSubscriptionHandlerContractTest` validates the generated
  OpenAPI schema against the handler responses (populated `list`/`create`, `delete` result).

- [x] **DONE**

## Links

Tracks: GSoC 2026 OpenAPI migration

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Note for review

All three methods are `POST` (none are `@ReadOnly`), matching the legacy handler. The
`PinnedSubscriptionDoc` return struct carries a `@JsonPropertyOrder({"id", "subscriptionId",
"systemId"})` so the documented field order (`id`, `subscription_id`, `system_id`) stays
deterministic and matches `PinnedSubscriptionSerializer`. The generated AsciiDoc and DocBook
were diffed against the legacy doclet output and remain compatible for all three methods.
