### PR TITLE
Cancel stale product requests during navigation

### DIFF
--- a/web/html/src/manager/admin/setup/products/products.test.tsx
+++ b/web/html/src/manager/admin/setup/products/products.test.tsx
@@ -3,7 +3,7 @@ import { screen } from "@testing-library/react";
 import { render } from "utils/test-utils";
 
 import { CheckListItem } from "./products";
-import { searchCriteriaInExtension } from "./products.utils";
+import { isProductRequestCancellation, searchCriteriaInExtension } from "./products.utils";
 
 const extension = {
   label: "suse base 1 2 asd",
@@ -87,6 +87,18 @@ describe("Testing searchCriteriaInExtension", () => {
     expect(searchCriteriaInExtension(extension, criteriaChannel1)).toBeTruthy();
     expect(searchCriteriaInExtension(extension, criteriaChannel2)).toBeTruthy();
     expect(searchCriteriaInExtension(extension, criteriaWrong)).toBeFalsy();
+  });
+});
+
+describe("product request error handling", () => {
+  test("ignores cancellation without an error", () => {
+    expect(isProductRequestCancellation(undefined)).toBe(true);
+  });
+
+  test("does not ignore a real request error with status zero", () => {
+    const connectionError = { status: 0 } as JQueryXHR;
+
+    expect(isProductRequestCancellation(connectionError)).toBe(false);
   });
 });
 

--- a/web/html/src/manager/admin/setup/products/products.tsx
+++ b/web/html/src/manager/admin/setup/products/products.tsx
@@ -162,7 +162,11 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
           });
         }
       })
-      .catch(this.handleResponseError);
+      .catch((error) => {
+        if (this.metadataRequest === metadataRequest) {
+          this.handleResponseError(error);
+        }
+      });
 
     const productsRequest = reloadData();
     this.productsRequest = productsRequest;
@@ -179,7 +183,11 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
           scheduledItems: [],
         });
       })
