### PR TITLE
Prevent duplicate ranking form submissions

### DIFF
--- a/java/spacewalk-java.changes.emaksy.rank-options
+++ b/java/spacewalk-java.changes.emaksy.rank-options
@@ -1,0 +1,1 @@
+- Align kickstart script ranking handler arguments.

--- a/java/webapp/src/main/webapp/WEB-INF/pages/activationkeys/configuration/rank.jsp
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/activationkeys/configuration/rank.jsp
@@ -44,7 +44,7 @@
                     <button type="submit" name="dispatcher"
                            role="button"
                            class="btn btn-primary"
-                           onclick="handle_ranking_dispatch('ranksWidget','rankedValues','channelRanksForm');">
+                           onclick="handle_ranking_dispatch('ranksWidget','rankedValues');">
                            ${rhn:localize('sdc.config.rank.jsp.update')}
                     </button>
                 </div>

--- a/java/webapp/src/main/webapp/WEB-INF/pages/activationkeys/configuration/rank.jsp
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/activationkeys/configuration/rank.jsp
@@ -44,7 +44,7 @@
                     <button type="submit" name="dispatcher"
                            role="button"
                            class="btn btn-primary"
-                           onclick="handle_ranking_dispatch('ranksWidget','rankedValues');">
+                           onclick="return handle_ranking_dispatch('ranksWidget','rankedValues');">
                            ${rhn:localize('sdc.config.rank.jsp.update')}
                     </button>
                 </div>

--- a/java/webapp/src/main/webapp/WEB-INF/pages/configuration/sdc/rankchannels.jsp
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/configuration/sdc/rankchannels.jsp
@@ -40,7 +40,7 @@
                 <div class="col-lg-offset-3 offset-lg-3 col-lg-6">
                     <html:hidden property="dispatch" value="${rhn:localize('sdc.config.rank.jsp.update')}"/>
                     <button type="submit" name="dispatcher" class="btn btn-primary"
-                        onclick="handle_ranking_dispatch('ranksWidget','rankedValues','channelRanksForm');">
+                        onclick="handle_ranking_dispatch('ranksWidget','rankedValues');">
                         ${rhn:localize('sdc.config.rank.jsp.update')}
                     </button>
                 </div>

--- a/java/webapp/src/main/webapp/WEB-INF/pages/configuration/sdc/rankchannels.jsp
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/configuration/sdc/rankchannels.jsp
@@ -40,7 +40,7 @@
                 <div class="col-lg-offset-3 offset-lg-3 col-lg-6">
                     <html:hidden property="dispatch" value="${rhn:localize('sdc.config.rank.jsp.update')}"/>
                     <button type="submit" name="dispatcher" class="btn btn-primary"
-                        onclick="handle_ranking_dispatch('ranksWidget','rankedValues');">
+                        onclick="return handle_ranking_dispatch('ranksWidget','rankedValues');">
                         ${rhn:localize('sdc.config.rank.jsp.update')}
                     </button>
                 </div>

--- a/java/webapp/src/main/webapp/WEB-INF/pages/configuration/ssm/rankchannels.jsp
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/configuration/ssm/rankchannels.jsp
@@ -52,7 +52,7 @@
       <hr />
       <html:hidden property="dispatch" value="${rhn:localize('ssm.config.rank.jsp.apply')}"/>
       <button type="submit" name="dispatcher" class="btn btn-default"
-        onclick="handle_ranking_dispatch('ranksWidget','rankedValues','channelRanksForm');">
+        onclick="handle_ranking_dispatch('ranksWidget','rankedValues');">
         ${rhn:localize('ssm.config.rank.jsp.apply')}
       </button>
     </div>

--- a/java/webapp/src/main/webapp/WEB-INF/pages/configuration/ssm/rankchannels.jsp
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/configuration/ssm/rankchannels.jsp
@@ -52,7 +52,7 @@
       <hr />
       <html:hidden property="dispatch" value="${rhn:localize('ssm.config.rank.jsp.apply')}"/>
       <button type="submit" name="dispatcher" class="btn btn-default"
-        onclick="handle_ranking_dispatch('ranksWidget','rankedValues');">
+        onclick="return handle_ranking_dispatch('ranksWidget','rankedValues');">
         ${rhn:localize('ssm.config.rank.jsp.apply')}
       </button>
     </div>

