### PR TITLE
Clean up SSM WebSocket connections on unmount

### DIFF
--- a/web/html/src/manager/shared/websocket/useWebSocket.test.tsx
+++ b/web/html/src/manager/shared/websocket/useWebSocket.test.tsx
@@ -1,0 +1,113 @@
+import { type Dispatch, type SetStateAction } from "react";
+
+import { render } from "utils/test-utils";
+
+import { useWebSocket } from "./useWebSocket";
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  onopen: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  send = jest.fn();
+  close = jest.fn(() => this.onclose?.(new CloseEvent("close")));
+
+  constructor(url: string | URL) {
+    this.url = url.toString();
+    MockWebSocket.instances.push(this);
+  }
+}
+
+type TestComponentProps = {
+  callback: (value: number) => void;
+  setErrors: Dispatch<SetStateAction<string[]>>;
+};
+
+function TestComponent({ callback, setErrors }: TestComponentProps) {
+  useWebSocket([], setErrors, "ssm-count", callback);
+  return null;
+}
+
+describe("useWebSocket", () => {
+  const originalWebSocket = window.WebSocket;
+
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    window.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    window.WebSocket = originalWebSocket;
+  });
+
+  function getSocket() {
+    expect(MockWebSocket.instances).toHaveLength(1);
+    return MockWebSocket.instances[0];
+  }
+
+  test("subscribes to the requested property when connected", () => {
+    const setErrors = jest.fn();
+    render(<TestComponent callback={jest.fn()} setErrors={setErrors} />);
+
+    const socket = getSocket();
+    socket.onopen?.(new Event("open"));
+
+    expect(socket.send).toHaveBeenCalledWith("[ssm-count]");
+  });
+
+  test("closes and detaches the socket without reporting an error on unmount", () => {
+    const setErrors = jest.fn();
+    const removeEventListener = jest.spyOn(window, "removeEventListener");
+    const { unmount } = render(<TestComponent callback={jest.fn()} setErrors={setErrors} />);
+    const socket = getSocket();
+
+    unmount();
+
+    expect(removeEventListener).toHaveBeenCalledWith("beforeunload", expect.any(Function));
+    expect(socket.close).toHaveBeenCalledTimes(1);
+    expect(socket.onopen).toBeNull();
+    expect(socket.onclose).toBeNull();
+    expect(socket.onerror).toBeNull();
+    expect(socket.onmessage).toBeNull();
+    expect(setErrors).not.toHaveBeenCalled();
+  });
+
+  test("reports an unexpected connection close", () => {
+    const setErrors = jest.fn();
+    render(<TestComponent callback={jest.fn()} setErrors={setErrors} />);
+
+    getSocket().onclose?.(new CloseEvent("close"));
+
+    expect(setErrors).toHaveBeenCalledTimes(1);
+    const updateErrors = setErrors.mock.calls[0][0] as (currentErrors: string[]) => string[];
+    const updatedErrors = updateErrors(["Existing error"]);
+    expect(updatedErrors[0]).toBe("Existing error");
+    expect(updatedErrors[1]).toContain("Websocket connection closed");
+  });
+
+  test("uses the latest callback without reconnecting", () => {
+    const firstCallback = jest.fn();
+    const latestCallback = jest.fn();
+    const setErrors = jest.fn();
+    const { rerender } = render(<TestComponent callback={firstCallback} setErrors={setErrors} />);
+    const socket = getSocket();
+
+    rerender(<TestComponent callback={latestCallback} setErrors={setErrors} />);
+    socket.onmessage?.(
+      new MessageEvent("message", {
+        data: JSON.stringify({ "ssm-count": 7 }),
+      })
+    );
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(firstCallback).not.toHaveBeenCalled();
+    expect(latestCallback).toHaveBeenCalledWith(7);
+  });
+});

--- a/web/html/src/manager/shared/websocket/useWebSocket.test.tsx
+++ b/web/html/src/manager/shared/websocket/useWebSocket.test.tsx
@@ -22,12 +22,15 @@ class MockWebSocket {
 }
 
 type TestComponentProps = {
-  callback: (value: number) => void;
+  callback?: (value: number) => void;
+  property?: string;
   setErrors: Dispatch<SetStateAction<string[]>>;
 };
 
