### PR TITLE
Avoid Hibernate errors with association helper (bsc#1271382)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/channel/ContentSource.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/channel/ContentSource.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009--2017 Red Hat, Inc.
+ * Copyright (c) 2010--2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,9 +13,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-/*
- * Copyright (c) 2010 SUSE LLC
- */
 package com.redhat.rhn.domain.channel;
 
 import com.redhat.rhn.domain.BaseDomainHelper;
@@ -22,8 +20,11 @@ import com.redhat.rhn.domain.Identifiable;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.scc.SCCRepositoryAuth;
 
+import com.suse.utils.persistence.EntityAssociationHelper;
+
 import org.hibernate.type.YesNoConverter;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -86,33 +87,11 @@ public class ContentSource extends BaseDomainHelper implements Identifiable {
     private Set<SCCRepositoryAuth> repositoryAuths = new HashSet<>();
 
     /**
-     * Constructor
-     */
-    public ContentSource() {
-    }
-
-    /**
-     * Copy Constructor
-     * @param cs content source template
-     */
-    public ContentSource(ContentSource cs) {
-        org = cs.getOrg();
-        type = cs.getType();
-        sourceUrl = cs.getSourceUrl();
-        label = cs.getLabel();
-        metadataSigned = cs.getMetadataSigned();
-        channels = new HashSet<>(cs.getChannels());
-        sslSets = new HashSet<>(cs.getSslSets());
-        repositoryAuths = new HashSet<>(cs.getRepositoryAuths());
-    }
-
-    /**
      * @return Returns the label.
      */
     public String getLabel() {
         return label;
     }
-
 
     /**
      * @param labelIn The label to set.
@@ -214,19 +193,44 @@ public class ContentSource extends BaseDomainHelper implements Identifiable {
     }
 
     /**
-     *
+     * Returns an unmodifiable view of SSL mappings for this content source.
+     * Use add/remove/clear helper methods to mutate the association.
      * @return SSL sets for content source
      */
     public Set<SslContentSource> getSslSets() {
-        return sslSets;
+        return Collections.unmodifiableSet(sslSets);
     }
 
     /**
-     *
+     * Reconciles SSL mappings in place to preserve Hibernate collection tracking
+     * with orphanRemoval semantics.
      * @param sslSetsIn SSL sets to assign to repository
      */
     public void setSslSets(Set<SslContentSource> sslSetsIn) {
-        this.sslSets = sslSetsIn;
+        EntityAssociationHelper.reconcile(this, sslSets, sslSetsIn, ContentSource::setSslContentSourceParent);
+    }
+
+    /**
+     * Adds an SSL mapping and keeps the child-to-parent reference in sync.
+     * @param sslContentSource SSL mapping to add
+     */
+    public void addSslSet(SslContentSource sslContentSource) {
+        EntityAssociationHelper.addMember(this, sslSets, sslContentSource, ContentSource::setSslContentSourceParent);
+    }
+
+    /**
+     * Removes an SSL mapping and clears the child-to-parent reference.
+     * @param sslContentSource SSL mapping to remove
+     */
+    public void removeSslSet(SslContentSource sslContentSource) {
+        EntityAssociationHelper.removeMember(sslSets, sslContentSource, ContentSource::setSslContentSourceParent);
+    }
+
+    /**
+     * Removes all SSL mappings and clears child-to-parent references.
+     */
+    public void clearSslSets() {
+        EntityAssociationHelper.clear(sslSets, ContentSource::setSslContentSourceParent);
     }
 
     /**
@@ -252,5 +256,9 @@ public class ContentSource extends BaseDomainHelper implements Identifiable {
                 ", label='" + label + '\'' +
                 ", metadataSigned=" + metadataSigned +
                 '}';
+    }
+
+    private static void setSslContentSourceParent(SslContentSource sslContentSource, ContentSource contentSource) {
+        sslContentSource.setContentSource(contentSource);
     }
 }

--- a/java/core/src/main/java/com/redhat/rhn/domain/channel/ContentSource.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/channel/ContentSource.java
@@ -197,7 +197,7 @@ public class ContentSource extends BaseDomainHelper implements Identifiable {
      * Use add/remove/clear helper methods to mutate the association.
      * @return SSL sets for content source
      */
-    public Set<SslContentSource> getSslSets() {
+    public Set<SslContentSource> getSslContentSources() {
         return Collections.unmodifiableSet(sslSets);
     }
 
@@ -206,7 +206,7 @@ public class ContentSource extends BaseDomainHelper implements Identifiable {
      * with orphanRemoval semantics.
      * @param sslSetsIn SSL sets to assign to repository
      */
-    public void setSslSets(Set<SslContentSource> sslSetsIn) {
+    public void setSslContentSources(Set<SslContentSource> sslSetsIn) {
         EntityAssociationHelper.reconcile(this, sslSets, sslSetsIn, ContentSource::setSslContentSourceParent);
     }
 
@@ -214,7 +214,7 @@ public class ContentSource extends BaseDomainHelper implements Identifiable {
      * Adds an SSL mapping and keeps the child-to-parent reference in sync.
      * @param sslContentSource SSL mapping to add
      */
-    public void addSslSet(SslContentSource sslContentSource) {
+    public void addSslContentSource(SslContentSource sslContentSource) {
         EntityAssociationHelper.addMember(this, sslSets, sslContentSource, ContentSource::setSslContentSourceParent);
     }
 
@@ -222,14 +222,14 @@ public class ContentSource extends BaseDomainHelper implements Identifiable {
      * Removes an SSL mapping and clears the child-to-parent reference.
      * @param sslContentSource SSL mapping to remove
      */
-    public void removeSslSet(SslContentSource sslContentSource) {
+    public void removeSslContentSource(SslContentSource sslContentSource) {
         EntityAssociationHelper.removeMember(sslSets, sslContentSource, ContentSource::setSslContentSourceParent);
     }
 
     /**
      * Removes all SSL mappings and clears child-to-parent references.
      */
-    public void clearSslSets() {
+    public void clearSslContentSources() {
         EntityAssociationHelper.clear(sslSets, ContentSource::setSslContentSourceParent);
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/manage/repo/RepoDetailsAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/manage/repo/RepoDetailsAction.java
@@ -227,9 +227,9 @@ public class RepoDetailsAction extends RhnAction {
         form.set(URL, repo.getSourceUrl());
         form.set(SOURCEID, repo.getId());
         form.set(TYPE, repo.getType().getLabel());
-        Set<SslContentSource> repoSslSets = repo.getSslSets();
-        if (!repoSslSets.isEmpty()) {
-            SslContentSource sslRepo = repoSslSets.iterator().next();
+        Set<SslContentSource> sslContentSources = repo.getSslContentSources();
+        if (!sslContentSources.isEmpty()) {
+            SslContentSource sslRepo = sslContentSources.iterator().next();
             form.set(SSL_CA_CERT, getStringId(sslRepo.getCaCert()));
             form.set(SSL_CLIENT_CERT, getStringId(sslRepo.getClientCert()));
             form.set(SSL_CLIENT_KEY, getStringId(sslRepo.getClientKey()));
@@ -345,8 +345,8 @@ public class RepoDetailsAction extends RhnAction {
         try {
             // Add SSL
             // OLDTODO: Allow to set multiple SSL sets per custom repo - new page?
-            repoCmd.deleteAllSslSets();
-            repoCmd.addSslSet(parseIdFromForm(form, SSL_CA_CERT),
+            repoCmd.deleteAllSslContentSources();
+            repoCmd.addSslContentSource(parseIdFromForm(form, SSL_CA_CERT),
                     parseIdFromForm(form, SSL_CLIENT_CERT),
                     parseIdFromForm(form, SSL_CLIENT_KEY));
             // Process filters

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -2198,7 +2198,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
          if (!StringUtils.isEmpty(sslCaCert)) {
              try {
                  // OLDTODO: Allow to set multiple SSL sets per custom repo - new API calls?
-                 repoCmd.addSslSet(getKeyId(loggedInUser, sslCaCert),
+                 repoCmd.addSslContentSource(getKeyId(loggedInUser, sslCaCert),
                          getKeyId(loggedInUser, sslCliCert),
                          getKeyId(loggedInUser, sslCliKey));
              }
@@ -2406,8 +2406,8 @@ public class ChannelSoftwareHandler extends BaseHandler {
         if (!StringUtils.isEmpty(sslCaCert)) {
             try {
                 // OLDTODO: Allow to set multiple SSL sets per custom repo - new API calls?
-                repoEditor.deleteAllSslSets();
-                repoEditor.addSslSet(getKeyId(loggedInUser, sslCaCert),
+                repoEditor.deleteAllSslContentSources();
+                repoEditor.addSslContentSource(getKeyId(loggedInUser, sslCaCert),
                         getKeyId(loggedInUser, sslCliCert),
                         getKeyId(loggedInUser, sslCliKey));
             }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/serializer/ContentSourceSerializer.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/serializer/ContentSourceSerializer.java
@@ -52,7 +52,7 @@ public class ContentSourceSerializer extends ApiResponseSerializer<ContentSource
                 .add("sourceUrl", src.getSourceUrl())
                 .add("type", src.getType().getLabel())
                 .add("hasSignedMetadata", src.getMetadataSigned())
-                .add("sslContentSources", src.getSslSets())
+                .add("sslContentSources", src.getSslContentSources())
                 .build();
     }
 }

--- a/java/core/src/main/java/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009--2017 Red Hat, Inc.
+ * Copyright (c) 2010--2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -11,9 +12,6 @@
  * Red Hat trademarks are not licensed under GPLv2. No permission is
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
- */
-/*
- * Copyright (c) 2010-2019 SUSE LLC
  */
 package com.redhat.rhn.manager.channel.repo;
 
@@ -209,12 +207,11 @@ public abstract class BaseRepoCommand {
     public void store() throws InvalidRepoUrlException, InvalidRepoLabelException,
             InvalidRepoTypeException, InvalidRepoUrlInputException {
 
-        Set<SslContentSource> repoSslSets = repo.getSslSets();
         for (SslContentSource sslSet : sslSetsToAdd) {
-            repoSslSets.add(sslSet);
+            repo.addSslSet(sslSet);
         }
         for (SslContentSource sslSet : sslSetsToDelete) {
-            repoSslSets.remove(sslSet);
+            repo.removeSslSet(sslSet);
         }
 
         repo.setOrg(org);

--- a/java/core/src/main/java/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
@@ -51,8 +51,8 @@ public abstract class BaseRepoCommand {
     private String label;
     private String url;
     private String type;
-    private Set<SslContentSource> sslSetsToAdd = new HashSet<>();
-    private Set<SslContentSource> sslSetsToDelete = new HashSet<>();
+    private Set<SslContentSource> sslContentSourcesToAdd = new HashSet<>();
+    private Set<SslContentSource> sslContentSourcesToDelete = new HashSet<>();
     private boolean metadataSigned;
 
     /**
@@ -136,7 +136,7 @@ public abstract class BaseRepoCommand {
     }
 
 
-    private SslContentSource createSslSet(Long sslCaCertId, Long sslClientCertId, Long sslClientKeyId)
+    private SslContentSource createSslContentSource(Long sslCaCertId, Long sslClientCertId, Long sslClientKeyId)
             throws InvalidCertificateException {
         SslCryptoKey caCert = lookupSslCryptoKey(sslCaCertId, org);
         if (caCert == null) {
@@ -160,22 +160,22 @@ public abstract class BaseRepoCommand {
      * @throws InvalidCertificateException in case ca cert is missing or client key is set,
      * but client certificate is missing
      */
-    public void addSslSet(Long sslCaCertId, Long sslClientCertId, Long sslClientKeyId)
+    public void addSslContentSource(Long sslCaCertId, Long sslClientCertId, Long sslClientKeyId)
             throws InvalidCertificateException {
-        SslContentSource sslSet = createSslSet(sslCaCertId, sslClientCertId, sslClientKeyId);
+        SslContentSource sslSet = createSslContentSource(sslCaCertId, sslClientCertId, sslClientKeyId);
         if (sslSet != null) {
-            sslSetsToAdd.add(sslSet);
-            sslSetsToDelete.remove(sslSet);
+            sslContentSourcesToAdd.add(sslSet);
+            sslContentSourcesToDelete.remove(sslSet);
         }
     }
 
     /**
      * Marks all assigned SSL sets for deletion
      */
-    public void deleteAllSslSets() {
-        Set<SslContentSource> repoSslSets = repo.getSslSets();
-        sslSetsToDelete.addAll(repoSslSets);
-        sslSetsToAdd.removeAll(repoSslSets);
+    public void deleteAllSslContentSources() {
+        Set<SslContentSource> repoSslSets = repo.getSslContentSources();
+        sslContentSourcesToDelete.addAll(repoSslSets);
+        sslContentSourcesToAdd.removeAll(repoSslSets);
     }
 
     /**
@@ -207,12 +207,8 @@ public abstract class BaseRepoCommand {
     public void store() throws InvalidRepoUrlException, InvalidRepoLabelException,
             InvalidRepoTypeException, InvalidRepoUrlInputException {
 
-        for (SslContentSource sslSet : sslSetsToAdd) {
-            repo.addSslSet(sslSet);
-        }
-        for (SslContentSource sslSet : sslSetsToDelete) {
-            repo.removeSslSet(sslSet);
-        }
+        sslContentSourcesToAdd.forEach(repo::addSslContentSource);
+        sslContentSourcesToDelete.forEach(repo::removeSslContentSource);
 
         repo.setOrg(org);
 

--- a/java/core/src/main/java/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataProcessor.java
+++ b/java/core/src/main/java/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataProcessor.java
@@ -143,14 +143,14 @@ public class PaygAuthDataProcessor {
                 SslCryptoKey caCert = cryptoKeyMap.get(repodata.get("sslcacert"));
 
                 // Reuse an existing instance when present to keep orphanRemoval collection updates stable.
-                SslContentSource sslContentSource = contentSource.getSslSets().stream().findFirst()
+                SslContentSource sslContentSource = contentSource.getSslContentSources().stream().findFirst()
                     .orElseGet(() -> new SslContentSource(contentSource));
 
                 sslContentSource.setClientCert(clientCert);
                 sslContentSource.setClientKey(clientKey);
                 sslContentSource.setCaCert(caCert);
 
-                contentSource.setSslSets(Set.of(sslContentSource));
+                contentSource.setSslContentSources(Set.of(sslContentSource));
             }
             else if (repodata.containsKey("sslclientcert") ||
                     repodata.containsKey("sslclientkey")) {

--- a/java/core/src/main/java/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataProcessor.java
+++ b/java/core/src/main/java/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 SUSE LLC
+ * Copyright (c) 2021--2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.redhat.rhn.taskomatic.task.payg;
@@ -142,11 +138,19 @@ public class PaygAuthDataProcessor {
                     cryptoKeyMap.containsKey(repodata.get("sslclientkey")) &&
                     repodata.containsKey("sslcacert") &&
                     cryptoKeyMap.containsKey(repodata.get("sslcacert"))) {
-                SslContentSource sslCs = new SslContentSource(contentSource);
-                sslCs.setClientCert(cryptoKeyMap.get(repodata.get("sslclientcert")));
-                sslCs.setClientKey(cryptoKeyMap.get(repodata.get("sslclientkey")));
-                sslCs.setCaCert(cryptoKeyMap.get(repodata.get("sslcacert")));
-                contentSource.setSslSets(Set.of(sslCs));
+                SslCryptoKey clientCert = cryptoKeyMap.get(repodata.get("sslclientcert"));
+                SslCryptoKey clientKey = cryptoKeyMap.get(repodata.get("sslclientkey"));
+                SslCryptoKey caCert = cryptoKeyMap.get(repodata.get("sslcacert"));
+
+                // Reuse an existing instance when present to keep orphanRemoval collection updates stable.
+                SslContentSource sslContentSource = contentSource.getSslSets().stream().findFirst()
+                    .orElseGet(() -> new SslContentSource(contentSource));
+
+                sslContentSource.setClientCert(clientCert);
+                sslContentSource.setClientKey(clientKey);
+                sslContentSource.setCaCert(caCert);
+
+                contentSource.setSslSets(Set.of(sslContentSource));
             }
             else if (repodata.containsKey("sslclientcert") ||
                     repodata.containsKey("sslclientkey")) {

--- a/java/core/src/main/java/com/suse/manager/admin/PaygAdminManager.java
+++ b/java/core/src/main/java/com/suse/manager/admin/PaygAdminManager.java
@@ -406,7 +406,7 @@ public class PaygAdminManager {
         else { // RHUI - some clouds have no credentials
             List<ContentSource> csUrls = PaygSshDataFactory.listRhuiRepositoriesCreatedByInstance(paygSshData);
             Set<SslCryptoKey> sslCryptoKeys = csUrls.stream()
-                    .flatMap(cs -> cs.getSslSets().stream())
+                    .flatMap(cs -> cs.getSslContentSources().stream())
                     .flatMap(scs -> Stream.of(scs.getCaCert(), scs.getClientCert(), scs.getClientKey()))
                     .collect(Collectors.toSet());
             if (LOG.isDebugEnabled()) {

--- a/java/core/src/main/java/com/suse/utils/persistence/EntityAssociationHelper.java
+++ b/java/core/src/main/java/com/suse/utils/persistence/EntityAssociationHelper.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.utils.persistence;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+/**
+ * Utility methods for mutating bidirectional entity associations in place.
+ * <p>
+ * Methods in this helper are intended for persistent collections, especially associations
+ * configured with {@code orphanRemoval}, where simply replacing the collection instance
+ * can break Hibernate tracking.
+ */
+public final class EntityAssociationHelper {
+
+    private EntityAssociationHelper() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Reconciles {@code managedChildren} with {@code desiredChildren} by removing missing entries
+     * and adding new ones while keeping child-to-parent references in sync.
+     * <p>
+     * If {@code desiredChildren} is {@code null}, it is treated as an empty set.
+     *
+     * @param parent owning parent entity
+     * @param managedChildren managed target set to mutate
+     * @param desiredChildren desired content of the set, may be {@code null}
+     * @param setParent setter that assigns a child parent reference
+     * @param <E> parent entity type
+     * @param <C> child entity type
+     */
+    public static <E, C> void reconcile(E parent, Set<C> managedChildren, Set<C> desiredChildren,
+                                        BiConsumer<C, E> setParent) {
+        Objects.requireNonNull(parent, () -> "Parent entity must not be null");
+        Objects.requireNonNull(managedChildren, () -> "Managed children set must not be null");
+        Objects.requireNonNull(setParent, () -> "Parent reference setter must not be null");
+
+        // If the source set is empty this is just a simple clear
+        if (desiredChildren == null || desiredChildren.isEmpty()) {
+            clear(managedChildren, setParent);
+            return;
+        }
+
+        // Remove children no longer present in the desired set and clear their parent reference
+        Iterator<C> it = managedChildren.iterator();
+        while (it.hasNext()) {
+            C existing = it.next();
+            if (!desiredChildren.contains(existing)) {
+                // To avoid equals/hashcode problem, mutate the child only after having removed it from the set
+                it.remove();
+                setParent.accept(existing, null);
+            }
+        }
+
+        // Add any new children that are not yet tracked, assigning the parent reference
+        desiredChildren.forEach(child -> addMember(parent, managedChildren, child, setParent));
+    }
+
+    /**
+     * Adds {@code child} to {@code managedChildren} and assigns its parent reference.
+     * <p>
+     * If {@code child} is {@code null}, the method is a no-op. Parent assignment is performed
+     * only when the child is effectively added to the set.
+     *
+     * @param parent owning parent entity
+     * @param managedChildren managed target set to mutate
+     * @param child child entity to add
+     * @param setParent setter that assigns a child parent reference
+     * @param <E> parent entity type
+     * @param <C> child entity type
+     */
+    public static <E, C> void addMember(E parent, Set<C> managedChildren, C child, BiConsumer<C, E> setParent) {
+        Objects.requireNonNull(parent, () -> "Parent entity must not be null");
+        Objects.requireNonNull(managedChildren, () -> "Managed children set must not be null");
+        Objects.requireNonNull(setParent, () -> "Parent reference setter must not be null");
+
+        if (child == null) {
+            return;
+        }
+
+        // Skip the parent assignment if the given child is already a member
+        if (managedChildren.add(child)) {
+            setParent.accept(child, parent);
+        }
+    }
+
+    /**
+     * Removes {@code child} from {@code managedChildren} and clears its parent reference.
+     * <p>
+     * If {@code child} is {@code null} or not present in {@code managedChildren}, the method is a no-op.
+     *
+     * @param managedChildren managed target set to mutate
+     * @param child child entity to remove
+     * @param setParent setter that assigns a child parent reference
+     * @param <E> parent entity type
+     * @param <C> child entity type
+     */
+    public static <E, C> void removeMember(Set<C> managedChildren, C child, BiConsumer<C, E> setParent) {
+        Objects.requireNonNull(managedChildren, () -> "Managed children set must not be null");
+        Objects.requireNonNull(setParent, () -> "Parent reference setter must not be null");
+
+        if (child == null || !managedChildren.contains(child)) {
+            return;
+        }
+
+        managedChildren.remove(child);
+        setParent.accept(child, null);
+    }
+
+    /**
+     * Removes all children from {@code managedChildren} and clears their parent references.
+     *
+     * @param managedChildren managed target set to mutate
+     * @param setParent setter that assigns a child parent reference
+     * @param <E> parent entity type
+     * @param <C> child entity type
+     */
+    public static <E, C> void clear(Set<C> managedChildren, BiConsumer<C, E> setParent) {
+        Objects.requireNonNull(managedChildren, () -> "Managed children set must not be null");
+        Objects.requireNonNull(setParent, () -> "Parent reference setter must not be null");
+
+        Iterator<C> it = managedChildren.iterator();
+        while (it.hasNext()) {
+            // To avoid equals/hashcode problem, mutate the child only after having removed it from the set
+            C child = it.next();
+            it.remove();
+            setParent.accept(child, null);
+        }
+    }
+}
+

--- a/java/core/src/test/java/com/redhat/rhn/manager/channel/CreateRepoCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/channel/CreateRepoCommandTest.java
@@ -150,17 +150,18 @@ public class CreateRepoCommandTest extends BaseTestCaseWithUser {
         repoCommand.setType("yum");
         repoCommand.setUrl("http://localhost");
         repoCommand.setMetadataSigned(false);
-        repoCommand.addSslSet(caCert.getId(), sslClientCert.getId(), sslClientKey.getId());
+        repoCommand.addSslContentSource(caCert.getId(), sslClientCert.getId(), sslClientKey.getId());
         repoCommand.store();
 
         TestUtils.flushAndClearSession();
 
         ContentSource contentSource = ChannelFactory.lookupContentSource(repoCommand.getRepo().getId(), user.getOrg());
         assertNotNull(contentSource);
-        assertNotNull(contentSource.getSslSets());
-        assertEquals(1, contentSource.getSslSets().size(), "One SSL set must be associated with the content source");
+        assertNotNull(contentSource.getSslContentSources());
+        assertEquals(1, contentSource.getSslContentSources().size(),
+            "One SSL set must be associated with the content source");
 
-        SslContentSource sslContentSource = contentSource.getSslSets().iterator().next();
+        SslContentSource sslContentSource = contentSource.getSslContentSources().iterator().next();
         assertEquals(caCert.getId(), sslContentSource.getCaCert().getId(), "CA cert ID should match");
         assertEquals(sslClientCert.getId(), sslContentSource.getClientCert().getId(), "CA cert ID should match");
         assertEquals(sslClientKey.getId(), sslContentSource.getClientKey().getId(), "CA cert ID should match");

--- a/java/core/src/test/java/com/redhat/rhn/manager/channel/EditRepoCommandTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/channel/EditRepoCommandTest.java
@@ -54,30 +54,31 @@ public class EditRepoCommandTest extends BaseTestCaseWithUser {
         SslCryptoKey sslClientCert = KickstartFactoryTest.createTestSslKey(user.getOrg());
         SslCryptoKey sslClientKey = KickstartFactoryTest.createTestSslKey(user.getOrg());
 
-        repoCommand.addSslSet(caCert.getId(), sslClientCert.getId(), sslClientKey.getId());
+        repoCommand.addSslContentSource(caCert.getId(), sslClientCert.getId(), sslClientKey.getId());
         repoCommand.store();
 
         TestUtils.flushAndClearSession();
 
         ContentSource contentSource = ChannelFactory.lookupContentSource(contentSourceId, user.getOrg());
         assertNotNull(contentSource);
-        assertNotNull(contentSource.getSslSets());
-        assertEquals(1, contentSource.getSslSets().size(), "One SSL set must be associated with the content source");
+        assertNotNull(contentSource.getSslContentSources());
+        assertEquals(1, contentSource.getSslContentSources().size(),
+            "One SSL set must be associated with the content source");
 
-        SslContentSource sslContentSource = contentSource.getSslSets().iterator().next();
+        SslContentSource sslContentSource = contentSource.getSslContentSources().iterator().next();
         assertEquals(caCert.getId(), sslContentSource.getCaCert().getId(), "CA cert ID should match");
         assertEquals(sslClientCert.getId(), sslContentSource.getClientCert().getId(), "CA cert ID should match");
         assertEquals(sslClientKey.getId(), sslContentSource.getClientKey().getId(), "CA cert ID should match");
 
         // Ensure we can also remove the ssl settings
-        repoCommand.deleteAllSslSets();
+        repoCommand.deleteAllSslContentSources();
         repoCommand.store();
 
         TestUtils.flushAndClearSession();
 
         contentSource = ChannelFactory.lookupContentSource(contentSourceId, user.getOrg());
         assertNotNull(contentSource);
-        assertTrue(CollectionUtils.isEmpty(contentSource.getSslSets()),
+        assertTrue(CollectionUtils.isEmpty(contentSource.getSslContentSources()),
                 "No SSL data should be associated with the content source after deletion");
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataProcessorTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 SUSE LLC
+ * Copyright (c) 2021--2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -7,16 +7,13 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 package com.redhat.rhn.taskomatic.task.payg;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.cloudpayg.CloudRmtHost;
@@ -39,17 +36,25 @@ import com.redhat.rhn.taskomatic.task.payg.beans.PaygInstanceInfo;
 import com.redhat.rhn.taskomatic.task.payg.beans.PaygProductInfo;
 import com.redhat.rhn.testing.TestUtils;
 
+import com.suse.manager.reactor.utils.LocalDateTimeISOAdapter;
+import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.InputStreamReader;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -62,8 +67,10 @@ public class PaygAuthDataProcessorTest extends BaseHandlerTestCase {
     private PaygInstanceInfo paygInstanceInfo;
 
     private static final Gson GSON = new GsonBuilder()
-            .serializeNulls()
-            .create();
+        .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeISOAdapter())
+        .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
+        .serializeNulls()
+        .create();
 
     private static final Map<String, Boolean> CHANNEL_SUFFIX = new HashMap<>();
     static {
@@ -76,23 +83,26 @@ public class PaygAuthDataProcessorTest extends BaseHandlerTestCase {
 
     @BeforeEach
     public void setUp() throws Exception {
-        paygData = createPaygSshData();
-        PaygSshDataFactory.savePaygSshData(paygData);
-        paygInstanceInfo = createPaygInstanceInfo();
-
         populateProducts();
     }
 
     @Test
     public void testFirstExecution() throws URISyntaxException {
-        paygDataProcessor.processPaygInstanceData(paygData, paygInstanceInfo);
-        paygDataProcessor.processPaygInstanceData(paygData, paygInstanceInfo);
-        assertExpectedData();
 
+        paygData = PaygSshDataFactory.savePaygSshData(createPaygSshData("My special instance"));
+        paygInstanceInfo = createPaygInstanceInfo();
+
+        paygDataProcessor.processPaygInstanceData(paygData, paygInstanceInfo);
+        paygDataProcessor.processPaygInstanceData(paygData, paygInstanceInfo);
+
+        assertExpectedData();
     }
 
     @Test
     public void testUpdateData() throws URISyntaxException {
+        paygData = PaygSshDataFactory.savePaygSshData(createPaygSshData("My special instance"));
+        paygInstanceInfo = createPaygInstanceInfo();
+
         CloudRMTCredentials cred = CredentialsFactory.createCloudRmtCredentials("user", "password", "//my_url");
         cred.setPaygSshData(paygData);
         CredentialsFactory.storeCredentials(cred);
@@ -113,6 +123,9 @@ public class PaygAuthDataProcessorTest extends BaseHandlerTestCase {
 
     @Test
     public void testUpdateRepos() throws URISyntaxException {
+        paygData = PaygSshDataFactory.savePaygSshData(createPaygSshData("My special instance"));
+        paygInstanceInfo = createPaygInstanceInfo();
+
         CloudRMTCredentials cred = CredentialsFactory.createCloudRmtCredentials("user", "password", "//my_url");
         cred.setPaygSshData(paygData);
         CredentialsFactory.storeCredentials(cred);
@@ -131,6 +144,36 @@ public class PaygAuthDataProcessorTest extends BaseHandlerTestCase {
 
         paygDataProcessor.processPaygInstanceData(paygData, paygInstanceInfo);
         assertExpectedData();
+    }
+
+    @Test
+    public void canExtractFromMultiplePaygInstances() throws Exception {
+        // First iteration creates the credential, second one reuses and updates them
+        for (int i = 0; i < 2; i++) {
+            Map.of("MLM PAYG", "server.json", "SLES 15 SP6", "sles.json", "RHEL 10", "rhui.json")
+                .entrySet()
+                .stream()
+                .map(entry -> {
+                    var sshData = PaygSshDataFactory.lookupByHostname(asHostName(entry.getKey())).orElse(null);
+                    if (sshData == null) {
+                        sshData = PaygSshDataFactory.savePaygSshData(createPaygSshData(entry.getKey()));
+                    }
+
+                    var serverInstanceInfo = parseResource(entry.getValue());
+
+                    return Pair.of(sshData, serverInstanceInfo);
+                })
+                .forEach(entry -> {
+                    try {
+                        paygDataProcessor.processPaygInstanceData(entry.getKey(), entry.getValue());
+                    }
+                    catch (Exception ex) {
+                        fail("Unable to process and save payg data", ex);
+                    }
+                });
+
+            TestUtils.flushAndClearSession();
+        }
     }
 
     private void assertExpectedData() {
@@ -212,17 +255,21 @@ public class PaygAuthDataProcessorTest extends BaseHandlerTestCase {
         return TestUtils.saveAndReload(repo);
     }
 
-    private PaygSshData createPaygSshData() {
+    private PaygSshData createPaygSshData(String name) {
         PaygSshData paygSshData = PaygSshDataFactory.createPaygSshData();
-        paygSshData.setDescription("My special instance");
-        paygSshData.setHost("my-instance");
-        paygSshData.setPort(21);
+        paygSshData.setDescription(name);
+        paygSshData.setHost(asHostName(name));
+        paygSshData.setPort(22);
         paygSshData.setUsername("username");
         paygSshData.setPassword("password");
         paygSshData.setKey("key");
         paygSshData.setKeyPassword("keyPassword");
         paygSshData.setErrorMessage("My status");
         return paygSshData;
+    }
+
+    private String asHostName(String name) {
+        return name.toLowerCase().replace(" ", "-");
     }
 
     private PaygInstanceInfo createPaygInstanceInfo() {
@@ -243,5 +290,15 @@ public class PaygAuthDataProcessorTest extends BaseHandlerTestCase {
         rmtHost.put("server_ca", "-----BEGIN CERTIFICATE-----");
 
         return new PaygInstanceInfo(products, basicAuth, headerAuth, rmtHost);
+    }
+
+    private static PaygInstanceInfo parseResource(String resource) {
+        try (var stream = PaygAuthDataProcessorTest.class.getResourceAsStream(resource);
+             var reader = new InputStreamReader(Objects.requireNonNull(stream), StandardCharsets.UTF_8)) {
+            return GSON.fromJson(reader, PaygInstanceInfo.class);
+        }
+        catch (Exception ex) {
+            return fail("Unable to load PaygInstanceInfo instance from resource " + resource, ex);
+        }
     }
 }

--- a/java/core/src/test/java/com/redhat/rhn/taskomatic/task/payg/PaygUpdateAuthTaskTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/taskomatic/task/payg/PaygUpdateAuthTaskTest.java
@@ -258,8 +258,8 @@ public class PaygUpdateAuthTaskTest extends JMockBaseTestCaseWithUser {
 
                     assertEquals("http://example.domain.top/path/to/repository_1?credentials=mirrcred_" + cid,
                             cs.getSourceUrl());
-                    assertEquals(1, cs.getSslSets().size());
-                    SslContentSource sslcerts = cs.getSslSets().stream().findFirst().orElseThrow();
+                    assertEquals(1, cs.getSslContentSources().size());
+                    SslContentSource sslcerts = cs.getSslContentSources().stream().findFirst().orElseThrow();
 
                     assertEquals(dCert, sslcerts.getClientCert().getDescription());
                     assertEquals("CLIENT CERTIFICATE 1", sslcerts.getClientCert().getKeyString());
@@ -276,8 +276,8 @@ public class PaygUpdateAuthTaskTest extends JMockBaseTestCaseWithUser {
 
                     assertEquals("http://example.domain.top/path/to/repository_2?credentials=mirrcred_" + cid,
                             cs.getSourceUrl());
-                    assertEquals(1, cs.getSslSets().size());
-                    SslContentSource sslcerts = cs.getSslSets().stream().findFirst().orElseThrow();
+                    assertEquals(1, cs.getSslContentSources().size());
+                    SslContentSource sslcerts = cs.getSslContentSources().stream().findFirst().orElseThrow();
 
                     assertEquals(dCert, sslcerts.getClientCert().getDescription());
                     assertEquals("CLIENT CERTIFICATE 2", sslcerts.getClientCert().getKeyString());

--- a/java/core/src/test/java/com/suse/utils/persistence/EntityAssociationHelperTest.java
+++ b/java/core/src/test/java/com/suse/utils/persistence/EntityAssociationHelperTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.utils.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+class EntityAssociationHelperTest {
+
+    @Test
+    @DisplayName("Reconciles set by removing orphans and adding missing children")
+    void reconcilesSetByRemovingOrphansAndAddingMissingChildren() {
+        Parent parent = new Parent("p1");
+        Parent otherParent = new Parent("p2");
+
+        Child keep = new Child("keep");
+        keep.setParent(parent);
+        Child remove = new Child("remove");
+        remove.setParent(parent);
+
+        Set<Child> managed = new HashSet<>(Set.of(keep, remove));
+
+        Child add = new Child("add");
+        Child keepEquivalent = new Child("keep");
+
+        Set<Child> desired = new HashSet<>(Set.of(keepEquivalent, add));
+
+        EntityAssociationHelper.reconcile(parent, managed, desired, Child::setParent);
+
+        assertEquals(2, managed.size());
+        assertTrue(managed.contains(keep));
+        assertTrue(managed.contains(add));
+        assertFalse(managed.contains(remove));
+        assertEquals(parent, keep.getParent());
+        assertEquals(parent, add.getParent());
+        assertNull(remove.getParent());
+
+        // Not added to managed, so helper must not mutate this equal but detached instance.
+        keepEquivalent.setParent(otherParent);
+        EntityAssociationHelper.addMember(parent, managed, keepEquivalent, Child::setParent);
+        assertEquals(otherParent, keepEquivalent.getParent());
+    }
+
+    @Test
+    @DisplayName("Clears managed set when desired children are null")
+    void clearsManagedSetWhenDesiredChildrenAreNull() {
+        Parent parent = new Parent("p1");
+        Child c1 = new Child("c1");
+        Child c2 = new Child("c2");
+        c1.setParent(parent);
+        c2.setParent(parent);
+
+        Set<Child> managed = new HashSet<>(Set.of(c1, c2));
+
+        EntityAssociationHelper.reconcile(parent, managed, null, Child::setParent);
+
+        assertTrue(managed.isEmpty());
+        assertNull(c1.getParent());
+        assertNull(c2.getParent());
+    }
+
+    @Test
+    @DisplayName("Adds child and assigns parent reference")
+    void addsChildAndAssignsParentReference() {
+        Parent parent = new Parent("p1");
+        Set<Child> managed = new HashSet<>();
+        Child child = new Child("c1");
+
+        EntityAssociationHelper.addMember(parent, managed, child, Child::setParent);
+
+        assertTrue(managed.contains(child));
+        assertEquals(parent, child.getParent());
+    }
+
+    @Test
+    @DisplayName("Removes child and clears parent reference")
+    void removesChildAndClearsParentReference() {
+        Parent parent = new Parent("p1");
+        Child child = new Child("c1");
+        child.setParent(parent);
+        Set<Child> managed = new HashSet<>(Set.of(child));
+
+        EntityAssociationHelper.removeMember(managed, child, Child::setParent);
+
+        assertFalse(managed.contains(child));
+        assertNull(child.getParent());
+    }
+
+    @Test
+    @DisplayName("Clears set and nulls all parent references")
+    void clearsSetAndNullsAllParentReferences() {
+        Parent parent = new Parent("p1");
+        Child c1 = new Child("c1");
+        Child c2 = new Child("c2");
+        c1.setParent(parent);
+        c2.setParent(parent);
+
+        Set<Child> managed = new HashSet<>(Set.of(c1, c2));
+
+        EntityAssociationHelper.clear(managed, Child::setParent);
+
+        assertTrue(managed.isEmpty());
+        assertNull(c1.getParent());
+        assertNull(c2.getParent());
+    }
+
+    @Test
+    @DisplayName("Throws NullPointerException for required null arguments")
+    void throwsNullPointerExceptionForRequiredNullArguments() {
+        Parent parent = new Parent("p1");
+        Set<Child> managed = new HashSet<>();
+        Child child = new Child("c1");
+
+        NullPointerException e1 = assertThrows(NullPointerException.class,
+            () -> EntityAssociationHelper.reconcile(null, managed, Set.of(), Child::setParent));
+        assertEquals("Parent entity must not be null", e1.getMessage());
+
+        NullPointerException e2 = assertThrows(NullPointerException.class,
+            () -> EntityAssociationHelper.addMember(parent, null, child, Child::setParent));
+        assertEquals("Managed children set must not be null", e2.getMessage());
+
+        NullPointerException e3 = assertThrows(NullPointerException.class,
+            () -> EntityAssociationHelper.removeMember(managed, child, null));
+        assertEquals("Parent reference setter must not be null", e3.getMessage());
+
+        NullPointerException e4 = assertThrows(NullPointerException.class,
+            () -> EntityAssociationHelper.clear(null, Child::setParent));
+        assertEquals("Managed children set must not be null", e4.getMessage());
+    }
+
+    private static final class Parent {
+        private final String id;
+
+        private Parent(String idIn) {
+            id = idIn;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof Parent other)) {
+                return false;
+            }
+            return id.equals(other.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return id.hashCode();
+        }
+    }
+
+    private static final class Child {
+        private final String key;
+        private Parent parent;
+
+        private Child(String keyIn) {
+            key = keyIn;
+        }
+
+        private Parent getParent() {
+            return parent;
+        }
+
+        private void setParent(Parent parentIn) {
+            parent = parentIn;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof Child other)) {
+                return false;
+            }
+            return key.equals(other.key);
+        }
+
+        @Override
+        public int hashCode() {
+            return key.hashCode();
+        }
+    }
+}

--- a/java/core/src/test/resources/com/redhat/rhn/taskomatic/task/payg/rhui.json
+++ b/java/core/src/test/resources/com/redhat/rhn/taskomatic/task/payg/rhui.json
@@ -1,0 +1,116 @@
+{
+  "type": "RHUI",
+  "header_auth": {
+    "X-RHUI-ID": "dummy",
+    "X-RHUI-SIGNATURE": "dummy"
+  },
+  "certs": {
+    "/etc/pki/rhui/cdn.redhat.com-chain.crt": "fake",
+    "/etc/pki/rhui/content-rhel10-debug.key": "fake",
+    "/etc/pki/rhui/content-rhel10-source.key": "fake",
+    "/etc/pki/rhui/content-rhel10.key": "fake",
+    "/etc/pki/rhui/rhui-client-config-server-10.key": "fake",
+    "/etc/pki/rhui/product/content-rhel10-debug.crt": "fake",
+    "/etc/pki/rhui/product/content-rhel10-source.crt": "fake",
+    "/etc/pki/rhui/product/content-rhel10.crt": "fake",
+    "/etc/pki/rhui/product/rhui-client-config-server-10.crt": "fake"
+  },
+  "repositories": {
+    "codeready-builder-for-rhel-10-rhui-debug-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/codeready-builder/debug",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10-debug.key",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10-debug.crt"
+    },
+    "codeready-builder-for-rhel-10-rhui-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/codeready-builder/os",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10.crt",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10.key"
+    },
+    "codeready-builder-for-rhel-10-rhui-source-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/codeready-builder/source/SRPMS",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10-source.key",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10-source.crt"
+    },
+    "rhel-10-appstream-rhui-debug-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/appstream/debug",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10-debug.key",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10-debug.crt"
+    },
+    "rhel-10-appstream-rhui-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/appstream/os",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10.key",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10.crt"
+    },
+    "rhel-10-appstream-rhui-source-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/appstream/source/SRPMS",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10-source.key",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10-source.crt"
+    },
+    "rhel-10-baseos-rhui-debug-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/baseos/debug",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10-debug.key",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10-debug.crt"
+    },
+    "rhel-10-baseos-rhui-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/baseos/os",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10.key",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10.crt"
+    },
+    "rhel-10-baseos-rhui-source-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/baseos/source/SRPMS",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10-source.key",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10-source.crt"
+    },
+    "rhel-10-extensions-rhui-debug-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/extensions/debug",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10-debug.key",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10-debug.crt"
+    },
+    "rhel-10-extensions-rhui-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/extensions/os",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10.key",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10.crt"
+    },
+    "rhel-10-extensions-rhui-source-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/extensions/source/SRPMS",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10-source.key",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10-source.crt"
+    },
+    "rhel-10-supplementary-rhui-debug-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/supplementary/debug",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10-debug.key",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10-debug.crt"
+    },
+    "rhel-10-supplementary-rhui-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/supplementary/os",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10.key",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10.crt"
+    },
+    "rhel-10-supplementary-rhui-source-rpms": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/content/dist/rhel10/rhui/10/x86_64/supplementary/source/SRPMS",
+      "sslclientkey": "/etc/pki/rhui/content-rhel10-source.key",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/content-rhel10-source.crt"
+    },
+    "rhui-client-config-server-10": {
+      "url": "https://rhui.eu-west-1.aws.ce.redhat.com/pulp/mirror/protected/rhui-client-config/rhel/server/10/x86_64/os",
+      "sslcacert": "/etc/pki/rhui/cdn.redhat.com-chain.crt",
+      "sslclientcert": "/etc/pki/rhui/product/rhui-client-config-server-10.crt",
+      "sslclientkey": "/etc/pki/rhui/rhui-client-config-server-10.key"
+    }
+  }
+}

--- a/java/core/src/test/resources/com/redhat/rhn/taskomatic/task/payg/server.json
+++ b/java/core/src/test/resources/com/redhat/rhn/taskomatic/task/payg/server.json
@@ -1,0 +1,41 @@
+{
+  "type": "CLOUDRMT",
+  "products": [
+    {
+      "name": "Multi-Linux-Manager-Server-SLE",
+      "version": "5.2",
+      "arch": "x86_64"
+    },
+    { "name": "SLES", "version": "15.7", "arch": "x86_64" },
+    { "name": "sle-module-basesystem", "version": "15.7", "arch": "x86_64" },
+    { "name": "sle-module-containers", "version": "15.7", "arch": "x86_64" },
+    { "name": "sle-module-public-cloud", "version": "15.7", "arch": "x86_64" },
+    {
+      "name": "sle-module-server-applications",
+      "version": "15.7",
+      "arch": "x86_64"
+    },
+    { "name": "sle-module-python3", "version": "15.7", "arch": "x86_64" },
+    {
+      "name": "sle-module-systems-management",
+      "version": "15.7",
+      "arch": "x86_64"
+    }
+  ],
+  "basic_auth": {
+    "username": "user",
+    "password": "password"
+  },
+  "header_auth": {
+    "X-Instance-Identifier": "SLES",
+    "X-Instance-Version": "15.7",
+    "X-Instance-Arch": "x86_64",
+    "X-Instance-Data": "dummy"
+  },
+  "rmt_host": {
+    "hostname": "smt-ec2.susecloud.net",
+    "ip": "1.2.3.4",
+    "server_ca": "fake"
+  },
+  "timestamp": 1784119625
+}

--- a/java/core/src/test/resources/com/redhat/rhn/taskomatic/task/payg/sles.json
+++ b/java/core/src/test/resources/com/redhat/rhn/taskomatic/task/payg/sles.json
@@ -1,0 +1,56 @@
+{
+  "type": "CLOUDRMT",
+  "products": [
+    { "name": "SLES", "version": "15.6", "arch": "x86_64" },
+    { "name": "sle-module-basesystem", "version": "15.6", "arch": "x86_64" },
+    {
+      "name": "sle-module-confidential-computing",
+      "version": "15.6",
+      "arch": "x86_64"
+    },
+    { "name": "sle-module-containers", "version": "15.6", "arch": "x86_64" },
+    {
+      "name": "sle-module-desktop-applications",
+      "version": "15.6",
+      "arch": "x86_64"
+    },
+    {
+      "name": "sle-module-development-tools",
+      "version": "15.6",
+      "arch": "x86_64"
+    },
+    { "name": "sle-module-public-cloud", "version": "15.6", "arch": "x86_64" },
+    { "name": "sle-module-python3", "version": "15.6", "arch": "x86_64" },
+    {
+      "name": "sle-module-server-applications",
+      "version": "15.6",
+      "arch": "x86_64"
+    },
+    { "name": "sle-module-web-scripting", "version": "15.6", "arch": "x86_64" },
+    {
+      "name": "sle-module-systems-management",
+      "version": "15.6",
+      "arch": "x86_64"
+    },
+    {
+      "name": "Multi-Linux-ManagerTools-SLE",
+      "version": "15",
+      "arch": "x86_64"
+    }
+  ],
+  "basic_auth": {
+    "username": "user",
+    "password": "password"
+  },
+  "header_auth": {
+    "X-Instance-Identifier": "SLES",
+    "X-Instance-Version": "15.6",
+    "X-Instance-Arch": "x86_64",
+    "X-Instance-Data": "dummy"
+  },
+  "rmt_host": {
+    "hostname": "smt-ec2.susecloud.net",
+    "ip": "1.2.3.4",
+    "server_ca": "fake"
+  }
+}

--- a/java/spacewalk-java.changes.mackdk.fix-hibernate-issue
+++ b/java/spacewalk-java.changes.mackdk.fix-hibernate-issue
@@ -1,0 +1,2 @@
+- Fixed Hibernate issue when updating the SSL content sources
+  during a pay-as-you-go connection data refresh (bsc#1271382)


### PR DESCRIPTION
## What does this PR change?

Added a persistence helper to safely handle lazy entity associations and used it in ContentSource PAYG processing paths. This prevents session related Hibernate failures caused by association sets containing objects in the wrong persistent state.

This helper has to be used at least in any entity that uses an association with `orphanRemoval = true` (for those, Hibernate wraps the set with a `PersistentSet`) and has usages of the association setter method. This should be addressed in a separate PR.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31253
Port(s): [5.2](https://github.com/SUSE/spacewalk/pull/31254)

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
