### PR TITLE
feat(openapi): migrate admin.configuration and admin.payg handlers to OpenAPI contract

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/admin/configuration/AdminConfigurationHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/admin/configuration/AdminConfigurationHandler.java
@@ -59,7 +59,7 @@ import javax.security.auth.login.LoginException;
  * @apidoc.namespace admin.configuration
  * @apidoc.doc Provides methods to configure the #product() server.
  */
-public class AdminConfigurationHandler extends BaseHandler {
+public class AdminConfigurationHandler extends BaseHandler implements AdminConfigurationHandlerApi {
     private static final Logger LOG = LogManager.getLogger(AdminConfigurationHandler.class);
     private final OrgHandler orgHandler;
     private final ServerGroupHandler serverGroupHandler;

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/admin/configuration/AdminConfigurationHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/admin/configuration/AdminConfigurationHandlerApi.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.admin.configuration;
+
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.docs.ApiEndpointDoc;
+import com.suse.manager.api.docs.LegacyDocParam;
+
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * API contract for {@link AdminConfigurationHandler}.
+ */
+@Tag(name = "admin.configuration", description = "Provides methods to configure the Uyuni server.")
+public interface AdminConfigurationHandlerApi {
+
+    /**
+     * Configure server.
+     *
+     * @param loggedInUser the current user
+     * @param content the Uyuni configuration formula data
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Configure server.",
+        requestClass = ConfigureRequest.class,
+        isIntegerResponse = true
+    )
+    int configure(User loggedInUser, Map<String, Object> content);
+
+    @Schema(name = "ConfigureServerRequest")
+    interface ConfigureRequest {
+
+        /**
+         * @return the Uyuni configuration formula data
+         */
+        @LegacyDocParam(type = "map")
+        @Schema(type = "object", description = "the Uyuni configuration formula data",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Object getContent();
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -15,6 +15,7 @@
 package com.suse.manager.api;
 
 import com.redhat.rhn.frontend.xmlrpc.access.AccessHandler;
+import com.redhat.rhn.frontend.xmlrpc.admin.configuration.AdminConfigurationHandler;
 import com.redhat.rhn.frontend.xmlrpc.admin.ssh.AdminSshHandler;
 import com.redhat.rhn.frontend.xmlrpc.api.ApiHandler;
 import com.redhat.rhn.frontend.xmlrpc.channel.access.ChannelAccessHandler;
@@ -24,6 +25,7 @@ import com.redhat.rhn.frontend.xmlrpc.saltkey.SaltKeyHandler;
 import com.redhat.rhn.frontend.xmlrpc.subscriptionmatching.PinnedSubscriptionHandler;
 
 import com.suse.manager.api.docs.UyuniSwaggerReader;
+import com.suse.manager.xmlrpc.admin.AdminPaygHandler;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -106,6 +108,8 @@ public final class OpenApiConfig {
     public static Map<String, Class<?>> getHandlerClasses() {
         Map<String, Class<?>> handlers = new LinkedHashMap<>();
         handlers.put("access", AccessHandler.class);
+        handlers.put("admin.configuration", AdminConfigurationHandler.class);
+        handlers.put("admin.payg", AdminPaygHandler.class);
         handlers.put("admin.ssh", AdminSshHandler.class);
         handlers.put("api", ApiHandler.class);
         handlers.put("channel.access", ChannelAccessHandler.class);

--- a/java/core/src/main/java/com/suse/manager/api/docs/LegacyDocParam.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/LegacyDocParam.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.docs;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Describes how a request parameter should be rendered in the legacy API documentation.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LegacyDocParam {
+
+    /**
+     * @return legacy parameter type
+     */
+    String type() default "";
+}

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -195,22 +195,39 @@ public class OpenApiToAsciidocParser {
         Map<String, Schema> allProps = getAllPossibleProperties(operation);
         for (String paramName : entry.activeParams()) {
             Schema schema = allProps.get(paramName);
-            if (schema != null) {
-                String type;
-                if ("array".equals(schema.getType())) {
-                    type = "[.array]#string array#";
-                }
-                else {
-                    type = "[." + displayType(schema) + "]#" + displayType(schema) + "#";
-                }
-                String descriptionText = findDescription(schema);
+            if (schema == null) {
+                continue;
+            }
+            String legacyParamType = getLegacyParamType(schema);
+            String descriptionText = findDescription(schema);
+            Schema<?> resolved = resolveSchemaReference(schema);
+            if ("struct".equals(legacyParamType) && resolved != null &&
+                    resolved.getProperties() != null && !resolved.getProperties().isEmpty()) {
                 writer.printf(
-                        "* %s  %s%s%n%n",
-                        type,
+                        "* [.struct]#struct#  %s%s%n%n",
                         paramName,
                         descriptionText.isEmpty() ? "" : " - " + descriptionText
                 );
+                printArrayStructProperties(writer, resolved);
+                writer.println();
+                continue;
             }
+            String type;
+            if (!legacyParamType.isEmpty()) {
+                type = "[." + legacyParamType + "]#" + legacyParamType + "#";
+            }
+            else if ("array".equals(schema.getType())) {
+                type = "[.array]#string array#";
+            }
+            else {
+                type = "[." + displayType(schema) + "]#" + displayType(schema) + "#";
+            }
+            writer.printf(
+                    "* %s  %s%s%n%n",
+                    type,
+                    paramName,
+                    descriptionText.isEmpty() ? "" : " - " + descriptionText
+            );
         }
 
         writer.println("\nReturns:\n");
@@ -298,8 +315,9 @@ public class OpenApiToAsciidocParser {
             return;
         }
 
+        String structLabel = (responseLabel != null && !responseLabel.isEmpty()) ? responseLabel : itemRefName;
         writer.println("* [.array]#array# :");
-        writer.printf("    * [.struct]#struct#  %s%n", itemRefName);
+        writer.printf("    * [.struct]#struct#  %s%n", structLabel);
         printArrayStructProperties(writer, resolved);
         writer.println();
     }
@@ -371,6 +389,14 @@ public class OpenApiToAsciidocParser {
 
     private String displayType(Schema<?> schema) {
         return "integer".equals(schema.getType()) ? "int" : schema.getType();
+    }
+
+    private String getLegacyParamType(Schema<?> schema) {
+        if (schema.getExtensions() == null) {
+            return "";
+        }
+        Object value = schema.getExtensions().get(UyuniSwaggerReader.DOC_PARAM_TYPE_EXTENSION);
+        return value == null ? "" : value.toString();
     }
 
     private String structPropertyType(Schema<?> schema) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -204,9 +204,17 @@ public class OpenApiToDocBookParser {
             if (schema == null) {
                 continue;
             }
-            String type = formatType(schema);
             String desc = findDescription(schema);
-            params.add(new ParamDoc(type, name, desc));
+            Schema<?> resolved = resolveSchemaReference(schema);
+            if ("struct".equals(getLegacyParamType(schema)) && resolved != null &&
+                    resolved.getProperties() != null && !resolved.getProperties().isEmpty()) {
+                params.add(new ParamDoc("struct", name, desc));
+                resolved.getProperties().forEach((propName, propSchema) ->
+                        params.add(new ParamDoc(formatType(propSchema), "\"" + propName + "\"",
+                                findDescription(propSchema))));
+                continue;
+            }
+            params.add(new ParamDoc(formatType(schema), name, desc));
         }
         return params;
     }
@@ -270,7 +278,8 @@ public class OpenApiToDocBookParser {
                         .toLowerCase().trim()
         );
 
-        return renderReturnSchema(schema, label, legacyDocResponse.type());
+        return renderReturnSchema(schema, label, legacyDocResponse.type(),
+                legacyDocResponse.label(responseDescription).orElse(""));
     }
 
     private LegacyDocResponseData getLegacyDocResponse(ApiResponse response) {
@@ -287,11 +296,7 @@ public class OpenApiToDocBookParser {
         );
     }
 
-    private String renderReturnSchema(Schema<?> schema, String label) {
-        return renderReturnSchema(schema, label, "");
-    }
-
-    private String renderReturnSchema(Schema<?> schema, String label, String typeOverride) {
+    private String renderReturnSchema(Schema<?> schema, String label, String typeOverride, String structLabel) {
         if (schema == null) {
             return "<listitem><para></para></listitem>";
         }
@@ -300,19 +305,20 @@ public class OpenApiToDocBookParser {
             return renderReturnSchema(
                     resolveSchemaReference(resultSchema),
                     getResultLabel(resultSchema, label),
-                    typeOverride
+                    typeOverride,
+                    structLabel
             );
         }
         if ("array".equals(schema.getType()) && schema.getItems() != null) {
-            return renderArrayReturn(schema, label);
+            return renderArrayReturn(schema, label, structLabel);
         }
         if (isSimpleType(schema)) {
             return renderSimpleReturn(schema, label, typeOverride);
         }
         if (schema.getAdditionalProperties() instanceof Schema<?> inner) {
-            return renderAdditionalPropertiesReturn(inner, label);
+            return renderAdditionalPropertiesReturn(inner, label, structLabel);
         }
-        return renderStructList(schema, label);
+        return renderStructList(schema, label, structLabel);
     }
 
     private Schema<?> getResultSchema(Schema<?> schema) {
@@ -327,7 +333,7 @@ public class OpenApiToDocBookParser {
         return resultSchema.get$ref() != null ? extractRefName(resultSchema.get$ref()) : label;
     }
 
-    private String renderArrayReturn(Schema<?> schema, String label) {
+    private String renderArrayReturn(Schema<?> schema, String label, String structLabel) {
         Schema<?> item = schema.getItems();
         Schema<?> resolvedItem = resolveSchemaReference(item);
         if (resolvedItem != null && isSimpleType(resolvedItem) && label != null && !label.isBlank()) {
@@ -341,7 +347,7 @@ public class OpenApiToDocBookParser {
         sb.append("<listitem>\n");
         sb.append("  <para>array</para>\n");
         sb.append("  <itemizedlist spacing=\"compact\">\n");
-        sb.append(indentLines(renderReturnSchema(resolvedItem, itemLabel), 4));
+        sb.append(indentLines(renderReturnSchema(resolvedItem, itemLabel, "", structLabel), 4));
         sb.append("\n  </itemizedlist>\n");
         sb.append("</listitem>");
         return sb.toString();
@@ -358,10 +364,10 @@ public class OpenApiToDocBookParser {
         return value instanceof String stringValue ? stringValue : "";
     }
 
-    private String renderAdditionalPropertiesReturn(Schema<?> inner, String label) {
+    private String renderAdditionalPropertiesReturn(Schema<?> inner, String label, String structLabel) {
         Schema<?> resolvedInner = resolveSchemaReference(inner);
         String innerLabel = getAdditionalPropertiesLabel(inner, label);
-        return renderReturnSchema(resolvedInner, innerLabel.isEmpty() ? "map" : innerLabel);
+        return renderReturnSchema(resolvedInner, innerLabel.isEmpty() ? "map" : innerLabel, "", structLabel);
     }
 
     private String getAdditionalPropertiesLabel(Schema<?> inner, String label) {
@@ -382,16 +388,17 @@ public class OpenApiToDocBookParser {
         return "integer".equals(schema.getType()) ? "int" : schema.getType();
     }
 
-    private String renderStructList(Schema<?> schema, String label) {
+    private String renderStructList(Schema<?> schema, String label, String legacyStructLabel) {
+        String structLabel = legacyStructLabel.isBlank() ? label : legacyStructLabel;
         if (schema == null) {
-            return String.format("<listitem><para>struct %s</para></listitem>", escapeXml(label));
+            return String.format("<listitem><para>struct %s</para></listitem>", escapeXml(structLabel));
         }
         if (schema.getProperties() == null || schema.getProperties().isEmpty()) {
-            return String.format("<listitem><para>struct %s</para></listitem>", escapeXml(label));
+            return String.format("<listitem><para>struct %s</para></listitem>", escapeXml(structLabel));
         }
         StringBuilder sb = new StringBuilder();
         sb.append("<listitem>\n");
-        sb.append("  <para>struct ").append(escapeXml(label)).append("</para>\n");
+        sb.append("  <para>struct ").append(escapeXml(structLabel)).append("</para>\n");
         sb.append("  <itemizedlist spacing=\"compact\">\n");
         schema.getProperties().forEach((name, prop) -> {
             Schema<?> propSchema = prop;
@@ -583,9 +590,21 @@ public class OpenApiToDocBookParser {
         return "";
     }
 
+    private String getLegacyParamType(Schema<?> schema) {
+        if (schema.getExtensions() == null) {
+            return "";
+        }
+        Object value = schema.getExtensions().get(UyuniSwaggerReader.DOC_PARAM_TYPE_EXTENSION);
+        return value == null ? "" : value.toString();
+    }
+
     private String formatType(Schema<?> s) {
         if (s == null) {
             return "string";
+        }
+        String legacyParamType = getLegacyParamType(s);
+        if (!legacyParamType.isEmpty()) {
+            return legacyParamType;
         }
         String type = s.getType();
         if ("array".equals(type)) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -54,6 +54,7 @@ public class UyuniSwaggerReader {
     public static final String DOC_RESPONSE_SCHEMA_EXTENSION = "x-uyuni-doc-response-schema";
     public static final String DOC_RESPONSE_TYPE_EXTENSION = "x-uyuni-doc-response-type";
     public static final String DOC_RESPONSE_NAME_EXTENSION = "x-uyuni-doc-response-name";
+    public static final String DOC_PARAM_TYPE_EXTENSION = "x-uyuni-doc-param-type";
     public static final String DEFAULT_MEDIA_TYPE = "application/json";
     public static final String HTTP_200 = "200";
 
@@ -154,10 +155,43 @@ public class UyuniSwaggerReader {
         MediaType mediaType = new MediaType();
 
         resolveAndRegisterSchema(apiDoc.requestClass());
+        applyLegacyDocParams(apiDoc.requestClass());
         mediaType.setSchema(buildSchemaRef(apiDoc.requestClass()));
         content.addMediaType(DEFAULT_MEDIA_TYPE, mediaType);
         requestBody.setContent(content);
         operation.setRequestBody(requestBody);
+    }
+
+    private void applyLegacyDocParams(Class<?> requestClass) {
+        if (this.components.getSchemas() == null) {
+            return;
+        }
+        Schema<?> requestSchema = this.components.getSchemas().get(schemaRefName(requestClass));
+        if (requestSchema == null || requestSchema.getProperties() == null) {
+            return;
+        }
+        for (Method getter : requestClass.getMethods()) {
+            LegacyDocParam legacyDocParam = getter.getAnnotation(LegacyDocParam.class);
+            if (legacyDocParam == null || legacyDocParam.type().isBlank()) {
+                continue;
+            }
+            Schema<?> property = requestSchema.getProperties().get(resolvePropertyName(getter));
+            if (property != null) {
+                property.addExtension(DOC_PARAM_TYPE_EXTENSION, legacyDocParam.type());
+            }
+        }
+    }
+
+    private String resolvePropertyName(Method getter) {
+        var schemaAnnotation = getter.getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
+        if (schemaAnnotation != null && !schemaAnnotation.name().isEmpty()) {
+            return schemaAnnotation.name();
+        }
+        String name = getter.getName();
+        if (name.startsWith("get")) {
+            name = name.substring(3);
+        }
+        return name.isEmpty() ? name : Character.toLowerCase(name.charAt(0)) + name.substring(1);
     }
 
     private void configureResponses(ApiEndpointDoc apiDoc, Operation operation) {
@@ -341,12 +375,15 @@ public class UyuniSwaggerReader {
     }
 
     private Schema<?> buildSchemaRef(Class<?> clazz) {
+        return new Schema<>().$ref("#/components/schemas/" + schemaRefName(clazz));
+    }
+
+    private String schemaRefName(Class<?> clazz) {
         var classAnnotation = findClassAnnotation(clazz, io.swagger.v3.oas.annotations.media.Schema.class);
-        String refName = Optional.ofNullable(classAnnotation)
+        return Optional.ofNullable(classAnnotation)
                 .map(io.swagger.v3.oas.annotations.media.Schema::name)
                 .filter(name -> !name.isEmpty())
                 .orElse(clazz.getSimpleName());
-        return new Schema<>().$ref("#/components/schemas/" + refName);
     }
 
     private <A extends Annotation> A findClassAnnotation(Class<?> cls, Class<A> annotationClass) {

--- a/java/core/src/main/java/com/suse/manager/xmlrpc/admin/AdminPaygHandler.java
+++ b/java/core/src/main/java/com/suse/manager/xmlrpc/admin/AdminPaygHandler.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * @apidoc.namespace admin.payg
  * @apidoc.doc Provides methods to access and modify PAYG ssh connection data
  */
-public class AdminPaygHandler extends BaseHandler {
+public class AdminPaygHandler extends BaseHandler implements AdminPaygHandlerApi {
 
     private PaygAdminManager paygAdminManager;
 

--- a/java/core/src/main/java/com/suse/manager/xmlrpc/admin/AdminPaygHandlerApi.java
+++ b/java/core/src/main/java/com/suse/manager/xmlrpc/admin/AdminPaygHandlerApi.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.xmlrpc.admin;
+
+import com.redhat.rhn.domain.cloudpayg.PaygSshData;
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+import com.suse.manager.api.docs.LegacyDocParam;
+import com.suse.manager.api.docs.LegacyDocResponse;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * API contract for {@link AdminPaygHandler}.
+ */
+@Tag(name = "admin.payg", description = "Provides methods to access and modify PAYG ssh connection data")
+public interface AdminPaygHandlerApi {
+
+    /**
+     * Create a new ssh connection data to extract data from.
+     *
+     * @param loggedInUser the current user
+     * @param description the description
+     * @param host the hostname or IP address to the instance
+     * @param port the ssh port
+     * @param username the ssh username
+     * @param password the ssh password
+     * @param key the private key to use in authentication
+     * @param keyPassword the private key password
+     * @param bastionHost the bastion hostname or IP address
+     * @param bastionPort the bastion ssh port
+     * @param bastionUsername the bastion ssh username
+     * @param bastionPassword the bastion ssh password
+     * @param bastionKey the private key to use in bastion authentication
+     * @param bastionKeyPassword the bastion private key password
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Create a new ssh connection data to extract data from",
+        requestClass = CreateRequest.class,
+        isIntegerResponse = true
+    )
+    int create(User loggedInUser, String description, String host, Integer port, String username,
+               String password, String key, String keyPassword,
+               String bastionHost, Integer bastionPort, String bastionUsername,
+               String bastionPassword, String bastionKey, String bastionKeyPassword);
+
+    /**
+     * Update the details of a ssh connection data.
+     *
+     * @param loggedInUser the current user
+     * @param host the hostname or IP address to the instance
+     * @param details the connection details to update
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Updates the details of a ssh connection data",
+        requestClass = SetDetailsRequest.class,
+        isIntegerResponse = true
+    )
+    int setDetails(User loggedInUser, String host, Map<String, Object> details);
+
+    /**
+     * List the registered ssh connection data.
+     *
+     * @param loggedInUser the current user
+     * @return the list of registered ssh connection data
+     */
+    @ApiEndpointDoc(
+        summary = "Returns a list of ssh connection data registered.",
+        responseClass = PaygSshDataListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "SSH data")
+    )
+    List<PaygSshData> list(User loggedInUser);
+
+    /**
+     * Get the ssh connection data registered for a given host.
+     *
+     * @param loggedInUser the current user
+     * @param host the hostname or IP address of the instance
+     * @return the ssh connection data registered for the host
+     */
+    @ApiEndpointDoc(
+        summary = "Returns the ssh connection data registered for a given host.",
+        requestClass = HostRequest.class,
+        responseClass = PaygSshDataResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "SSH data")
+    )
+    PaygSshData getDetails(User loggedInUser, String host);
+
+    /**
+     * Delete the ssh connection data registered for a given host.
+     *
+     * @param loggedInUser the current user
+     * @param host the hostname or IP address of the instance
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Deletes the ssh connection data registered for a given host.",
+        requestClass = HostRequest.class,
+        isIntegerResponse = true
+    )
+    int delete(User loggedInUser, String host);
+
+    @Schema(name = "CreatePaygSshDataRequest")
+    @JsonPropertyOrder({"description", "host", "port", "username", "password", "key", "keyPassword",
+        "bastionHost", "bastionPort", "bastionUsername", "bastionPassword", "bastionKey", "bastionKeyPassword"})
+    interface CreateRequest {
+
+        /**
+         * @return the description
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getDescription();
+
+        /**
+         * @return the hostname or IP address to the instance
+         */
+        @Schema(description = "hostname or IP address to the instance, will fail if already in use.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getHost();
+
+        /**
+         * @return the ssh port
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getPort();
+
+        /**
+         * @return the ssh username
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUsername();
+
+        /**
+         * @return the ssh password
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getPassword();
+
+        /**
+         * @return the private key to use in authentication
+         */
+        @Schema(description = "private key to use in authentication", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getKey();
+
+        /**
+         * @return the private key password
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getKeyPassword();
+
+        /**
+         * @return the bastion hostname or IP address
+         */
+        @Schema(description = "hostname or IP address to a bastion host",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getBastionHost();
+
+        /**
+         * @return the bastion ssh port
+         */
+        @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Integer getBastionPort();
+
+        /**
+         * @return the bastion ssh username
+         */
+        @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getBastionUsername();
+
+        /**
+         * @return the bastion ssh password
+         */
+        @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getBastionPassword();
+
+        /**
+         * @return the private key to use in bastion authentication
+         */
+        @Schema(description = "private key to use in bastion authentication",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getBastionKey();
+
+        /**
+         * @return the bastion private key password
+         */
+        @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getBastionKeyPassword();
+    }
+
+    @Schema(name = "HostRequest")
+    interface HostRequest {
+
+        /**
+         * @return the hostname or IP address to the instance
+         */
+        @Schema(description = "hostname or IP address to the instance, will fail if host doesn't exist.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getHost();
+    }
+
+    @Schema(name = "SetPaygDetailsRequest")
+    @JsonPropertyOrder({"host", "details"})
+    interface SetDetailsRequest {
+
+        /**
+         * @return the hostname or IP address to the instance
+         */
+        @Schema(description = "hostname or IP address to the instance, will fail if host doesn't exist.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getHost();
+
+        /**
+         * @return the connection details to update
+         */
+        @LegacyDocParam(type = "struct")
+        @Schema(description = "user details", requiredMode = Schema.RequiredMode.REQUIRED)
+        PaygDetailsDoc getDetails();
+    }
+
+    @Schema(name = "PaygDetails", description = "user details")
+    @JsonPropertyOrder({"description", "port", "username", "password", "key", "keyPassword",
+        "bastionHost", "bastionPort", "bastionUsername", "bastionPassword", "bastionKey", "bastionKeyPassword"})
+    interface PaygDetailsDoc {
+
+        /**
+         * @return the description
+         */
+        @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getDescription();
+
+        /**
+         * @return the ssh port
+         */
+        @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Integer getPort();
+
+        /**
+         * @return the ssh username
+         */
+        @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getUsername();
+
+        /**
+         * @return the ssh password
+         */
+        @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getPassword();
+
+        /**
+         * @return the private key
+         */
+        @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getKey();
+
+        /**
+         * @return the private key password
+         */
+        @Schema(name = "key_password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getKeyPassword();
+
+        /**
+         * @return the bastion hostname
+         */
+        @Schema(name = "bastion_host", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getBastionHost();
+
+        /**
+         * @return the bastion ssh port
+         */
+        @Schema(name = "bastion_port", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Integer getBastionPort();
+
+        /**
+         * @return the bastion ssh username
+         */
+        @Schema(name = "bastion_username", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getBastionUsername();
+
+        /**
+         * @return the bastion ssh password
+         */
+        @Schema(name = "bastion_password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getBastionPassword();
+
+        /**
+         * @return the bastion private key
+         */
+        @Schema(name = "bastion_key", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getBastionKey();
+
+        /**
+         * @return the bastion private key password
+         */
+        @Schema(name = "bastion_key_password", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getBastionKeyPassword();
+    }
+
+    @Schema(name = "PaygSshData", description = "SSH data")
+    @JsonPropertyOrder({"description", "hostname", "port", "username",
+        "bastionHostname", "bastionPort", "bastionUsername"})
+    interface PaygSshDataDoc {
+
+        /**
+         * @return the description
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getDescription();
+
+        /**
+         * @return the hostname
+         */
+        @Schema(name = "hostname", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getHostname();
+
+        /**
+         * @return the ssh port
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getPort();
+
+        /**
+         * @return the ssh username
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUsername();
+
+        /**
+         * @return the bastion hostname
+         */
+        @Schema(name = "bastion_hostname", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getBastionHostname();
+
+        /**
+         * @return the bastion ssh port
+         */
+        @Schema(name = "bastion_port", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getBastionPort();
+
+        /**
+         * @return the bastion ssh username
+         */
+        @Schema(name = "bastion_username", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getBastionUsername();
+    }
+
+    @Schema(name = "ApiResponsePaygSshDataList")
+    interface PaygSshDataListResponse extends ApiResponseWrapper<List<PaygSshDataDoc>> { }
+
+    @Schema(name = "ApiResponsePaygSshData")
+    interface PaygSshDataResponse extends ApiResponseWrapper<PaygSshDataDoc> { }
+}

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/AdminConfigurationHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/AdminConfigurationHandlerContractTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.admin.configuration.AdminConfigurationHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class AdminConfigurationHandlerContractTest extends BaseOpenApiTest {
+
+    @Override
+    protected String getApiNamespace() {
+        return "admin.configuration";
+    }
+
+    @Override
+    protected Class<AdminConfigurationHandler> getHandlerClass() {
+        return AdminConfigurationHandler.class;
+    }
+
+    private AdminConfigurationHandler handler() {
+        return (AdminConfigurationHandler) handlerMock;
+    }
+
+    @Test
+    public void testConfigure() throws Exception {
+        var content = Map.<String, Object>of("mgr_server_hostname", "manager.example.com");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).configure(with(mockUser), with(content));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/admin.configuration/configure", "POST")
+                .withBody(Map.of("content", content))
+                .onHandlerMethod("configure", User.class, Map.class);
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/AdminPaygHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/AdminPaygHandlerContractTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.cloudpayg.PaygSshData;
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.xmlrpc.admin.AdminPaygHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class AdminPaygHandlerContractTest extends BaseOpenApiTest {
+
+    @Override
+    protected String getApiNamespace() {
+        return "admin.payg";
+    }
+
+    @Override
+    protected Class<AdminPaygHandler> getHandlerClass() {
+        return AdminPaygHandler.class;
+    }
+
+    private AdminPaygHandler handler() {
+        return (AdminPaygHandler) handlerMock;
+    }
+
+    /**
+     * Builds a PaygSshData serialized by the registered PaygSshDataSerializer, so the
+     * response is validated against the documented snake_case schema.
+     */
+    private PaygSshData paygSshData() {
+        var data = new PaygSshData();
+        data.setDescription("test instance");
+        data.setHost("payg.example.com");
+        data.setPort(22);
+        data.setUsername("root");
+        data.setBastionHost("bastion.example.com");
+        data.setBastionPort(2222);
+        data.setBastionUsername("bastion");
+        return data;
+    }
+
+    @Test
+    public void testCreate() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).create(with(mockUser), with("test instance"), with("payg.example.com"), with(22),
+                    with("root"), with("secret"), with("private-key"), with("key-secret"),
+                    with("bastion.example.com"), with(2222), with("bastion"), with("bastion-secret"),
+                    with("bastion-key"), with("bastion-key-secret"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/admin.payg/create", "POST")
+                .withBody(Map.ofEntries(
+                        Map.entry("description", "test instance"),
+                        Map.entry("host", "payg.example.com"),
+                        Map.entry("port", 22),
+                        Map.entry("username", "root"),
+                        Map.entry("password", "secret"),
+                        Map.entry("key", "private-key"),
+                        Map.entry("keyPassword", "key-secret"),
+                        Map.entry("bastionHost", "bastion.example.com"),
+                        Map.entry("bastionPort", 2222),
+                        Map.entry("bastionUsername", "bastion"),
+                        Map.entry("bastionPassword", "bastion-secret"),
+                        Map.entry("bastionKey", "bastion-key"),
+                        Map.entry("bastionKeyPassword", "bastion-key-secret")))
+                .onHandlerMethod("create", User.class, String.class, String.class, Integer.class, String.class,
+                        String.class, String.class, String.class, String.class, Integer.class, String.class,
+                        String.class, String.class, String.class);
+    }
+
+    @Test
+    public void testSetDetails() throws Exception {
+        var details = Map.<String, Object>of("description", "updated", "port", 22, "username", "root");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setDetails(with(mockUser), with("payg.example.com"), with(details));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/admin.payg/setDetails", "POST")
+                .withBody(Map.of("host", "payg.example.com", "details", details))
+                .onHandlerMethod("setDetails", User.class, String.class, Map.class);
+    }
+
+    @Test
+    public void testList() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).list(with(mockUser));
+            will(returnValue(List.of(paygSshData())));
+        }});
+
+        validateApiContract("/admin.payg/list", "POST")
+                .onHandlerMethod("list", User.class);
+    }
+
+    @Test
+    public void testGetDetails() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getDetails(with(mockUser), with("payg.example.com"));
+            will(returnValue(paygSshData()));
+        }});
+
+        validateApiContract("/admin.payg/getDetails", "POST")
+                .withBody(Map.of("host", "payg.example.com"))
+                .onHandlerMethod("getDetails", User.class, String.class);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).delete(with(mockUser), with("payg.example.com"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/admin.payg/delete", "POST")
+                .withBody(Map.of("host", "payg.example.com"))
+                .onHandlerMethod("delete", User.class, String.class);
+    }
+}


### PR DESCRIPTION
Migrates the `admin.configuration` handler (`configure`) and the `admin.payg` handler
(`create`, `setDetails`, `list`, `getDetails`, `delete`) to the OpenAPI contract approach.
Two handlers in one PR as discussed.

## Note :-

These two handlers need parameter-side documentation support that the parsers did not have
yet, so this PR adds it. Both additions are opt-in behind a new annotation ,a request
parameter that does not carry it goes down exactly the same code path as before.

The first addition is `@LegacyDocParam(type = ...)`, the parameter-side counterpart to the
existing `@LegacyDocResponse`. `admin.configuration.configure` takes a `map` in the legacy
docs, but OpenAPI has no `map` primitive and swagger-core normalises it to `object`, so the
type has to be carried separately. The annotation is read in `UyuniSwaggerReader` and emitted
as `x-uyuni-doc-param-type`, alongside the `x-uyuni-doc-response-*` extensions already in use,
and both parsers pick it up when rendering the parameter list.

The reason this is applied in the reader rather than declared directly on the getter is worth
spelling out, because it looks like avoidable indirection otherwise. Swagger's
`@Schema(extensions = ...)` does propagate to the property schema and works fine for
`admin.configuration`, whose `content` property is an inline object. It does not work for
`admin.payg.setDetails`, whose `details` property is a `$ref` to `PaygDetails`: OpenAPI 3.0
collapses a `$ref` property to a bare `{"$ref": ...}` and drops the sibling annotations, so the
extension never reaches the spec. Re-applying it in the reader after `resolveAndRegisterSchema`
is what makes it survive for both shapes.

The second addition is the expansion of a nested struct parameter into its properties, which
mirrors the array-of-struct expansion already implemented for return values, and reuses
`printArrayStructProperties`. `admin.payg.setDetails` takes a `PaygDetails` struct with twelve
scalar fields, and the legacy doclet lists all of them under the parameter. This is not a
change to existing rendering: a `$ref` parameter was not handled at all before, because
`displayType()` returns `schema.getType()`, which is null for a `$ref`, so the parameter came
out as a literal `[.null]#null#` line in the AsciiDoc. The expansion fills that gap rather than
altering behaviour that previously worked. Since it is gated on the annotation, an unannotated
`$ref` parameter still renders the old way, if you would rather have that fixed
unconditionally for every handler, I am happy to change it, it just seemed safer not to touch
the default path in this PR.

One smaller parser change comes with it. `@LegacyDocResponse(name = ...)` already labelled the
array-item struct in AsciiDoc but not in DocBook, so `admin.payg.list` and `getDetails` picked
up the schema-derived `payg ssh data` instead of the serializer's `SSH data`. The label is now
passed down through `renderReturnSchema` to `renderStructList` in the same way `typeOverride`
already was. It has to be the full label rather than just `name()`, otherwise `api`'s
`method_info - Available...` loses its description, which the before/after comparison caught.


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Unit tests were added: `AdminConfigurationHandlerContractTest` and
  `AdminPaygHandlerContractTest` validate the generated OpenAPI schema against the handler
  responses. The `admin.payg` test covers all five methods, including the 13-field `create`
  body and the nested `details` struct on `setDetails`.

- [x] **DONE**

## Changelogs

- [x] No changelog needed
