### PR TITLE
testsuite: remove vestigial non-versioned sle15_sshminion arch-map key

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -672,7 +672,6 @@ PKGARCH_BY_CLIENT = {
   'deblike_minion' => 'amd64',
   'sles12sp5_minion' => 'x86_64',
   'sles12sp5_sshminion' => 'x86_64',
-  'sle15_sshminion' => 'x86_64',
   'sles15sp3_minion' => 'x86_64',
   'sles15sp3_sshminion' => 'x86_64',
   'sles15sp4_minion' => 'x86_64',


### PR DESCRIPTION
## What does this PR change?

Removes a vestigial non-versioned key `'sle15_sshminion' => 'x86_64'` from the
`PKGARCH_BY_CLIENT` node→arch map in `testsuite/features/support/constants.rb`.
Every other SLE entry in that map is versioned; this lone non-versioned key
matches no real node (it most likely referred to SLE 15 GA, which no longer
exists) and is referenced nowhere else in the test suite.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): SUSE/spacewalk#31321
Port(s): SUSE/spacewalk#31328, SUSE/spacewalk#31329

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
