### PR TITLE
QE: Update URL of Rocky 8 ISO

### DIFF
--- a/testsuite/features/build_validation/add_non_MU_repositories/rocky8_minion_add_iso.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/rocky8_minion_add_iso.feature
@@ -8,7 +8,7 @@ Feature: Add the Rocky 8 distribution custom repositories
   I want to filter them out to remove the modules information
 
   Scenario: Download the iso of Rocky 8 DVD and mount it on the server
-    When I mount as "rocky-8-iso" the ISO from "http://mirror.chpc.utah.edu/pub/rocky/8/isos/x86_64/Rocky-8-latest-x86_64-dvd.iso" in the server, validating its checksum
+    When I mount as "rocky-8-iso" the ISO from "http://mirror.chpc.utah.edu/pub/rocky/8/isos/x86_64/Rocky-8-latest-x86_64-dvd1.iso" in the server, validating its checksum
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section


### PR DESCRIPTION
## What does this PR change?

Updates the URL of the Rocky 8 ISO DVD image.
http://mirror.chpc.utah.edu/pub/rocky/8/isos/x86_64/Rocky-8-latest-x86_64-dvd.iso was the old one, changed to
http://mirror.chpc.utah.edu/pub/rocky/8/isos/x86_64/Rocky-8-latest-x86_64-dvd1.iso (from "dvd" to  "dvd1")

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): N/D
Port(s): 

- [x] 4.3 https://github.com/SUSE/spacewalk/pull/31297
- [x] 5.1 https://github.com/SUSE/spacewalk/pull/31296
- [x] 5.2 https://github.com/SUSE/spacewalk/pull/31298

- [x] **DONE**

## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
