### PR TITLE
Wait for taskomatic in SaltReactor (bsc#1265472)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/reactor/SaltReactor.java
+++ b/java/core/src/main/java/com/suse/manager/reactor/SaltReactor.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.cloud.CloudPaygManager;
@@ -100,6 +101,11 @@ public class SaltReactor {
     // Indicate that the reactor has been stopped
     private volatile boolean isStopped = false;
 
+    // The thread that initializes the event stream connection asynchronously
+    private Thread initializerThread;
+
+    private TaskomaticApi taskomaticApi = new TaskomaticApi();
+
     /**
      * Processing salt events
      * @param saltApiIn instance to talk to salt
@@ -148,7 +154,49 @@ public class SaltReactor {
 
         MessageQueue.publish(new RefreshGeneratedSaltFilesEventMessage());
 
-        connectToEventStream();
+        startEventStreamAsynchronously();
+    }
+
+    /**
+     * Set the taskomatic api instance.
+     * @param taskomaticApiIn the taskomatic api
+     */
+    public void setTaskomaticApi(TaskomaticApi taskomaticApiIn) {
+        this.taskomaticApi = taskomaticApiIn;
+    }
+
+    /**
+     * Start the salt reactor connection asynchronously, waiting for Taskomatic to be responsive first.
+     */
+    private void startEventStreamAsynchronously() {
+        if (initializerThread != null && initializerThread.isAlive()) {
+            return;
+        }
+        initializerThread = new Thread(() -> {
+            int retries = 0;
+            while (!isStopped && !taskomaticApi.isRunning()) {
+                if (retries == 24) {
+                    LOG.error("Taskomatic API is not online after 2 minutes. Still waiting...");
+                }
+                else {
+                    LOG.info("Waiting for Taskomatic API to become online before connecting to the Salt event bus...");
+                }
+                try {
+                    Thread.sleep(5000L);
+                }
+                catch (InterruptedException e) {
+                    LOG.error("Interrupted while waiting for Taskomatic API to start", e);
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                retries++;
+            }
+            if (!isStopped) {
+                LOG.info("Taskomatic API is online. Connecting to the Salt event bus...");
+                connectToEventStream();
+            }
+        }, "salt-event-stream-initializer");
+        initializerThread.start();
     }
 
     /**
@@ -156,6 +204,9 @@ public class SaltReactor {
      */
     public void stop() {
         isStopped = true;
+        if (initializerThread != null) {
+            initializerThread.interrupt();
+        }
         if (eventStream != null) {
             eventStream.removeEventListener(listener);
             try {

--- a/java/core/src/test/java/com/suse/manager/reactor/SaltReactorTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/SaltReactorTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.taskomatic.TaskomaticApi;
+
+import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
+import com.suse.manager.utils.SaltUtils;
+import com.suse.manager.webui.services.SaltServerActionService;
+import com.suse.manager.webui.services.TestSaltApi;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.salt.netapi.event.EventStream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for {@link SaltReactor}.
+ */
+class SaltReactorTest {
+
+    @Test
+    void testAsynchronousStart() throws Exception {
+        // We will create a SaltReactor with dummy parameters.
+        // It should start the wait-thread asynchronously and not block.
+        SaltApi saltApi = null;
+        SystemQuery systemQuery = null;
+        SaltServerActionService saltServerActionService = null;
+        SaltUtils saltUtils = null;
+        CloudPaygManager paygMgr = null;
+        AttestationManager attestationMgr = null;
+
+        SaltReactor reactor = new SaltReactor(
+            saltApi,
+            systemQuery,
+            saltServerActionService,
+            saltUtils,
+            paygMgr,
+            attestationMgr
+        );
+
+        // Call start() - it should return immediately without blocking.
+        long startTime = System.currentTimeMillis();
+        reactor.start();
+        long duration = System.currentTimeMillis() - startTime;
+
+        // Since the check loop has a 5000ms delay, if it was synchronous, it would take >5000ms.
+        // If it's asynchronous, it will complete in less than 1000ms (typically a few ms).
+        assertTrue(duration < 2000, "start() took too long: " + duration + "ms");
+
+        // Verify that the background thread "salt-event-stream-initializer" is running or was created.
+        Thread waitThread = null;
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if ("salt-event-stream-initializer".equals(t.getName())) {
+                waitThread = t;
+                break;
+            }
+        }
+
+        assertNotNull(waitThread, "Asynchronous wait thread 'salt-event-stream-initializer' was not found");
+
+        // Stop the reactor, which should terminate the thread.
+        reactor.stop();
+
+        // Wait a brief moment for the thread to exit.
+        waitThread.join(3000);
+        assertTrue(!waitThread.isAlive(), "Background wait thread did not terminate after stopping the reactor");
+    }
+
+    @Test
+    void testAsynchronousStartWithRunningTaskomatic() throws Exception {
+        final boolean[] getEventStreamCalled = { false };
+
+        SaltApi saltApi = new TestSaltApi() {
+            @Override
+            public EventStream getEventStream() {
+                getEventStreamCalled[0] = true;
+                return null; // Return null to trigger NPE on listener addition and terminate the thread
+            }
+        };
+        SystemQuery systemQuery = null;
+        SaltServerActionService saltServerActionService = null;
+        SaltUtils saltUtils = null;
+        CloudPaygManager paygMgr = null;
+        AttestationManager attestationMgr = null;
+
+        SaltReactor reactor = new SaltReactor(
+            saltApi,
+            systemQuery,
+            saltServerActionService,
+            saltUtils,
+            paygMgr,
+            attestationMgr
+        );
+
+        // Inject mock TaskomaticApi that is already running
+        reactor.setTaskomaticApi(new TaskomaticApi() {
+            @Override
+            public boolean isRunning() {
+                return true;
+            }
+        });
+
+        // Call start() - it should immediately attempt connection
+        reactor.start();
+
+        // Verify that the background thread was created
+        Thread waitThread = null;
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if ("salt-event-stream-initializer".equals(t.getName())) {
+                waitThread = t;
+                break;
+            }
+        }
+
+        assertNotNull(waitThread, "Asynchronous wait thread 'salt-event-stream-initializer' was not found");
+
+        // Wait a brief moment for the thread to run and exit (either successfully or with NPE due to null SaltApi)
+        waitThread.join(3000);
+        assertTrue(!waitThread.isAlive(), "Background wait thread did not terminate after Taskomatic became online");
+
+        // Verify that getEventStream() was indeed invoked, explicitly checking that the connection was attempted!
+        assertTrue(getEventStreamCalled[0], "Stream connection was not attempted");
+    }
+}

--- a/java/spacewalk-java.changes.nadvornik.wait_for_tasko
+++ b/java/spacewalk-java.changes.nadvornik.wait_for_tasko
@@ -1,0 +1,1 @@
+- Wait for taskomatic before processing events (bsc#1265472)


### PR DESCRIPTION
## What does this PR change?

Taskomatic is started as the last service, after tomcat and salt.
The SaltReactor however calls taskomatic API for scheduling actions.
There is ~15s window when SaltReactor creates pending actions in the database, but it can't notify taskomatic, so the actions stay pending forever.

This PR  delays processing of salt events until the taskomatic API is available.


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: fix

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30757
https://bugzilla.suse.com/show_bug.cgi?id=1265472
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
