### PR TITLE
Improve healthcheck (bsc#1271124)

### DIFF
--- a/containers/server-image/Dockerfile.mlm
+++ b/containers/server-image/Dockerfile.mlm
@@ -143,4 +143,4 @@ LABEL io.artifacthub.package.readme-url="%SOURCEURL_WITH(README.md)%"
 LABEL org.uyuni.version="${PRODUCT_VERSION}"
 
 CMD ["/docker-entrypoint-init"]
-HEALTHCHECK --interval=10s --start-period=180s --timeout=120s --retries=1 CMD ["/usr/bin/liveness-check.sh"]
+HEALTHCHECK --interval=10s --start-period=600s --timeout=120s --retries=1 CMD ["/usr/bin/liveness-check.sh"]

--- a/containers/server-image/Dockerfile.mlm
+++ b/containers/server-image/Dockerfile.mlm
@@ -143,4 +143,4 @@ LABEL io.artifacthub.package.readme-url="%SOURCEURL_WITH(README.md)%"
 LABEL org.uyuni.version="${PRODUCT_VERSION}"
 
 CMD ["/docker-entrypoint-init"]
-HEALTHCHECK --interval=10s --start-period=600s --timeout=120s --retries=1 CMD ["/usr/bin/liveness-check.sh"]
+HEALTHCHECK --interval=10s --start-period=600s --timeout=120s --retries=1 CMD ["/usr/bin/healthcheck.sh"]

--- a/containers/server-image/Dockerfile.uyuni
+++ b/containers/server-image/Dockerfile.uyuni
@@ -143,4 +143,4 @@ LABEL io.artifacthub.package.readme-url="%SOURCEURL_WITH(README.md)%"
 LABEL org.uyuni.version="${PRODUCT_VERSION}"
 
 CMD ["/docker-entrypoint-init"]
-HEALTHCHECK --interval=10s --start-period=180s --timeout=120s --retries=1 CMD ["/usr/bin/liveness-check.sh"]
+HEALTHCHECK --interval=10s --start-period=600s --timeout=120s --retries=1 CMD ["/usr/bin/liveness-check.sh"]

--- a/containers/server-image/Dockerfile.uyuni
+++ b/containers/server-image/Dockerfile.uyuni
@@ -143,4 +143,4 @@ LABEL io.artifacthub.package.readme-url="%SOURCEURL_WITH(README.md)%"
 LABEL org.uyuni.version="${PRODUCT_VERSION}"
 
 CMD ["/docker-entrypoint-init"]
-HEALTHCHECK --interval=10s --start-period=600s --timeout=120s --retries=1 CMD ["/usr/bin/liveness-check.sh"]
+HEALTHCHECK --interval=10s --start-period=600s --timeout=120s --retries=1 CMD ["/usr/bin/healthcheck.sh"]

--- a/containers/server-image/README.md
+++ b/containers/server-image/README.md
@@ -3,3 +3,7 @@ This image runs systemd as PID 1 and requires additional permissions to run.
 
 This image cannot be used independently.
 Refer to the Uyuni server installation documentation either on [podman](https://www.uyuni-project.org/uyuni-docs/en/uyuni/installation-and-upgrade/container-deployment/uyuni/server-deployment-uyuni.html) or [Kubernetes](https://www.uyuni-project.org/uyuni-docs/en/uyuni/specialized-guides/kubernetes-guide/server-kubernetes-deployment.html).
+
+## Container Startup and Lifecycle Management
+
+Container initialization and runtime health are managed through the interaction of `00-diskcheck.sh`, container healthchecks, and the `uyuni-server.service` systemd unit. During early startup, the entry point script `00-diskcheck.sh` checks for critically low disk space and aborts the initialization with a non-zero exit code (1) if space is exhausted, causing the systemd service (configured with `Restart=on-success`) to stop immediately in a failed state rather than restarting endlessly. Conversely, if the system is running and a periodic healthcheck fails, Podman's `--health-on-failure=stop` flag triggers a graceful stop (exit code 0), allowing systemd to automatically restart the service and attempt recovery; if the underlying issue is a full disk, the subsequent restart will be safely caught and halted by the early `00-diskcheck.sh` startup check.

--- a/containers/server-image/root/docker-entrypoint-init.d/00-diskcheck.sh
+++ b/containers/server-image/root/docker-entrypoint-init.d/00-diskcheck.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SUSE LLC
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+# Check if disk space is critically low
+/usr/bin/spacewalk-diskcheck -f || {
+    RC=$?
+    if [ $RC -eq 3 ]; then
+        echo "Startup aborted: Critically low disk space detected!"
+        exit 1
+    fi
+    true
+}

--- a/containers/server-image/server-image.changes.nadvornik.startup_healthcheck
+++ b/containers/server-image/server-image.changes.nadvornik.startup_healthcheck
@@ -1,0 +1,2 @@
+- Increase start-period (bsc#1271124)
+- Check disk space on startup

--- a/containers/server-image/server-image.changes.nadvornik.startup_healthcheck
+++ b/containers/server-image/server-image.changes.nadvornik.startup_healthcheck
@@ -1,2 +1,3 @@
 - Increase start-period (bsc#1271124)
 - Check disk space on startup
+- Use correct healthcheck cmd (bsc#1273144)

--- a/containers/server-postgresql-image/Dockerfile
+++ b/containers/server-postgresql-image/Dockerfile
@@ -40,4 +40,4 @@ RUN echo "${REFERENCE_PREFIX}/server-postgresql:${PRODUCT_VERSION}.%RELEASE%" > 
 ENTRYPOINT ["/uyuni-entrypoint.sh"]
 
 CMD ["postgres"]
-HEALTHCHECK --interval=10s --start-period=10s --timeout=5s --retries=3 CMD ["/usr/bin/healthcheck.sh"]
+HEALTHCHECK --interval=10s --start-period=600s --timeout=120s --retries=3 CMD ["/usr/bin/healthcheck.sh"]

--- a/containers/server-postgresql-image/README.md
+++ b/containers/server-postgresql-image/README.md
@@ -3,3 +3,7 @@ This image adds init scripts that are specific to Uyuni.
 
 This image cannot be used independently.
 Refer to the Uyuni server installation documentation either on [podman](https://www.uyuni-project.org/uyuni-docs/en/uyuni/installation-and-upgrade/container-deployment/uyuni/server-deployment-uyuni.html) or [Kubernetes](https://www.uyuni-project.org/uyuni-docs/en/uyuni/specialized-guides/kubernetes-guide/server-kubernetes-deployment.html).
+
+## Container Startup and Lifecycle Management
+
+Container initialization and runtime health are managed through the interaction of `diskcheck.sh` script, container healthchecks, and the `uyuni-db-server.service` systemd unit. During early startup, the entrypoint `uyuni-entrypoint.sh` executes `/usr/bin/diskcheck.sh` to check for critically low disk space and aborts startup with a non-zero exit code (1) if space is exhausted. This ensures the systemd service (configured with `Restart=on-success`) halts immediately in a failed state rather than restarting endlessly on a full disk. Conversely, if a periodic healthcheck fails during runtime, Podman's `--health-on-failure=stop` flag gracefully stops the container (exit code 0), prompting systemd to automatically restart it and attempt recovery; any persistent disk exhaustion will then be caught and cleanly halted during the subsequent startup's early disk check.

--- a/containers/server-postgresql-image/root/usr/bin/diskcheck.sh
+++ b/containers/server-postgresql-image/root/usr/bin/diskcheck.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 SUSE LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+THRESHOLD=${DISKTHRESHOLD:-95}
+PGDATA="${PGDATA:-/var/lib/pgsql/data}"
+
+DISK_USAGE=$(df --output=pcent "$PGDATA" | tail -1 | tr -d '%')
+
+if [ "$DISK_USAGE" -gt "$THRESHOLD" ]; then
+    echo "Disk usage is at ${DISK_USAGE}%, which exceeds the ${THRESHOLD}% threshold."
+    exit 1
+fi
+
+echo "Disk usage is at ${DISK_USAGE}% (Threshold: ${THRESHOLD}%)."
+exit 0

--- a/containers/server-postgresql-image/root/usr/bin/healthcheck.sh
+++ b/containers/server-postgresql-image/root/usr/bin/healthcheck.sh
@@ -1,18 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set threshold to env var DISKTHRESHOLD, default to 95 if not set
-THRESHOLD=${DISKTHRESHOLD:-95}
 PGUSER=${POSTGRES_USER:-postgres}
 PGPORT=${POSTGRES_PORT:-5432}
 
-# Get current disk usage percentage
-DISK_USAGE=$(df --output=pcent /var/lib/pgsql/data | tail -1 | tr -d '%')
-
 UPGRADE_IN_PROGRESS="/run/postgresql/upgrade_in_progress"
 
-if [ "$DISK_USAGE" -gt "$THRESHOLD" ]; then
-    echo "Healthcheck failed: Disk usage is at ${DISK_USAGE}%, which exceeds the ${THRESHOLD}% threshold."
+if ! /usr/bin/diskcheck.sh; then
     exit 1
 fi
 
@@ -26,5 +20,5 @@ if ! pg_isready -U "$PGUSER" -h localhost -p "$PGPORT" > /dev/null; then
     exit 1
 fi
 
-echo "Healthcheck passed: Disk usage is at ${DISK_USAGE}% (Threshold: ${THRESHOLD}%), PostgreSQL is ready."
+echo "Healthcheck passed: PostgreSQL is ready."
 exit 0

--- a/containers/server-postgresql-image/root/uyuni-entrypoint.sh
+++ b/containers/server-postgresql-image/root/uyuni-entrypoint.sh
@@ -150,6 +150,12 @@ main() {
         exec "$@"
     fi
 
+    # Check if disk space is critically low before starting up
+    if ! /usr/bin/diskcheck.sh; then
+        log "Startup aborted due to disk space check failure."
+        exit 1
+    fi
+
     if ! db_already_exists; then
         log "No existing database found – running upstream entrypoint: $UPSTREAM_ENTRYPOINT"
         exec "$UPSTREAM_ENTRYPOINT" "$@"

--- a/containers/server-postgresql-image/server-postgresql-image.changes.nadvornik.startup_healthcheck
+++ b/containers/server-postgresql-image/server-postgresql-image.changes.nadvornik.startup_healthcheck
@@ -1,0 +1,2 @@
+- Increase start-period and timeout (bsc#1271124)
+- Check disk space on startup

--- a/python/spacewalk/satellite_tools/spacewalk-diskcheck
+++ b/python/spacewalk/satellite_tools/spacewalk-diskcheck
@@ -8,15 +8,19 @@ usage: $0 options
 
 OPTIONS:
     -h              Show this message
+    -f              Skip checking if spacewalk services are running
 EOF
 }
 
 function parseArguments {
-    while getopts "h?" opt; do
+    while getopts "h?f" opt; do
         case "$opt" in
             h|\?)
                 usage
                 exit 0
+                ;;
+            f)
+                SKIP_SERVICES_CHECK=1
                 ;;
         esac
     done
@@ -48,6 +52,9 @@ function parseConfiguration {
 }
 
 function ensureSpacewalkRunning {
+    if [ "$SKIP_SERVICES_CHECK" = "1" ]; then
+        return
+    fi
     systemctl status spacewalk.target > /dev/null 2>&1
     if [ $? != 0 ]; then
         echo  "DISKCHECK: spacewalk services are not running - skipping disk check."
@@ -64,10 +71,10 @@ function updateSeverity {
 # Main script
 
 CHECKSEVERITY=0
-
-ensureSpacewalkRunning
+SKIP_TARGET_CHECK=0
 
 parseArguments "$@"
+ensureSpacewalkRunning
 parseConfiguration /etc/rhn/rhn.conf
 
 for DIR in "${DISKCHECKDIRS_ARR[@]}"; do

--- a/python/spacewalk/spacewalk-backend.changes.nadvornik.startup_healthcheck
+++ b/python/spacewalk/spacewalk-backend.changes.nadvornik.startup_healthcheck
@@ -1,0 +1,1 @@
+- Allow using spacewalk-diskcheck without running service


### PR DESCRIPTION
## What does this PR change?

This PR:
- increases healthcheck start-period to 600s
- calls spacewalk-diskcheck also on service startup

This means the container has enough time to start.
If the container has been taken down because of low disk space, it won't try to start the services again.

UPDATE: I moved the startup check to the entrypoint and added similar changes for postgres container
UPDATE2: Added fix for https://bugzilla.suse.com/show_bug.cgi?id=1273144 -  Specify correct healthcheck command in Dockerfile, so it does not need to be changed on podman commandline https://github.com/uyuni-project/uyuni-tools/pull/837

This does not affect kubernetes - the healthcheck from the Dockerfile is ignored there.




## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: fix

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31163 https://github.com/SUSE/spacewalk/issues/31380
https://bugzilla.suse.com/show_bug.cgi?id=1271124
Port(s): https://github.com/SUSE/spacewalk/pull/31621 https://github.com/SUSE/spacewalk/pull/31397

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
