### PR TITLE
Fix product checkbox interaction for the new tri-state (indeterminate) Setup Wizard widget

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -60,6 +60,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I should see the "Basesystem Module 15 SP7 x86_64" selected
     And I should see the "Server Applications Module 15 SP7 x86_64" selected
     And I should see the "SUSE Multi-Linux Manager Client Tools for SLE 15 x86_64" selected
+    And I should see that the "SUSE Linux Enterprise Server 15 SP7 x86_64" product is partially selected
+    And I should see that the "Basesystem Module 15 SP7 x86_64" product is partially selected
     When I select "Desktop Applications Module 15 SP7 x86_64" as a product
     And I select "Development Tools Module 15 SP7 x86_64" as a product
     Then I should see the "Desktop Applications Module 15 SP7 x86_64" selected

--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -80,9 +80,36 @@ When(/^I view the subscription list for "([^"]*)"$/) do |user|
 end
 
 When(/^I (deselect|select) "([^"]*)" as a product$/) do |select, product|
-  # click on the checkbox to select the product
+  # the product checkbox is a tri-state widget: selecting a parent whose subtree isn't
+  # entirely selected yet legitimately leaves it "indeterminate" rather than fully checked,
+  # so Capybara's #set click-and-verify (which waits for a plain checked=true/false) never
+  # resolves and Playwright raises "Clicking the checkbox did not change its state"; click it
+  # directly and poll until it joins/leaves the selection (checked or indeterminate) instead
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/input[@type='checkbox']"
-  raise ScriptError, "xpath: #{xpath} not found" unless find(:xpath, xpath).set(select == 'select')
+  desired_selected = (select == 'select')
+  checkbox = find(:xpath, xpath)
+  indeterminate = page.evaluate_script("document.getElementById('#{checkbox[:id]}').indeterminate")
+  checkbox.click unless (checkbox.checked? || indeterminate) == desired_selected
+  repeat_until_timeout(message: "checkbox for product #{product} did not reach '#{select}' state") do
+    checkbox = find(:xpath, xpath)
+    indeterminate = page.evaluate_script("document.getElementById('#{checkbox[:id]}').indeterminate")
+    break if (checkbox.checked? || indeterminate) == desired_selected
+
+    sleep 1
+  end
+end
+
+Then(/^I should see that the "(.*?)" product is partially selected$/) do |product|
+  # indeterminate is a live DOM property (not an HTML attribute), so it cannot be matched via
+  # xpath or Capybara's checked?; read it straight from the element via JS. It is also set by
+  # an async UI re-render after a selection change, so poll instead of asserting once.
+  xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/input[@type='checkbox']"
+  repeat_until_timeout(message: "#{product} checkbox did not reach the indeterminate state") do
+    checkbox_id = find(:xpath, xpath)[:id]
+    break if page.evaluate_script("document.getElementById('#{checkbox_id}').indeterminate")
+
+    sleep 1
+  end
 end
 
 When(/^I select or deselect "([^"]*)" beta client tools$/) do |channel|
@@ -139,9 +166,13 @@ Then(/^I should see that the "(.*?)" product is "(.*?)"$/) do |product, recommen
 end
 
 Then(/^I should see the "(.*?)" selected$/) do |product|
+  # a parent product counts as selected whether it is fully checked or only indeterminate
+  # (some but not all of its subtree selected) -- both mean it is part of the sync selection
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]"
   within(:xpath, xpath) do
-    raise ScriptError, "#{find(:xpath, '.')['data-identifier']} is not checked" unless find(:xpath, './div/input[@type=\'checkbox\']').checked?
+    checkbox = find(:xpath, './div/input[@type=\'checkbox\']')
+    indeterminate = page.evaluate_script("document.getElementById('#{checkbox[:id]}').indeterminate")
+    raise ScriptError, "#{find(:xpath, '.')['data-identifier']} is not selected (neither checked nor indeterminate)" unless checkbox.checked? || indeterminate
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

## Fix product checkbox interaction for the new tri-state (indeterminate) Setup Wizard widget

### Problem

`Synchronize SLES 15 SP7 product with recommended sub-products, including MLM Client Tools` (`features/reposync/srv_sync_products.feature`) fails at `When I select "SUSE Linux Enterprise Server 15 SP7 x86_64" as a product` with:

```
Clicking the checkbox did not change its state (Playwright::Error)
```

### Root cause

The Setup Wizard Products page checkbox is becoming a tri-state widget (checked / unchecked / **indeterminate**) — see uyuni#12081. A parent product's checkbox is only fully `checked` when its *entire* subtree is selected; if only some descendants are selected it renders as `indeterminate` (the DOM `indeterminate` property, not an HTML attribute).

Selecting the root SLES product only auto-adds its *recommended* children — several non-recommended descendants (e.g. Desktop Applications Module) remain unselected — so the root checkbox legitimately settles on `indeterminate`, never `checked: true`. Capybara's `.set(bool)` maps to Playwright's `check()`/`uncheck()`, which clicks and then waits for the
native `checked` property to flip to the requested boolean. Since it can never reach `true` here, Playwright retries until it gives up and raises the error above.

### Fix

`testsuite/features/step_definitions/setup_steps.rb`:
- `I (deselect|select) "..." as a product`: click the checkbox directly instead of using   `.set`, then poll until it *joins/leaves the selection* (`checked? || indeterminate`)  rather than waiting for an exact `checked` boolean.
- `I should see the "..." selected`: now also accepts the `indeterminate` state — a parent is "selected" whether its subtree is fully or only partially covered.
- New step `I should see that the "..." product is partially selected`: asserts the `indeterminate` DOM property directly via `evaluate_script`, since it has no attribute/xpath representation.

`testsuite/features/reposync/srv_sync_products.feature`:
- After selecting the root product, assert that the root and `Basesystem Module` — both of which still have unselected descendants at that point (Desktop Applications Module isn't selected yet) — show as **partially selected**, matching the new tri-state UI.


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/pull/12081
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/31255

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
