### PR TITLE
testsuite: gate @sle15sp7_terminal on the SP7 terminal MAC

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -757,7 +757,7 @@ Before('@sles15sp6_terminal') do
 end
 
 Before('@sles15sp7_terminal') do
-  skip_this_scenario unless $sles15sp6_terminal_mac
+  skip_this_scenario unless $sles15sp7_terminal_mac
 end
 
 Before('@suse_minion') do |scenario|


### PR DESCRIPTION
## What does this PR change?

The `Before('@sle15sp7_terminal')` hook in `testsuite/features/support/env.rb`
gated on `$sle15sp6_terminal_mac` instead of `$sle15sp7_terminal_mac`. This was a
copy-paste from the SP6 hook when SP7 buildhost/terminal support was added in the
retail refactor, so SP7 terminal scenarios were skipped or run based on the wrong
(SP6) terminal MAC. This points the hook at the correct SP7 variable, which is
already defined and used elsewhere in `env.rb`.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): SUSE/spacewalk#31321
Port(s): SUSE/spacewalk#31322, SUSE/spacewalk#31323, SUSE/spacewalk#31324

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
