### PR TITLE
Fix schema packages versions for next SUSE Multi-Linux Manager version

### DIFF
--- a/susemanager-utils/testing/automation/VERSION.SUSE-Manager
+++ b/susemanager-utils/testing/automation/VERSION.SUSE-Manager
@@ -6,8 +6,8 @@ NODEJS_CONTAINER=devel/galaxy/manager/head/docker/containers/suma-$VER-nodejs
 REPORTDB_DOC_CONTAINER=devel/galaxy/manager/head/docker/containers/suma-$VER-reportdb-docs
 # Base version for the idempotency test. All PostgreSQL since this version must be idempotent for the test to pass
 # This value is is used if the file for the PR is not found (we assume we are on a branch)
-IDEMPOTENCY_SCHEMA_BASE_VERSION='4.3.8'
-IDEMPOTENCY_REPORTDB_SCHEMA_BASE_VERSION='4.3.1'
-SCHEMA_PACKAGES='susemanager-schema-4.3.8-150400.1.5.noarch.rpm susemanager-schema-utility-4.3.8-150400.1.5.noarch.rpm'
-REPORTDB_SCHEMA_PACKAGES='susemanager-schema-4.3.8-150400.1.5.noarch.rpm susemanager-schema-utility-4.3.8-150400.1.5.noarch.rpm uyuni-reportdb-schema-4.3.1-150400.1.5.noarch.rpm'
+IDEMPOTENCY_SCHEMA_BASE_VERSION='5.2.13'
+IDEMPOTENCY_REPORTDB_SCHEMA_BASE_VERSION='5.2.3'
+SCHEMA_PACKAGES='susemanager-schema-5.2.13-150002.1.3.noarch.rpm susemanager-schema-utility-5.2.13-150002.1.3.noarch.rpm'
+REPORTDB_SCHEMA_PACKAGES='susemanager-schema-5.2.13-150002.1.3.noarch.rpm susemanager-schema-utility-5.2.13-150002.1.3.noarch.rpm uyuni-reportdb-schema-5.2.3-150002.1.4.noarch.rpm'
 BRAND_NAME='SUSE Multi-Linux Manager'


### PR DESCRIPTION
## What does this PR change?

This PR fixes the expectations for schema packages to install in the CI containers for testing the next version of SUSE Multi-Linux Manager, according to what we have at: https://build.suse.de/package/show/Devel:Galaxy:Manager:Head:Docker/suma-head-base

These version are taken from what was released for 5.2 GA.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30276

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
