### PR TITLE
testsuite: point @sle12sp5_sshminion sanity checks at the SSH minion host

### DIFF
--- a/testsuite/features/build_validation/core/allcli_sanity.feature
+++ b/testsuite/features/build_validation/core/allcli_sanity.feature
@@ -34,10 +34,10 @@ Feature: Sanity checks
 
 @sles12sp5_sshminion
   Scenario: The SLES 12 SP5 Salt SSH minion is healthy
-    Then "sles12sp5_minion" should have a FQDN
-    And reverse resolution should work for "sles12sp5_minion"
-    And "sles12sp5_minion" should communicate with the server using public interface
-    And the clock from "sles12sp5_minion" should be exact
+    Then "sles12sp5_sshminion" should have a FQDN
+    And reverse resolution should work for "sles12sp5_sshminion"
+    And "sles12sp5_sshminion" should communicate with the server using public interface
+    And the clock from "sles12sp5_sshminion" should be exact
 
 @sles15sp3_minion
   Scenario: The SLES 15 SP3 minion is healthy


### PR DESCRIPTION
## What does this PR change?

The `@sle12sp5_sshminion` sanity scenario in
`testsuite/features/build_validation/core/allcli_sanity.feature` ran its health
checks (FQDN, reverse resolution, connectivity, clock) against the regular
`sle12sp5_minion` host instead of the `sle12sp5_sshminion` host — a copy-paste
from the plain-minion scenario that was never updated. It therefore validated the
wrong node. This points the four steps at the SSH minion host.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): SUSE/spacewalk#31321
Port(s): SUSE/spacewalk#31325, SUSE/spacewalk#31326, SUSE/spacewalk#31327

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
