### PR TITLE
Add QE test suite docs: IDE setup, modular repositories, contribution workflow

### DIFF
--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -52,12 +52,20 @@ environment.
 To know how to test with or without optional components like a proxy, a Red Hat-like minion or a SSH minion, look at
 the [optional components instructions](documentation/optional.md).
 
+## Development environment
+
+To set up an IDE or editor (RubyMine or VS Code / VSCodium) and to run the RuboCop linter
+locally the same way the CI does, see [IDE and editor setup](documentation/ide-setup.md).
+
 ## Contributing
 
 ### Procedure
 
 1. **Always** create a PR (even for backporting)
 2. Your PR always needs at least one reviewer to approve
+
+For the full upstream-first / backporting workflow between Uyuni and Multi-Linux Manager,
+see the [contribution workflow](documentation/contributing-workflow.md).
 
 ### Guidelines for coding
 
@@ -95,3 +103,6 @@ packages for `Test-Base-Channel-x86_64` and `Fake-Base-Channel-Debian-like` chan
 - Normal dummy packages: `andromeda-dummy`, `hoag-dummy`, `orion-dummy`, `milkyway-dummy`, etc.
 - Wrong encoding of RPM attributes: `blackhole-dummy`. This package should be successfully imported and you will see it
 available as part of the `Test-Base-Channel-x86_64` if reposync handled the encoding correctly.
+
+To build and test modular (AppStream) repositories with dummy packages on Red Hat-like
+systems, see [Setting up and using a modular repository](documentation/modular-repositories.md).

