### PR TITLE
Add changelog entry escaping

### DIFF
--- a/.github/workflows/changelogs/changelogs.py
+++ b/.github/workflows/changelogs/changelogs.py
@@ -35,6 +35,7 @@ class RegexRules:
     WRONG_SPACING = re.compile(r"([.,;:])[^ \n]")
     VERSION_REGEX = re.compile(r"\b(?:v?(\d+\.\d+(\.\d+)?)(?:[-.][a-zA-Z0-9]+)?)\b")
     TRACKER_LIKE = re.compile(r".{2,5}#\d+")
+    QUOTED = re.compile(r"`[^`\n]*`|\"[^\"\n]*\"|(?<!\w)'[^'\n]*'(?!\w)")
 
     def __init__(self, tracker_filename: str = None):
         trackers = {}
@@ -419,15 +420,21 @@ class ChangelogValidator:
         )
         return self.extract_trackers(title_and_commits)
 
+    def mask_quoted(self, text: str) -> str:
+        return re.sub(self.regex.QUOTED, lambda m: "_" * len(m.group(0)), text)
+
     def validate_chlog_entry(
         self, entry: Entry, entries_in_file: list[Entry]
     ) -> list[Issue]:
         """Validate a single changelog entry"""
 
         issues = []
+        # Quoted text is not checked for capitalization and spacing
+        text = self.mask_quoted(entry.entry)
+
         # Test capitalization
-        if re.match(self.regex.WRONG_CAP_START, entry.entry) or re.search(
-            self.regex.WRONG_CAP_AFTER, entry.entry
+        if re.match(self.regex.WRONG_CAP_START, text) or re.search(
+            self.regex.WRONG_CAP_AFTER, text
         ):
             issues.append(
                 Issue(IssueType.WRONG_CAP, entry.file, entry.line, entry.end_line)
@@ -440,12 +447,12 @@ class ChangelogValidator:
             lambda ver_str, match: ver_str.start() <= match.start()
             and ver_str.end() >= match.end()
         )
-        for match in re.finditer(self.regex.WRONG_SPACING, entry.entry):
+        for match in re.finditer(self.regex.WRONG_SPACING, text):
             # Ignore if part of a version string
             if not any(
                 overlaps(ver_str, match)
                 for ver_str in re.finditer(
-                    self.regex.VERSION_REGEX, entry.entry[: match.end()]
+                    self.regex.VERSION_REGEX, text[: match.end()]
                 )
             ):
                 issues.append(

--- a/.github/workflows/changelogs/test_changelogs.py
+++ b/.github/workflows/changelogs/test_changelogs.py
@@ -268,6 +268,10 @@ def test_get_entry_obj_with_multiple_trackers(validator_with_trackers):
         "- This is a valid changelog entry\n",
         "- This is a valid\n  multiline changelog entry\n",
         "- This is an entry with a version-1.2.3 string\n",
+        "- This is an entry with an escaped `string.literal`\n",
+        '- This is an entry with an escaped "string.literal"\n',
+        "- This is an entry with an escaped 'string.literal'\n",
+        "- This is a `foo,bar`. It is valid\n",
     ],
 )
 # pylint: disable-next=redefined-outer-name
@@ -357,8 +361,20 @@ def test_validate_chlog_file_multiple_issues_and_entries(validator, chlog_file):
             IssueType.WRONG_CAP,
         ),
         (
+            "- This entry has wrong capitalization. right after a full stop\n",
+            IssueType.WRONG_CAP,
+        ),
+        (
             "- This entry does not have a space.After a full stop\n",
             IssueType.WRONG_SPACING,
+        ),
+        (
+            "- This entry escapes `this.entry, but not`.Right here\n",
+            IssueType.WRONG_SPACING,
+        ),
+        (
+            "- This entry escapes `this.entry` but not. right here\n",
+            IssueType.WRONG_CAP,
         ),
         ("- This entry does not have a space:After a colon\n", IssueType.WRONG_SPACING),
         (


### PR DESCRIPTION
## What does this PR change?

Allows escaping strings in changelog entries, like:
```
- Add `web.version.eol` setting to provide an end of life date
```
This would previously trip the changelog entry check.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
