### PR TITLE
Fix filtered package search select all

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/controllers/PackageController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/PackageController.java
@@ -168,7 +168,7 @@ public class PackageController {
     }
 
     private static Object channelPackages(Request request, Response response, User user) {
-        PageControlHelper pageHelper = new PageControlHelper(request, "server_name");
+        PageControlHelper pageHelper = new PageControlHelper(request, "nvrea");
         PageControl pc = pageHelper.getPageControl();
 
         boolean source = request.params(":binary").equals("source");
@@ -186,10 +186,19 @@ public class PackageController {
                         "left join rhnPackage P on SRPM.id = P.source_rpm_id " +
                         "left join rhnChannelPackage CP on CP.package_id = P.id";
 
-                String packageFrom = "rhnPackage P left join rhnChannelPackage CP on CP.package_id = P.id";
+                String filterColumn = pc.getFilterColumn();
+                if ("nvrea".equals(filterColumn)) {
+                    pc.setFilterColumn(source ? "SRPM.name" : "PN.name");
+                }
 
-                DataResult<PackageOverview> packages = new PagedSqlQueryBuilder("id")
-                        .select("id")
+                String packageFrom = "rhnPackage P " +
+                        "inner join rhnPackageName PN on P.name_id = PN.id " +
+                        "left join rhnChannelPackage CP on CP.package_id = P.id";
+
+                String idColumn = source ? "PS.id" : "P.id";
+
+                DataResult<PackageOverview> packages = new PagedSqlQueryBuilder(idColumn)
+                        .select(idColumn + " AS id")
                         .from(source ? packageSourceFrom : packageFrom)
                         .where("org_id = :org_id AND CP.channel_id = :cid")
                         .run(Map.of("org_id", user.getOrg().getId(), "cid", cid), pc,

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/PackageControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/PackageControllerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactoryTest;
+import com.redhat.rhn.domain.channel.ChannelTestUtility;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageTest;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.testing.TestUtils;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import spark.Request;
+import spark.Response;
+
+public class PackageControllerTest extends BaseControllerTestCase {
+
+    private static final Gson GSON = new Gson();
+
+    @Test
+    public void testChannelPackagesSelectAllRespectsPackageNameFilter() throws Exception {
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        Channel otherChannel = ChannelFactoryTest.createTestChannel(user);
+
+        Package matchingPackageOne = PackageTest.createTestPackage(user.getOrg(), "alpha-package-one");
+        Package matchingPackageTwo = PackageTest.createTestPackage(user.getOrg(), "alpha-package-two");
+        Package nonMatchingPackage = PackageTest.createTestPackage(user.getOrg(), "omega-package");
+        Package otherChannelPackage = PackageTest.createTestPackage(user.getOrg(), "alpha-package-three");
+
+        ChannelTestUtility.testAddPackage(channel, matchingPackageOne);
+        ChannelTestUtility.testAddPackage(channel, matchingPackageTwo);
+        ChannelTestUtility.testAddPackage(channel, nonMatchingPackage);
+        ChannelTestUtility.testAddPackage(otherChannel, otherChannelPackage);
+        TestUtils.flushSession();
+
+        Request request = getRequestWithCsrfAndParams(
+                "/manager/api/packages/list/:binary/channel/:cid",
+                Map.of("f", "id", "q", "alpha"),
+                "binary",
+                channel.getId()
+        );
+
+        assertEquals(
+                Set.of(matchingPackageOne.getId(), matchingPackageTwo.getId()),
+                Set.copyOf(invokeChannelPackages(request, response, user))
+        );
+    }
+
+    private List<Long> invokeChannelPackages(Request request, Response responseIn, User userIn) throws Exception {
+        Method method = PackageController.class.getDeclaredMethod("channelPackages",
+                Request.class, Response.class, User.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(null, request, responseIn, userIn);
+        return GSON.fromJson(result, new TypeToken<List<Long>>() { }.getType());
+    }
+}


### PR DESCRIPTION
## What does this PR change?

Fix the channel package search "Select all x items." path so it respects the active package-name filter.

The `f=id` code path in `PackageController.channelPackages(...)` still defaulted to `server_name`, so filtered package searches could return an empty ID list. This change switches the default filter to `nvrea`, maps that filter to the correct package name column for binary and source packages, joins `rhnPackageName` for binary package ID queries, and qualifies the selected ID column.

A regression test was added to verify that filtered select-all returns only matching packages from the selected channel.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No visual difference. The fix changes the existing filtered select-all behavior.

Before:
Filtered package search could return no selected IDs for the current filter.

After:
Filtered package search returns the IDs for the matching packages in the selected channel.

- [x] **DONE**

## Documentation
- No documentation needed: this fixes existing package selection behavior without introducing a new workflow, setting, or visible UI element.

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Unit tests were added
- Focused WSL validation was run with `mvn -pl core -DskipTests=false -Dtest=PackageControllerTest#testChannelPackagesSelectAllRespectsPackageNameFilter -DfailIfNoTests=true test`

- [x] **DONE**

## Links

Issue(s): #12211
Port(s): None

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
