### PR TITLE
remove token auth in package_push (bsc#1230949)

### DIFF
--- a/client/tools/mgr-push/mgr-push.changes.mczernek.auth-removal-push-package
+++ b/client/tools/mgr-push/mgr-push.changes.mczernek.auth-removal-push-package
@@ -1,0 +1,2 @@
+- Remove token based authentication mechanism for package_push
+  (bsc#1230949)

--- a/client/tools/mgr-push/rhnpush_v2.py
+++ b/client/tools/mgr-push/rhnpush_v2.py
@@ -18,19 +18,12 @@
 # Package uploading tool
 #
 
-import base64
-
 from rhnpush import connection
 
 
 # pylint: disable-next=missing-class-docstring
 class PackageUpload(connection.PackageUpload):
     user_agent = "rhnpush"
-
-    def set_auth(self, username, password):
-        auth_vals = self.encode_values([username, password])
-        # pylint: disable-next=consider-using-f-string
-        self.headers["%s-%s" % (self.header_prefix, "Auth")] = auth_vals
 
     def set_session(self, session_string):
         # pylint: disable-next=consider-using-f-string
@@ -51,23 +44,6 @@ class PackageUpload(connection.PackageUpload):
 
     def set_timeout(self, timeout):
         self.connection.set_timeout(timeout)
-
-    # Encodes an array of variables into Base64 (column-separated)
-    @staticmethod
-    def encode_values(arr):
-        val = ":".join([x.strip() for x in map(base64.b64encode, arr)])
-        # Get rid of the newlines
-        val = val.replace("\n", "")
-        # And split the result into lines of fixed size
-        line_len = 80
-        result = []
-        start = 0
-        while 1:
-            if start >= len(val):
-                break
-            result.append(val[start : start + line_len])
-            start = start + line_len
-        return result
 
 
 class PingPackageUpload(connection.PackageUpload):

--- a/python/spacewalk/server/basePackageUpload.py
+++ b/python/spacewalk/server/basePackageUpload.py
@@ -43,54 +43,24 @@ class BasePackageUpload:
         self.org_id = None
 
     def headerParserHandler(self, req):
-        """This whole function is ugly as hell. The Auth field in the header used to be required, but now
-        it must have either the Auth field or the Auth-Session field.
-        """
         # Initialize the logging
         log_debug(3, "Method", req.method)
 
-        # Header string. This is what the Auth-Session field will look like in the header.
-        # pylint: disable-next=consider-using-f-string
-        session_header = "%s-%s" % (self.header_prefix, "Auth-Session")
-
         # legacy rhnpush sends File-MD5sum; translate it into File-Checksum
-        # pylint: disable-next=consider-using-f-string
-        md5sum_header = "%s-%s" % (self.header_prefix, "File-MD5sum")
+        md5sum_header = f"{self.header_prefix}-File-MD5sum"
         if md5sum_header in req.headers_in:
-            # pylint: disable-next=consider-using-f-string
-            req.headers_in["%s-%s" % (self.header_prefix, "File-Checksum-Type")] = "md5"
-            req.headers_in[
-                # pylint: disable-next=consider-using-f-string
-                "%s-%s"
-                % (self.header_prefix, "File-Checksum")
-            ] = req.headers_in[md5sum_header]
+            req.headers_in[f"{self.header_prefix}-File-Checksum-Type"] = "md5"
+            req.headers_in[f"{self.header_prefix}-File-Checksum"] = req.headers_in[
+                md5sum_header
+            ]
 
         for f in self.required_fields:
-            # pylint: disable-next=consider-using-f-string
-            hf = "%s-%s" % (self.header_prefix, f)
+            hf = f"{self.header_prefix}-{f}"
             if hf not in req.headers_in:
-                # If the current field is Auth and Auth-Session field isn't present, something is wrong.
-                if f == "Auth" and (session_header not in req.headers_in):
-                    # pylint: disable-next=consider-using-f-string
-                    log_debug(4, "Required field %s missing" % f)
-                    raise rhnFault(500, f)
+                log_debug(4, f"Required field {f} missing")
+                raise rhnFault(500, f)
 
-                # The current field is Auth and the Auth-Session field is present, so everything is good.
-                elif f == "Auth" and (session_header in req.headers_in):
-                    self.field_data["Auth-Session"] = req.headers_in[session_header]
-                    continue
-
-                # The current field being looked for isn't the Auth field and it's missing, so something is wrong.
-                else:
-                    # pylint: disable-next=consider-using-f-string
-                    log_debug(4, "Required field %s missing" % f)
-                    raise rhnFault(500, f)
-
-            if not (f == "Auth" and (hf not in req.headers_in)):
-                self.field_data[f] = req.headers_in[hf]
-            else:
-                if session_header in req.headers_in:
-                    self.field_data[f] = req.headers_in[hf]
+            self.field_data[f] = req.headers_in[hf]
 
         self.package_name = self.field_data["Package-Name"]
         self.package_version = self.field_data["Package-Version"]

--- a/python/spacewalk/spacewalk-backend.changes.mczernek.auth-removal-push-package
+++ b/python/spacewalk/spacewalk-backend.changes.mczernek.auth-removal-push-package
@@ -1,0 +1,2 @@
+- Remove token based authentication mechanism for package_push
+  (bsc#1230949)

--- a/python/spacewalk/upload_server/handlers/package_push/package_push.py
+++ b/python/spacewalk/upload_server/handlers/package_push/package_push.py
@@ -19,7 +19,6 @@
 #
 
 import os
-import base64
 import sys
 from rhn import rpclib
 
@@ -37,15 +36,13 @@ class PackagePush(basePackageUpload.BasePackageUpload):
         basePackageUpload.BasePackageUpload.__init__(self, req)
         self.required_fields.extend(
             [
-                "Auth",
+                "Auth-Session",
                 "Force",
             ]
         )
         self.null_org = None
         # Default packaging is rpm
         self.packaging = "rpm"
-        self.username = None
-        self.password = None
         self.force = None
         self.rel_package_path = None
         self.org_id = None
@@ -56,8 +53,7 @@ class PackagePush(basePackageUpload.BasePackageUpload):
         # Optional headers
         maps = [["Null-Org", "null_org"], ["Packaging", "packaging"]]
         for hn, sn in maps:
-            # pylint: disable-next=consider-using-f-string
-            header_name = "%s-%s" % (self.header_prefix, hn)
+            header_name = f"{self.header_prefix}-{hn}"
             if header_name in req.headers_in:
                 setattr(self, sn, req.headers_in[header_name])
 
@@ -79,39 +75,17 @@ class PackagePush(basePackageUpload.BasePackageUpload):
 
         # Init the database connection
         rhnSQL.initDB()
-        use_session = 0
-        if self.field_data.has_key("Auth-Session"):
-            session_token = self.field_data["Auth-Session"]
-            use_session = 1
-        else:
-            encoded_auth_token = self.field_data["Auth"]
-
-        if not use_session:
-            # pylint: disable-next=possibly-used-before-assignment
-            auth_token = self.get_auth_token(encoded_auth_token)
-
-            if len(auth_token) < 2:
-                log_debug(3, auth_token)
-                raise rhnFault(105, "Unable to autenticate")
-
-            self.username, self.password = auth_token[:2]
+        session_token = self.field_data["Auth-Session"]
 
         force = self.field_data["Force"]
         force = int(force)
-        log_debug(1, "Username", self.username, "Force", force)
+        log_debug(1, "Force", force)
 
-        if use_session:
-            self.org_id, self.force = rhnPackageUpload.authenticate_session(
-                # pylint: disable-next=possibly-used-before-assignment
-                session_token,
-                force=force,
-                null_org=self.null_org,
-            )
-        else:
-            # We don't push to any channels
-            self.org_id, self.force = rhnPackageUpload.authenticate(
-                self.username, self.password, force=force, null_org=self.null_org
-            )
+        self.org_id, self.force = rhnPackageUpload.authenticate_session(
+            session_token,
+            force=force,
+            null_org=self.null_org,
+        )
 
         return apache.OK
 
@@ -186,9 +160,3 @@ class PackagePush(basePackageUpload.BasePackageUpload):
         req.send_http_header()
         req.write(reply)
         return apache.OK
-
-    @staticmethod
-    def get_auth_token(value):
-        s = "".join([x.strip() for x in value.split(",")])
-        arr = list(map(base64.b64decode, s.split(":")))
-        return arr


### PR DESCRIPTION
## What does this PR change?

The `/package-push` allowed username/password authentication even though `mgrpush` is the only code that uses the endpoint, and `mgrpush` uses session-based authentication.

Consequently, this PR removes any unused handling of user/password in both `mgrpush` and the `package-push` endpoint handler.


## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25306
Port(s): https://github.com/SUSE/spacewalk/pull/31306, https://github.com/SUSE/spacewalk/pull/31307

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
