### PR TITLE
Use the chart appVersion as the default tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,4 +113,5 @@ schema/reportdb/postgres/main.sql
 schema/reportdb/postgres/tables/common/
 schema/reportdb/postgres/views/common/
 
-
+# Charts
+.debug

--- a/containers/proxy-helm/Chart.yaml
+++ b/containers/proxy-helm/Chart.yaml
@@ -7,6 +7,7 @@ type: application
 home: https://www.uyuni-project.org/
 icon: https://www.uyuni-project.org/img/uyuni-logo.svg
 version: 5.3.0
+appVersion: 0.0.0 # Will be replaced by chart_push.sh script
 keywords:
   - linux
   - configuration-management

--- a/containers/proxy-helm/proxy-helm.changes.cbosdo.chart-tag
+++ b/containers/proxy-helm/proxy-helm.changes.cbosdo.chart-tag
@@ -1,0 +1,2 @@
+- Use the appVersion of the chart as the default tag for images
+  (bsc#1271902)

--- a/containers/proxy-helm/templates/_helpers.tpl
+++ b/containers/proxy-helm/templates/_helpers.tpl
@@ -3,7 +3,10 @@
 {{/*   "global", the root object */}}
 {{/*   "local", the configuration object containing the image and tag to override with */}}
 {{- define "uyuni.image" -}}
-{{- $tag := .global.Values.tag -}}
+{{- $tag := .global.Chart.AppVersion -}}
+{{- if .global.Values.tag -}}
+{{- $tag = .global.Values.tag -}}
+{{- end -}}
 {{- if .local.tag -}}
 {{- $tag = .local.tag -}}
 {{- end -}}

--- a/containers/proxy-helm/tests/deployment_test.yaml
+++ b/containers/proxy-helm/tests/deployment_test.yaml
@@ -27,14 +27,14 @@ tests:
           any: true
           content:
             name: init-httpd
-            image: registry.opensuse.org/uyuni/proxy-httpd:latest
+            image: registry.opensuse.org/uyuni/proxy-httpd:0.0.0
             imagePullPolicy: Always
       - contains:
           path: spec.template.spec.initContainers
           any: true
           content:
             name: init-sshd
-            image: registry.opensuse.org/uyuni/proxy-ssh:latest
+            image: registry.opensuse.org/uyuni/proxy-ssh:0.0.0
             imagePullPolicy: Always
 
       # Verify All Main Containers (Images and PullPolicy)
@@ -43,28 +43,28 @@ tests:
           any: true
           content:
             name: httpd
-            image: registry.opensuse.org/uyuni/proxy-httpd:latest
+            image: registry.opensuse.org/uyuni/proxy-httpd:0.0.0
             imagePullPolicy: Always
       - contains:
           path: spec.template.spec.containers
           any: true
           content:
             name: salt-broker
-            image: registry.opensuse.org/uyuni/proxy-salt-broker:latest
+            image: registry.opensuse.org/uyuni/proxy-salt-broker:0.0.0
             imagePullPolicy: Always
       - contains:
           path: spec.template.spec.containers
           any: true
           content:
             name: squid
-            image: registry.opensuse.org/uyuni/proxy-squid:latest
+            image: registry.opensuse.org/uyuni/proxy-squid:0.0.0
             imagePullPolicy: Always
       - contains:
           path: spec.template.spec.containers
           any: true
           content:
             name: ssh
-            image: registry.opensuse.org/uyuni/proxy-ssh:latest
+            image: registry.opensuse.org/uyuni/proxy-ssh:0.0.0
             imagePullPolicy: Always
 
       # Verify registrySecret is not present by default

--- a/containers/proxy-helm/tests/tftp_test.yaml
+++ b/containers/proxy-helm/tests/tftp_test.yaml
@@ -26,7 +26,7 @@ tests:
           any: true
           content:
             name: tftpd
-            image: registry.opensuse.org/uyuni/proxy-tftpd:latest
+            image: registry.opensuse.org/uyuni/proxy-tftpd:0.0.0
             imagePullPolicy: Always
             command:
             - /usr/bin/tftp_wrapper.py

--- a/containers/proxy-helm/values.schema.json
+++ b/containers/proxy-helm/values.schema.json
@@ -10,9 +10,8 @@
       "description": "The default repository for images."
     },
     "tag": {
-      "type": "string",
-      "default": "latest",
-      "description": "The default image tag."
+      "type": ["string", "null"],
+      "description": "The default image tag. Will be the chart's AppVersion if unset"
     },
     "pullPolicy": {
       "type": "string",

--- a/containers/proxy-helm/values.yaml
+++ b/containers/proxy-helm/values.yaml
@@ -1,6 +1,8 @@
 # The default repository and image version if not defined otherwise
 repository: registry.opensuse.org/uyuni
-tag: latest
+# The default tag to use for images, can be overridden for each image
+# By default the tab will be the appVersion of the Chart.
+tag: 
 
 # Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 #

--- a/containers/server-helm/Chart.yaml
+++ b/containers/server-helm/Chart.yaml
@@ -7,6 +7,7 @@ type: application
 home: https://www.uyuni-project.org/
 icon: https://www.uyuni-project.org/img/uyuni-logo.svg
 version: 5.3.0
+appVersion: 0.0.0 # Will be replaced by chart_push.sh script
 keywords:
   - linux
   - configuration-management

--- a/containers/server-helm/server-helm.changes.cbosdo.chart-tag
+++ b/containers/server-helm/server-helm.changes.cbosdo.chart-tag
@@ -1,0 +1,2 @@
+- Use the appVersion of the chart as the default tag for images
+  (bsc#1271902)

--- a/containers/server-helm/templates/_helpers.tpl
+++ b/containers/server-helm/templates/_helpers.tpl
@@ -3,7 +3,10 @@
 {{/*   "global", the root object */}}
 {{/*   "local", the configuration object containing the image and tag to override with */}}
 {{- define "uyuni.image" -}}
-{{- $tag := .global.Values.tag -}}
+{{- $tag := .global.Chart.AppVersion -}}
+{{- if .global.Values.tag -}}
+{{- $tag = .global.Values.tag -}}
+{{- end -}}
 {{- if .local.tag -}}
 {{- $tag = .local.tag -}}
 {{- end -}}

--- a/containers/server-helm/tests/db_test.yaml
+++ b/containers/server-helm/tests/db_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: db
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry.opensuse.org/uyuni/server-postgresql:latest
+          value: registry.opensuse.org/uyuni/server-postgresql:0.0.0
 
   - it: should override image when values.images is provided
     set:

--- a/containers/server-helm/tests/deployment_test.yaml
+++ b/containers/server-helm/tests/deployment_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: uyuni
       - equal:
           path: spec.template.spec.containers[?(@.name=="uyuni")].image
-          value: registry.opensuse.org/uyuni/server:latest
+          value: registry.opensuse.org/uyuni/server:0.0.0
       - notContains:
           path: spec.template.spec.containers[?(@.name=="uyuni")].env
           content:

--- a/containers/server-helm/tests/hub_test.yaml
+++ b/containers/server-helm/tests/hub_test.yaml
@@ -23,7 +23,7 @@ tests:
           value: hub-xmlrpc
       - equal:
           path: spec.template.spec.containers[?(@.name=="hub-xmlrpc")].image
-          value: registry.opensuse.org/uyuni/server-hub-xmlrpc-api:latest
+          value: registry.opensuse.org/uyuni/server-hub-xmlrpc-api:0.0.0
       - contains:
           path: spec.template.spec.containers[?(@.name=="hub-xmlrpc")].env
           content:

--- a/containers/server-helm/tests/optional_components_test.yaml
+++ b/containers/server-helm/tests/optional_components_test.yaml
@@ -41,7 +41,7 @@ tests:
           value: hub-xmlrpc
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "registry.opensuse.org/uyuni/server-hub-xmlrpc-api:latest"
+          value: "registry.opensuse.org/uyuni/server-hub-xmlrpc-api:0.0.0"
         template: hub.yaml
         documentSelector:
           path: metadata.name
@@ -70,7 +70,7 @@ tests:
           value: coco-attestation
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "registry.opensuse.org/uyuni/server-attestation:latest"
+          value: "registry.opensuse.org/uyuni/server-attestation:0.0.0"
         template: coco.yaml
         documentSelector:
           path: metadata.name
@@ -99,7 +99,7 @@ tests:
           value: saline
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "registry.opensuse.org/uyuni/server-saline:latest"
+          value: "registry.opensuse.org/uyuni/server-saline:0.0.0"
         template: saline.yaml
         documentSelector:
           path: metadata.name
@@ -120,21 +120,21 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "example.org/test/saline:latest"
+          value: "example.org/test/saline:0.0.0"
         template: saline.yaml
         documentSelector:
           path: metadata.name
           value: saline
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "example.org/test/coco:latest"
+          value: "example.org/test/coco:0.0.0"
         template: coco.yaml
         documentSelector:
           path: metadata.name
           value: coco-attestation
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "example.org/test/hub:latest"
+          value: "example.org/test/hub:0.0.0"
         template: hub.yaml
         documentSelector:
           path: metadata.name

--- a/containers/server-helm/values.schema.json
+++ b/containers/server-helm/values.schema.json
@@ -13,9 +13,8 @@
       "default": "registry.opensuse.org/uyuni"
     },
     "tag": {
-      "type": "string",
-      "description": "The default tag to use for images",
-      "default": "latest"
+      "type": ["string", "null"],
+      "description": "The default tag to use for images. This is the chart's appVersion"
     },
     "pullPolicy": {
       "type": "string",

--- a/containers/server-helm/values.yaml
+++ b/containers/server-helm/values.yaml
@@ -1,7 +1,8 @@
 # The default repository with the path where to find all the images.
 repository: registry.opensuse.org/uyuni
-# The default tag to use for images, can be overridden for each image.
-tag: latest
+# The default tag to use for images, can be overridden for each image
+# By default the tab will be the appVersion of the Chart.
+tag:
 
 # Ref: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 pullPolicy: "IfNotPresent"
@@ -22,7 +23,7 @@ server:
   # Leave undefined to use the default
   image:
   # tag overrides the default tag in the tag property
-  # Leave undefined to use the default
+  # Leave undefined to use the default (AppVersion set in the Chart.yaml)
   tag:
 
   # Email will be the email used for the notifications sent by the server.

--- a/rel-eng/chart_push.sh
+++ b/rel-eng/chart_push.sh
@@ -48,7 +48,7 @@ if [ -f "${SRPM_PKG_DIR}/Chart.yaml" ]; then
         NAME="uyuni\/${NAME}"
     fi
 
-    sed "/^version:.\+$/aappVersion: \"${PRODUCT_VERSION}\"" -i ${SRPM_PKG_DIR}/Chart.yaml
+    sed "s/^appVersion:.\+$/appVersion: \"${PRODUCT_VERSION}\"/" -i ${SRPM_PKG_DIR}/Chart.yaml
     # Remove leading zero from Uyuni release and add potentially missing micro part
     # The regexp needs to convert versions like:
     #    2025.02 to 2025.2.0


### PR DESCRIPTION
## What does this PR change?

Using latest as the image tag is dangerous and users are easily confused between the chart and image tags. Since they are in sync, use the appVersion as the default image tag (bsc#1271902)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were changed

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31281
Port(s): https://github.com/SUSE/spacewalk/pull/31286

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
