### PR TITLE
Prevent async updates after shared component cleanup

### DIFF
--- a/web/html/src/components/action-schedule.test.tsx
+++ b/web/html/src/components/action-schedule.test.tsx
@@ -1,0 +1,49 @@
+import { localizedMoment } from "utils/datetime";
+import Network from "utils/network";
+import { act, render } from "utils/test-utils";
+
+import { ActionSchedule } from "./action-schedule";
+
+describe("ActionSchedule", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  test("ignores a maintenance response after unmount", async () => {
+    let resolveRequest: (data: any) => void = () => undefined;
+    const request = new Promise((resolve) => {
+      resolveRequest = resolve;
+    });
+    jest.spyOn(Network, "post").mockReturnValue(request as any);
+    const onDateTimeChanged = jest.fn();
+
+    const { unmount } = render(
+      <ActionSchedule
+        earliest={localizedMoment()}
+        systemIds={[1000]}
+        actionType="state.apply"
+        onDateTimeChanged={onDateTimeChanged}
+      />
+    );
+
+    unmount();
+
+    await act(async () => {
+      resolveRequest({
+        data: {
+          maintenanceWindowsMultiSchedules: false,
+          maintenanceWindows: [
+            {
+              id: 1,
+              from: "2026-07-22 10:00",
+              to: "2026-07-22 11:00",
+              fromMilliseconds: 1784710800000,
+              toMilliseconds: 1784714400000,
+            },
+          ],
+        },
+      });
+      await request;
+    });
+
+    expect(onDateTimeChanged).not.toHaveBeenCalled();
+  });
+});

