### PR TITLE
Add @scope_rhlike scope tag to Red Hat-like minion features

### DIFF
--- a/testsuite/config/cucumber.yml
+++ b/testsuite/config/cucumber.yml
@@ -29,7 +29,7 @@ reportdb: --tags @scope_reportdb
 res: --tags @scope_res
 retail: --tags @scope_retail
 retracted_patches: --tags @scope_retracted_patches
-rhlike: --tags @rhlike_minion
+rhlike: --tags @scope_rhlike
 salt_ssh: --tags @scope_salt_ssh
 salt: --tags @scope_salt
 software_channels_and_repositories: --tags @scope_software_channels_and_repositories

--- a/testsuite/features/secondary/min_deblike_monitoring.feature
+++ b/testsuite/features/secondary/min_deblike_monitoring.feature
@@ -6,6 +6,7 @@
 
 @scope_monitoring
 @scope_res
+@scope_deblike
 @deblike_minion
 Feature: Monitor MLM environment with Prometheus on a Debian-like Salt minion
   In order to monitor Uyuni server

--- a/testsuite/features/secondary/min_rhlike_appstreams.feature
+++ b/testsuite/features/secondary/min_rhlike_appstreams.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@scope_rhlike
 @rhlike_minion
 Feature: Native AppStreams support for Red Hat-like Salt minion
   

--- a/testsuite/features/secondary/min_rhlike_monitoring.feature
+++ b/testsuite/features/secondary/min_rhlike_monitoring.feature
@@ -6,6 +6,7 @@
 
 @scope_monitoring
 @scope_res
+@scope_rhlike
 @rhlike_minion
 Feature: Monitor MLM environment with Prometheus on a Red Hat-like Salt minion
   In order to monitor Uyuni server

--- a/testsuite/features/secondary/min_rhlike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_rhlike_openscap_audit.feature
@@ -4,6 +4,7 @@
 @skip_if_github_validation
 @scope_openscap
 @scope_res
+@scope_rhlike
 @rhlike_minion
 Feature: OpenSCAP audit of Red Hat-like Salt minion
   In order to audit a Red Hat-like Salt minion

--- a/testsuite/features/secondary/min_rhlike_remote_command.feature
+++ b/testsuite/features/secondary/min_rhlike_remote_command.feature
@@ -6,6 +6,7 @@
 
 @skip_if_github_validation
 @scope_res
+@scope_rhlike
 @rhlike_minion
 Feature: Remote command on the Red Hat-like Salt minion
   In order to manage a Red Hat-like Salt minion

--- a/testsuite/features/secondary/min_rhlike_salt_install_package_and_patch.feature
+++ b/testsuite/features/secondary/min_rhlike_salt_install_package_and_patch.feature
@@ -4,6 +4,7 @@
 @flaky
 @scope_res
 @scope_salt
+@scope_rhlike
 @rhlike_minion
 Feature: Install a patch on the Red Hat-like minion via Salt through the UI
 

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -14,6 +14,7 @@
 
 @skip_if_github_validation
 @scope_res
+@scope_rhlike
 @rhlike_minion
 Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operations on it
 


### PR DESCRIPTION
## What does this PR change?

Makes the `rhlike` (Red Hat-like) minion family symmetric with `deblike` for scope tagging, as part of the minion-name standardization epic:

- Adds `@scope_rhlike` to the 6 rhlike secondary features (alongside the existing `@rhlike_minion`), mirroring how deblike features already carry both `@scope_deblike` + `@deblike_minion`.
- Points the cucumber `rhlike` profile at `@scope_rhlike` (was `@rhlike_minion`) in `config/cucumber.yml`.
- Adds the missing `@scope_deblike` tag to `min_deblike_monitoring.feature` (the only secondary deblike feature that lacked it).

This makes rhlike secondary tests selectable via a `functional_scopes` checkbox exactly like deblike. The matching `@scope_rhlike` entry is added to the CI `functional_scopes` lists in susemanager-ci in a companion PR.

Testsuite-only change; no product code touched.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): SUSE/spacewalk#31347
Part of epic SUSE/spacewalk#25062

Ports:
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31348
Manager-5.1: https://github.com/SUSE/spacewalk/pull/31349
Manager-4.3: https://github.com/SUSE/spacewalk/pull/31350

CI companion (susemanager-ci): https://github.com/SUSE/susemanager-ci/pull/2129

- [x] **DONE**

## Changelogs

- [x] No changelog needed
