### PR TITLE
Move testsuite controller container to openSUSE Leap 16.0

### DIFF
--- a/testsuite/dockerfiles/controller-dev/Dockerfile
+++ b/testsuite/dockerfiles/controller-dev/Dockerfile
@@ -45,9 +45,15 @@ RUN echo 'GEM_PATH="/usr/lib64/ruby/gems/3.4.0"' >> ./root/.bashrc
 RUN ln -sf /usr/bin/ruby.ruby3.4 /usr/bin/ruby
 RUN ln -sf /usr/bin/gem.ruby3.4 /usr/bin/gem
 RUN ln -sf /usr/bin/irb.ruby3.4 /usr/bin/irb
-# On Leap 16 the ruby3.4 package already installs the unsuffixed defaults
-# (/usr/bin/{rake,bundle,rdoc,ri}) pointing to 3.4, and registers no
-# update-alternatives group, so no `update-alternatives --set` is needed.
+# On Leap 16 the default /usr/bin/{rake,bundle,rdoc,ri} are ELF wrappers, which
+# `ruby -S <name>` (used by the cucumber rake task, e.g. `ruby -S bundle exec
+# cucumber`) cannot parse as Ruby source. Point them at the actual Ruby scripts
+# (the *.ruby.ruby3.4 variants) so `ruby -S bundle`/`rake` work. ruby3.4 registers
+# no update-alternatives group (single Ruby), so use symlinks instead of --set.
+RUN ln -sf /usr/bin/rake.ruby.ruby3.4 /usr/bin/rake
+RUN ln -sf /usr/bin/bundle.ruby.ruby3.4 /usr/bin/bundle
+RUN ln -sf /usr/bin/rdoc.ruby.ruby3.4 /usr/bin/rdoc
+RUN ln -sf /usr/bin/ri.ruby.ruby3.4 /usr/bin/ri
 
 # debug
 RUN ruby -v

--- a/testsuite/dockerfiles/controller-dev/Dockerfile
+++ b/testsuite/dockerfiles/controller-dev/Dockerfile
@@ -4,14 +4,14 @@ RUN zypper -n ar -f --no-gpgcheck http://download.opensuse.org/repositories/deve
 
 RUN zypper ref -f && \
     zypper -n ar --no-gpgcheck http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/16.0/ tools && \
-    zypper -n install nmap tar gzip iputils \
+    zypper -n install tar gzip iputils \
       gcc \
       make \
       wget \
       ruby3.4 \
       ruby3.4-devel \
       ruby3.4-devel-extra \
-      python-devel \
+      python313-devel \
       autoconf \
       ca-certificates-mozilla \
       automake \
@@ -26,12 +26,13 @@ RUN zypper ref -f && \
       postgresql16-devel \
       chromium \
       libgbm-devel \
-      npm \
+      nodejs-default \
+      npm-default \
       openssh-server \
       openssh-clients \
       hostname \
       iproute2 \
-      vi \
+      vim \
       libssh4 \
       libssh-devel && \
     zypper -n clean -a

--- a/testsuite/dockerfiles/controller-dev/Dockerfile
+++ b/testsuite/dockerfiles/controller-dev/Dockerfile
@@ -23,7 +23,7 @@ RUN zypper ref -f && \
       zlib-devel \
       libxslt-devel \
       mozilla-nss-tools \
-      postgresql16-devel \
+      postgresql18-devel \
       chromium \
       libgbm-devel \
       nodejs-default \

--- a/testsuite/dockerfiles/controller-dev/Dockerfile
+++ b/testsuite/dockerfiles/controller-dev/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/opensuse/leap:16.0@sha256:f239b4819f4dd322d99509f1b5b14f2107bf238
 RUN zypper -n ar -f --no-gpgcheck http://download.opensuse.org/repositories/devel:/languages:/ruby/16.0/ ruby_devel
 
 RUN zypper ref -f && \
-    zypper -n ar --no-gpgcheck http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/16.0/ tools && \
+    zypper -n ar --no-gpgcheck http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_16.0/ tools && \
     zypper -n install tar gzip iputils \
       gcc \
       make \

--- a/testsuite/dockerfiles/controller-dev/Dockerfile
+++ b/testsuite/dockerfiles/controller-dev/Dockerfile
@@ -45,10 +45,9 @@ RUN echo 'GEM_PATH="/usr/lib64/ruby/gems/3.4.0"' >> ./root/.bashrc
 RUN ln -sf /usr/bin/ruby.ruby3.4 /usr/bin/ruby
 RUN ln -sf /usr/bin/gem.ruby3.4 /usr/bin/gem
 RUN ln -sf /usr/bin/irb.ruby3.4 /usr/bin/irb
