### PR TITLE
feat(openapi): migrate distchannel handler to OpenAPI contract

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/distchannel/DistChannelHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/distchannel/DistChannelHandler.java
@@ -38,7 +38,7 @@ import org.apache.commons.lang3.StringUtils;
  * @apidoc.namespace distchannel
  * @apidoc.doc Provides methods to access and modify distribution channel information
  */
-public class DistChannelHandler extends BaseHandler {
+public class DistChannelHandler extends BaseHandler implements DistChannelHandlerApi {
 
     /**
      * Lists the default distribution channel maps

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/distchannel/DistChannelHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/distchannel/DistChannelHandlerApi.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.distchannel;
+
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import spark.route.HttpMethod;
+
+/**
+ * API contract for {@link DistChannelHandler}.
+ */
+@Tag(name = "distchannel", description = "Provides methods to access and modify distribution channel information")
+public interface DistChannelHandlerApi {
+
+    /**
+     * Lists the default distribution channel maps.
+     *
+     * @param loggedInUser the current user
+     * @return list of dist channel maps
+     */
+    @ApiEndpointDoc(
+        summary = "Lists the default distribution channel maps",
+        method = HttpMethod.get,
+        responseClass = DistChannelMapListResponse.class
+    )
+    Object[] listDefaultMaps(@Parameter(hidden = true) User loggedInUser);
+
+    /**
+     * Lists distribution channel maps valid for an organization, product admin rights needed.
+     * When no organization is given, the maps valid for the user's own organization are listed.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization ID, or null for the user's own organization
+     * @return list of dist channel maps
+     */
+    @ApiEndpointDoc(
+        summary = "Lists distribution channel maps valid for an organization, Uyuni admin rights needed. " +
+                  "When orgId is omitted, the maps valid for the user's own organization are listed.",
+        method = HttpMethod.get,
+        responseClass = DistChannelMapListResponse.class
+    )
+    Object[] listMapsForOrg(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(
+            name = "orgId",
+            in = ParameterIn.QUERY,
+            required = false
+        ) Integer orgId
+    );
+
+    /**
+     * Sets, overrides (/removes if channelLabel empty) a distribution channel map
+     * within an organization.
+     *
+     * @param loggedInUser the current user
+     * @param os the operating system
+     * @param release the release
+     * @param archName the channel architecture label
+     * @param channelLabel the channel label
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Sets, overrides (/removes if channelLabel empty) a distribution channel map " +
+                  "within an organization",
+        requestClass = SetMapForOrgRequest.class,
+        isIntegerResponse = true
+    )
+    int setMapForOrg(User loggedInUser, String os, String release, String archName, String channelLabel);
+
+    @Schema(name = "SetMapForOrgRequest")
+    @JsonPropertyOrder({"os", "release", "archName", "channelLabel"})
+    interface SetMapForOrgRequest {
+
+        /**
+         * @return the operating system
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getOs();
+
+        /**
+         * @return the release
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getRelease();
+
+        /**
+         * @return the channel architecture label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getArchName();
+
+        /**
+         * @return the channel label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+    }
+
+    @Schema(name = "DistributionChannelMap")
+    @JsonPropertyOrder({"os", "release", "archName", "channelLabel", "orgSpecific"})
+    interface DistChannelMapDoc {
+
+        /**
+         * @return the operating system
+         */
+        @Schema(description = "operating system", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getOs();
+
+        /**
+         * @return the OS release
+         */
+        @Schema(description = "OS release", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getRelease();
+
+        /**
+         * @return the channel architecture
+         */
+        @Schema(name = "arch_name", description = "channel architecture",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getArchName();
+
+        /**
+         * @return the channel label
+         */
+        @Schema(name = "channel_label", description = "channel label",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return 'Y' if organization specific, 'N' if default
+         */
+        @Schema(name = "org_specific", description = "'Y' organization specific, 'N' default",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getOrgSpecific();
+    }
+
+    @Schema(name = "ApiResponseDistChannelMapList")
+    interface DistChannelMapListResponse extends ApiResponseWrapper<List<DistChannelMapDoc>> { }
+}

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -18,6 +18,7 @@ import com.redhat.rhn.frontend.xmlrpc.access.AccessHandler;
 import com.redhat.rhn.frontend.xmlrpc.admin.ssh.AdminSshHandler;
 import com.redhat.rhn.frontend.xmlrpc.api.ApiHandler;
 import com.redhat.rhn.frontend.xmlrpc.channel.access.ChannelAccessHandler;
+import com.redhat.rhn.frontend.xmlrpc.distchannel.DistChannelHandler;
 import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
 import com.redhat.rhn.frontend.xmlrpc.saltkey.SaltKeyHandler;
 import com.redhat.rhn.frontend.xmlrpc.subscriptionmatching.PinnedSubscriptionHandler;
@@ -108,6 +109,7 @@ public final class OpenApiConfig {
         handlers.put("admin.ssh", AdminSshHandler.class);
         handlers.put("api", ApiHandler.class);
         handlers.put("channel.access", ChannelAccessHandler.class);
+        handlers.put("distchannel", DistChannelHandler.class);
         handlers.put("preferences.locale", PreferencesLocaleHandler.class);
         handlers.put("saltkey", SaltKeyHandler.class);
         handlers.put("subscriptionmatching.pinnedsubscription", PinnedSubscriptionHandler.class);

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/DistChannelHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/DistChannelHandlerContractTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelArch;
+import com.redhat.rhn.domain.channel.DistChannelMap;
+import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.distchannel.DistChannelHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class DistChannelHandlerContractTest extends BaseOpenApiTest {
+
+    @Override
+    protected String getApiNamespace() {
+        return "distchannel";
+    }
+
+    @Override
+    protected Class<DistChannelHandler> getHandlerClass() {
+        return DistChannelHandler.class;
+    }
+
+    private DistChannelHandler handler() {
+        return (DistChannelHandler) handlerMock;
+    }
+
+    /**
+     * Builds a dist channel map serialized by the registered DistChannelMapSerializer,
+     * so the response is validated against the documented snake_case schema.
+     */
+    private DistChannelMap distChannelMap() {
+        var arch = new ChannelArch();
+        arch.setName("x86_64");
+
+        var channel = new Channel();
+        channel.setLabel("test-channel");
+
+        var map = new DistChannelMap();
+        map.setOs("SLES");
+        map.setRelease("15.5");
+        map.setChannelArch(arch);
+        map.setChannel(channel);
+        map.setOrg(new Org());
+
+        return map;
+    }
+
+    @Test
+    public void testListDefaultMaps() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listDefaultMaps(with(mockUser));
+            will(returnValue(new Object[]{distChannelMap()}));
+        }});
+
+        validateApiContract("/distchannel/listDefaultMaps", "GET")
+                .onHandlerMethod("listDefaultMaps", User.class);
+    }
+
+    @Test
+    public void testListMapsForOrg() throws Exception {
+        var orgId = 1;
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).listMapsForOrg(with(mockUser), with(orgId));
+            will(returnValue(new Object[]{distChannelMap()}));
+        }});
+
+        validateApiContract("/distchannel/listMapsForOrg", "GET")
+                .withParams(Map.of("orgId", new String[]{String.valueOf(orgId)}))
+                .onHandlerMethod("listMapsForOrg", User.class, Integer.class);
+    }
+
+    /**
+     * The orgId parameter is optional, so the call without it must dispatch to the
+     * overload that lists the maps of the user's own organization.
+     */
+    @Test
+    public void testListMapsForOrgWithoutOrgId() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listMapsForOrg(with(mockUser));
+            will(returnValue(new Object[]{distChannelMap()}));
+        }});
+
+        validateApiContract("/distchannel/listMapsForOrg", "GET")
+                .onHandlerMethod("listMapsForOrg", User.class);
+    }
+
+    @Test
+    public void testSetMapForOrg() throws Exception {
+        var os = "SLES";
+        var release = "15.5";
+        var archName = "x86_64";
+        var channelLabel = "test-channel";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setMapForOrg(with(mockUser), with(os), with(release), with(archName),
+                    with(channelLabel));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/distchannel/setMapForOrg", "POST")
+                .withBody(Map.of("os", os, "release", release, "archName", archName,
+                        "channelLabel", channelLabel))
+                .onHandlerMethod("setMapForOrg", User.class, String.class, String.class, String.class,
+                        String.class);
+    }
+}


### PR DESCRIPTION
Migrates the `distchannel` XML-RPC handler to the OpenAPI contract approach
(`listDefaultMaps`, `listMapsForOrg`, `setMapForOrg`).
## Note :-

`DistChannelHandler` has two `listMapsForOrg` overloads — `(User)` and `(User, Integer orgId)` —
which the legacy doclet documents as two separate `GET` methods. OpenAPI cannot describe two
operations sharing a path and an HTTP method, so this is documented as a single operation with
`orgId` marked `required = false`, and only the wider overload is declared in the contract
interface (the narrower one is skipped since it carries no annotation).

The return struct comes from `$DistChannelMapSerializer`; `@Schema(name = "DistributionChannelMap")`
resolves to the legacy `distribution channel map` label through the parser's camel-case split.
`setMapForOrg` carries `@JsonPropertyOrder({"os", "release", "archName", "channelLabel"})` so the
documented body order stays deterministic.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Unit tests were added: `DistChannelHandlerContractTest` validates the generated OpenAPI
  schema against the handler responses, including both `listMapsForOrg` variants (with and
  without `orgId`).

- [x] **DONE**

## Links

Tracks: GSoC 2026 OpenAPI migration

- [x] **DONE**

## Changelogs

- [x] No changelog needed


