### PR TITLE
Add missing bugzilla reference to changelog

### DIFF
--- a/python/spacewalk/spacewalk-backend.changes
+++ b/python/spacewalk/spacewalk-backend.changes
@@ -129,7 +129,7 @@ Tue Jun 17 19:29:59 CEST 2025 - marina.latini@suse.com
     GPG keys during reposync execution
   * Make reposync to allow commas as part of HTTP Proxy password
     (bsc#1243460)
-  * Use cryptographically secure random generation for secrets
+  * Use cryptographically secure random generation for secrets (bsc#1230568)
   * Fix zstd-compressed comps file reposync use case (bsc#1243821)
   * Fix fetching the mirrorlist with a ca bundle which include only
     the intermediate CAs. This is the case for RHUI CA bundles


### PR DESCRIPTION
## What does this PR change?

This PR simply adds a missing bugzilla reference for an existing changelog entry.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31181

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