--- a/testsuite/documentation/contributing-workflow.md
+++ b/testsuite/documentation/contributing-workflow.md
@@ -1,0 +1,54 @@
+# Contribution workflow (Uyuni and Multi-Linux Manager)
+
+This document describes the basic workflow for working with the
+[Uyuni](https://github.com/uyuni-project/uyuni) and
+[Multi-Linux Manager (spacewalk)](https://github.com/SUSE/spacewalk) repositories when
+creating new tests, fixing existing ones and opening pull requests (PRs).
+
+For coding style and conventions, see the [guidelines](guidelines.md) and the
+[Cucumber steps documentation](cucumber-steps.md).
+
+## General rules
+
+- **Upstream first:** Uyuni is the upstream project. Make your changes there first, then
+  back-port them to Multi-Linux Manager (spacewalk).
+- **Release branch policy:** back-port new tests/features to supported Multi-Linux Manager
+  versions when needed. If a branch is locked, coordinate with the team and keep changes
+  focused on what is required for that branch.
+- Check whether a branch is locked before starting new work. Branch locking is
+  coordinated within the team.
+
+## Uyuni (upstream)
+
+1. Make your changes in a local branch of your fork.
+2. Test your changes locally / on your test server with
+   [sumaform](https://github.com/uyuni-project/sumaform), or run a complete test suite
+   run in CI.
+3. Open a draft PR with all your changes.
+   - Leave the PR template intact and only remove the lines that do not apply.
+   - Tick the checkboxes, except the one under the _links_ section — you tick that later,
+     once the spacewalk back-port PR exists (or right away if no back-port is needed).
+4. The automatic PR tests must pass before the PR can be merged.
+5. Mark the draft PR as ready for review and wait for a review from the team
+   (maintainers / reviewers).
+6. Before merging, squash your commits into one (see the project's
+   "how to branch and merge" guidance).
+7. If the branch is locked, coordinate with the maintainers / release engineers to merge.
+
+## Multi-Linux Manager / spacewalk (back-port)
+
+After your upstream Uyuni PR is merged, back-port the changes to Multi-Linux Manager:
+
+1. Cherry-pick the changes with `git` into a local branch of your spacewalk fork.
+2. Open a PR against each supported Multi-Linux Manager version.
+3. Go back to the Uyuni PR and add a link to the spacewalk PR under the _links_ section.
+4. If the branch is locked, add the `merge-candidate` label and coordinate with the
+   maintainers / release engineers to merge.
+5. If the Uyuni `master` branch is locked and your change is small, you may merge the
+   spacewalk PRs before the Uyuni PR is merged — as long as the Uyuni PR has already been
+   approved.
+
+## Changelog
+
+If your change needs a changelog entry, follow the changelog guidance in the project
+documentation.

--- a/testsuite/documentation/ide-setup.md
+++ b/testsuite/documentation/ide-setup.md
@@ -1,0 +1,267 @@
+# IDE and editor setup
+
+This document describes how to set up an IDE or editor to work on the test suite, plus
+how to run the [RuboCop](https://github.com/rubocop/rubocop) linter locally the same way
+the CI does.
+
+Two options are covered:
+
+- [RubyMine](#rubymine) — a full Ruby IDE (commercial)
+- [Visual Studio Code / VSCodium](#visual-studio-code--vscodium) — a free editor
+
+Use whichever you prefer; you do not need both.
+
+## RubyMine
+
+This is a short tutorial on how to set up development with RubyMine on openSUSE (tested
+with Tumbleweed).
+
+> **License:** RubyMine is a commercial JetBrains product and requires a license for
+> commercial use. Obtain one through your organization's usual software-request process.
+> If you prefer a free tool, use [VS Code / VSCodium](#visual-studio-code--vscodium)
+> instead.
+
+### Installation
+
+The example below installs RubyMine on openSUSE Tumbleweed using Snap. See also the
+[Snapcraft install page](https://snapcraft.io/install/rubymine/opensuse). Run these
+commands as `root` (or prefix each with `sudo`), since they change repositories, install
+packages and manage services.
+
+```bash
+# add the snappy repository
+# replace openSUSE_Tumbleweed if you're using a different version of openSUSE
+zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Tumbleweed snappy
+# import its GPG key
+zypper --gpg-auto-import-keys refresh
+# update zypper and install snapd
+zypper dup --from snappy
+zypper install snapd
+# enable system services for snapd
+systemctl enable snapd
+systemctl start snapd
+# only needed for Tumbleweed
+systemctl enable snapd.apparmor
+systemctl start snapd.apparmor
+# install RubyMine
+snap install rubymine --classic
+# only needed for Tumbleweed if you receive a java error when you open it
+zypper install libgthread-2_0-0
+```
+
+### Prerequisites
+
+#### Installing Ruby
+
+The test suite pins its Ruby version in [`testsuite/.ruby-version`](../.ruby-version)
+(currently `3.3.4`) — always use that version so your setup does not drift from the repo.
+Use your favourite version manager (`asdf`, `rvm`, `rbenv`, `chruby`) or your OS package
+manager. For openSUSE Leap you can add the Ruby devel repositories from
+<https://download.opensuse.org/repositories/devel:/languages:/ruby/>.
+
+The example below uses `rvm` (replace `3.3.4` if `testsuite/.ruby-version` changes):
+
+> **Note:** the `rvm` one-liner below pipes a remote script into your shell. Review the
+> script first, or follow rvm's [GPG-verified install](https://rvm.io/rvm/install)
+> (import the signing keys, then run the installer) if you prefer a verified path.
+
+```bash
+# fetch rvm (see the note above about reviewing/verifying the installer)
+curl -sSL https://get.rvm.io | bash -s stable
+# install the pinned Ruby version (see testsuite/.ruby-version)
+rvm install 3.3.4
+# set it as the default version
+rvm alias create default ruby-3.3.4
+# list Ruby versions
+rvm list
+# use Ruby 3.3.4
+rvm use ruby-3.3.4
+# check Ruby version
+ruby --version
+```
+
+On recent macOS laptops the installation can be trickier; the following works with
+`rbenv` and Homebrew:
+
+```bash
+brew install readline
+brew install openssl
+# Set this in ~/.zshrc
+# Homebrew
+export PATH=/opt/homebrew/bin:$PATH
+export PATH="/opt/homebrew/sbin:$PATH"
+# rbenv
+export RBENV_ROOT=/opt/homebrew/opt/rbenv
+export PATH=$RBENV_ROOT/bin:$PATH
+eval "$(rbenv init -)"
+# openssl
+export PATH="/opt/homebrew/opt/openssl@1.1/bin:$PATH"
+export LDFLAGS="-L/opt/homebrew/opt/openssl@1.1/lib"
+export CPPFLAGS="-I/opt/homebrew/opt/openssl@1.1/include"
+export PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@1.1/lib/pkgconfig"
+export RUBY_CONFIGURE_OPTS="--with-openssl-dir=/opt/homebrew/opt/openssl@1.1"
+# then install the pinned Ruby version (see testsuite/.ruby-version)
+RUBY_CFLAGS="-Wno-error=implicit-function-declaration" rbenv install 3.3.4
+```
+
+#### Importing the SSL certificate from the server
+
+To let your IDE talk to a deployed server over HTTPS, import the server certificate. You
+have to do this for every new deployment (and for every server if you use several).
+
+```bash
+# replace $SERVER with the FQDN of your server VM
+wget http://$SERVER/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/$SERVER.cert
+update-ca-certificates
+certutil -d sql:/root/.pki/nssdb -A -t TC -n "susemanager" -i /etc/pki/trust/anchors/$SERVER.cert
+```
+
+> **Note:** the certificate is fetched over plain HTTP, which is acceptable for local,
+> throwaway sumaform test VMs. On any less trusted network, copy the certificate over an
+> authenticated channel instead (e.g. `scp root@$SERVER:/srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT .`)
+> or verify its fingerprint before trusting it.
+
+### Setting up RubyMine
+
+#### Ruby SDK
+
+Inside RubyMine, go to **File → Settings → Languages and Frameworks → Ruby SDK and
+gems** and select the Ruby version pinned in `testsuite/.ruby-version` (currently
+`3.3.4`). The installed gems for that version are listed on the right.
+
+#### Login shell
+
+Inside RubyMine, go to **File → Settings → Tools → Terminal → Application settings** and
+set the shell path to `/bin/zsh --login` (or `/bin/bash --login`).
+
+#### Environment variables
+
+The Cucumber run configuration needs the environment variables that point to your
+deployed VMs. Inside RubyMine:
+
+1. Go to **Run → Edit configurations**.
+2. Click **Edit configuration templates...** (bottom left).
+3. Select **Cucumber** on the left and paste your variables into the **Environment
+   variables** field.
+
+The values must match the machines you deployed with sumaform. Replace `<prefix>` with
+the `name_prefix` you set in your sumaform `main.tf`; the `.tf.local` domain is the
+sumaform default. You do not need all variables — only those matching what you deployed.
+
+```bash
+SERVER=<prefix>-srv.tf.local;CLIENT=<prefix>-cli-sles15.tf.local;MINION=<prefix>-min-sles15.tf.local;PROXY=<prefix>-pxy.tf.local;RHLIKE_MINION=<prefix>-min-centos7.tf.local;SSHMINION=<prefix>-minssh-sles15.tf.local;DEBLIKE_MINION=<prefix>-min-ubuntu2204.tf.local;BUILD_HOST=<prefix>-min-build.tf.local;VIRTHOST_KVM_URL=<prefix>-min-kvm.tf.local;VIRTHOST_KVM_PASSWORD=<password>;PXEBOOT_MAC=<mac-address>;DEBUG=1;GITPROFILES=https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles
+```
+
+The basic RubyMine setup is now complete.
+
+## Visual Studio Code / VSCodium
+
+### Installation
+
+There are several ways to install VS Code; one is via the OBS Package Installer (`opi`).
+See also the [openSUSE VS Code page](https://en.opensuse.org/Visual_Studio_Code).
+
+```bash
+# install the OBS Package Installer (opi)
+sudo zypper in opi
+# install VS Code via opi. A new zypper repository is added and should be kept for updates
+opi vscode
+# alternative: VSCodium (without MS branding/telemetry/licensing): https://github.com/VSCodium/vscodium
+opi vscodium
+```
+
+### Extensions
+
+The following extensions are useful when working on the test suite. Some of them should
+be configured (e.g. to point at the right Ruby or RuboCop version).
+
+Relevant to the test suite:
+
+- [Ruby](https://github.com/rubyide/vscode-ruby)
+- [Cucumber (Gherkin)](https://github.com/cucumber/vscode)
+- [Better Jinja](https://github.com/samuelcolvin/jinjahtml-vscode) — Salt/Jinja
+- [HashiCorp Terraform](https://github.com/hashicorp/vscode-terraform) — Terraform/sumaform
+
+Generally useful:
+
+- Mogami — checks for the latest version of each dependency
+- AsciiDoc
+- Code Spell Checker
+- Error Lens
+- GitHub Markdown Preview
+- GitHub Pull Requests and Issues
+- GitLens
+- markdownlint
+- Output Colorizer
+- TODO Highlight
+- vscode-icons
+- YAML
+
+### Viewing remote files
+
+When browsing log files on a remote server to debug a test case, VS Code gives you syntax
+highlighting and easy copy/paste. This needs two extensions (both closed-source):
+
+- Remote - SSH
+- Remote - SSH: Editing Configuration Files
+
+> **Warning:** be careful on production systems — VS Code can copy proprietary software
+> onto the remote host, which may not be allowed. For local (sumaform) VMs this is not a
+> problem.
+
+Install them by pressing <kbd>Ctrl</kbd>+<kbd>P</kbd> inside VS Code and pasting the
+following, one after another (or search for them in the Extensions tab):
+
+```bash
+ext install ms-vscode-remote.remote-ssh
+ext install ms-vscode-remote.remote-ssh-edit
+```
+
+Then open the Remote Explorer, add a new remote target, connect to it, and open the
+folder you want to browse (for example `/var/log/rhn`).
+
+## Running RuboCop locally
+
+The CI lints the test suite Ruby code with RuboCop. To reproduce it exactly, run RuboCop
+through Bundler so you get the version pinned in
+[`testsuite/Gemfile`](../Gemfile) (currently `rubocop 1.82.1`) — this is what the
+[`rubocop` GitHub workflow](../../.github/workflows/rubocop.yml) does:
+
+```bash
+# from a checkout of Uyuni (or spacewalk)
+cd testsuite
+gem install bundler
+bundle install
+# same command the CI runs
+bundle exec rubocop features/*
+```
+
+You can also lint a single file while iterating:
+
+```bash
+cd testsuite
+bundle exec rubocop features/step_definitions/common_steps.rb
+```
+
+### Disabling a check
+
+You can temporarily disable a cop around a block of code:
+
+```ruby
+# rubocop:disable Metrics/BlockLength
+Then(/^the uptime for "([^"]*)" should be correct$/) do |host|
+  # ...
+end
+# rubocop:enable Metrics/BlockLength
+```
+
+### Configuration files
+
+The RuboCop configuration is project-specific and lives inside the test suite folder:
+
+```bash
+cd testsuite
+ls -l .rubocop.yml .rubocop_todo.yml
+```
+
+Edit these to define which checks should be enabled or ignored.

--- a/testsuite/documentation/modular-repositories.md
+++ b/testsuite/documentation/modular-repositories.md
@@ -1,0 +1,309 @@
+# Setting up and using a modular repository
+
+This document explains how AppStream / modular repositories work, how to build one with
+the [Open Build Service (OBS)](https://build.opensuse.org/), and how to use it on a
+Red Hat-like system. It is aimed at testing modular content with Uyuni and Multi-Linux
+Manager.
+
+Throughout the examples, replace `home:<obs_user>:Test-Packages:Pool` with your own OBS
+project, and treat host names such as `rocky8-minion` as placeholders for your own test
+machines.
+
+## AppStream and modular repositories
+
+AppStream is an open-source project that provides a unified framework for managing and
+presenting software metadata in Linux distributions. It standardizes the way software
+metadata is created, distributed, and consumed.
+
+Modular repositories carry an extra piece of metadata (*modular metadata*) served in a
+`.yaml` file. This file defines the modules, the relationships between them, and the
+ownership of modular packages.
+
+Red Hat-like distributions approach modularity slightly differently across versions:
+
+- **RH8** defines every alternative version as a separate module stream, marking one of
+  them as the default.
+- **RH9** ships the default versions as regular, non-modular packages, but defines any
+  other alternative version as a separate module stream.
+
+### Features of a modular repository
+
+- **Modularity:** software is divided into modules, each containing a set of related
+  packages (specific versions of applications, libraries, or development tools).
+- **Streams and profiles:** modules can have multiple streams (different versions) and
+  profiles (configurations for specific use cases), so users can select the version and
+  configuration that fits their needs.
+- **Isolated environments:** each module can be enabled or disabled independently, so
+  different versions of software can coexist without conflicts.
+
+## Creating a modular repository with OBS
+
+### Requirements and limitations
+
+Modular repositories are mainly built for RH-like systems. OBS supports creating modules
+but can only correctly parse and use a subset of the available options. In particular:
+
+- The module metadata must reside in a file named `_modulemd.yaml`, inside a package
+  named `modulemd` placed at the project's root. It is parsed at build time to produce a
+  `modules.yaml` file inside the `repodata` directory of a repository.
+- Only version 2 is supported for `modulemd` documents.
+- Only version 1 is supported for `modulemd-defaults` documents.
+- Only one `modulemd` document can be defined inside a `_modulemd.yaml` file.
+- You must explicitly define a stream for the `modulemd` document entry.
+- It does not appear possible to define multiple streams for a single module using one
+  `modulemd` document.
+- Most configuration entries are ignored (filters, artifacts, ...) or get their value
+  replaced by one calculated during the build (references, version numbers, context ID).
+
+### Project configuration
+
+Set the following flags in the *Project Config* section of the OBS project. See the
+[OBS documentation](https://openbuildservice.org/help/manuals/obs-user-guide/) for a
+detailed explanation.
+
+```
+BuildFlags: modulemdplatform:80000:.module_el8.0.0:platform-el8:platform-el8.0.0
+ExpandFlags: !module:common
+```
+
+TL;DR:
+
+- The OBS `modulemd` parser expects a `modulemdplatform` build flag, which it uses to
+  obtain version and distribution prefixes (by splitting on `:`). In the example, the
+  setup targets a module that ends up in a CentOS 8 repository.
+- `ExpandFlags` excludes the `common` module from the build. If it is present, it breaks
+  the parser, which expects modules to follow a `NAME-STREAM` convention; otherwise it
+  fails to calculate a modularity label (metadata identifying the module's content).
+
+### Writing a `_modulemd.yaml`
+
+As noted above, this file must live in a `modulemd` package at the project's root. OBS
+reports that the `modulemd` package is excluded from builds, but it is still parsed to
+produce a `modules.yaml` file if its contents are valid.
+
+OBS does not support many of the possible `modulemd` options, so a typical
+`_modulemd.yaml` is quite concise; you rely on other strategies for things like having
+multiple streams of the same module.
+
+Example `_modulemd.yaml` for a dummy package used in testing:
+
+```yaml
+document: modulemd
+version: 2
+data:
+  name: andromeda
+  stream: 2.0
+  summary: andromeda module to test Uyuni and SUMA V 2.0
+  description: andromeda module to test Uyuni and SUMA V 2.0
+  license:
+    module:
+      - GPL-2.0
+  dependencies:
+    - requires:
+        platform:
+          - el8
+  profiles:
+    default:
+      rpms:
+        - andromeda-dummy
+  api:
+    rpms:
+      - andromeda-dummy
+  components:
+    rpms:
+      andromeda-dummy:
+        rationale: This is version 2.0 of the andromeda-dummy package.
+        buildorder: 10
+        version: 2.0
+```
+
+The stream name/number and the RPM component version number are independent. The values
+under `rpms` refer to the actual final built RPM, which is usually created by another
+package that defines it in its `.spec` file.
+
+Given that you have:
+
+- a `_modulemd.yaml` file in your project, inside a `modulemd` package;
+- other packages responsible for building the RPMs needed by the module (declared in the
+  `_modulemd.yaml` `components` section);
+- a final repository for a distribution supporting modular packages as build target;
+
+the build results should include a `modules.yaml` alongside the RPMs. The produced
+`modules.yaml` in the `repodata` directory will look like:
+
+```yaml
+document: modulemd
+version: 2
+data:
+  name: andromeda
+  stream: "2.0"
+  version: 8000020240527114652
+  context: d6fc407f
+  arch: x86_64
+  summary: andromeda module to test Uyuni and SUMA V 2.0
+  description: >-
+    andromeda module to test Uyuni and SUMA V 2.0
+  license:
+    module:
+      - GPL-2.0
+    content:
+      - GPL-2.0
+  xmd: {}
+  dependencies:
+    - requires:
+        platform: [el8]
+  profiles:
+    default:
+      rpms:
+        - andromeda-dummy
+  api:
+    rpms:
+      - andromeda-dummy
+  components:
+    rpms:
+      andromeda-dummy:
+        rationale: This is version 2.0 of the andromeda-dummy package.
+        ref: obs://build.opensuse.org/home:<obs_user>:Test-Packages:Pool/CentOS_8/<hash>-andromeda-dummy-2.0
+        buildorder: 10
+        version: "2.0"
+  artifacts:
+    rpms:
+      - andromeda-dummy-0:2.0-1.2.noarch
+      - andromeda-dummy-0:2.0-1.2.src
+```
+
+### Setting up multiple streams for a module
+
+The following instructions are mainly a way to work around OBS limitations. If you find a
+straightforward way to do this without hacks, please update these docs.
+
+As an example, assume you need a repository that satisfies these requirements:
+
+- A single module that contains only one of the dummy packages and has a similar name to
+  the package (e.g. module `andromeda`).
+- The module must have 2 different streams (e.g. `2.0` and `2.1`) containing different
+  versions of the package (`andromeda-dummy-2.0` and `andromeda-dummy-2.1`).
+- The `andromeda-dummy` package must also be available as a regular package with an older
+  version than the modular ones (e.g. `andromeda-dummy-1.0`). Otherwise unrelated features
+  break, since modular packages are hidden from clients unless the module is enabled.
+
+Normally you would define multiple streams or multiple documents in the `_modulemd.yaml`,
+but OBS does not seem to support either approach. Attempting to build multiple streams at
+once usually ends up with only the last version of a package considered, and all RPMs
+included in the `artifacts` section — or it is just not possible.
+
+What works relies on the fact that each build happens in its own *context*. Because of
+that, you can change the entries in `_modulemd.yaml` multiple times to define a different
+stream for the same package, having each build use a different RPM version. If this is
+done in a build context where only the relevant RPM version is built, other versions are
+unknown at build time, and the final `modules.yaml` gets a `modulemd` document defining
+only that stream. (A single `modules.yaml` can contain multiple `modulemd` documents.)
+
+1. Build your non-modular packages (can also be done at the end), e.g. build
+   `andromeda-dummy-1.0` as a standard RPM.
+2. Disable the build flag for the repositories you intend to build modules for.
+3. Have one package for each version of the RPMs used by the modules, e.g.
+   `andromeda-dummy` (1.0), `andromeda-dummy-2.0` and `andromeda-dummy-2.1`.
+4. Set up `_modulemd.yaml` to define a single stream and use a specific package; change
+   it accordingly when you want to build a new stream. In this example, build once with
+   stream `2.0` and the `andromeda-dummy` 2.0 RPM, then change it to stream `2.1` and the
+   2.1 RPM.
+5. Re-enable the build flag for the `modulemd` package and the package(s) it uses.
+6. A build should trigger — verify both the RPM version and a `modules.yaml` file are
+   produced without errors.
+7. Verify the `modules.yaml` in the repository is correctly updated with the new stream
+   info.
+8. Disable the build flag for the package version(s) and the `modulemd` package.
+9. Repeat steps 4–8 as needed.
+
+The resulting `modules.yaml` then contains one `modulemd` document per stream, for example
+streams `2.0` and `2.1` of the `andromeda` module.
+
+## Using a modular repository on a RH-like system
+
+The examples below use a Rocky 8 minion. Add the repository and sync it:
+
+```console
+[root@rocky8-minion ~]# dnf config-manager --add-repo=https://download.opensuse.org/repositories/home:/<obs_user>:/Test-Packages:/Pool/CentOS_8/home:<obs_user>:Test-Packages:Pool.repo
+[root@rocky8-minion ~]# dnf repolist
+[root@rocky8-minion ~]# dnf makecache
+```
+
+Verify the available modules:
+
+```console
+[root@rocky8-minion ~]# dnf module list
+Name       Stream  Profiles          Summary
+andromeda  2.0 [x] default           andromeda module to test Uyuni and SUMA V 2.0
+andromeda  2.1 [x] default           andromeda module to test Uyuni and SUMA V 2.1
+Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled
+```
+
+With no module enabled, only the standard `andromeda-dummy-1.0` RPM is available; the
+modular versions are filtered out:
+
+```console
+[root@rocky8-minion ~]# dnf install andromeda-dummy
+Installing:
+ andromeda-dummy   noarch   1.0-1.1   home_<obs_user>_Test-Packages_Pool   14 k
+
+[root@rocky8-minion ~]# dnf install andromeda-dummy-2.0
+Error: Unable to find a match: andromeda-dummy-2.0   # filtered out by modular filtering
+```
+
+Enable stream `2.0` and the resolved version changes:
+
+```console
+[root@rocky8-minion ~]# dnf module enable andromeda:2.0
+Enabling module streams:
+ andromeda   2.0
+
+[root@rocky8-minion ~]# dnf install andromeda-dummy
+Installing:
+ andromeda-dummy   noarch   2.0-1.2   home_<obs_user>_Test-Packages_Pool   14 k
+
+[root@rocky8-minion ~]# dnf install andromeda-dummy-1.0
+Error: Unable to find a match: andromeda-dummy-1.0   # 1.0 now filtered out
+```
+
+Disable a module with:
+
+```console
+[root@rocky8-minion ~]# dnf module disable andromeda
+```
+
+You cannot have multiple streams of the same module active at the same time:
+
+```console
+[root@rocky8-minion ~]# dnf module enable andromeda:2.1
+The operation would result in switching of module 'andromeda' stream '2.0' to stream '2.1'
+Error: It is not possible to switch enabled streams of a module unless explicitly enabled
+via configuration option module_stream_switch.
+```
+
+To switch, reset the module first (`dnf module reset andromeda`), then enable the other
+stream.
+
+## Setting up a local OBS dev environment
+
+Running OBS locally is useful to test your project setup without waiting for OBS
+scheduling, or to inspect its inner workings and debug build errors.
+
+OBS is open source and the code is [available on GitHub](https://github.com/openSUSE/open-build-service).
+A local setup uses Docker and Docker Compose to run the containers for the front end and
+back end. Some parts are built in Ruby and generated with Rake, so you need:
+
+- Git
+- Docker Engine
+- Docker Compose v2
+- Rake
+
+The OBS *Contributing* README has a detailed walk-through of how to set up a dev
+environment.
+
+## Resources
+
+- [Introduction to modularity — Fedora docs](https://docs.fedoraproject.org/en-US/modularity/)
+- [Red Hat 9 documentation about modularity](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/)
+- [Open Build Service documentation](https://openbuildservice.org/help/)
+- [Open Build Service wiki](https://github.com/openSUSE/open-build-service/wiki)


### PR DESCRIPTION
Publishes non-confidential QE documentation from the internal QE Confluence space into the public test suite documentation.

New documents under `testsuite/documentation/`:
- **ide-setup.md** — RubyMine and VS Code/VSCodium setup, plus running RuboCop locally the same way the CI does.
- **modular-repositories.md** — building and using AppStream/modular repositories with OBS on Red Hat-like systems.
- **contributing-workflow.md** — upstream-first Uyuni → Multi-Linux Manager (spacewalk) back-port workflow.

`testsuite/README.md` links the three new documents.

All content was reviewed and sanitized: internal host names, IBS/OBS project paths, license service-request/approver details, mailing lists and chat channels were removed or genericized.

Part of SUSE/spacewalk#18899 (epic SUSE/spacewalk#18013).