--- a/web/html/src/components/action-schedule.tsx
+++ b/web/html/src/components/action-schedule.tsx
@@ -47,6 +47,7 @@ type ActionScheduleState = {
 
 class ActionSchedule extends Component<ActionScheduleProps, ActionScheduleState> {
   newActionChainOpt = { id: Number(0), text: t("new action chain") };
+  private isUnmounted = false;
 
   constructor(props: ActionScheduleProps) {
     super(props);
@@ -81,6 +82,10 @@ class ActionSchedule extends Component<ActionScheduleProps, ActionScheduleState>
       };
       Network.post("/rhn/manager/api/maintenance/upcoming-windows", postData)
         .then((data) => {
+          if (this.isUnmounted) {
+            return;
+          }
+
           const multiMaintWindows = data.data.maintenanceWindowsMultiSchedules;
           const maintenanceWindows = data.data.maintenanceWindows;
 
@@ -114,7 +119,15 @@ class ActionSchedule extends Component<ActionScheduleProps, ActionScheduleState>
     }
   };
 
+  componentWillUnmount() {
+    this.isUnmounted = true;
+  }
+
   handleResponseError = (jqXHR) => {
+    if (this.isUnmounted) {
+      return;
+    }
+
     Loggerhead.error(Network.responseErrorMessage(jqXHR));
     this.setState({ loading: false });
   };

--- a/web/html/src/components/buttons/index.tsx
+++ b/web/html/src/components/buttons/index.tsx
@@ -82,11 +82,21 @@ type AsyncState = {
  * A button which performs an asynchronous action and displays an animation while waiting for the result.
  */
 export class AsyncButton extends _ButtonBase<AsyncProps, AsyncState> {
+  private isComponentMounted = false;
+
   constructor(props: AsyncProps) {
     super(props);
     this.state = {
       value: props.initialValue ? props.initialValue : "initial",
     };
+  }
+
+  componentDidMount() {
+    this.isComponentMounted = true;
+  }
+
+  componentWillUnmount() {
+    this.isComponentMounted = false;
   }
 
   trigger = () => {
@@ -102,14 +112,18 @@ export class AsyncButton extends _ButtonBase<AsyncProps, AsyncState> {
     }
     future.then(
       () => {
-        this.setState({
-          value: "success",
-        });
+        if (this.isComponentMounted) {
+          this.setState({
+            value: "success",
+          });
+        }
       },
       () => {
-        this.setState({
-          value: "failure",
-        });
+        if (this.isComponentMounted) {
+          this.setState({
+            value: "failure",
+          });
+        }
       }
     );
   };

--- a/web/html/src/components/states-picker.tsx
+++ b/web/html/src/components/states-picker.tsx
@@ -72,14 +72,27 @@ class StatesPickerState {
 
 class StatesPicker extends Component<StatesPickerProps, StatesPickerState> {
   state = new StatesPickerState();
+  private isComponentMounted = false;
 
   constructor(props: StatesPickerProps) {
     super(props);
+  }
+
+  componentDidMount() {
+    this.isComponentMounted = true;
     this.init();
+  }
+
+  componentWillUnmount() {
+    this.isComponentMounted = false;
   }
 
   init = () => {
     Network.get(this.props.matchUrl()).then((data) => {
+      if (!this.isComponentMounted) {
+        return;
+      }
+
       data = this.getSortedList(data);
       this.setState((prevState) => ({
         channels: data,
@@ -141,6 +154,10 @@ class StatesPicker extends Component<StatesPickerProps, StatesPickerState> {
     }
     const request = this.props.saveRequest(channels).then(
       (data) => {
+        if (!this.isComponentMounted) {
+          return;
+        }
+
         const newSearchResults = this.state.search.results.map((channel) => {
           const changed = this.state.changed.get(channelKey(channel));
           // We want to make sure the search results are updated with the changes. If there was a change
@@ -173,6 +190,10 @@ class StatesPicker extends Component<StatesPickerProps, StatesPickerState> {
         this.hideRanking();
       },
       () => {
+        if (!this.isComponentMounted) {
+          return;
+        }
+
         this.setMessages(MessagesUtils.error(t("An error occurred on save.")));
       }
     );
@@ -192,12 +213,20 @@ class StatesPicker extends Component<StatesPickerProps, StatesPickerState> {
 
   search = () => {
     return Promise.resolve().then(() => {
+      if (!this.isComponentMounted) {
+        return;
+      }
+
       if (this.state.filter !== this.state.search.filter) {
         // Since we don't commit our changes to the backend in case of state type we perform a local search
         if (this.props.type === "state") {
           this.stateTypeSearch();
         } else {
           Network.get(this.props.matchUrl(this.state.filter)).then((data) => {
+            if (!this.isComponentMounted) {
+              return;
+            }
+
             this.setState((prevState) => ({
               search: {
                 filter: prevState.filter,
@@ -323,6 +352,10 @@ class StatesPicker extends Component<StatesPickerProps, StatesPickerState> {
 
   showPopUp = (channel) => {
     Network.get("/rhn/manager/api/states/" + channel.id + "/content").then((data) => {
+      if (!this.isComponentMounted) {
+        return;
+      }
+
       this.setState({
         showSaltState: Object.assign({}, channel, { content: data }),
       });
@@ -345,6 +378,10 @@ class StatesPicker extends Component<StatesPickerProps, StatesPickerState> {
   };
 
   setMessages = (message) => {
+    if (!this.isComponentMounted) {
+      return;
+    }
+
     this.setState({
       messages: message,
     });
@@ -390,7 +427,12 @@ class StatesPicker extends Component<StatesPickerProps, StatesPickerState> {
         const assigned = currentAssignment.length > 0;
         buttons = [
           typeof this.props.applyRequest !== "undefined" && (
-            <ExecuteStatesButton assigned={assigned} applySaltState={this.applySaltState} type={this.props.type} />
+            <ExecuteStatesButton
+              key="execute-states"
+              assigned={assigned}
+              applySaltState={this.applySaltState}
+              type={this.props.type}
+            />
           ),
         ];
 

--- a/web/html/src/components/table/TableDataHandler.tsx
+++ b/web/html/src/components/table/TableDataHandler.tsx
@@ -142,6 +142,7 @@ export class TableDataHandler extends Component<Props, State> {
     columns: [],
   };
   panelHeaderRef: React.RefObject<HTMLDivElement>;
+  private isComponentMounted = false;
 
   constructor(props: Props) {
     super(props);
@@ -188,7 +189,7 @@ export class TableDataHandler extends Component<Props, State> {
   }
 
   getData() {
-    if (!this.state.provider) {
+    if (!this.isComponentMounted || !this.state.provider) {
       return;
     }
 
@@ -205,16 +206,30 @@ export class TableDataHandler extends Component<Props, State> {
     this.setState({ loading: true }, () => {
       this.state.provider.get((promise) => {
         promise
-          .then((data) => this.updateData(data))
+          .then((data) => {
+            if (this.isComponentMounted) {
+              this.updateData(data);
+            }
+          })
           .finally(() => {
-            this.setState({ loading: false });
+            if (this.isComponentMounted) {
+              this.setState({ loading: false });
+            }
           });
       }, pageControl);
     });
   }
 
   updateData({ items, total, selectedIds }: PagedData) {
+    if (!this.isComponentMounted) {
+      return;
+    }
+
     this.setState({ data: items, totalItems: total }, () => {
+      if (!this.isComponentMounted) {
+        return;
+      }
+
       if (!DEPRECATED_unsafeEquals(selectedIds, null)) {
         this.props.onSelect?.(selectedIds);
       }
@@ -232,6 +247,7 @@ export class TableDataHandler extends Component<Props, State> {
   }
 
   componentDidMount() {
+    this.isComponentMounted = true;
     this.getData();
 
     if (this.panelHeaderRef.current) {
@@ -249,6 +265,8 @@ export class TableDataHandler extends Component<Props, State> {
   }
 
   componentWillUnmount() {
+    this.isComponentMounted = false;
+
     if (this.context && this.context.saveState) {
       this.context.saveState(this.state);
     }
@@ -358,6 +376,7 @@ export class TableDataHandler extends Component<Props, State> {
     if (!searchField && this.props.onSearch) {
       searchField = <SearchField />;
     }
+    const searchPanelChildren = Children.toArray([searchField, ...(this.props.additionalFilters ?? [])]);
     const isTableHeaderEmpty = !this.props.titleButtons && !searchField && !this.props.additionalFilters;
     const stickyHeader = this.props.stickyHeader;
 
@@ -419,15 +438,31 @@ export class TableDataHandler extends Component<Props, State> {
     };
 
     const handleSearchPanelSelectAll = () => {
+      if (!this.isComponentMounted) {
+        return;
+      }
+
       this.setState({ loading: true }, () => {
+        if (!this.isComponentMounted) {
+          return;
+        }
+
         this.state.provider.getIds(
           (promise) =>
             promise
               .then((data) => {
+                if (!this.isComponentMounted) {
+                  return;
+                }
+
                 const selected = selectedItems;
                 this.setSelection(selected.concat(data.filter((id) => !selected.includes(id))));
               })
-              .finally(() => this.setState({ loading: false })),
+              .finally(() => {
+                if (this.isComponentMounted) {
+                  this.setState({ loading: false });
+                }
+              }),
           this.state.criteria
         );
       });
@@ -455,8 +490,7 @@ export class TableDataHandler extends Component<Props, State> {
                     selectable={isSelectable}
                     searchPanelInline={this.props.searchPanelInline}
                   >
-                    {searchField}
-                    {this.props.additionalFilters}
+                    {searchPanelChildren}
                   </SearchPanel>
                   <div className="spacewalk-list-head-addons-extra table-items-per-page-wrapper">
                     {this.renderTitleButtons()}

--- a/web/spacewalk-web.changes.emaksy.shared-async-cleanup
+++ b/web/spacewalk-web.changes.emaksy.shared-async-cleanup
@@ -1,0 +1,1 @@
+- Prevent asynchronous updates after shared components unmount.


### PR DESCRIPTION
## What does this PR change?

This PR fixes these console log errors

```
Warning: Can't perform a React state update on an unmounted component.
This is a no-op, but it indicates a memory leak in your application.

Warning: Each child in a list should have a unique "key" prop.
```

The changes prevents asynchronous callbacks in shared React components from updating
state after the component has been unmounted.

Affected components:

- `ActionSchedule` ignores maintenance-window responses after unmount.
- `AsyncButton` does not update its status after unmount.
- `StatesPicker` ignores late load, search, save, and popup responses.
- `TableDataHandler` ignores late provider and selection responses.
- Table search-panel children receive stable React keys.

Normal behavior while the components remain mounted is unchanged.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

Navigating away while a request was pending could produce:

```text
Can't perform a React state update on an unmounted component
```

Late responses are ignored once the corresponding component has been
unmounted.

- [ X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): # Combined PR --> https://github.com/uyuni-project/uyuni/pull/12282
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
