### PR TITLE
Remove salt dependency from spacewalk-proxy-salt

### DIFF
--- a/proxy/proxy/spacewalk-proxy.changes.vzhestkov.remove-salt-broker-dep
+++ b/proxy/proxy/spacewalk-proxy.changes.vzhestkov.remove-salt-broker-dep
@@ -1,0 +1,1 @@
+- Remove salt dependency from spacewalk-proxy-salt package

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -98,7 +98,9 @@ Spacewalk Proxy components.
 
 %package salt
 Summary:        A ZeroMQ Proxy for Salt Minions
-Requires(pre):  salt
+Requires:       python3-base
+Requires:       python3-PyYAML
+Requires:       python3-pyzmq
 
 %description salt
 A ZeroMQ Proxy for Salt Minions
@@ -174,6 +176,7 @@ fi
 
 %files salt
 %{_bindir}/salt-broker
+%dir %{_sysconfdir}/salt
 %config(noreplace) %{_sysconfdir}/salt/broker
 %dir %{_sysconfdir}/salt/broker.d
 

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -34,6 +34,7 @@ License:        GPL-2.0-only
 URL:            https://github.com/uyuni-project/uyuni
 #!CreateArchive: %{name}
 Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
+BuildRequires:  ca-certificates
 BuildRequires:  make
 BuildRequires:  python3
 BuildRequires:  spacewalk-backend >= 1.7.24


### PR DESCRIPTION
## What does this PR change?

Even if `salt-broker` is intended to serve Salt traffic it has no idea about Salt in genral as it operates on lower level with ZeroMQ sockets and just proxying two pairs of sockets, so technically `salt` module is not used at all and all of the dependencies it brings with `salt` are redundant.

To simplify and reduce the size of `salt-broker` container we need to drop these dependencies and use just direct dependencies to the python modules used by `salt-broker`: PyYAML and pyzmq besides of python base modules.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: just reduces the size of `salt-broker` container.

## Links

Issue(s): #

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
