### PR TITLE
Change 'Desktop SP3' to 'Server SP6' in listing checks

### DIFF
--- a/testsuite/features/secondary/srv_mgr_sync_list_products.feature
+++ b/testsuite/features/secondary/srv_mgr_sync_list_products.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2025 SUSE LLC
+# Copyright (c) 2018-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: List available products
@@ -9,7 +9,7 @@ Feature: List available products
 @susemanager
   Scenario: List available products
     When I execute mgr-sync "list products" with user "admin" and password "admin"
-    Then I should get "[ ] SUSE Linux Enterprise Desktop 15 SP3 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Server 15 SP6 x86_64"
 
 @uyuni
   Scenario: List available products
@@ -19,6 +19,6 @@ Feature: List available products
 @susemanager
   Scenario: List all available products
     When I execute mgr-sync "list products -e"
-    Then I should get "[ ] SUSE Linux Enterprise Desktop 15 SP3 x86_64"
-    And I should get "  [ ] (R) Basesystem Module 15 SP3 x86_64"
-    And I should get "  [ ] Desktop Applications Module 15 SP3 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Server 15 SP6 x86_64"
+    And I should get "  [ ] (R) Basesystem Module 15 SP6 x86_64"
+    And I should get "  [ ] Desktop Applications Module 15 SP6 x86_64"


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/31373 by @alichiel.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes.

- [x] **DONE**


## Test coverage

Cucumber tests were updated.

- [x] **DONE**


## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/31382
 * 5.1: https://github.com/SUSE/spacewalk/pull/31381
 * 5.2: https://github.com/SUSE/spacewalk/pull/31383

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
