### PR TITLE
Testsuite: proxy port listening check update that changed with podman 6.0, also compatible backwards

### DIFF
--- a/testsuite/features/proxy/proxy_container.feature
+++ b/testsuite/features/proxy/proxy_container.feature
@@ -61,9 +61,9 @@ Feature: Setup containerized proxy
     And I wait until "uyuni-proxy-squid" service is active on "proxy"
     And I wait until "uyuni-proxy-ssh" service is active on "proxy"
     And I wait until "uyuni-proxy-tftpd" service is active on "proxy"
-    And I wait until port "8022" is listening on "proxy" container
-    And I wait until port "80" is listening on "proxy" container
-    And I wait until port "443" is listening on "proxy" container
+    And I check that "proxy" host is listening on TCP port "8022"
+    And I check that "proxy" host is listening on TCP port "80"
+    And I check that "proxy" host is listening on TCP port "443"
     And I visit "Proxy" endpoint of this "proxy"
 
   Scenario: The containerized proxy should be registered automatically

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1620,6 +1620,11 @@ When(/^I wait until port "([^"]*)" is listening on "([^"]*)" (host|container)$/)
   node.run_until_ok("lsof  -i:#{port}", runs_in_container: location == 'container')
 end
 
+When(/^I check that "([^"]*)" (host|container) is listening on TCP port "([^"]*)"$/) do |host, location, port|
+  node = get_target(host)
+  node.run_until_ok("timeout 2 bash -c 'cat < /dev/null > /dev/tcp/#{host}/#{port}'", runs_in_container: location == 'container')
+end
+
 Then(/^port "([^"]*)" should be (open|closed)$/) do |port, selection|
   _output, code = get_target('server').run("ss --listening --numeric | grep :#{port}", check_errors: false, verbose: true)
   port_opened = code.zero?


### PR DESCRIPTION
With change to podman 6.0, the ports check of proxy doesn't work anymore. The entire routing withing the Linux kernel is handled by netavark via nftables. This change will the test issue and it's compatible backwards.