### PR TITLE
Fix React key and ref warnings

### DIFF
--- a/web/html/src/components/toastr/toastr.tsx
+++ b/web/html/src/components/toastr/toastr.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode, ReactNodeArray } from "react";
+import { type ReactNode, type ReactNodeArray, forwardRef, useImperativeHandle } from "react";
+
 import { cssTransition, toast, ToastContainer } from "react-toastify";
 
 type OptionalParams = {
@@ -78,7 +79,9 @@ export function showInfoToastr(message: ReactNode, optionalParams: OptionalParam
   show(message, notify);
 }
 
-export const MessagesContainer = (props: MessagesContainerProps) => {
+export const MessagesContainer = forwardRef((props: MessagesContainerProps, ref) => {
+  useImperativeHandle(ref, () => ({}), []);
+
   return (
     <ToastContainer
       className="sticky-container"
@@ -94,4 +97,4 @@ export const MessagesContainer = (props: MessagesContainerProps) => {
       transition={FadeTransition}
     />
   );
-};
+});

--- a/web/html/src/manager/login/uyuni/login.tsx
+++ b/web/html/src/manager/login/uyuni/login.tsx
@@ -121,7 +121,9 @@ const UyuniThemeLogin = (props: ThemeProps) => {
               {t("{productName} release {versionNumber}", {
                 productName,
                 versionNumber: (
-                  <a href={`/docs/${docsLocale}/release-notes/release-notes-server.html`}>{props.webVersion}</a>
+                  <a key="version" href={`/docs/${docsLocale}/release-notes/release-notes-server.html`}>
+                    {props.webVersion}
+                  </a>
                 ),
               })}
             </div>

--- a/web/html/src/manager/minion/details/support-data.tsx
+++ b/web/html/src/manager/minion/details/support-data.tsx
@@ -52,11 +52,15 @@ export const SupportData: FC<Props> = ({ serverId, availableRegions, supportProg
   );
 
   function getFormattedProgramName(programName: string): ReactNode {
-    return <code>{programName}</code>;
+    return <code key="program-name">{programName}</code>;
   }
 
   function getActionLink(text: string, actionId: number): ReactNode {
-    return <ActionLink id={actionId}>{text}</ActionLink>;
+    return (
+      <ActionLink key="scheduled-action-link" id={actionId}>
+        {text}
+      </ActionLink>
+    );
   }
 
   function onSubmit(): void {

--- a/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
+++ b/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
@@ -451,7 +451,7 @@ class SystemChannels extends Component<SystemChannelsProps, SystemChannelsState>
     let childChannels;
     const isNoneChecked = -1 === (this.state.selectedBase && this.state.selectedBase.id);
     baseChannels.push(
-      <div className="radio">
+      <div className="radio" key="none">
         <input
           type="radio"
           value="-1"
@@ -470,7 +470,7 @@ class SystemChannels extends Component<SystemChannelsProps, SystemChannelsState>
 
       if (baseOptions.length > 0) {
         baseChannels.push(
-          <div>
+          <div key="suse">
             <h4>{t("SUSE Channels")}</h4>
             {baseOptions.map((c) => {
               const isChecked = c.id === (this.state.selectedBase && this.state.selectedBase.id);
@@ -496,7 +496,7 @@ class SystemChannels extends Component<SystemChannelsProps, SystemChannelsState>
       }
       if (customOptions.length > 0) {
         baseChannels.push(
-          <div>
+          <div key="custom">
             <h4>{t("Custom Channels")}</h4>
             {customOptions.map((c) => {
               const isChecked = c.id === (this.state.selectedBase && this.state.selectedBase.id);

--- a/web/spacewalk-web.changes.emaksy.react-render-warnings
+++ b/web/spacewalk-web.changes.emaksy.react-render-warnings
@@ -1,0 +1,1 @@
+- Fix React key and ref warnings in several frontend views.


### PR DESCRIPTION
## What does this PR change?

Fixes React development warnings caused by missing keys and an unsupported ref.

Adds stable keys to translated login content.
Adds stable keys to formatted support-data values and action links.
Adds stable keys to software channel selection sections.
Allows the global toastr message container to safely handle the ref added by the SPA renderer.

These changes do not modify business logic or visible behavior.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x ] **DONE**

## Documentation

- No documentation needed

- [ x] **DONE**

## Test coverage

- No new tests: the changes only add React keys and ref support without changing application logic.
- The complete frontend unit test suite, TypeScript check, and production lint passed.

- [X ] **DONE**

## Links

Issue(s): # https://github.com/uyuni-project/uyuni/pull/12282 --> this is the combined pr
Port(s): # **add downstream PR(s), if any**

- [ X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
