### PR TITLE
Testsuite: use hostname command rather than test variable host for the proxy ports check

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1622,7 +1622,7 @@ end
 
 When(/^I check that "([^"]*)" (host|container) is listening on TCP port "([^"]*)"$/) do |host, location, port|
   node = get_target(host)
-  node.run_until_ok("timeout 2 bash -c 'cat < /dev/null > /dev/tcp/#{host}/#{port}'", runs_in_container: location == 'container')
+  node.run_until_ok("timeout 2 bash -c 'cat < /dev/null > /dev/tcp/$(hostname -f)/#{port}'", runs_in_container: location == 'container')
 end
 
 Then(/^port "([^"]*)" should be (open|closed)$/) do |port, selection|


### PR DESCRIPTION
The "host" variable worked from terminal but it fails in CI with:
"bash: line 1: /dev/tcp/proxy/8022: Invalid argument"
because the variable is translated to "proxy". Another option is go with 127.0.0.1 but I'd rather go with regular hostname (external address).

The current CI run passed thru the proxy checks, #4102