### PR TITLE
Quiet Trivy false positives on python and Java scans

### DIFF
--- a/containers/server-attestation-image/Dockerfile
+++ b/containers/server-attestation-image/Dockerfile
@@ -15,9 +15,17 @@ RUN echo "rpm.install.excludedocs = yes" >>/etc/zypp/zypp.conf && \
         uyuni-coco-attestation-core \
         uyuni-coco-attestation-module-secureboot \
         ${ARCH_SPECIFIC_MODULES} \
-        javassist ognl procps && \
+        javassist ognl procps zip unzip && \
+    #Remove maven and version from jars to prevent scanners from reporting false positives: RPMs is the source of truth
+    for jar in $(find /usr/share/java/ -name "*.jar" -type f ! -type l); do \
+        zip -d "$jar" "META-INF/maven/*" || true; \
+        unzip -p "$jar" META-INF/MANIFEST.MF | \
+            sed -E '/^(Implementation-Version|Bundle-Version|Specification-Version):/d' > /tmp/MANIFEST.MF && \
+        zip -u "$jar" /tmp/MANIFEST.MF && \
+        rm -f /tmp/MANIFEST.MF; \
+    done && \
     zypper --non-interactive clean --all && \
-    rpm -e zypper libzypp container-suseconnect && \
+    rpm -e zypper libzypp container-suseconnect zip unzip && \
     rm -rf /var/log/{alternatives.log,lastlog,tallylog,suseconnect.log,zypper.log,zypp/history,YaST2}
 
 ARG PRODUCT=Uyuni

--- a/containers/server-attestation-image/server-attestation-image.changes.cbosdo.trivy-false-positives
+++ b/containers/server-attestation-image/server-attestation-image.changes.cbosdo.trivy-false-positives
@@ -1,0 +1,1 @@
+- Quiet Trivy false positives for java packages

--- a/containers/server-image/Dockerfile.uyuni
+++ b/containers/server-image/Dockerfile.uyuni
@@ -83,9 +83,18 @@ RUN set -euo pipefail; \
         virtual-host-gatherer-libcloud \
         virtualization-formulas \
         mozilla-nss-sysinit \
-        zchunk && \
+        zchunk \
+        zip unzip && \
+    #Remove maven and version from jars to prevent scanners from reporting false positives: RPMs is the source of truth
+    for jar in $(find /usr/share/java/ -name "*.jar" -type f ! -type l); do \
+        zip -d "$jar" "META-INF/maven/*" || true; \
+        unzip -p "$jar" META-INF/MANIFEST.MF | \
+            sed -E '/^(Implementation-Version|Bundle-Version|Specification-Version):/d' > /tmp/MANIFEST.MF && \
+        zip -u "$jar" /tmp/MANIFEST.MF && \
+        rm -f /tmp/MANIFEST.MF; \
+    done && \
     zypper --non-interactive clean --all && \
-    (rpm -e container-suseconnect || true) && \
+    (rpm -e container-suseconnect zip unzip || true) && \
     systemctl enable prometheus-node_exporter && \
     systemctl enable sssd && \
     rm /etc/krb5.conf.d/crypto-policies && \
@@ -103,6 +112,8 @@ RUN set -euo pipefail; \
     ln -sf /dev/null /etc/systemd/system/systemd-timedated.service && \
     ln -sf /dev/null /etc/systemd/system/systemd-tmpfiles-clean.service && \
     ln -sf /dev/null /etc/systemd/system/console-getty.service && \
+# Remove egg-info as they lead trivy to think the package misses security fixes: force it to only use SUSE's data
+    rm -rf /usr/lib/python*/site-packages/*.egg-info && \
     zypper --non-interactive removerepo --all; \
     rm -rf /var/log/{alternatives.log,lastlog,tallylog,suseconnect.log,zypper.log,zypp/history,YaST2}
 

--- a/containers/server-image/server-image.changes.cbosdo.trivy-false-positives
+++ b/containers/server-image/server-image.changes.cbosdo.trivy-false-positives
@@ -1,0 +1,1 @@
+- Quiet Trivy false positives for python and Java packages

--- a/containers/server-saline-image/Dockerfile
+++ b/containers/server-saline-image/Dockerfile
@@ -34,6 +34,7 @@ RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-li
     rm -f /usr/bin/distro* /usr/bin/pydoc* /usr/bin/salt-call* /usr/bin/salt-support* /usr/bin/spm* && \
     zypper --non-interactive clean --all && \
     rpm -e zypper libzypp container-suseconnect && \
+    rm -rf /usr/lib/python*/site-packages/*.egg-info && \
     find /etc -maxdepth 1 -type f -name '*-' -delete && \
     rm -rf /etc/salt /run/zypp.pid /srv/spm /usr/lib/rpm/macros.d/macros.python3 \
            /usr/share/doc /usr/share/licenses /usr/share/man && \

--- a/containers/server-saline-image/server-saline-image.changes.cbosdo.trivy-false-positives
+++ b/containers/server-saline-image/server-saline-image.changes.cbosdo.trivy-false-positives
@@ -1,0 +1,1 @@
+- Quiet Trivy false positives for python packages


### PR DESCRIPTION
## What does this PR change?

egg-infos are used by trivy to analyze the python packages for security issues. However this leads to false positives as SUSE backports the fixes. Removing the egg-infos forces trivy to only use the SUSE data.

For Java, Trivy uses the pom.xml inside the jar files and the MANIFEST.MF's *Version properties to identify the Jar version to compare against upstream databases. Removing them does the trick.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: packaging change

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31370
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