--- a/java/webapp/src/main/webapp/WEB-INF/pages/kickstart/scriptorder.jsp
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/kickstart/scriptorder.jsp
@@ -127,7 +127,7 @@
       <html:hidden name="kickstartScriptOrderForm" property="rankedPostValues" styleId="rankedPostValues"/>
       <div align="right">
             <button type="submit" name="dispatcher" class="btn btn-primary"
-                   onclick="handle_ranking('preRanksWidget','rankedPreValues','kickstartScriptOrderForm'); handle_ranking_dispatch('postRanksWidget','rankedPostValues','kickstartScriptOrderForm');">
+                   onclick="handle_ranking('preRanksWidget','rankedPreValues'); handle_ranking_dispatch('postRanksWidget','rankedPostValues');">
                    ${rhn:localize('kickstartscript.order.update')}
             </button>
       </div>

--- a/java/webapp/src/main/webapp/WEB-INF/pages/kickstart/scriptorder.jsp
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/kickstart/scriptorder.jsp
@@ -127,7 +127,7 @@
       <html:hidden name="kickstartScriptOrderForm" property="rankedPostValues" styleId="rankedPostValues"/>
       <div align="right">
             <button type="submit" name="dispatcher" class="btn btn-primary"
-                   onclick="handle_ranking('preRanksWidget','rankedPreValues'); handle_ranking_dispatch('postRanksWidget','rankedPostValues');">
+                   onclick="return handle_ranking('preRanksWidget','rankedPreValues') &amp;&amp; handle_ranking_dispatch('postRanksWidget','rankedPostValues');">
                    ${rhn:localize('kickstartscript.order.update')}
             </button>
       </div>

--- a/web/html/javascript/rank_options.js
+++ b/web/html/javascript/rank_options.js
@@ -23,12 +23,11 @@ to asynchronously post to the channel rankings update page.
 */
 
 function move_selected_up(rankingWidgetName) {
-   return move_selected(rankingWidgetName, true);
+  return move_selected(rankingWidgetName, true);
 }
 function move_selected_down(rankingWidgetName) {
-   return move_selected(rankingWidgetName, false);
+  return move_selected(rankingWidgetName, false);
 }
-
 
 /**
 This function gets called when the 'up'/'down' button/arrow/image is pressed.
@@ -44,25 +43,27 @@ saving to a set etc..)..
                 (up if true, down if false).
 */
 function move_selected(rankingWidgetName, moveUp) {
+  let element = document.getElementById(rankingWidgetName);
+  let index = element.selectedIndex;
+  if (index > -1) {
+    let selected = element.options[index];
+    if ((moveUp && index > 0) || (!moveUp && index < element.options.length - 1)) {
+      let moveToIndex = index - 1;
+      if (!moveUp) {
+        moveToIndex = index + 1;
+      }
 
-    var element = document.getElementById(rankingWidgetName);    
-    var index = element.selectedIndex;
-    if (index > -1) {
-         var selected = element.options[index];
-        if ((moveUp && index > 0) || 
-                    (!moveUp && index < element.options.length - 1)) {
-            moveToIndex = index - 1;
-            if (!moveUp) {
-                moveToIndex = index + 1;
-            }
-
-            element.options[index] = new Option(element.options[moveToIndex].text,
-                                     element.options[moveToIndex].value, false, false);
-            element.options[moveToIndex] = selected;
-        }
-   }
-   // return false so that a form submit doesnot happen
-   return false;
+      element.options[index] = new Option(
+        element.options[moveToIndex].text,
+        element.options[moveToIndex].value,
+        false,
+        false
+      );
+      element.options[moveToIndex] = selected;
+    }
+  }
+  // return false so that a form submit doesnot happen
+  return false;
 }
 
 /**
@@ -70,39 +71,43 @@ This function should get called when a form submit action is clicked.
 Behaviour:
 1) Basically joins the values of the rankingWidgetElements into a comma separated string,
 2) Stores the value in the element provided by 'storerName'
-3) Does a form submit..
+3) Lets the submit button perform its native form submission.
 This comma separated magic is required for handling cases where the browser
 supports javascript but does not support ajax..
 @param rankingWidgetName the name of the ranking widget list box.
 @param storerName name of the element in whom the CS string will be stored
        ('rankedValues' in the case of SDC channel rankings)
-@param formName name of the form who has to be submitted.
 */