-      .catch(this.handleResponseError);
+      .catch((error) => {
+        if (this.productsRequest === productsRequest) {
+          this.handleResponseError(error);
+        }
+      });
   };
 
   handleSelectedItems = (items) => {
@@ -205,6 +213,10 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
   };
 
   updateSccSyncRunning = (sccSyncStatus) => {
+    if (this.isUnmounted) {
+      return;
+    }
+
     // if it was running and now it's finished
     if (this.state.sccSyncRunning && !sccSyncStatus) {
       this.refreshServerData(); // reload data

--- a/web/html/src/manager/admin/setup/products/products.tsx
+++ b/web/html/src/manager/admin/setup/products/products.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, Component, useEffect, useState } from "react";
+import { type ReactNode, Component, Fragment, useEffect, useState } from "react";
 
 import _partition from "lodash/partition";
 
@@ -17,13 +17,14 @@ import { SearchField } from "components/table/SearchField";
 import { Toggler } from "components/toggler";
 import { DEPRECATED_onClick } from "components/utils";
 
+import { Cancelable } from "utils/functions";
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
 import Network from "utils/network";
 
 import { SetupHeader } from "../setup-header";
 import { getProductSelectionState } from "./product-check/product-selection.utils";
 import { ProductCheck } from "./product-check/ProductCheck";
-import { searchCriteriaInExtension } from "./products.utils";
+import { isProductRequestCancellation, searchCriteriaInExtension } from "./products.utils";
 import { SCCDialog } from "./products-scc-dialog";
 
 declare global {
@@ -97,11 +98,20 @@ class ProductsPageWrapperState {
  */
 class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPageWrapperState> {
   state = new ProductsPageWrapperState();
+  private metadataRequest?: Cancelable;
+  private productsRequest?: Cancelable;
+  private isUnmounted = false;
 
   UNSAFE_componentWillMount() {
     if (!this.state.refreshRunning) {
       this.refreshServerData();
     }
+  }
+
+  componentWillUnmount() {
+    this.isUnmounted = true;
+    this.metadataRequest?.cancel();
+    this.productsRequest?.cancel();
   }
 
   forceStartSccSync = () => {
@@ -114,10 +124,22 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
   };
 
   refreshServerData = () => {
+    if (this.isUnmounted) {
+      return;
+    }
+
     this.setState({ loading: true });
 
-    loadMetadata()
+    this.metadataRequest?.cancel();
+    this.productsRequest?.cancel();
+
+    const metadataRequest = loadMetadata();
+    this.metadataRequest = metadataRequest;
+    metadataRequest
       .then((metadata) => {
+        if (this.isUnmounted || this.metadataRequest !== metadataRequest) {
+          return;
+        }
         this.setState({
           issMaster: metadata.issMaster,
           refreshNeeded: metadata.refreshNeeded,
@@ -142,8 +164,13 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
       })
       .catch(this.handleResponseError);
 
-    reloadData()
+    const productsRequest = reloadData();
+    this.productsRequest = productsRequest;
+    productsRequest
       .then((data) => {
+        if (this.isUnmounted || this.productsRequest !== productsRequest) {
+          return;
+        }
         this.setState({
           serverData: data[_DATA_ROOT_ID],
           loading: false,
@@ -197,6 +224,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
       this.state.selectedItems.map((i) => i.identifier)
     )
       .then((data) => {
+        if (this.isUnmounted) {
+          return;
+        }
         // returned data format is { productId : "error" }. If the value is null or missing the operation succeeded
         const failedProducts = this.state.selectedItems.filter(
           (i) => !DEPRECATED_unsafeEquals(data[i.identifier], null)
@@ -207,9 +237,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
         } else {
           resultMessages = MessagesUtils.warning(
             failedProducts.map((a) => (
-              <>
+              <Fragment key={a.identifier}>
                 {a.label}: {data[a.identifier]}
-              </>
+              </Fragment>
             )),
             true,
             t("The following product installations failed. Please check log files.")
@@ -231,6 +261,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
 
       Network.post("/rhn/manager/admin/setup/products", [id])
         .then((data) => {
+          if (this.isUnmounted) {
+            return;
+          }
           // if the id is not present in the response or it is null, the operation went fine.
           if (DEPRECATED_unsafeEquals(data[id], null)) {
             this.setState((innerPrevState) => ({
@@ -255,6 +288,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
     this.setState({ addingProducts: true, errors: [] });
     Network.post("/rhn/manager/admin/setup/channels/optional", channels)
       .then((data) => {
+        if (this.isUnmounted) {
+          return;
+        }
         // returned data format is { channel : "error" }. If the value is null or missing the operation succeeded
         const failedChannels = channels.filter((c) => !DEPRECATED_unsafeEquals(data[c], null));
         let resultMessages: MessageType[] | null = null;
@@ -263,9 +299,9 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
         } else {
           resultMessages = MessagesUtils.warning(
             failedChannels.map((c) => (
-              <>
+              <Fragment key={c}>
                 {c}: {data[c]}
-              </>
+              </Fragment>
             )),
             true,
             t('The following channel installations for "{product}" failed. Please check log files.', { product })
@@ -281,7 +317,11 @@ class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPa
       .catch(this.handleResponseError);
   };
 
-  handleResponseError = (jqXHR: JQueryXHR, arg = {}) => {
+  handleResponseError = (jqXHR: JQueryXHR | Error | undefined, arg = {}) => {
+    if (this.isUnmounted || isProductRequestCancellation(jqXHR)) {
+      return;
+    }
+
     this.setState((prevState) => {
       const msg = Network.responseErrorMessage(jqXHR, (status, msg) =>
         messageMap[msg] ? t(messageMap[msg], arg) : null

--- a/web/html/src/manager/admin/setup/products/products.utils.ts
+++ b/web/html/src/manager/admin/setup/products/products.utils.ts
@@ -22,3 +22,7 @@ export function searchCriteriaInExtension(baseExtension: any, criteria?: string)
   }
   return true;
 }
+
+export function isProductRequestCancellation(error: JQueryXHR | Error | undefined): error is undefined {
+  return !error;
+}

--- a/web/html/src/manager/admin/setup/products/products.utils.ts
+++ b/web/html/src/manager/admin/setup/products/products.utils.ts
@@ -24,5 +24,5 @@ export function searchCriteriaInExtension(baseExtension: any, criteria?: string)
 }
 
 export function isProductRequestCancellation(error: JQueryXHR | Error | undefined): error is undefined {
-  return !error;
+  return error === undefined;
 }

--- a/web/spacewalk-web.changes.emaksy.products-request-lifecycle
+++ b/web/spacewalk-web.changes.emaksy.products-request-lifecycle
@@ -1,0 +1,1 @@
+- Cancel stale product requests during page navigation.


### PR DESCRIPTION
## What does this PR change?

This PR improves lifecycle handling for the product-list and metadata GET
requests on the Admin Setup Products page:

- Cancels superseded product-list and metadata requests.
- Cancels those pending GET requests when `ProductsPageWrapper` unmounts.
- Ignores responses and failures from requests that are no longer current.
- Prevents `ProductsPageWrapper` from updating its state after navigation.

This prevents the following client-side errors for those requests:

```text
Warning: Can't perform a React state update on an unmounted component.
TypeError: Cannot read properties of undefined (reading 'status')
```

Only the undefined rejection produced by request cancellation is ignored.
The SCC refresh and other mutation POST workflows are not changed.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni) [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: this only changes the internal lifecycle of
  frontend requests and does not change user-facing behavior.

- [x] **DONE**

## Test coverage

- Unit tests cover cancellation-error classification and ensure that HTTP status 0 is not mistaken for request cancellation.


- [x] **DONE**

## Links

Issue(s): Combined pr https://github.com/uyuni-project/uyuni/pull/12282
Port(s): N/A

- [x] **DONE**

## Changelogs

Added `web/spacewalk-web.changes.emaksy.products-request-lifecycle`.

- [ ] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