-RUN update-alternatives --set rake /usr/bin/rake.ruby.ruby3.4
-RUN update-alternatives --set bundle /usr/bin/bundle.ruby.ruby3.4
-RUN update-alternatives --set rdoc /usr/bin/rdoc.ruby.ruby3.4
-RUN update-alternatives --set ri /usr/bin/ri.ruby.ruby3.4
+# On Leap 16 the ruby3.4 package already installs the unsuffixed defaults
+# (/usr/bin/{rake,bundle,rdoc,ri}) pointing to 3.4, and registers no
+# update-alternatives group, so no `update-alternatives --set` is needed.
 
 # debug
 RUN ruby -v

--- a/testsuite/dockerfiles/controller-dev/Dockerfile
+++ b/testsuite/dockerfiles/controller-dev/Dockerfile
@@ -1,16 +1,16 @@
-FROM docker.io/opensuse/leap:15.6@sha256:b084d6e29d975ce9123fd52bd201ac020628797f2772e9171ef76f33cc92d591
+FROM docker.io/opensuse/leap:16.0@sha256:f239b4819f4dd322d99509f1b5b14f2107bf23857f9ccd3c14333f0928a2bcc6
 # Ruby 3 devel repos
-RUN zypper -n ar -f --no-gpgcheck http://download.opensuse.org/repositories/devel:/languages:/ruby/15.6/ ruby_devel
-RUN zypper -n ar -f --no-gpgcheck http://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/15.6/ rubey_devel_extensions
+RUN zypper -n ar -f --no-gpgcheck http://download.opensuse.org/repositories/devel:/languages:/ruby/16.0/ ruby_devel
 
 RUN zypper ref -f && \
-    zypper -n ar --no-gpgcheck http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.6/ tools && \
+    zypper -n ar --no-gpgcheck http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/16.0/ tools && \
     zypper -n install nmap tar gzip iputils \
       gcc \
       make \
       wget \
-      ruby3.3 \
-      ruby3.3-devel \
+      ruby3.4 \
+      ruby3.4-devel \
+      ruby3.4-devel-extra \
       python-devel \
       autoconf \
       ca-certificates-mozilla \
@@ -23,7 +23,7 @@ RUN zypper ref -f && \
       zlib-devel \
       libxslt-devel \
       mozilla-nss-tools \
-      postgresql14-devel \
+      postgresql16-devel \
       chromium \
       libgbm-devel \
       npm \
@@ -39,15 +39,15 @@ COPY etc_pam.d_sshd /etc/pam.d/sshd
 CMD ssh-keygen -A && /usr/sbin/sshd -De
 
 ### Ruby 3 changes ###
-RUN export GEM_PATH="/usr/lib64/ruby/gems/3.3.0"
-RUN echo 'GEM_PATH="/usr/lib64/ruby/gems/3.3.0"' >> ./root/.bashrc
-RUN ln -sf /usr/bin/ruby.ruby3.3 /usr/bin/ruby
-RUN ln -sf /usr/bin/gem.ruby3.3 /usr/bin/gem
-RUN ln -sf /usr/bin/irb.ruby3.3 /usr/bin/irb
-RUN update-alternatives --set rake /usr/bin/rake.ruby.ruby3.3
-RUN update-alternatives --set bundle /usr/bin/bundle.ruby.ruby3.3
-RUN update-alternatives --set rdoc /usr/bin/rdoc.ruby.ruby3.3
-RUN update-alternatives --set ri /usr/bin/ri.ruby.ruby3.3
+RUN export GEM_PATH="/usr/lib64/ruby/gems/3.4.0"
+RUN echo 'GEM_PATH="/usr/lib64/ruby/gems/3.4.0"' >> ./root/.bashrc
+RUN ln -sf /usr/bin/ruby.ruby3.4 /usr/bin/ruby
+RUN ln -sf /usr/bin/gem.ruby3.4 /usr/bin/gem
+RUN ln -sf /usr/bin/irb.ruby3.4 /usr/bin/irb
+RUN update-alternatives --set rake /usr/bin/rake.ruby.ruby3.4
+RUN update-alternatives --set bundle /usr/bin/bundle.ruby.ruby3.4
+RUN update-alternatives --set rdoc /usr/bin/rdoc.ruby.ruby3.4
+RUN update-alternatives --set ri /usr/bin/ri.ruby.ruby3.4
 
 # debug
 RUN ruby -v