-function handle_ranking_dispatch (rankingWidgetName, storerName, formName) {
-    element = document.getElementById(rankingWidgetName);
-    storer = document.getElementById(storerName);
-    form = document.getElementById(formName);
-    storer.value = make_ranking_csv(rankingWidgetName);
-    form.submit();
-    return true;
+function handle_ranking_dispatch(rankingWidgetName, storerName) {
+  const element = document.getElementById(rankingWidgetName);
+  const storer = document.getElementById(storerName);
+  if (!element || !storer) {
+    return false;
+  }
+
+  storer.value = make_ranking_csv(rankingWidgetName);
+  return true;
 }
 
 /**
  * This function does the same thing that handle_ranking_dispatch does,
  * but without submitting the form. This is necessary so that you can submit
- * a form with more than one rankingWidget in it. The last rakingWidget should
- * call handle_config_channels_dispatch to submit the form.
+ * a form with more than one rankingWidget in it. The last rankingWidget should
+ * call handle_ranking_dispatch to submit the form.
  * @param rankingWidgetName the name of the ranking widget list box.
  * @param storerName name of the element in whom the CS string will be stored
  *        ('rankedValues' in the case of SDC channel rankings)
- * @param formName name of the form who has to be submitted.
  */
-function handle_ranking (rankingWidgetName, storerName, formName) {
-    element = document.getElementById(rankingWidgetName);
-    storer = document.getElementById(storerName);
-    form = document.getElementById(formName);
-    storer.value = make_ranking_csv(rankingWidgetName);
+function handle_ranking(rankingWidgetName, storerName) {
+  const element = document.getElementById(rankingWidgetName);
+  const storer = document.getElementById(storerName);
+
+  if (!element || !storer) {
     return false;
+  }
+
+  storer.value = make_ranking_csv(rankingWidgetName);
+  return false;
 }
 
 /**
@@ -111,10 +116,14 @@ This function binds the values of each element of a list box  ('listBox') in a c
 @return a comma separated list of list elements...
 */
 function make_ranking_csv(listBoxName) {
-    var values =  new Array();
-    var listBox  = document.getElementById(listBoxName);
-    for (var i = 0; i < listBox.options.length; i++) {
-        values.push(listBox.options[i].value);
-    }
-    return values.join(',');
+  const values = new Array();
+  const listBox = document.getElementById(listBoxName);
+  if (!listBox) {
+    return "";
+  }
+
+  for (let i = 0; i < listBox.options.length; i++) {
+    values.push(listBox.options[i].value);
+  }
+  return values.join(",");
 }

--- a/web/html/javascript/rank_options.js
+++ b/web/html/javascript/rank_options.js
@@ -111,7 +111,7 @@ function handle_ranking(rankingWidgetName, storerName) {
   }
 
   storer.value = make_ranking_csv(rankingWidgetName);
-  return false;
+  return true;
 }
 
 /**

--- a/web/html/javascript/rank_options.js
+++ b/web/html/javascript/rank_options.js
@@ -43,10 +43,14 @@ saving to a set etc..)..
                 (up if true, down if false).
 */
 function move_selected(rankingWidgetName, moveUp) {
-  let element = document.getElementById(rankingWidgetName);
-  let index = element.selectedIndex;
+  const element = document.getElementById(rankingWidgetName);
+  if (!element) {
+    return false;
+  }
+
+  const index = element.selectedIndex;
   if (index > -1) {
-    let selected = element.options[index];
+    const selected = element.options[index];
     if ((moveUp && index > 0) || (!moveUp && index < element.options.length - 1)) {
       let moveToIndex = index - 1;
       if (!moveUp) {

--- a/web/html/javascript/rank_options.js
+++ b/web/html/javascript/rank_options.js
@@ -66,7 +66,7 @@ function move_selected(rankingWidgetName, moveUp) {
       element.options[moveToIndex] = selected;
     }
   }
-  // return false so that a form submit doesnot happen
+  // Return false to prevent the move controls from submitting the form.
   return false;
 }
 
@@ -94,10 +94,9 @@ function handle_ranking_dispatch(rankingWidgetName, storerName) {
 }
 
 /**
- * This function does the same thing that handle_ranking_dispatch does,
- * but without submitting the form. This is necessary so that you can submit
- * a form with more than one rankingWidget in it. The last rankingWidget should
- * call handle_ranking_dispatch to submit the form.
+ * Populates an additional ranking value in forms containing multiple widgets.
+ * Combine the handlers in the button's onclick expression so the native
+ * submission proceeds only when all handlers return true.
  * @param rankingWidgetName the name of the ranking widget list box.
  * @param storerName name of the element in whom the CS string will be stored
  *        ('rankedValues' in the case of SDC channel rankings)

--- a/web/html/src/utils/rank-options.test.ts
+++ b/web/html/src/utils/rank-options.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+type RankingFunctions = {
+  handle_ranking: (rankingWidgetName: string, storerName: string) => boolean;
+  handle_ranking_dispatch: (rankingWidgetName: string, storerName: string) => boolean;
+};
+
+const rankingSource = readFileSync(resolve(__dirname, "../../javascript/rank_options.js"), "utf8");
+const loadRankingFunctions = new Function(
+  `${rankingSource}\nreturn { handle_ranking, handle_ranking_dispatch };`
+) as () => RankingFunctions;
+
+const { handle_ranking, handle_ranking_dispatch } = loadRankingFunctions();
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  jest.restoreAllMocks();
+});
+
+describe("rank options form submission", () => {
+  test("populates a ranking value and lets the form submit natively", () => {
+    document.body.innerHTML = `
+      <form>
+        <select id="ranksWidget">
+          <option value="first">First</option>
+          <option value="second">Second</option>
+        </select>
+        <input id="rankedValues">
+        <button type="submit">Submit</button>
+      </form>
+    `;
+
+    const form = document.querySelector("form") as HTMLFormElement;
+    const button = document.querySelector("button") as HTMLButtonElement;
+    const programmaticSubmit = jest.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(() => undefined);
+    let nativeSubmits = 0;
+
+    button.addEventListener("click", () => handle_ranking_dispatch("ranksWidget", "rankedValues"));
+    form.addEventListener("submit", (event) => {
+      nativeSubmits += 1;
+      event.preventDefault();
+    });
+
+    button.click();
+
+    expect(programmaticSubmit).not.toHaveBeenCalled();
+    expect(nativeSubmits).toBe(1);
+    expect((document.getElementById("rankedValues") as HTMLInputElement).value).toBe("first,second");
+  });
+
+  test("populates both kickstart rankings before one native submission", () => {
+    document.body.innerHTML = `
+      <form>
+        <select id="preRanksWidget">
+          <option value="pre-first">Pre first</option>
+          <option value="pre-second">Pre second</option>
+        </select>
+        <input id="rankedPreValues">
+        <select id="postRanksWidget">
+          <option value="post-first">Post first</option>
+          <option value="post-second">Post second</option>
+        </select>
+        <input id="rankedPostValues">
+        <button type="submit">Submit</button>
+      </form>
+    `;
+
+    const form = document.querySelector("form") as HTMLFormElement;
+    const button = document.querySelector("button") as HTMLButtonElement;
+    const programmaticSubmit = jest.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(() => undefined);
+    let nativeSubmits = 0;
+
+    button.addEventListener("click", () => {
+      handle_ranking("preRanksWidget", "rankedPreValues");
+      handle_ranking_dispatch("postRanksWidget", "rankedPostValues");
+    });
+    form.addEventListener("submit", (event) => {
+      nativeSubmits += 1;
+      event.preventDefault();
+    });
+
+    button.click();
+
+    expect(programmaticSubmit).not.toHaveBeenCalled();
+    expect(nativeSubmits).toBe(1);
+    expect((document.getElementById("rankedPreValues") as HTMLInputElement).value).toBe("pre-first,pre-second");
+    expect((document.getElementById("rankedPostValues") as HTMLInputElement).value).toBe("post-first,post-second");
+  });
+});

--- a/web/html/src/utils/rank-options.test.ts
+++ b/web/html/src/utils/rank-options.test.ts
@@ -5,14 +5,19 @@ import { resolve } from "path";
 type RankingFunctions = {
   handle_ranking: (rankingWidgetName: string, storerName: string) => boolean;
   handle_ranking_dispatch: (rankingWidgetName: string, storerName: string) => boolean;
+  move_selected: (rankingWidgetName: string, moveUp: boolean) => boolean;
 };
 
 const rankingSource = readFileSync(resolve(__dirname, "../../javascript/rank_options.js"), "utf8");
 const loadRankingFunctions = new Function(
-  `${rankingSource}\nreturn { handle_ranking, handle_ranking_dispatch };`
+  `${rankingSource}\nreturn { handle_ranking, handle_ranking_dispatch, move_selected };`
 ) as () => RankingFunctions;
 
-const { handle_ranking, handle_ranking_dispatch } = loadRankingFunctions();
+const { handle_ranking, handle_ranking_dispatch, move_selected } = loadRankingFunctions();
+const rankingHandlers = [
+  { name: "handle_ranking", handler: handle_ranking },
+  { name: "handle_ranking_dispatch", handler: handle_ranking_dispatch },
+];
 
 afterEach(() => {
   document.body.innerHTML = "";
@@ -87,5 +92,26 @@ describe("rank options form submission", () => {
     expect(nativeSubmits).toBe(1);
     expect((document.getElementById("rankedPreValues") as HTMLInputElement).value).toBe("pre-first,pre-second");
     expect((document.getElementById("rankedPostValues") as HTMLInputElement).value).toBe("post-first,post-second");
+  });
+
+  test.each(rankingHandlers)("$name does not throw when a ranking widget is missing", ({ handler }) => {
+    document.body.innerHTML = '<input id="rankedValues">';
+
+    expect(handler("missingRanksWidget", "rankedValues")).toBe(false);
+    expect((document.getElementById("rankedValues") as HTMLInputElement).value).toBe("");
+  });
+
+  test.each(rankingHandlers)("$name does not throw when a ranking value field is missing", ({ handler }) => {
+    document.body.innerHTML = `
+      <select id="ranksWidget">
+        <option value="first">First</option>
+      </select>
+    `;
+
+    expect(handler("ranksWidget", "missingRankedValues")).toBe(false);
+  });
+
+  test("does not throw when moving a missing ranking widget", () => {
+    expect(move_selected("missingRanksWidget", true)).toBe(false);
   });
 });

--- a/web/html/src/utils/rank-options.test.ts
+++ b/web/html/src/utils/rank-options.test.ts
@@ -14,10 +14,6 @@ const loadRankingFunctions = new Function(
 ) as () => RankingFunctions;
 
 const { handle_ranking, handle_ranking_dispatch, move_selected } = loadRankingFunctions();
-const rankingHandlers = [
-  { name: "handle_ranking", handler: handle_ranking },
-  { name: "handle_ranking_dispatch", handler: handle_ranking_dispatch },
-];
 
 afterEach(() => {
   document.body.innerHTML = "";
@@ -42,7 +38,7 @@ describe("rank options form submission", () => {
     const programmaticSubmit = jest.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(() => undefined);
     let nativeSubmits = 0;
 
-    button.addEventListener("click", () => handle_ranking_dispatch("ranksWidget", "rankedValues"));
+    button.onclick = () => handle_ranking_dispatch("ranksWidget", "rankedValues");
     form.addEventListener("submit", (event) => {
       nativeSubmits += 1;
       event.preventDefault();
@@ -77,10 +73,9 @@ describe("rank options form submission", () => {
     const programmaticSubmit = jest.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(() => undefined);
     let nativeSubmits = 0;
 
-    button.addEventListener("click", () => {
-      handle_ranking("preRanksWidget", "rankedPreValues");
+    button.onclick = () =>
+      handle_ranking("preRanksWidget", "rankedPreValues") &&
       handle_ranking_dispatch("postRanksWidget", "rankedPostValues");
-    });
     form.addEventListener("submit", (event) => {
       nativeSubmits += 1;
       event.preventDefault();
@@ -94,22 +89,60 @@ describe("rank options form submission", () => {
     expect((document.getElementById("rankedPostValues") as HTMLInputElement).value).toBe("post-first,post-second");
   });
 
-  test.each(rankingHandlers)("$name does not throw when a ranking widget is missing", ({ handler }) => {
-    document.body.innerHTML = '<input id="rankedValues">';
-
-    expect(handler("missingRanksWidget", "rankedValues")).toBe(false);
-    expect((document.getElementById("rankedValues") as HTMLInputElement).value).toBe("");
-  });
-
-  test.each(rankingHandlers)("$name does not throw when a ranking value field is missing", ({ handler }) => {
+  test.each([
+    { missingElement: "ranksWidget", markup: '<input id="rankedValues">' },
+    {
+      missingElement: "rankedValues",
+      markup: '<select id="ranksWidget"><option value="first">First</option></select>',
+    },
+  ])("cancels submission when $missingElement is missing", ({ markup }) => {
     document.body.innerHTML = `
-      <select id="ranksWidget">
-        <option value="first">First</option>
-      </select>
+      <form>
+        ${markup}
+        <button type="submit">Submit</button>
+      </form>
     `;
 
-    expect(handler("ranksWidget", "missingRankedValues")).toBe(false);
+    const form = document.querySelector("form") as HTMLFormElement;
+    const button = document.querySelector("button") as HTMLButtonElement;
+    const submitHandler = jest.fn((event: SubmitEvent) => event.preventDefault());
+
+    button.onclick = () => handle_ranking_dispatch("ranksWidget", "rankedValues");
+    form.addEventListener("submit", submitHandler);
+
+    button.click();
+
+    expect(submitHandler).not.toHaveBeenCalled();
   });
+
+  test.each(["preRanksWidget", "rankedPreValues", "postRanksWidget", "rankedPostValues"])(
+    "cancels kickstart submission when %s is missing",
+    (missingElement) => {
+      document.body.innerHTML = `
+        <form>
+          <select id="preRanksWidget"><option value="pre-first">Pre first</option></select>
+          <input id="rankedPreValues">
+          <select id="postRanksWidget"><option value="post-first">Post first</option></select>
+          <input id="rankedPostValues">
+          <button type="submit">Submit</button>
+        </form>
+      `;
+
+      const form = document.querySelector("form") as HTMLFormElement;
+      const button = document.querySelector("button") as HTMLButtonElement;
+      const submitHandler = jest.fn((event: SubmitEvent) => event.preventDefault());
+
+      document.getElementById(missingElement)?.remove();
+      button.onclick = () =>
+        handle_ranking("preRanksWidget", "rankedPreValues") &&
+        handle_ranking_dispatch("postRanksWidget", "rankedPostValues");
+      form.addEventListener("submit", submitHandler);
+
+      button.click();
+
+      expect(submitHandler).not.toHaveBeenCalled();
+    }
+  );
 
   test("does not throw when moving a missing ranking widget", () => {
     expect(move_selected("missingRanksWidget", true)).toBe(false);

--- a/web/spacewalk-web.changes.emaksy.rank-options
+++ b/web/spacewalk-web.changes.emaksy.rank-options
@@ -1,0 +1,1 @@
+- Submit ranking forms once using the native browser flow.


### PR DESCRIPTION
## What does this PR change?

This PR fixes JavaScript errors and duplicate submission handling in channel
and kickstart ranking forms.

Previously, the handlers attempted to resolve a Struts form name as a DOM ID
and call `form.submit()`, which could produce:

    Uncaught TypeError: Cannot read properties of null (reading 'submit')

It could also trigger both programmatic and native form submissions.

The changes:

- Populate hidden ranking fields before submission.
- Use the submit button’s native browser submission.
- Submit forms containing two ranking widgets only once.
- Cancel submission safely when required ranking elements are missing.
- Remove unused form-name arguments and DOM lookups.
- Update JSP handlers to use the simplified signatures.
- Add regression tests for successful and cancelled submissions.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni) [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: the form controls and user workflow remain
  unchanged.

- [x] **DONE**

## Test coverage

- Unit tests verify that ranking values are populated and that both
  single- and multi-ranking forms perform exactly one native submission.

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/pull/12282 combined pr
Port(s): N/A

- [x] **DONE**

## Changelogs

Added changelog entries for the `java` and `web` packages.

- [ ] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
