### PR TITLE
mgr-libmod: fix issue building package due version inconsistency

### DIFF
--- a/susemanager-utils/mgr-libmod/mgr-libmod.changes.meaksh.master-fix-mgr-libmod
+++ b/susemanager-utils/mgr-libmod/mgr-libmod.changes.meaksh.master-fix-mgr-libmod
@@ -1,0 +1,1 @@
+- Fix issue setting the right package version

--- a/susemanager-utils/mgr-libmod/mgr-libmod.spec
+++ b/susemanager-utils/mgr-libmod/mgr-libmod.spec
@@ -50,8 +50,8 @@ mkdir -p %{buildroot}%{_bindir}
 cp -R scripts/* %{buildroot}%{_bindir}
 
 %files
-%{python3_sitelib}/mgr-libmod
-%{python3_sitelib}/mgr-libmod-%{version}*-info
+%{python3_sitelib}/mgrlibmod
+%{python3_sitelib}/mgrlibmod-%{version}*-info
 %{_bindir}/mgr-libmod
 %license LICENSE
 

--- a/susemanager-utils/mgr-libmod/setup.py
+++ b/susemanager-utils/mgr-libmod/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name="mgrlibmod",
-    version="5.2.1",
+    version="5.3.0",
     packages=[
         "mgrlibmod",
     ],


### PR DESCRIPTION
## What does this PR change?

This PR fixes small issue introduced after the refactor done by https://github.com/uyuni-project/uyuni/pull/12290, and also fixes small inconsistency between RPM version and Python lib version.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