@@ -63,5 +63,5 @@ RUN npm install -g playwright@${PLAYWRIGHT_VERSION} && \
 ENV PLAYWRIGHT_CLI_EXECUTABLE_PATH=/usr/local/bin/playwright
 
 ARG GEMFILE_BRANCH=master
-RUN curl https://raw.githubusercontent.com/uyuni-project/uyuni/${GEMFILE_BRANCH}/testsuite/Gemfile -o Gemfile && bundle.ruby3.3 install --verbose && rm Gemfile
+RUN curl https://raw.githubusercontent.com/uyuni-project/uyuni/${GEMFILE_BRANCH}/testsuite/Gemfile -o Gemfile && bundle.ruby3.4 install --verbose && rm Gemfile
 RUN gem list

--- a/testsuite/documentation/playwright-controller-setup.md
+++ b/testsuite/documentation/playwright-controller-setup.md
@@ -31,7 +31,7 @@ If you bump the gem, bump the npm package to the matching version.
 
 ## Dependencies to install on the controller
 
-1. **Ruby 3.3 + build deps** — already provisioned for the suite (`ruby3.3`, `ruby3.3-devel`, `gcc`, `make`, …).
+1. **Ruby 3.4 + build deps** — already provisioned for the suite (`ruby3.4`, `ruby3.4-devel`, `gcc`, `make`, …).
 2. **The gems** — `bundle install` against `testsuite/Gemfile` installs `capybara-playwright-driver` (and drops
    `selenium-webdriver`). No change to how gems are installed.
 3. **Node.js + npm** — package `npm-default` (already used by the suite for the HTML reporter).

--- a/testsuite/podman_runner/05_install_gems_in_controller.sh
+++ b/testsuite/podman_runner/05_install_gems_in_controller.sh
@@ -7,7 +7,7 @@ else
   PODMAN_CMD="sudo -i podman"
 fi
 
-$PODMAN_CMD exec controller bash --login -c 'export GEM_PATH="/usr/lib64/ruby/gems/3.3.0"'
-$PODMAN_CMD exec controller bash --login -c "cd /testsuite && bundle.ruby3.3 install --gemfile Gemfile --verbose"
-$PODMAN_CMD exec controller bash --login -c "cd /testsuite; bundle.ruby3.3 check || bundle.ruby3.3 install --gemfile Gemfile --verbose"
-$PODMAN_CMD exec controller bash --login -c "cd /testsuite; bundle.ruby3.3 check"
+$PODMAN_CMD exec controller bash --login -c 'export GEM_PATH="/usr/lib64/ruby/gems/3.4.0"'
+$PODMAN_CMD exec controller bash --login -c "cd /testsuite && bundle.ruby3.4 install --gemfile Gemfile --verbose"
+$PODMAN_CMD exec controller bash --login -c "cd /testsuite; bundle.ruby3.4 check || bundle.ruby3.4 install --gemfile Gemfile --verbose"
+$PODMAN_CMD exec controller bash --login -c "cd /testsuite; bundle.ruby3.4 check"


### PR DESCRIPTION
## What does this PR change?

Migrates the CI test-suite **controller** container (`testsuite/dockerfiles/controller-dev`) from openSUSE Leap 15.6 (EOL since April 2026) to openSUSE Leap 16.0.

Changes:
- Base image `opensuse/leap:15.6` → `opensuse/leap:16.0` (digest pinned).
- `devel:languages:ruby` repo repointed to `16.0/`; the `devel:languages:ruby:extensions` repo is removed (it has no 16.0 build — `ruby3.4-devel-extra` from the ruby repo covers it).
- `systemsmanagement:sumaform:tools` repo repointed to `16.0/` (Leap 16 dropped the `openSUSE_Leap_*` naming).
- Ruby `3.3` → `3.4` (packages, `GEM_PATH`, symlinks, update-alternatives, `bundle.ruby3.4`).
- `postgresql14-devel` → `postgresql16-devel`.

Part of migrating the test-suite controller host OS to Leap 16.0. Companion PRs: sumaform (controller VM image) and susemanager-ci (Uyuni Master controller node).

Note on `build_containers.yml`: the currently-failing `server-all-in-one-dev` container is fixed separately by #12120. For the full workflow to go green, both that PR and this one must land on master.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31270

- [x] **DONE**

## Changelogs

- [x] No changelog needed
