### PR TITLE
Propagate cert validation errors to UI (bsc#1271332)

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
@@ -18,7 +18,6 @@ import tempfile
 import time
 from salt.utils.minions import CkMinions
 
-
 log = logging.getLogger(__name__)
 
 GROUP_OWNER = "susemanager"
@@ -242,7 +241,11 @@ def check_ssl_cert(root_ca, server_crt, server_key, intermediate_cas):
         )
         return {"cert": result.stdout.decode()}
     except subprocess.CalledProcessError as err:
-        return {"error": str(err)}
+        stderr_lines = err.stderr.decode("utf-8", errors="replace").splitlines()
+        for line in reversed(stderr_lines):
+            if line.startswith("ERROR: "):
+                return {"error": line[len("ERROR: ") :]}
+        return {"error": "Certificate validation failed"}
 
 
 def select_minions(target, target_type):

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.cbbayburt.bsc1271332
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.cbbayburt.bsc1271332
@@ -1,0 +1,1 @@
+- Propagate cert validation errors to UI (bsc#1271332)


### PR DESCRIPTION
Port of: https://github.com/SUSE/spacewalk/pull/31299

Currently in the proxy config UI, only the return code is reported as an error from `mgr-ssl-cert-setup`. This PR parses `stderr` to capture a proper error message from the tool and passes it upstream to the UI.

See: https://bugzilla.suse.com/show_bug.cgi?id=1271332

## GUI diff

Before:

<img width="1192" height="508" alt="Screenshot From 2026-07-21 13-28-24" src="https://github.com/user-attachments/assets/f92973d8-09b1-490c-970a-7c4b4b7c3bad" />

After:

<img width="1192" height="343" alt="Screenshot From 2026-07-21 13-29-38" src="https://github.com/user-attachments/assets/d2f609a4-e44c-4969-8800-8a279864fbd9" />


## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31222

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
