### PR TITLE
Guard Ace editor setup and disable PJAX autofocus

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/list/ListTagUtil.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/list/ListTagUtil.java
@@ -647,7 +647,11 @@ public class ListTagUtil {
         sb.append("<div class=\"input-group\">");
 
         String placeHolder = StringUtils.defaultString(ls.getMessage("message.filterby", fields.get(0)));
-        sb.append(String.format("<input autofocus=\"autofocus\" type=\"text\" " +
+        sb.append("<input ");
+        if (!Boolean.parseBoolean(request.getHeader("x-pjax"))) {
+            sb.append("autofocus=\"autofocus\" ");
+        }
+        sb.append(String.format("type=\"text\" " +
                 "name=\"%s\" value=\"%s\" class=\"form-control\" placeholder=\"%s\" " +
                 "onkeypress=\"return enterKeyHandler(event, jQuery('button[name=%s]'))\"/>",
                                 filterValueKey,

--- a/java/spacewalk-java.changes.emaksy.fix-legacy-console-warnings
+++ b/java/spacewalk-java.changes.emaksy.fix-legacy-console-warnings
@@ -1,0 +1,1 @@
+- Avoid autofocus warnings during PJAX navigation.

--- a/web/html/javascript/spacewalk-essentials.js
+++ b/web/html/javascript/spacewalk-essentials.js
@@ -226,6 +226,15 @@ function onDocumentReadyAutoBootstrapGrid() {
  * shows a select box to choose it.
  */
 function setupTextareaEditor(textarea, mode) {
+  // Some legacy JSP fragments include the editor setup even when the
+  // matching textarea is not rendered for the current form type.
+  if (!textarea || textarea.length === 0) {
+    return;
+  }
+
+  const currentTextareaValue = textarea.val();
+  const textareaValue = typeof currentTextareaValue === "string" ? currentTextareaValue : "";
+
   // if textarea is not shown, the height will be negative,
   // so we set the height of the editor in the popup to the 70% of the window height
   var tH = textarea.height() > 0 ? textarea.height() : (jQuery(window).height()  * 0.7);
@@ -241,7 +250,7 @@ function setupTextareaEditor(textarea, mode) {
   textarea.hide();
 
   var editor = ace.edit(editDiv[0]);
-  editor.getSession().setValue(textarea.val());
+  editor.getSession().setValue(textareaValue);
   editor.getSession().setOptions({ tabSize: 4, useSoftTabs: true });
 
   editor.setTheme("ace/theme/xcode");

--- a/web/spacewalk-web.changes.emaksy.fix-legacy-console-warnings
+++ b/web/spacewalk-web.changes.emaksy.fix-legacy-console-warnings
@@ -1,1 +1,1 @@
-- Avoid autofocus warnings during PJAX navigation.
+- Guard legacy Ace editor setup when its textarea is absent.

--- a/web/spacewalk-web.changes.emaksy.fix-legacy-console-warnings
+++ b/web/spacewalk-web.changes.emaksy.fix-legacy-console-warnings
@@ -1,0 +1,1 @@
+- Avoid autofocus warnings during PJAX navigation.


### PR DESCRIPTION
## What does this PR change?

Fixes these error: 
```
Autofocus processing was blocked because a document already has a focused element.
TypeError: Cannot read properties of undefined (reading 'match')
``` 

- Prevents list filter inputs from requesting autofocus during PJAX
  navigation when another element may already have focus.
- Skips Ace editor initialization when the corresponding textarea is not
  present on the current legacy page.
- Ensures that only string values are passed to the Ace editor.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

PJAX navigation could produce an autofocus warning, and some legacy pages
could attempt to initialize Ace without a textarea.

After:

The expected edge cases are handled without console warnings.

- [X ] **DONE**

## Documentation

- No documentation needed: only internal handling of legacy UI edge cases
  was changed.


- [X ] **DONE**

## Test coverage

- No new tests: the changes are defensive guards around legacy DOM
  initialization.
- Production frontend lint and Java compilation were used for validation.


- [ X] **DONE**

## Links

Issue(s): # https://github.com/uyuni-project/uyuni/pull/12282 --> pr which contains all changes
Port(s): # **add downstream PR(s), if any**

- [ X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
