### PR TITLE
Fix schema migration tests after bumping versions

### DIFF
--- a/susemanager-utils/testing/docker/scripts/schema_migration_test_pgsql.sh
+++ b/susemanager-utils/testing/docker/scripts/schema_migration_test_pgsql.sh
@@ -63,12 +63,6 @@ if [ -d /etc/sysconfig/rhn/postgres -a ! -e /usr/share/susemanager/db/postgres ]
     ln -s /etc/sysconfig/rhn/postgres /usr/share/susemanager/db/postgres
 fi
 
-# We need SUPERUSER role to install the old schema as they add extensions.
-# evr_t also didn't exist when installing those packages.
-# This basically reproduces the upgrade from an existing DB setup.
-su - postgres -c "echo 'ALTER ROLE spacewalk WITH SUPERUSER;
-DROP TYPE IF EXISTS evr_t CASCADE;' | psql -d susemanager"
-
 spacewalk-sql /usr/share/susemanager/db/postgres/main.sql
 
 # this copy the latest schema from the git into the system


### PR DESCRIPTION
## What does this PR change?

In the same way we did at https://github.com/SUSE/spacewalk/pull/31357, this PR fixes issue on the schema migration tests after bumping versions:

```
psql:/usr/share/susemanager/db/postgres/main.sql:2874: ERROR:  type "evr_t" does not exist
LINE 8:     evr      EVR_T NOT NULL,
                     ^
```

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
