### PR TITLE
Prevent async updates after manager view cleanup

### DIFF
--- a/web/html/src/manager/admin/config/monitoring-admin.tsx
+++ b/web/html/src/manager/admin/config/monitoring-admin.tsx
@@ -213,6 +213,10 @@ const MonitoringAdmin = () => {
     }
     changeStatus(enable)
       .then((result: any) => {
+        if (!result) {
+          return;
+        }
+
         if (result.success) {
           setMessages(MessagesUtils.success(messageMap[result.message]));
         } else {

--- a/web/html/src/manager/admin/config/use-monitoring-api.ts
+++ b/web/html/src/manager/admin/config/use-monitoring-api.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { MessageType } from "components/messages/messages";
 
@@ -14,13 +14,24 @@ function isRestartNeeded(data: ExportersResultType) {
 }
 
 const useMonitoringApi = () => {
+  const isMounted = useRef(true);
   const [action, setAction] = useState<null | "checking" | "enabling" | "disabling">(null);
   const [exportersStatus, setExportersStatus] = useState<Record<string, boolean> | null | undefined>(null);
   const [exportersMessages, setExportersMessages] = useState<Record<string, string>>({});
   const [restartNeeded, setRestartNeeded] = useState<boolean>(false);
   const [messages, setMessages] = useState<MessageType[]>([]);
 
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
   const handleResponseError = (jqXHR: JQueryXHR): any => {
+    if (!isMounted.current) {
+      return;
+    }
+
     const msg = Network.responseErrorMessage(jqXHR);
     setMessages(msg);
   };
@@ -29,6 +40,10 @@ const useMonitoringApi = () => {
     setAction("checking");
     return Network.get("/rhn/manager/api/admin/config/monitoring")
       .then((data: JsonResult<ExportersResultType>) => {
+        if (!isMounted.current) {
+          return;
+        }
+
         setExportersStatus(data.data.exporters);
         setExportersMessages(data.data.messages);
         setRestartNeeded(isRestartNeeded(data.data));
@@ -36,7 +51,9 @@ const useMonitoringApi = () => {
       })
       .catch(handleResponseError)
       .finally(() => {
-        setAction(null);
+        if (isMounted.current) {
+          setAction(null);
+        }
       });
   };
 
@@ -44,6 +61,10 @@ const useMonitoringApi = () => {
     setAction(toEnable ? "enabling" : "disabling");
     return Network.post("/rhn/manager/api/admin/config/monitoring", { enable: toEnable })
       .then((data: JsonResult<ExportersResultType>) => {
+        if (!isMounted.current) {
+          return;
+        }
+
         if (data.data.exporters) {
           setExportersStatus(data.data.exporters);
           setExportersMessages(data.data.messages);
@@ -92,7 +113,9 @@ const useMonitoringApi = () => {
       })
       .catch(handleResponseError)
       .finally(() => {
-        setAction(null);
+        if (isMounted.current) {
+          setAction(null);
+        }
       });
   };
 

--- a/web/html/src/manager/admin/config/use-monitoring-api.ts
+++ b/web/html/src/manager/admin/config/use-monitoring-api.ts
@@ -40,13 +40,12 @@ const useMonitoringApi = () => {
     setAction("checking");
     return Network.get("/rhn/manager/api/admin/config/monitoring")
       .then((data: JsonResult<ExportersResultType>) => {
-        if (!isMounted.current) {
-          return;
+        if (isMounted.current) {
+          setExportersStatus(data.data.exporters);
+          setExportersMessages(data.data.messages);
+          setRestartNeeded(isRestartNeeded(data.data));
         }
 
-        setExportersStatus(data.data.exporters);
-        setExportersMessages(data.data.messages);
-        setRestartNeeded(isRestartNeeded(data.data));
         return data.data.exporters;
       })
       .catch(handleResponseError)

--- a/web/html/src/manager/maintenance/maintenance-windows.tsx
+++ b/web/html/src/manager/maintenance/maintenance-windows.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -36,6 +36,7 @@ function getHashAction() {
 }
 
 const MaintenanceWindows = () => {
+  const isMounted = useRef(true);
   const [messages, setMessages] = useState<any[]>([]);
   const [items, setItems] = useState<any[]>([]);
   const [action, setAction] = useState<string | undefined>();
@@ -47,12 +48,23 @@ const MaintenanceWindows = () => {
     if (window.type === "schedule") {
       getCalendarNames();
     }
-    window.addEventListener("popstate", () => {
+
+    const onPopState = () => {
       updateView(getHashAction(), getHashId());
-    });
+    };
+    window.addEventListener("popstate", onPopState);
+
+    return () => {
+      isMounted.current = false;
+      window.removeEventListener("popstate", onPopState);
+    };
   }, []);
 
   const updateView = (newAction, id) => {
+    if (!isMounted.current) {
+      return;
+    }
+
     if (newAction === "details" && id) {
       getDetails(id, "details");
     } else if (id || !newAction) {
@@ -67,6 +79,10 @@ const MaintenanceWindows = () => {
     /* Returns a list of maintenance schedules or calendars depending on the type provided */
     return MaintenanceWindowsApi.list(window.type)
       .then((newItems) => {
+        if (!isMounted.current) {
+          return;
+        }
+
         setAction(undefined);
         setSelected(undefined);
         setItems(newItems);
@@ -77,6 +93,10 @@ const MaintenanceWindows = () => {
   const getCalendarNames = () => {
     return MaintenanceWindowsApi.calendarNames()
       .then((newCalendarNames) => {
+        if (!isMounted.current) {
+          return;
+        }
+
         /* Convert list of calendar names into ComboboxItem
       Add "<None>" as first element to allow unassigning of calendars */
         const names = Array.from(new Array(newCalendarNames.length + 1).keys()).map((id) =>
@@ -91,6 +111,10 @@ const MaintenanceWindows = () => {
     /* Returns the details of given schedule or calendar depending on the type provided */
     return MaintenanceWindowsApi.details(row, window.type)
       .then((newItem) => {
+        if (!isMounted.current) {
+          return;
+        }
+
         setSelected(newItem);
         setAction(newAction);
         window.history.pushState(null, "", "#/" + newAction + "/" + newItem.id);
@@ -109,6 +133,10 @@ const MaintenanceWindows = () => {
   const update = (itemIn) => {
     return Network.post("/rhn/manager/api/maintenance/" + window.type + "/save", itemIn)
       .then(() => {
+        if (!isMounted.current) {
+          return;
+        }
+
         const successMsg = (
           <span>
             {t(
@@ -130,6 +158,10 @@ const MaintenanceWindows = () => {
   const deleteItem = (itemIn) => {
     return Network.del("/rhn/manager/api/maintenance/" + window.type + "/delete", itemIn)
       .then(() => {
+        if (!isMounted.current) {
+          return;
+        }
+
         setMessages(
           MessagesUtils.info(
             (window.type === "schedule" ? "Schedule " : "Calendar ") + "'" + itemIn.name + "' has been deleted."
@@ -138,6 +170,10 @@ const MaintenanceWindows = () => {
         handleForwardAction();
       })
       .catch((data) => {
+        if (!isMounted.current) {
+          return;
+        }
+
         const errorMsg = MessagesUtils.error(t("Error when deleting the " + window.type));
         const msgs = data && data.status === 400 ? errorMsg : Network.responseErrorMessage(data);
         setMessages(msgs);
@@ -147,6 +183,10 @@ const MaintenanceWindows = () => {
   const refreshCalendar = (itemIn) => {
     return Network.post("/rhn/manager/api/maintenance/calendar/refresh", itemIn)
       .then(() => {
+        if (!isMounted.current) {
+          return;
+        }
+
         const msgs = messages.concat(MessagesUtils.info(t("Calendar successfully refreshed")));
         setAction(undefined);
         setMessages(msgs.slice(-messagesCounterLimit));
@@ -157,9 +197,17 @@ const MaintenanceWindows = () => {
   };
 
   const handleForwardAction = (newAction?: string) => {
+    if (!isMounted.current) {
+      return;
+    }
+
     const loc = window.location;
     if (newAction === undefined || newAction === "back") {
       listMaintenanceWindowItems().then(() => {
+        if (!isMounted.current) {
+          return;
+        }
+
         window.history.pushState(null, "", loc.pathname + loc.search);
       });
     } else {
@@ -169,10 +217,18 @@ const MaintenanceWindows = () => {
   };
 
   const clearMessages = () => {
+    if (!isMounted.current) {
+      return;
+    }
+
     setMessages([]);
   };
 
   const handleResponseError = (jqXHR) => {
+    if (!isMounted.current) {
+      return;
+    }
+
     setMessages(Network.responseErrorMessage(jqXHR));
   };
 

--- a/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
+++ b/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
@@ -20,6 +20,8 @@ type State = {
 };
 
 class FormulaCatalog extends Component<Props, State> {
+  private isComponentMounted = false;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -30,12 +32,21 @@ class FormulaCatalog extends Component<Props, State> {
 
   refreshServerData = () => {
     Network.get("/rhn/manager/api/formula-catalog/data").then((data) => {
+      if (!this.isComponentMounted) {
+        return;
+      }
+
       this.setState({ serverData: data });
     });
   };
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
+    this.isComponentMounted = true;
     this.refreshServerData();
+  }
+
+  componentWillUnmount() {
+    this.isComponentMounted = false;
   }
 
   sortByText = (aRaw = "", bRaw = "", columnKey, sortDirection) => {
@@ -61,6 +72,7 @@ class FormulaCatalog extends Component<Props, State> {
               {
                 link: (str) => (
                   <a
+                    key="salt-formulas-link"
                     href="https://docs.saltproject.io/en/latest/topics/development/conventions/formulas.html"
                     target="_blank"
                     rel="noopener noreferrer"

--- a/web/html/src/manager/salt/keys/key-management.tsx
+++ b/web/html/src/manager/salt/keys/key-management.tsx
@@ -98,6 +98,8 @@ type State = {
 };
 
 class KeyManagement extends Component<Props, State> {
+  private isComponentMounted = false;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -105,12 +107,27 @@ class KeyManagement extends Component<Props, State> {
       isOrgAdmin: false,
       loading: true,
     };
+  }
+
+  componentDidMount() {
+    this.isComponentMounted = true;
     this.reloadKeys();
   }
 
+  componentWillUnmount() {
+    this.isComponentMounted = false;
+  }
+
   reloadKeys = () => {
-    this.setState({ loading: true });
+    if (this.isComponentMounted) {
+      this.setState({ loading: true });
+    }
+
     return listKeys().then((data) => {
+      if (!this.isComponentMounted) {
+        return;
+      }
+
       this.setState({
         keys: data["minions"],
         isOrgAdmin: data["isOrgAdmin"],

--- a/web/html/src/manager/state/highstate-summary.test.tsx
+++ b/web/html/src/manager/state/highstate-summary.test.tsx
@@ -1,9 +1,12 @@
 import HighstateSummary from "manager/state/highstate-summary";
 
-import { click, render, screen, server, waitForElementToBeRemoved, within } from "utils/test-utils";
+import Network from "utils/network";
+import { act, click, render, screen, server, waitForElementToBeRemoved, within } from "utils/test-utils";
 
 const API_SUMMARY = "/rhn/manager/api/states/summary?sid=1000";
 const API_HIGHSTATE = "/rhn/manager/api/states/highstate?sid=1000";
+
+afterEach(() => jest.restoreAllMocks());
 
 describe("Highstate summary", () => {
   test("Render summary table", async () => {
@@ -76,6 +79,50 @@ describe("Highstate summary", () => {
     within(rows[3]).getByRole("link", { name: "My config channel" });
     within(rows[3]).getByText("Config channel");
     within(rows[3]).getByRole("link", { name: "My org" });
+  });
+
+  test("ignores a stale response after the requested minion changes", async () => {
+    let resolveFirstRequest: (data: any[]) => void = () => undefined;
+    const firstRequest = new Promise<any[]>((resolve) => {
+      resolveFirstRequest = resolve;
+    });
+    jest.spyOn(Network, "get").mockImplementation((url) => {
+      if (url.includes("sid=1000")) {
+        return firstRequest as any;
+      }
+      return Promise.resolve([
+        {
+          id: 2,
+          name: "Current state",
+          type: "STATE",
+          sourceId: 2,
+          sourceName: "Current system",
+          sourceType: "SYSTEM",
+        },
+      ]) as any;
+    });
+
+    const { rerender } = render(<HighstateSummary minionId={1000} />);
+    rerender(<HighstateSummary minionId={2000} />);
+
+    await screen.findByText("Current state");
+
+    await act(async () => {
+      resolveFirstRequest([
+        {
+          id: 1,
+          name: "Stale state",
+          type: "STATE",
+          sourceId: 1,
+          sourceName: "Old system",
+          sourceType: "SYSTEM",
+        },
+      ]);
+      await firstRequest;
+    });
+
+    expect(screen.queryByText("Stale state")).toBeNull();
+    screen.getByText("Current state");
   });
 });
 

--- a/web/html/src/manager/state/highstate-summary.test.tsx
+++ b/web/html/src/manager/state/highstate-summary.test.tsx
@@ -1,5 +1,6 @@
-import HighstateSummary from "manager/state/highstate-summary";
+import HighstateSummary, { StateSource } from "manager/state/highstate-summary";
 
+import { Cancelable } from "utils/functions";
 import Network from "utils/network";
 import { act, click, render, screen, server, waitForElementToBeRemoved, within } from "utils/test-utils";
 
@@ -82,13 +83,15 @@ describe("Highstate summary", () => {
   });
 
   test("ignores a stale response after the requested minion changes", async () => {
-    let resolveFirstRequest: (data: any[]) => void = () => undefined;
-    const firstRequest = new Promise<any[]>((resolve) => {
+    type RawStateSource = Omit<StateSource, "typeName">;
+
+    let resolveFirstRequest: (data: RawStateSource[]) => void = () => undefined;
+    const firstRequest = new Promise<RawStateSource[]>((resolve) => {
       resolveFirstRequest = resolve;
     });
     jest.spyOn(Network, "get").mockImplementation((url) => {
       if (url.includes("sid=1000")) {
-        return firstRequest as any;
+        return firstRequest as unknown as Cancelable<StateSource[]>;
       }
       return Promise.resolve([
         {
@@ -99,7 +102,7 @@ describe("Highstate summary", () => {
           sourceName: "Current system",
           sourceType: "SYSTEM",
         },
-      ]) as any;
+      ] as RawStateSource[]) as unknown as Cancelable<StateSource[]>;
     });
 
     const { rerender } = render(<HighstateSummary minionId={1000} />);

--- a/web/html/src/manager/state/highstate-summary.tsx
+++ b/web/html/src/manager/state/highstate-summary.tsx
@@ -40,11 +40,25 @@ export default function HighstateSummary({ minionId }) {
   };
 
   useEffect(() => {
+    let isCurrentRequest = true;
+
     setIsLoading(true);
     Network.get(`/rhn/manager/api/states/summary?sid=${minionId}`)
       .then((data) => data.map(toDisplayValues))
-      .then(setSummary)
-      .then(() => setIsLoading(false));
+      .then((data) => {
+        if (isCurrentRequest) {
+          setSummary(data);
+        }
+      })
+      .then(() => {
+        if (isCurrentRequest) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      isCurrentRequest = false;
+    };
   }, [minionId]);
 
   if (isLoading) {

--- a/web/html/src/manager/state/highstate-summary.tsx
+++ b/web/html/src/manager/state/highstate-summary.tsx
@@ -9,7 +9,7 @@ import { Table } from "components/table/Table";
 import { Utils } from "utils/functions";
 import Network from "utils/network";
 
-type StateSource = {
+export type StateSource = {
   id?: number;
   name: string;
   type: "STATE" | "CONFIG" | "FORMULA" | "INTERNAL";

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager.tsx
@@ -47,6 +47,8 @@ type State = {
 };
 
 class VirtualHostManager extends Component<Props, State> {
+  private isComponentMounted = false;
+
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -57,15 +59,33 @@ class VirtualHostManager extends Component<Props, State> {
   }
 
   componentDidMount() {
+    this.isComponentMounted = true;
     this.updateView(getHashAction(), getHashId());
-    window.addEventListener("popstate", () => {
-      this.updateView(getHashAction(), getHashId());
-    });
+    window.addEventListener("popstate", this.onPopState);
   }
 
+  componentWillUnmount() {
+    this.isComponentMounted = false;
+    window.removeEventListener("popstate", this.onPopState);
+  }
+
+  onPopState = () => {
+    this.updateView(getHashAction(), getHashId());
+  };
+
   updateView(action, id) {
+    if (!this.isComponentMounted) {
+      return;
+    }
+
     if ((action === "edit" || action === "details") && id)
-      this.getVhmDetails(id).then((data) => this.setState({ selected: data.data, action: action }));
+      this.getVhmDetails(id).then((data) => {
+        if (!this.isComponentMounted || !data) {
+          return;
+        }
+
+        this.setState({ selected: data.data, action: action });
+      });
     else if (!action) {
       this.getAvailableModules();
       this.getVhmList();
@@ -76,12 +96,20 @@ class VirtualHostManager extends Component<Props, State> {
   }
 
   handleResponseError = (jqXHR) => {
+    if (!this.isComponentMounted) {
+      return;
+    }
+
     this.setState({
       messages: Network.responseErrorMessage(jqXHR),
     });
   };
 
   clearMessages() {
+    if (!this.isComponentMounted) {
+      return;
+    }
+
     this.setState({
       messages: undefined,
     });
@@ -93,13 +121,25 @@ class VirtualHostManager extends Component<Props, State> {
 
   getVhmList() {
     return Network.get("/rhn/manager/api/vhms")
-      .then((data) => this.setState({ action: undefined, selected: undefined, vhms: data.data }))
+      .then((data) => {
+        if (!this.isComponentMounted) {
+          return;
+        }
+
+        this.setState({ action: undefined, selected: undefined, vhms: data.data });
+      })
       .catch(this.handleResponseError);
   }
 
   getAvailableModules = () => {
     return Network.get("/rhn/manager/api/vhms/modules")
-      .then((data) => this.setState({ availableModules: data }))
+      .then((data) => {
+        if (!this.isComponentMounted) {
+          return;
+        }
+
+        this.setState({ availableModules: data });
+      })
       .catch(this.handleResponseError);
   };
 
@@ -111,6 +151,10 @@ class VirtualHostManager extends Component<Props, State> {
     if (!item) return false;
     return Network.del("/rhn/manager/api/vhms/delete/" + item.id)
       .then(() => {
+        if (!this.isComponentMounted) {
+          return;
+        }
+
         this.handleBackAction();
         this.setState({
           messages: MessagesUtils.info("Virtual Host Manager has been deleted."),
@@ -121,6 +165,10 @@ class VirtualHostManager extends Component<Props, State> {
 
   handleBackAction = () => {
     this.getVhmList().then(() => {
+      if (!this.isComponentMounted) {
+        return;
+      }
+
       const loc = window.location;
       window.history.pushState(null, "", loc.pathname + loc.search);
     });
@@ -129,6 +177,10 @@ class VirtualHostManager extends Component<Props, State> {
 
   handleDetailsAction = (row) => {
     this.getVhmDetails(row.id).then((data) => {
+      if (!this.isComponentMounted || !data) {
+        return;
+      }
+
       this.setState({ selected: data.data, action: "details" });
       window.history.pushState(null, "", "#/details/" + row.id);
     });
@@ -136,6 +188,10 @@ class VirtualHostManager extends Component<Props, State> {
 
   handleEditAction = (row) => {
     this.getVhmDetails(row.id).then((data) => {
+      if (!this.isComponentMounted || !data) {
+        return;
+      }
+
       this.setState({ selected: data.data, action: "edit" });
       window.history.pushState(null, "", "#/edit/" + row.id);
     });

--- a/web/spacewalk-web.changes.emaksy.manager-async-cleanup
+++ b/web/spacewalk-web.changes.emaksy.manager-async-cleanup
@@ -1,0 +1,1 @@
+- Prevent asynchronous updates after manager views unmount.


### PR DESCRIPTION
## What does this PR change?

This PR fixes two kinds of bugs caused by slow or delayed API responses in manager views.

1. Most views: if a user navigates away before an API response arrives,
   the response used to still try to update the (now gone) view. This
   caused a React console warning about updating state on an unmounted
   component and could leak memory. These views now ignore responses
   that arrive after the user has left.

2. Highstate Summary: switching between minions quickly could let a slow
   response for the previous minion overwrite the data for the newly
   selected one, showing the wrong information (no console warning, just
   incorrect data on screen).

Affected views:
- Monitoring configuration: ignores late API responses after navigation.
- Maintenance windows: removes its popstate listener and ignores late list, details, save, delete, and refresh responses.
- Formula Catalog: loads its data after mounting and ignores responses after unmount.
- Salt Key Management: ignores late key-list responses.
- Highstate Summary: ignores stale responses when the requested minion changes.
- Virtual Host Manager: removes its popstate listener and ignores late API responses and navigation callbacks.

Normal behavior while the views remain mounted is unchanged.



## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni) [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

Navigating away while a request was pending could produce React state-update warnings or allow a late response to update the previous view.

After:

Late responses and navigation callbacks are ignored after cleanup. Highstate responses for a previously selected minion are also ignored.

- [x] **DONE**

## Documentation

- No documentation needed: only internal request and component lifecycle handling was changed.

- [x] **DONE**

## Test coverage

- Unit tests cover ignoring a stale Highstate response after the requested minion changes.
- TypeScript and production lint checks passed.

```bash
npm --prefix web run test -- --runInBand \
  html/src/manager/state/highstate-summary.test.tsx

npm --prefix web run tsc
npm --prefix web run lint:production
```

- [x] **DONE**

## Links

Issue(s):  https://github.com/uyuni-project/uyuni/pull/12282 --> combined pr 
Port(s): N/A

- [x] **DONE**

## Changelogs

Added:

```text
web/spacewalk-web.changes.emaksy.manager-async-cleanup
```

- [ ] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