-function TestComponent({ callback, setErrors }: TestComponentProps) {
-  useWebSocket([], setErrors, "ssm-count", callback);
+const noop = () => undefined;
+
+function TestComponent({ callback = noop, property = "ssm-count", setErrors }: TestComponentProps) {
+  useWebSocket([], setErrors, property, callback);
   return null;
 }
 
@@ -54,7 +57,7 @@ describe("useWebSocket", () => {
 
   test("subscribes to the requested property when connected", () => {
     const setErrors = jest.fn();
-    render(<TestComponent callback={jest.fn()} setErrors={setErrors} />);
+    render(<TestComponent setErrors={setErrors} />);
 
     const socket = getSocket();
     socket.onopen?.(new Event("open"));
@@ -65,10 +68,12 @@ describe("useWebSocket", () => {
   test("closes and detaches the socket without reporting an error on unmount", () => {
     const setErrors = jest.fn();
     const removeEventListener = jest.spyOn(window, "removeEventListener");
-    const { unmount } = render(<TestComponent callback={jest.fn()} setErrors={setErrors} />);
+    const { unmount } = render(<TestComponent setErrors={setErrors} />);
     const socket = getSocket();
+    const pendingCloseHandler = socket.onclose;
 
     unmount();
+    pendingCloseHandler?.(new CloseEvent("close"));
 
     expect(removeEventListener).toHaveBeenCalledWith("beforeunload", expect.any(Function));
     expect(socket.close).toHaveBeenCalledTimes(1);
@@ -81,7 +86,7 @@ describe("useWebSocket", () => {
 
   test("reports an unexpected connection close", () => {
     const setErrors = jest.fn();
-    render(<TestComponent callback={jest.fn()} setErrors={setErrors} />);
+    render(<TestComponent setErrors={setErrors} />);
 
     getSocket().onclose?.(new CloseEvent("close"));
 
@@ -90,6 +95,52 @@ describe("useWebSocket", () => {
     const updatedErrors = updateErrors(["Existing error"]);
     expect(updatedErrors[0]).toBe("Existing error");
     expect(updatedErrors[1]).toContain("Websocket connection closed");
+  });
+
+  test("does not report a second error when an errored connection closes", () => {
+    const setErrors = jest.fn();
+    render(<TestComponent setErrors={setErrors} />);
+    const socket = getSocket();
+
+    socket.onerror?.(new Event("error"));
+    socket.onclose?.(new CloseEvent("close"));
+
+    expect(setErrors).toHaveBeenCalledTimes(1);
+    expect(setErrors).toHaveBeenCalledWith([expect.stringContaining("Error connecting to server")]);
+  });
+
+  test("does not report a close while the page is unloading", () => {
+    const setErrors = jest.fn();
+    render(<TestComponent setErrors={setErrors} />);
+
+    window.dispatchEvent(new Event("beforeunload"));
+    getSocket().onclose?.(new CloseEvent("close"));
+
+    expect(setErrors).not.toHaveBeenCalled();
+  });
+
+  test("reports a close for a new subscription after the previous connection errored", () => {
+    const setErrors = jest.fn();
+    const { rerender } = render(<TestComponent property="ssm-count" setErrors={setErrors} />);
+
+    MockWebSocket.instances[0].onerror?.(new Event("error"));
+    rerender(<TestComponent property="other-property" setErrors={setErrors} />);
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+    MockWebSocket.instances[1].onclose?.(new CloseEvent("close"));
+    expect(setErrors).toHaveBeenCalledTimes(2);
+  });
+
+  test("reports a close for a new subscription after the previous page started unloading", () => {
+    const setErrors = jest.fn();
+    const { rerender } = render(<TestComponent property="ssm-count" setErrors={setErrors} />);
+
+    window.dispatchEvent(new Event("beforeunload"));
+    rerender(<TestComponent property="other-property" setErrors={setErrors} />);
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+    MockWebSocket.instances[1].onclose?.(new CloseEvent("close"));
+    expect(setErrors).toHaveBeenCalledTimes(1);
   });
 
   test("uses the latest callback without reconnecting", () => {

--- a/web/html/src/manager/shared/websocket/useWebSocket.ts
+++ b/web/html/src/manager/shared/websocket/useWebSocket.ts
@@ -1,22 +1,28 @@
-import { useEffect, useState } from "react";
+import { type Dispatch, type SetStateAction, useEffect, useRef } from "react";
 
 export function useWebSocket(
   errors: string[],
-  setErrors: (...args: any[]) => any,
+  setErrors: Dispatch<SetStateAction<string[]>>,
   property: string,
   callback: (value: any) => void
 ) {
-  const [webSocketErr, setWebSocketErr] = useState(false);
-  const [pageUnloading, setPageUnloading] = useState(false);
+  const callbackRef = useRef(callback);
+  const errorsRef = useRef(errors);
+  const pageUnloadingRef = useRef(false);
+  const webSocketErrRef = useRef(false);
 
-  const onBeforeUnload = () => {
-    setPageUnloading(true);
-  };
+  callbackRef.current = callback;
+  errorsRef.current = errors;
 
   useEffect(() => {
+    let closedByCleanup = false;
     const { port } = window.location;
     const url = `wss://${window.location.hostname}${port ? `:${port}` : ""}/rhn/websocket/notifications`;
     const ws = new WebSocket(url);
+
+    const onBeforeUnload = () => {
+      pageUnloadingRef.current = true;
+    };
 
     ws.onopen = () => {
       // Tell the websocket what we want to hear about
@@ -24,29 +30,38 @@ export function useWebSocket(
     };
 
     ws.onclose = () => {
-      setErrors(
-        (errors || []).concat(
-          !pageUnloading && !webSocketErr ? t("Websocket connection closed. Refresh the page to try again.") : []
-        )
-      );
+      if (!closedByCleanup && !pageUnloadingRef.current && !webSocketErrRef.current) {
+        setErrors((currentErrors) =>
+          (currentErrors || errorsRef.current || []).concat(
+            t("Websocket connection closed. Refresh the page to try again.")
+          )
+        );
+      }
     };
 
     ws.onerror = () => {
-      setErrors([t("Error connecting to server. Refresh the page to try again.")]);
-      setWebSocketErr(true);
+      if (!closedByCleanup) {
+        webSocketErrRef.current = true;
+        setErrors([t("Error connecting to server. Refresh the page to try again.")]);
+      }
     };
 
     ws.onmessage = (e) => {
-      if (typeof e.data === "string") {
+      if (!closedByCleanup && typeof e.data === "string") {
         const data = JSON.parse(e.data);
-        callback(data[property]);
+        callbackRef.current(data[property]);
       }
     };
 
     window.addEventListener("beforeunload", onBeforeUnload);
 
     return () => {
+      closedByCleanup = true;
       window.removeEventListener("beforeunload", onBeforeUnload);
+      ws.onopen = null;
+      ws.onclose = null;
+      ws.onerror = null;
+      ws.onmessage = null;
       ws.close();
     };
   }, [property]);

--- a/web/html/src/manager/shared/websocket/useWebSocket.ts
+++ b/web/html/src/manager/shared/websocket/useWebSocket.ts
@@ -8,20 +8,21 @@ export function useWebSocket(
 ) {
   const callbackRef = useRef(callback);
   const errorsRef = useRef(errors);
-  const pageUnloadingRef = useRef(false);
-  const webSocketErrRef = useRef(false);
 
   callbackRef.current = callback;
   errorsRef.current = errors;
 
   useEffect(() => {
     let closedByCleanup = false;
+    let pageUnloading = false;
+    let webSocketErr = false;
+
     const { port } = window.location;
     const url = `wss://${window.location.hostname}${port ? `:${port}` : ""}/rhn/websocket/notifications`;
     const ws = new WebSocket(url);
 
     const onBeforeUnload = () => {
-      pageUnloadingRef.current = true;
+      pageUnloading = true;
     };
 
     ws.onopen = () => {
@@ -30,7 +31,7 @@ export function useWebSocket(
     };
 
     ws.onclose = () => {
-      if (!closedByCleanup && !pageUnloadingRef.current && !webSocketErrRef.current) {
+      if (!closedByCleanup && !pageUnloading && !webSocketErr) {
         setErrors((currentErrors) =>
           (currentErrors || errorsRef.current || []).concat(
             t("Websocket connection closed. Refresh the page to try again.")
@@ -41,7 +42,7 @@ export function useWebSocket(
 
     ws.onerror = () => {
       if (!closedByCleanup) {
-        webSocketErrRef.current = true;
+        webSocketErr = true;
         setErrors([t("Error connecting to server. Refresh the page to try again.")]);
       }
     };
@@ -58,6 +59,7 @@ export function useWebSocket(
     return () => {
       closedByCleanup = true;
       window.removeEventListener("beforeunload", onBeforeUnload);
+      // Detach handlers before closing to prevent events from updating state after unmount.
       ws.onopen = null;
       ws.onclose = null;
       ws.onerror = null;

--- a/web/html/src/manager/systems/ssm/ssm-counter.tsx
+++ b/web/html/src/manager/systems/ssm/ssm-counter.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export function SsmCounter(props: Props) {
   const [count, setCount] = useState(props.count ?? 0);
-  const [errors, setErrors] = useState([]);
+  const [errors, setErrors] = useState<string[]>([]);
   useWebSocket(errors, setErrors, "ssm-count", (value: number) => {
     setCount(value);
   });

--- a/web/spacewalk-web.changes.emaksy.ssm-websocket-cleanup
+++ b/web/spacewalk-web.changes.emaksy.ssm-websocket-cleanup
@@ -1,0 +1,1 @@
+- Clean up SSM WebSocket connections when leaving the page.


### PR DESCRIPTION
## What does this PR change?

This PR fixes the lifecycle handling of the WebSocket used by the SSM
counter:

Fixed error:
```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function. in SsmCounter 
```

- Closes the WebSocket when the component is unmounted.
- Removes WebSocket handlers and the `beforeunload` listener during
  cleanup.
- Does not report an expected cleanup as a connection failure.
- Continues to report unexpected connection and close errors.
- Uses the latest callback without reconnecting after every render.
- Resets connection-error tracking when a new subscription is created.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni) [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: this only changes internal WebSocket lifecycle
  handling and does not change the user workflow.

- [x] **DONE**

## Test coverage

- Unit tests cover subscription, expected cleanup, unexpected connection
  closure, callback updates, and new subscriptions after an error.
- TypeScript and production lint checks pass.

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/pull/12282
Port(s): N/A

- [x] **DONE**

## Changelogs

Added `web/spacewalk-web.changes.emaksy.ssm-websocket-cleanup`.

- [ ] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
