### PR TITLE
Native LDAP Phase 2: login wiring and auth_type routing

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -32,6 +32,7 @@
         <dependency org="suse" name="cache-api" rev="1.1.1" />
         <dependency org="suse" name="geronimo-jta_1.1_spec" rev="1.2" />
         <dependency org="suse" name="gson" rev="2.8.9" />
+        <dependency org="com.unboundid" name="unboundid-ldapsdk" rev="7.0.4" />
         <dependency org="suse" name="hibernate-c3p0" rev="7.1.6" />
         <dependency org="suse" name="hibernate-models" rev="1.0.1" />
         <dependency org="suse" name="hibernate-core" rev="7.1.6" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -82,6 +82,15 @@ artifacts:
     package: google-gson
     jar: gson\.jar
     repository: Leap
+  # TODO(ldap): UnboundID LDAP SDK (com.unboundid:unboundid-ldapsdk) is used by the native LDAP
+  # authentication feature. The Ant/Ivy CI build resolves it from Maven Central (see ivy-suse.xml),
+  # but the OBS product/RPM build is network-isolated and resolves only packaged artifacts. Before
+  # this feature can be released, an OBS package (e.g. in systemsmanagement:Uyuni:Master or :Other)
+  # must be created and the new third-party dependency approved (licensing). Activate this entry
+  # once that package exists.
+  # - artifact: unboundid-ldapsdk
+  #   package: unboundid-ldapsdk
+  #   repository: Uyuni
   - artifact: hibernate-c3p0
     package: hibernate-c3p0
     jar: hibernate-c3p0

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -102,6 +102,10 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.unboundid</groupId>
+            <artifactId>unboundid-ldapsdk</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-c3p0</artifactId>
         </dependency>

--- a/java/core/src/main/java/com/redhat/rhn/domain/user/AuthType.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/user/AuthType.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.domain.user;
+
+import java.util.Locale;
+
+/**
+ * Backend that authenticates a given user's password.
+ *
+ * <p>Stored per user on {@code rhnUserInfo.auth_type} and used by the login layer to route each
+ * known user to exactly one backend without cascading between them. Existing users are migrated
+ * from the legacy {@code use_pam_authentication} flag: {@code Y} becomes {@link #PAM}, everything
+ * else becomes {@link #LOCAL}. Just-in-time provisioned directory users are stored as
+ * {@link #LDAP}.</p>
+ */
+public enum AuthType {
+
+    /** Local database password check ({@code UserImpl.authenticate}, non-PAM branch). */
+    LOCAL,
+
+    /** Host PAM stack ({@code UserImpl.authenticate}, PAM branch); replaces {@code use_pam_authentication}. */
+    PAM,
+
+    /** Native LDAP/Active Directory bind handled by the login orchestration layer. */
+    LDAP;
+
+    /**
+     * Resolves an {@link AuthType} from its stored label, falling back to {@link #LOCAL} for a
+     * {@code null}, blank, or unrecognized value so that a bad row can never crash a login.
+     *
+     * @param label the stored label, case-insensitive
+     * @return the matching auth type, or {@link #LOCAL} if the label cannot be resolved
+     */
+    public static AuthType fromLabel(String label) {
+        if (label == null || label.isBlank()) {
+            return LOCAL;
+        }
+        try {
+            return valueOf(label.trim().toUpperCase(Locale.ROOT));
+        }
+        catch (IllegalArgumentException e) {
+            return LOCAL;
+        }
+    }
+}

--- a/java/core/src/main/java/com/redhat/rhn/domain/user/User.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/user/User.java
@@ -99,6 +99,18 @@ public interface User extends Serializable {
     void setUsePamAuthentication(boolean usePamAuthenticationIn);
 
     /**
+     * Gets the authentication backend that validates this user's password.
+     * @return the {@link AuthType}, never {@code null}
+     */
+    AuthType getAuthType();
+
+    /**
+     * Sets the authentication backend that validates this user's password.
+     * @param authTypeIn the new {@link AuthType}
+     */
+    void setAuthType(AuthType authTypeIn);
+
+    /**
      * Gets the factory to create the {@link PamService}
      * @return an instance of {@link PamServiceFactory}
      */

--- a/java/core/src/main/java/com/redhat/rhn/domain/user/legacy/UserImpl.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/user/legacy/UserImpl.java
@@ -37,6 +37,7 @@ import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.domain.user.Address;
 import com.redhat.rhn.domain.user.AddressImpl;
+import com.redhat.rhn.domain.user.AuthType;
 import com.redhat.rhn.domain.user.EnterpriseUser;
 import com.redhat.rhn.domain.user.Pane;
 import com.redhat.rhn.domain.user.RhnTimeZone;
@@ -637,6 +638,18 @@ public class UserImpl extends BaseDomainHelper implements User {
     @Override
     public void setUsePamAuthentication(boolean usePamAuthenticationIn) {
         this.userInfo.setUsePamAuthentication(usePamAuthenticationIn);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public AuthType getAuthType() {
+        return this.userInfo.getAuthType();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setAuthType(AuthType authTypeIn) {
+        this.userInfo.setAuthType(authTypeIn);
     }
 
     /** {@inheritDoc} */

--- a/java/core/src/main/java/com/redhat/rhn/domain/user/legacy/UserInfo.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/user/legacy/UserInfo.java
@@ -16,6 +16,7 @@
 
 package com.redhat.rhn.domain.user.legacy;
 
+import com.redhat.rhn.domain.user.AuthType;
 import com.redhat.rhn.domain.user.RhnTimeZone;
 import com.redhat.rhn.domain.user.User;
 
@@ -27,6 +28,8 @@ import java.util.Date;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -60,6 +63,10 @@ public class UserInfo extends AbstractUserChild implements Serializable {
     @Column(name = "use_pam_authentication")
     @Convert(converter = YesNoConverter.class)
     private boolean usePamAuthentication;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "auth_type", nullable = false)
+    private AuthType authType = AuthType.LOCAL;
 
     @Column(name = "show_system_group_list")
     private String showSystemGroupList;
@@ -136,6 +143,22 @@ public class UserInfo extends AbstractUserChild implements Serializable {
      */
     public void setUsePamAuthentication(boolean usePamAuthenticationIn) {
         this.usePamAuthentication = usePamAuthenticationIn;
+    }
+
+    /**
+     * Getter for authType
+     * @return the authentication backend for this user, never {@code null}
+     */
+    public AuthType getAuthType() {
+        return authType == null ? AuthType.LOCAL : authType;
+    }
+
+    /**
+     * Setter for authType
+     * @param authTypeIn New value for authType
+     */
+    public void setAuthType(AuthType authTypeIn) {
+        this.authType = authTypeIn == null ? AuthType.LOCAL : authTypeIn;
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/auth/AuthHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/auth/AuthHandler.java
@@ -26,10 +26,14 @@ import com.redhat.rhn.manager.user.UserManager;
 import com.suse.manager.api.ApiIgnore;
 import com.suse.manager.api.ApiType;
 import com.suse.manager.api.ReadOnly;
+import com.suse.manager.webui.utils.LoginHelper;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 import java.util.Objects;
 
 import javax.security.auth.login.LoginException;
@@ -109,13 +113,32 @@ public class AuthHandler extends BaseHandler {
     @ApiIgnore(ApiType.HTTP)
     public String login(String username, String password, Integer duration) {
         //Log in the user (handles authentication and active/disabled logic)
-        User user = null;
-        try {
-            user = UserManager.loginReadOnlyUser(username, password);
+        // Native LDAP is tried first so that already-provisioned LDAP users (auth_type = LDAP) can
+        // authenticate through the API and get their group-to-role membership refreshed. Unlike the
+        // Web UI, the XML-RPC path does NOT just-in-time provision unknown users (allowJit = false,
+        // per RFC v1): only existing accounts may log in here. The API allows read-only accounts, so
+        // read-only LDAP users are permitted.
+        List<String> ldapErrors = new ArrayList<>();
+        User user = LoginHelper.checkLdapAuthentication(username, password, true, false,
+                new ArrayList<>(), ldapErrors);
+        if (user != null) {
+            // Post-login bookkeeping the local path would otherwise do via performLoginActions. We do
+            // not reset temporary roles here: they were just recomputed from live LDAP group membership.
+            user.setLastLoggedIn(new Date());
+            UserManager.storeUser(user);
         }
-        catch (LoginException e) {
-            // Convert to fault exception
-            throw new UserLoginException(e.getMessage());
+        else {
+            if (!ldapErrors.isEmpty()) {
+                // Known LDAP user that failed authentication: reject, do not fall back.
+                throw new UserLoginException(ldapErrors.get(0));
+            }
+            try {
+                user = UserManager.loginReadOnlyUser(username, password);
+            }
+            catch (LoginException e) {
+                // Convert to fault exception
+                throw new UserLoginException(e.getMessage());
+            }
         }
 
         long dur = getDuration(duration);

--- a/java/core/src/main/java/com/suse/manager/ldap/ConfigLdapAuthConfigProvider.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/ConfigLdapAuthConfigProvider.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 /**
  * Interim {@link LdapAuthConfigProvider} that reads a single directory server from the product
@@ -53,7 +54,7 @@ public class ConfigLdapAuthConfigProvider implements LdapAuthConfigProvider {
     private static final Logger LOG = LogManager.getLogger(ConfigLdapAuthConfigProvider.class);
     private static final long DEFAULT_ORG_ID = 1L;
 
-    private final Function<String, String> stringReader;
+    private final UnaryOperator<String> stringReader;
     private final Function<String, Boolean> booleanReader;
     private final Function<String, Integer> intReader;
 
@@ -74,7 +75,7 @@ public class ConfigLdapAuthConfigProvider implements LdapAuthConfigProvider {
      * @param booleanReaderIn reads a boolean value for a key
      * @param intReaderIn reads an int value for a key, returning {@code 0} if unset
      */
-    public ConfigLdapAuthConfigProvider(Function<String, String> stringReaderIn,
+    public ConfigLdapAuthConfigProvider(UnaryOperator<String> stringReaderIn,
                                         Function<String, Boolean> booleanReaderIn,
                                         Function<String, Integer> intReaderIn) {
         this.stringReader = stringReaderIn;

--- a/java/core/src/main/java/com/suse/manager/ldap/ConfigLdapAuthConfigProvider.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/ConfigLdapAuthConfigProvider.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import com.redhat.rhn.common.conf.Config;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Interim {@link LdapAuthConfigProvider} that reads a single directory server from the product
+ * configuration file ({@code rhn.conf}). It exists so the login layer can be wired end-to-end
+ * before the persisted server records and admin UI land in a later phase.
+ *
+ * <p>LDAP is disabled unless {@code ldap.auth_enabled = 1} is set, so on a default installation
+ * this provider returns no servers and login behaves exactly as it did before. A misconfigured
+ * but enabled setup logs the problem and also returns no servers rather than throwing, so a
+ * configuration mistake can never take down the login page.</p>
+ *
+ * <p>Recognized keys (all prefixed {@code ldap.}):</p>
+ * <ul>
+ *   <li>{@code auth_enabled} - {@code 1}/{@code true} to enable (default off)</li>
+ *   <li>{@code server_type} - {@code ACTIVE_DIRECTORY}, {@code FREE_IPA} or {@code OPEN_LDAP}</li>
+ *   <li>{@code host}, {@code port}, {@code transport} ({@code PLAIN}/{@code LDAPS}/{@code STARTTLS})</li>
+ *   <li>{@code bind_dn}, {@code bind_password} (omit both to attempt an anonymous bind)</li>
+ *   <li>{@code user_base_dn} (required), {@code user_filter}, {@code login_attribute}</li>
+ *   <li>{@code group_base_dn}, {@code group_filter}, {@code group_name_attribute}</li>
+ *   <li>{@code provisioning_mode} ({@code JIT}/{@code EXISTING_ONLY}), {@code default_org_id}</li>
+ * </ul>
+ */
+public class ConfigLdapAuthConfigProvider implements LdapAuthConfigProvider {
+
+    /** Configuration key prefix for all native LDAP settings. */
+    public static final String PREFIX = "ldap.";
+    /** Key gating whether native LDAP authentication is active. */
+    public static final String KEY_ENABLED = PREFIX + "auth_enabled";
+
+    private static final Logger LOG = LogManager.getLogger(ConfigLdapAuthConfigProvider.class);
+    private static final long DEFAULT_ORG_ID = 1L;
+
+    private final Function<String, String> stringReader;
+    private final Function<String, Boolean> booleanReader;
+    private final Function<String, Integer> intReader;
+
+    /**
+     * Creates a provider backed by the global {@link Config}.
+     */
+    public ConfigLdapAuthConfigProvider() {
+        this(key -> Config.get().getString(key),
+             key -> Config.get().getBoolean(key),
+             key -> Config.get().getInt(key, 0));
+    }
+
+    /**
+     * Creates a provider backed by explicit readers. Mainly useful for tests that want to feed
+     * configuration values without a live {@link Config}.
+     *
+     * @param stringReaderIn reads a string value for a key, returning {@code null} if unset
+     * @param booleanReaderIn reads a boolean value for a key
+     * @param intReaderIn reads an int value for a key, returning {@code 0} if unset
+     */
+    public ConfigLdapAuthConfigProvider(Function<String, String> stringReaderIn,
+                                        Function<String, Boolean> booleanReaderIn,
+                                        Function<String, Integer> intReaderIn) {
+        this.stringReader = stringReaderIn;
+        this.booleanReader = booleanReaderIn;
+        this.intReader = intReaderIn;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return Boolean.TRUE.equals(booleanReader.apply(KEY_ENABLED));
+    }
+
+    @Override
+    public List<LdapAuthServerSettings> getServers() {
+        if (!isEnabled()) {
+            return List.of();
+        }
+        try {
+            return List.of(buildFromConfig());
+        }
+        catch (IllegalArgumentException | IllegalStateException e) {
+            LOG.error("Native LDAP authentication is enabled but misconfigured; skipping LDAP: {}",
+                    e.getMessage());
+            return List.of();
+        }
+    }
+
+    private LdapAuthServerSettings buildFromConfig() {
+        LdapServerType serverType = parseServerType(str("server_type"));
+        String host = requireValue("host", str("host"));
+        String userBaseDn = requireValue("user_base_dn", str("user_base_dn"));
+
+        LdapServerConfig.Builder builder = LdapServerConfig.builder(serverType, host, userBaseDn);
+
+        parseTransport(str("transport")).ifPresent(builder::transport);
+        int port = intReader.apply(PREFIX + "port");
+        if (port > 0) {
+            builder.port(port);
+        }
+
+        String bindDn = str("bind_dn");
+        String bindPassword = str("bind_password");
+        if (StringUtils.isNotBlank(bindDn)) {
+            builder.bind(bindDn, bindPassword);
+        }
+        else {
+            builder.anonymousBind();
+        }
+
+        applyIfSet("user_filter", builder::userFilter);
+        applyIfSet("login_attribute", builder::loginAttribute);
+        applyIfSet("group_base_dn", builder::groupBaseDn);
+        applyIfSet("group_filter", builder::groupFilter);
+        applyIfSet("group_name_attribute", builder::groupNameAttribute);
+
+        LdapProvisioningMode mode = LdapProvisioningMode.fromLabel(str("provisioning_mode"));
+        int orgId = intReader.apply(PREFIX + "default_org_id");
+        Long defaultOrgId = orgId > 0 ? (long) orgId : DEFAULT_ORG_ID;
+
+        return new LdapAuthServerSettings(builder.build(), mode, defaultOrgId, 0);
+    }
+
+    private void applyIfSet(String key, Function<String, LdapServerConfig.Builder> setter) {
+        String value = str(key);
+        if (StringUtils.isNotBlank(value)) {
+            setter.apply(value);
+        }
+    }
+
+    private String str(String key) {
+        return stringReader.apply(PREFIX + key);
+    }
+
+    private static String requireValue(String key, String value) {
+        if (StringUtils.isBlank(value)) {
+            throw new IllegalArgumentException("missing required key " + PREFIX + key);
+        }
+        return value;
+    }
+
+    private static LdapServerType parseServerType(String value) {
+        if (StringUtils.isBlank(value)) {
+            return LdapServerType.OPEN_LDAP;
+        }
+        try {
+            return LdapServerType.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        }
+        catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("unknown " + PREFIX + "server_type '" + value + "'");
+        }
+    }
+
+    private static Optional<LdapTransport> parseTransport(String value) {
+        if (StringUtils.isBlank(value)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(LdapTransport.valueOf(value.trim().toUpperCase(Locale.ROOT)));
+        }
+        catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("unknown " + PREFIX + "transport '" + value + "'");
+        }
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/DefaultLdapServiceFactory.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/DefaultLdapServiceFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+/**
+ * Default {@link LdapServiceFactory} producing UnboundID-backed services.
+ */
+public class DefaultLdapServiceFactory implements LdapServiceFactory {
+
+    private final LdapConnectionFactory connectionFactory;
+
+    /**
+     * Creates a factory using the default connection factory.
+     */
+    public DefaultLdapServiceFactory() {
+        this(new LdapConnectionFactory());
+    }
+
+    /**
+     * Creates a factory using a custom connection factory. Mainly useful for tests that point the
+     * service at an in-memory directory server.
+     *
+     * @param connectionFactoryIn the connection factory to use
+     */
+    public DefaultLdapServiceFactory(LdapConnectionFactory connectionFactoryIn) {
+        this.connectionFactory = connectionFactoryIn;
+    }
+
+    @Override
+    public LdapAuthenticationService getInstance(LdapServerConfig configIn) {
+        return new UnboundIdLdapAuthenticationService(configIn, connectionFactory);
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapAuthConfigProvider.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapAuthConfigProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import java.util.List;
+
+/**
+ * Supplies the LDAP servers the login layer should consult, in priority order.
+ *
+ * <p>This is the seam between login orchestration and the source of directory configuration. The
+ * Phase 2 implementation reads server settings from the product configuration file; a later phase
+ * will provide an implementation backed by persisted {@code suseLdapAuthServer} records and the
+ * admin UI, without any change to the callers in the login layer.</p>
+ */
+public interface LdapAuthConfigProvider {
+
+    /**
+     * @return {@code true} if native LDAP authentication is configured and enabled; when
+     *         {@code false} the login layer skips LDAP entirely and behaves exactly as before
+     */
+    boolean isEnabled();
+
+    /**
+     * @return the enabled directory servers ordered by ascending {@link LdapAuthServerSettings#priority()};
+     *         an empty list when LDAP is disabled or unconfigured
+     */
+    List<LdapAuthServerSettings> getServers();
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapAuthServerSettings.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapAuthServerSettings.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import java.util.Objects;
+
+/**
+ * A single directory server together with the login-layer policy that applies to it: how the
+ * connection and searches are configured ({@link #connectionConfig()}), whether accounts may be
+ * provisioned just-in-time ({@link #provisioningMode()}), which organization JIT users are created
+ * in ({@link #defaultOrgId()}), and the order in which servers are probed for unknown users
+ * ({@link #priority()}, lower first).
+ *
+ * <p>This is the login layer's view of an LDAP server. Phase 2 builds these from configuration; a
+ * later phase will build them from persisted {@code suseLdapAuthServer} records without changing
+ * this contract.</p>
+ *
+ * @param connectionConfig the connection and search configuration for the directory
+ * @param provisioningMode whether unknown users may be created just-in-time
+ * @param defaultOrgId the organization id JIT users are created in
+ * @param priority the probe order for unknown users; lower values are tried first
+ */
+public record LdapAuthServerSettings(
+        LdapServerConfig connectionConfig,
+        LdapProvisioningMode provisioningMode,
+        Long defaultOrgId,
+        int priority) {
+
+    /**
+     * Canonical constructor. Requires a connection configuration and defaults a missing
+     * provisioning mode to {@link LdapProvisioningMode#JIT}.
+     */
+    public LdapAuthServerSettings {
+        Objects.requireNonNull(connectionConfig, "connectionConfig must not be null");
+        provisioningMode = provisioningMode == null ? LdapProvisioningMode.JIT : provisioningMode;
+    }
+
+    /**
+     * @return {@code true} if unknown users may be created just-in-time on this server
+     */
+    public boolean allowsJit() {
+        return provisioningMode == LdapProvisioningMode.JIT;
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapAuthenticationService.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapAuthenticationService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import java.util.Optional;
+
+/**
+ * Authenticates a user against a single directory server and resolves the profile attributes
+ * and external group labels needed by the login layer.
+ *
+ * <p>The service performs the directory work only; it does not touch the Uyuni database, create
+ * accounts, or assign roles. Those steps belong to the login orchestration layer.</p>
+ */
+public interface LdapAuthenticationService {
+
+    /**
+     * Attempts to authenticate the given credentials using the bind/search/bind sequence.
+     *
+     * <p>An empty result means the credentials were rejected (unknown user, ambiguous match,
+     * empty or wrong password). An {@link LdapException} means the directory could not be
+     * consulted (unreachable host, failed service bind, malformed filter). Callers should treat
+     * both as a failed login for the user while logging the exception details for the
+     * administrator.</p>
+     *
+     * @param login the user-supplied login name
+     * @param password the user-supplied password
+     * @return the authenticated user on success, or empty if the credentials were rejected
+     * @throws LdapException if the directory cannot be consulted because of an infrastructure
+     *                       or configuration problem
+     */
+    Optional<LdapUser> authenticate(String login, String password) throws LdapException;
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapAuthenticationService.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapAuthenticationService.java
@@ -26,7 +26,7 @@ public interface LdapAuthenticationService {
      * Attempts to authenticate the given credentials using the bind/search/bind sequence.
      *
      * <p>An empty result means the credentials were rejected (unknown user, ambiguous match,
-     * empty or wrong password). An {@link LdapException} means the directory could not be
+     * empty or wrong password). An {@link LdapServiceException} means the directory could not be
      * consulted (unreachable host, failed service bind, malformed filter). Callers should treat
      * both as a failed login for the user while logging the exception details for the
      * administrator.</p>
@@ -34,8 +34,8 @@ public interface LdapAuthenticationService {
      * @param login the user-supplied login name
      * @param password the user-supplied password
      * @return the authenticated user on success, or empty if the credentials were rejected
-     * @throws LdapException if the directory cannot be consulted because of an infrastructure
+     * @throws LdapServiceException if the directory cannot be consulted because of an infrastructure
      *                       or configuration problem
      */
-    Optional<LdapUser> authenticate(String login, String password) throws LdapException;
+    Optional<LdapUser> authenticate(String login, String password) throws LdapServiceException;
 }

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapConnectionFactory.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapConnectionFactory.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import com.unboundid.ldap.sdk.LDAPConnection;
+import com.unboundid.ldap.sdk.LDAPConnectionOptions;
+import com.unboundid.ldap.sdk.LDAPConnectionPool;
+import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.SimpleBindRequest;
+import com.unboundid.util.ssl.SSLUtil;
+
+import java.security.GeneralSecurityException;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * Creates the LDAP connections used by {@link UnboundIdLdapAuthenticationService}.
+ *
+ * <p>This class is the seam that lets the service be exercised against an in-memory directory
+ * server in tests: tests subclass it and override {@link #socketFactory(LdapServerConfig)} (or the
+ * connection factory wiring) so no real TLS material or network access is required.</p>
+ *
+ * <p>Supports {@link LdapTransport#PLAIN} and {@link LdapTransport#LDAPS}. Custom trust material
+ * (administrator-uploaded directory CA certificates) and StartTLS are not supported yet; until
+ * then a secure transport relies on the JVM default trust store.</p>
+ */
+public class LdapConnectionFactory {
+
+    private static final int INITIAL_POOL_CONNECTIONS = 1;
+    private static final int MAX_POOL_CONNECTIONS = 4;
+
+    /**
+     * Builds the {@link LDAPConnectionOptions} (timeouts, follow-referrals policy) for a server.
+     *
+     * @param config the server configuration
+     * @return connection options derived from the configuration
+     */
+    protected LDAPConnectionOptions connectionOptions(LdapServerConfig config) {
+        LDAPConnectionOptions options = new LDAPConnectionOptions();
+        options.setConnectTimeoutMillis(config.getConnectTimeoutMillis());
+        options.setResponseTimeoutMillis(config.getResponseTimeoutMillis());
+        options.setFollowReferrals(false);
+        return options;
+    }
+
+    /**
+     * Returns the socket factory used to reach the directory, or {@code null} for a plain
+     * (cleartext) connection.
+     *
+     * @param config the server configuration
+     * @return a socket factory for secure transports, or {@code null} for {@link LdapTransport#PLAIN}
+     * @throws LdapException if a TLS socket factory cannot be created
+     */
+    protected SocketFactory socketFactory(LdapServerConfig config) throws LdapException {
+        if (config.getTransport() == LdapTransport.PLAIN) {
+            return null;
+        }
+        if (config.getTransport() == LdapTransport.STARTTLS) {
+            throw new LdapException("StartTLS is not supported yet; use LDAPS or PLAIN");
+        }
+        try {
+            // Until custom CA trust is wired in, rely on the JVM default trust store.
+            SSLUtil sslUtil = new SSLUtil();
+            SSLSocketFactory factory = sslUtil.createSSLSocketFactory();
+            return factory;
+        }
+        catch (GeneralSecurityException e) {
+            throw new LdapException("Unable to initialize TLS for LDAPS connection", e);
+        }
+    }
+
+    /**
+     * Opens a single, unauthenticated connection. Used for the credential bind so that the
+     * pooled service connections keep their service-account identity.
+     *
+     * @param config the server configuration
+     * @return a new open connection
+     * @throws LdapException if the connection cannot be established
+     */
+    public LDAPConnection openConnection(LdapServerConfig config) throws LdapException {
+        try {
+            SocketFactory factory = socketFactory(config);
+            LDAPConnectionOptions options = connectionOptions(config);
+            if (factory == null) {
+                return new LDAPConnection(options, config.getHost(), config.getPort());
+            }
+            return new LDAPConnection(factory, options, config.getHost(), config.getPort());
+        }
+        catch (LDAPException e) {
+            throw new LdapException("Unable to connect to LDAP server " + config.getHost(), e);
+        }
+    }
+
+    /**
+     * Creates a connection pool bound as the configured service account (or anonymous when
+     * explicitly allowed). The pool is used for user and group searches.
+     *
+     * @param config the server configuration
+     * @return a ready connection pool the caller must close
+     * @throws LdapException if the connection or service bind fails
+     */
+    public LDAPConnectionPool createServicePool(LdapServerConfig config) throws LdapException {
+        LDAPConnection connection = openConnection(config);
+        try {
+            if (config.getBindDn().isPresent()) {
+                connection.bind(new SimpleBindRequest(config.getBindDn().get(),
+                        config.getBindPassword().orElse("")));
+            }
+            return new LDAPConnectionPool(connection, INITIAL_POOL_CONNECTIONS, MAX_POOL_CONNECTIONS);
+        }
+        catch (LDAPException e) {
+            connection.close();
+            throw new LdapException("Service-account bind failed for LDAP server " + config.getHost(), e);
+        }
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapConnectionFactory.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapConnectionFactory.java
@@ -21,7 +21,6 @@ import com.unboundid.util.ssl.SSLUtil;
 import java.security.GeneralSecurityException;
 
 import javax.net.SocketFactory;
-import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Creates the LDAP connections used by {@link UnboundIdLdapAuthenticationService}.
@@ -70,9 +69,7 @@ public class LdapConnectionFactory {
         }
         try {
             // Until custom CA trust is wired in, rely on the JVM default trust store.
-            SSLUtil sslUtil = new SSLUtil();
-            SSLSocketFactory factory = sslUtil.createSSLSocketFactory();
-            return factory;
+            return new SSLUtil().createSSLSocketFactory();
         }
         catch (GeneralSecurityException e) {
             throw new LdapException("Unable to initialize TLS for LDAPS connection", e);
@@ -112,8 +109,9 @@ public class LdapConnectionFactory {
     public LDAPConnectionPool createServicePool(LdapServerConfig config) throws LdapException {
         LDAPConnection connection = openConnection(config);
         try {
-            if (config.getBindDn().isPresent()) {
-                connection.bind(new SimpleBindRequest(config.getBindDn().get(),
+            var bindDn = config.getBindDn();
+            if (bindDn.isPresent()) {
+                connection.bind(new SimpleBindRequest(bindDn.get(),
                         config.getBindPassword().orElse("")));
             }
             return new LDAPConnectionPool(connection, INITIAL_POOL_CONNECTIONS, MAX_POOL_CONNECTIONS);

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapConnectionFactory.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapConnectionFactory.java
@@ -58,21 +58,21 @@ public class LdapConnectionFactory {
      *
      * @param config the server configuration
      * @return a socket factory for secure transports, or {@code null} for {@link LdapTransport#PLAIN}
-     * @throws LdapException if a TLS socket factory cannot be created
+     * @throws LdapServiceException if a TLS socket factory cannot be created
      */
-    protected SocketFactory socketFactory(LdapServerConfig config) throws LdapException {
+    protected SocketFactory socketFactory(LdapServerConfig config) throws LdapServiceException {
         if (config.getTransport() == LdapTransport.PLAIN) {
             return null;
         }
         if (config.getTransport() == LdapTransport.STARTTLS) {
-            throw new LdapException("StartTLS is not supported yet; use LDAPS or PLAIN");
+            throw new LdapServiceException("StartTLS is not supported yet; use LDAPS or PLAIN");
         }
         try {
             // Until custom CA trust is wired in, rely on the JVM default trust store.
             return new SSLUtil().createSSLSocketFactory();
         }
         catch (GeneralSecurityException e) {
-            throw new LdapException("Unable to initialize TLS for LDAPS connection", e);
+            throw new LdapServiceException("Unable to initialize TLS for LDAPS connection", e);
         }
     }
 
@@ -82,9 +82,9 @@ public class LdapConnectionFactory {
      *
      * @param config the server configuration
      * @return a new open connection
-     * @throws LdapException if the connection cannot be established
+     * @throws LdapServiceException if the connection cannot be established
      */
-    public LDAPConnection openConnection(LdapServerConfig config) throws LdapException {
+    public LDAPConnection openConnection(LdapServerConfig config) throws LdapServiceException {
         try {
             SocketFactory factory = socketFactory(config);
             LDAPConnectionOptions options = connectionOptions(config);
@@ -94,7 +94,7 @@ public class LdapConnectionFactory {
             return new LDAPConnection(factory, options, config.getHost(), config.getPort());
         }
         catch (LDAPException e) {
-            throw new LdapException("Unable to connect to LDAP server " + config.getHost(), e);
+            throw new LdapServiceException("Unable to connect to LDAP server " + config.getHost(), e);
         }
     }
 
@@ -104,9 +104,9 @@ public class LdapConnectionFactory {
      *
      * @param config the server configuration
      * @return a ready connection pool the caller must close
-     * @throws LdapException if the connection or service bind fails
+     * @throws LdapServiceException if the connection or service bind fails
      */
-    public LDAPConnectionPool createServicePool(LdapServerConfig config) throws LdapException {
+    public LDAPConnectionPool createServicePool(LdapServerConfig config) throws LdapServiceException {
         LDAPConnection connection = openConnection(config);
         try {
             var bindDn = config.getBindDn();
@@ -118,7 +118,7 @@ public class LdapConnectionFactory {
         }
         catch (LDAPException e) {
             connection.close();
-            throw new LdapException("Service-account bind failed for LDAP server " + config.getHost(), e);
+            throw new LdapServiceException("Service-account bind failed for LDAP server " + config.getHost(), e);
         }
     }
 }

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapException.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+/**
+ * Raised when an LDAP operation cannot be completed because of an infrastructure or
+ * configuration problem, for example the directory is unreachable, the service account
+ * bind fails, or a configured filter is malformed.
+ *
+ * <p>This is deliberately distinct from an authentication <em>decision</em>: a user who
+ * simply supplied the wrong password, or who does not exist in the directory, is reported
+ * as an empty result by {@link LdapAuthenticationService#authenticate(String, String)}
+ * rather than by throwing. Callers should log the details of this exception for the
+ * administrator while presenting only a generic message to the end user.</p>
+ */
+public class LdapException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Builds an instance with the given message.
+     *
+     * @param messageIn human readable description of the failure
+     */
+    public LdapException(String messageIn) {
+        super(messageIn);
+    }
+
+    /**
+     * Builds an instance with the given message and cause.
+     *
+     * @param messageIn human readable description of the failure
+     * @param causeIn the underlying cause
+     */
+    public LdapException(String messageIn, Exception causeIn) {
+        super(messageIn, causeIn);
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapFilters.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapFilters.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import com.unboundid.ldap.sdk.Filter;
+import com.unboundid.ldap.sdk.LDAPException;
+
+/**
+ * Builds search filters from administrator-supplied templates.
+ *
+ * <p>The only supported placeholders are {@code {login}} (the user-supplied login name) and
+ * {@code {userDn}} (the resolved user entry DN). Every substituted value is escaped with
+ * {@link Filter#encodeValue(String)} <em>before</em> it is inserted into the template, so that
+ * untrusted input can never alter the structure of the resulting filter (LDAP injection).</p>
+ */
+public final class LdapFilters {
+
+    /** Placeholder replaced by the escaped, user-supplied login name. */
+    public static final String LOGIN_PLACEHOLDER = "{login}";
+
+    /** Placeholder replaced by the escaped DN of the resolved user entry. */
+    public static final String USER_DN_PLACEHOLDER = "{userDn}";
+
+    private LdapFilters() {
+    }
+
+    /**
+     * Builds a user search filter by substituting the escaped login into the template.
+     *
+     * @param template the filter template, must contain {@value #LOGIN_PLACEHOLDER}
+     * @param login the user-supplied login name
+     * @return a parsed, injection-safe {@link Filter}
+     * @throws LdapException if the template is missing the placeholder or is not a valid filter
+     */
+    public static Filter userFilter(String template, String login) throws LdapException {
+        return buildFilter(template, LOGIN_PLACEHOLDER, login, "user");
+    }
+
+    /**
+     * Builds a group search filter by substituting the escaped user DN into the template.
+     *
+     * @param template the filter template, must contain {@value #USER_DN_PLACEHOLDER}
+     * @param userDn the DN of the resolved user entry
+     * @return a parsed, injection-safe {@link Filter}
+     * @throws LdapException if the template is missing the placeholder or is not a valid filter
+     */
+    public static Filter groupFilter(String template, String userDn) throws LdapException {
+        return buildFilter(template, USER_DN_PLACEHOLDER, userDn, "group");
+    }
+
+    private static Filter buildFilter(String template, String placeholder, String rawValue, String kind)
+            throws LdapException {
+        if (template == null || !template.contains(placeholder)) {
+            throw new LdapException(
+                    "The " + kind + " filter template must contain the " + placeholder + " placeholder");
+        }
+        if (rawValue == null || rawValue.isEmpty()) {
+            throw new LdapException("Refusing to build a " + kind + " filter from an empty value");
+        }
+        String escaped = Filter.encodeValue(rawValue);
+        String filterString = template.replace(placeholder, escaped);
+        try {
+            return Filter.create(filterString);
+        }
+        catch (LDAPException e) {
+            throw new LdapException("Configured " + kind + " filter is not a valid LDAP filter", e);
+        }
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapFilters.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapFilters.java
@@ -39,9 +39,9 @@ public final class LdapFilters {
      * @param template the filter template, must contain {@value #LOGIN_PLACEHOLDER}
      * @param login the user-supplied login name
      * @return a parsed, injection-safe {@link Filter}
-     * @throws LdapException if the template is missing the placeholder or is not a valid filter
+     * @throws LdapServiceException if the template is missing the placeholder or is not a valid filter
      */
-    public static Filter userFilter(String template, String login) throws LdapException {
+    public static Filter userFilter(String template, String login) throws LdapServiceException {
         return buildFilter(template, LOGIN_PLACEHOLDER, login, "user");
     }
 
@@ -51,20 +51,20 @@ public final class LdapFilters {
      * @param template the filter template, must contain {@value #USER_DN_PLACEHOLDER}
      * @param userDn the DN of the resolved user entry
      * @return a parsed, injection-safe {@link Filter}
-     * @throws LdapException if the template is missing the placeholder or is not a valid filter
+     * @throws LdapServiceException if the template is missing the placeholder or is not a valid filter
      */
-    public static Filter groupFilter(String template, String userDn) throws LdapException {
+    public static Filter groupFilter(String template, String userDn) throws LdapServiceException {
         return buildFilter(template, USER_DN_PLACEHOLDER, userDn, "group");
     }
 
     private static Filter buildFilter(String template, String placeholder, String rawValue, String kind)
-            throws LdapException {
+            throws LdapServiceException {
         if (template == null || !template.contains(placeholder)) {
-            throw new LdapException(
+            throw new LdapServiceException(
                     "The " + kind + " filter template must contain the " + placeholder + " placeholder");
         }
         if (rawValue == null || rawValue.isEmpty()) {
-            throw new LdapException("Refusing to build a " + kind + " filter from an empty value");
+            throw new LdapServiceException("Refusing to build a " + kind + " filter from an empty value");
         }
         String escaped = Filter.encodeValue(rawValue);
         String filterString = template.replace(placeholder, escaped);
@@ -72,7 +72,7 @@ public final class LdapFilters {
             return Filter.create(filterString);
         }
         catch (LDAPException e) {
-            throw new LdapException("Configured " + kind + " filter is not a valid LDAP filter", e);
+            throw new LdapServiceException("Configured " + kind + " filter is not a valid LDAP filter", e);
         }
     }
 }

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapProvisioningMode.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapProvisioningMode.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import java.util.Locale;
+
+/**
+ * Controls whether a successful LDAP authentication may create a Uyuni account on the fly.
+ */
+public enum LdapProvisioningMode {
+
+    /** Create the Uyuni user just-in-time on first successful LDAP login if it does not exist. */
+    JIT,
+
+    /** Authenticate only users that already exist in Uyuni; never create accounts from LDAP. */
+    EXISTING_ONLY;
+
+    /**
+     * Resolves a mode from its stored label, defaulting to {@link #JIT} for an unknown value.
+     *
+     * @param label the stored label, case-insensitive
+     * @return the matching mode, or {@link #JIT} if the label cannot be resolved
+     */
+    public static LdapProvisioningMode fromLabel(String label) {
+        if (label == null || label.isBlank()) {
+            return JIT;
+        }
+        try {
+            return valueOf(label.trim().toUpperCase(Locale.ROOT));
+        }
+        catch (IllegalArgumentException e) {
+            return JIT;
+        }
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapServerConfig.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapServerConfig.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable connection and search configuration for a single directory server.
+ *
+ * <p>Callers build these instances in code until persisted LDAP server records (and bind
+ * credentials from {@code suseCredentials}) are available.</p>
+ *
+ * <p>Defaults for search filters and attribute names come from the chosen {@link LdapServerType}
+ * and can each be overridden through the {@link Builder}.</p>
+ */
+public final class LdapServerConfig {
+
+    private final LdapServerType serverType;
+    private final String host;
+    private final int port;
+    private final LdapTransport transport;
+
+    private final String bindDn;
+    private final String bindPassword;
+    private final boolean allowAnonymousBind;
+
+    private final String userBaseDn;
+    private final String userFilter;
+    private final String loginAttribute;
+
+    private final String groupBaseDn;
+    private final String groupFilter;
+    private final String groupNameAttribute;
+
+    private final String firstNameAttribute;
+    private final String lastNameAttribute;
+    private final String emailAttribute;
+
+    private final int connectTimeoutMillis;
+    private final int responseTimeoutMillis;
+
+    private LdapServerConfig(Builder builder) {
+        this.serverType = builder.serverType;
+        this.host = builder.host;
+        this.port = builder.port;
+        this.transport = builder.transport;
+        this.bindDn = builder.bindDn;
+        this.bindPassword = builder.bindPassword;
+        this.allowAnonymousBind = builder.allowAnonymousBind;
+        this.userBaseDn = builder.userBaseDn;
+        this.userFilter = builder.userFilter;
+        this.loginAttribute = builder.loginAttribute;
+        this.groupBaseDn = builder.groupBaseDn;
+        this.groupFilter = builder.groupFilter;
+        this.groupNameAttribute = builder.groupNameAttribute;
+        this.firstNameAttribute = builder.firstNameAttribute;
+        this.lastNameAttribute = builder.lastNameAttribute;
+        this.emailAttribute = builder.emailAttribute;
+        this.connectTimeoutMillis = builder.connectTimeoutMillis;
+        this.responseTimeoutMillis = builder.responseTimeoutMillis;
+    }
+
+    /**
+     * Starts a new builder for the given server type, host and user base DN.
+     *
+     * @param serverTypeIn the directory flavor, supplies the default filters and attributes
+     * @param hostIn the directory host name or address
+     * @param userBaseDnIn the base DN under which user entries are searched
+     * @return a builder pre-populated with the defaults of the server type
+     */
+    public static Builder builder(LdapServerType serverTypeIn, String hostIn, String userBaseDnIn) {
+        return new Builder(serverTypeIn, hostIn, userBaseDnIn);
+    }
+
+    /**
+     * @return the directory flavor
+     */
+    public LdapServerType getServerType() {
+        return serverType;
+    }
+
+    /**
+     * @return the directory host name or address
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * @return the directory TCP port
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * @return the transport security mode
+     */
+    public LdapTransport getTransport() {
+        return transport;
+    }
+
+    /**
+     * @return the service-account bind DN, empty for an anonymous bind
+     */
+    public Optional<String> getBindDn() {
+        return Optional.ofNullable(bindDn);
+    }
+
+    /**
+     * @return the service-account bind password, empty for an anonymous bind
+     */
+    public Optional<String> getBindPassword() {
+        return Optional.ofNullable(bindPassword);
+    }
+
+    /**
+     * @return {@code true} if an anonymous service bind is explicitly permitted
+     */
+    public boolean isAllowAnonymousBind() {
+        return allowAnonymousBind;
+    }
+
+    /**
+     * @return the base DN under which user entries are searched
+     */
+    public String getUserBaseDn() {
+        return userBaseDn;
+    }
+
+    /**
+     * @return the user search filter template (contains the {@code {login}} placeholder)
+     */
+    public String getUserFilter() {
+        return userFilter;
+    }
+
+    /**
+     * @return the attribute carrying the normalized login name
+     */
+    public String getLoginAttribute() {
+        return loginAttribute;
+    }
+
+    /**
+     * @return the base DN under which group entries are searched
+     */
+    public String getGroupBaseDn() {
+        return groupBaseDn;
+    }
+
+    /**
+     * @return the group search filter template (contains the {@code {userDn}} placeholder)
+     */
+    public String getGroupFilter() {
+        return groupFilter;
+    }
+
+    /**
+     * @return the attribute carrying a group's external label
+     */
+    public String getGroupNameAttribute() {
+        return groupNameAttribute;
+    }
+
+    /**
+     * @return the attribute carrying the user's first (given) name
+     */
+    public String getFirstNameAttribute() {
+        return firstNameAttribute;
+    }
+
+    /**
+     * @return the attribute carrying the user's last (family) name
+     */
+    public String getLastNameAttribute() {
+        return lastNameAttribute;
+    }
+
+    /**
+     * @return the attribute carrying the user's e-mail address
+     */
+    public String getEmailAttribute() {
+        return emailAttribute;
+    }
+
+    /**
+     * @return the TCP connect timeout in milliseconds
+     */
+    public int getConnectTimeoutMillis() {
+        return connectTimeoutMillis;
+    }
+
+    /**
+     * @return the per-operation response timeout in milliseconds
+     */
+    public int getResponseTimeoutMillis() {
+        return responseTimeoutMillis;
+    }
+
+    /**
+     * Fluent builder for {@link LdapServerConfig}. Optional values default to those of the
+     * configured {@link LdapServerType}; timeouts default to ten seconds.
+     */
+    public static final class Builder {
+
+        private static final int DEFAULT_TIMEOUT_MILLIS = 10_000;
+
+        private final LdapServerType serverType;
+        private final String host;
+        private final String userBaseDn;
+
+        private int port;
+        private LdapTransport transport = LdapTransport.LDAPS;
+        private String bindDn;
+        private String bindPassword;
+        private boolean allowAnonymousBind;
+        private String userFilter;
+        private String loginAttribute;
+        private String groupBaseDn;
+        private String groupFilter;
+        private String groupNameAttribute;
+        private String firstNameAttribute;
+        private String lastNameAttribute;
+        private String emailAttribute;
+        private int connectTimeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+        private int responseTimeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+
+        private Builder(LdapServerType serverTypeIn, String hostIn, String userBaseDnIn) {
+            this.serverType = Objects.requireNonNull(serverTypeIn, "serverType must not be null");
+            this.host = Objects.requireNonNull(hostIn, "host must not be null");
+            this.userBaseDn = Objects.requireNonNull(userBaseDnIn, "userBaseDn must not be null");
+            this.port = transport.getDefaultPort();
+            this.userFilter = serverTypeIn.getDefaultUserFilter();
+            this.loginAttribute = serverTypeIn.getDefaultLoginAttribute();
+            this.groupBaseDn = userBaseDnIn;
+            this.groupFilter = serverTypeIn.getDefaultGroupFilter();
+            this.groupNameAttribute = serverTypeIn.getDefaultGroupNameAttribute();
+            this.firstNameAttribute = serverTypeIn.getDefaultFirstNameAttribute();
+            this.lastNameAttribute = serverTypeIn.getDefaultLastNameAttribute();
+            this.emailAttribute = serverTypeIn.getDefaultEmailAttribute();
+        }
+
+        /**
+         * @param portIn the directory TCP port
+         * @return this builder
+         */
+        public Builder port(int portIn) {
+            this.port = portIn;
+            return this;
+        }
+
+        /**
+         * Sets the transport mode. Also updates the port to that transport's default unless a
+         * non-zero port has already been set explicitly.
+         *
+         * @param transportIn the transport security mode
+         * @return this builder
+         */
+        public Builder transport(LdapTransport transportIn) {
+            this.transport = Objects.requireNonNull(transportIn, "transport must not be null");
+            if (this.port <= 0) {
+                this.port = transportIn.getDefaultPort();
+            }
+            return this;
+        }
+
+        /**
+         * Configures a service-account (authenticated) bind.
+         *
+         * @param bindDnIn the service-account DN
+         * @param bindPasswordIn the service-account password
+         * @return this builder
+         */
+        public Builder bind(String bindDnIn, String bindPasswordIn) {
+            this.bindDn = bindDnIn;
+            this.bindPassword = bindPasswordIn;
+            this.allowAnonymousBind = false;
+            return this;
+        }
+
+        /**
+         * Explicitly permits an anonymous service bind (no service-account credentials).
+         *
+         * @return this builder
+         */
+        public Builder anonymousBind() {
+            this.bindDn = null;
+            this.bindPassword = null;
+            this.allowAnonymousBind = true;
+            return this;
+        }
+
+        /**
+         * @param userFilterIn the user search filter template (must contain {@code {login}})
+         * @return this builder
+         */
+        public Builder userFilter(String userFilterIn) {
+            this.userFilter = userFilterIn;
+            return this;
+        }
+
+        /**
+         * @param loginAttributeIn the attribute carrying the normalized login name
+         * @return this builder
+         */
+        public Builder loginAttribute(String loginAttributeIn) {
+            this.loginAttribute = loginAttributeIn;
+            return this;
+        }
+
+        /**
+         * @param groupBaseDnIn the base DN under which group entries are searched
+         * @return this builder
+         */
+        public Builder groupBaseDn(String groupBaseDnIn) {
+            this.groupBaseDn = groupBaseDnIn;
+            return this;
+        }
+
+        /**
+         * @param groupFilterIn the group search filter template (must contain {@code {userDn}})
+         * @return this builder
+         */
+        public Builder groupFilter(String groupFilterIn) {
+            this.groupFilter = groupFilterIn;
+            return this;
+        }
+
+        /**
+         * @param groupNameAttributeIn the attribute carrying a group's external label
+         * @return this builder
+         */
+        public Builder groupNameAttribute(String groupNameAttributeIn) {
+            this.groupNameAttribute = groupNameAttributeIn;
+            return this;
+        }
+
+        /**
+         * Overrides the profile attribute names read from the user entry.
+         *
+         * @param firstNameAttributeIn first-name attribute
+         * @param lastNameAttributeIn last-name attribute
+         * @param emailAttributeIn e-mail attribute
+         * @return this builder
+         */
+        public Builder profileAttributes(String firstNameAttributeIn, String lastNameAttributeIn,
+                                         String emailAttributeIn) {
+            this.firstNameAttribute = firstNameAttributeIn;
+            this.lastNameAttribute = lastNameAttributeIn;
+            this.emailAttribute = emailAttributeIn;
+            return this;
+        }
+
+        /**
+         * @param connectTimeoutMillisIn TCP connect timeout in milliseconds
+         * @return this builder
+         */
+        public Builder connectTimeoutMillis(int connectTimeoutMillisIn) {
+            this.connectTimeoutMillis = connectTimeoutMillisIn;
+            return this;
+        }
+
+        /**
+         * @param responseTimeoutMillisIn per-operation response timeout in milliseconds
+         * @return this builder
+         */
+        public Builder responseTimeoutMillis(int responseTimeoutMillisIn) {
+            this.responseTimeoutMillis = responseTimeoutMillisIn;
+            return this;
+        }
+
+        /**
+         * Validates and builds the immutable configuration.
+         *
+         * @return a new {@link LdapServerConfig}
+         * @throws IllegalStateException if the bind configuration is inconsistent
+         */
+        public LdapServerConfig build() {
+            if (port <= 0) {
+                port = transport.getDefaultPort();
+            }
+            boolean hasBindDn = bindDn != null && !bindDn.isBlank();
+            if (!hasBindDn && !allowAnonymousBind) {
+                throw new IllegalStateException(
+                        "A service-account bind DN is required unless anonymous bind is explicitly allowed");
+            }
+            if (hasBindDn && (bindPassword == null || bindPassword.isEmpty())) {
+                throw new IllegalStateException("A bind password is required when a bind DN is set");
+            }
+            return new LdapServerConfig(this);
+        }
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapServerConfig.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapServerConfig.java
@@ -240,7 +240,10 @@ public final class LdapServerConfig {
             this.serverType = Objects.requireNonNull(serverTypeIn, "serverType must not be null");
             this.host = Objects.requireNonNull(hostIn, "host must not be null");
             this.userBaseDn = Objects.requireNonNull(userBaseDnIn, "userBaseDn must not be null");
-            this.port = transport.getDefaultPort();
+            // Leave the port unset (0) so it can follow the transport's default until either the
+            // transport or an explicit port is chosen; build() resolves a still-unset port to the
+            // transport default.
+            this.port = 0;
             this.userFilter = serverTypeIn.getDefaultUserFilter();
             this.loginAttribute = serverTypeIn.getDefaultLoginAttribute();
             this.groupBaseDn = userBaseDnIn;

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapServerType.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapServerType.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+/**
+ * Well-known directory server flavors. Each value supplies sensible default search filters
+ * and attribute names so an administrator only has to override values that differ from the
+ * defaults for their directory.
+ *
+ * <p>Filter templates use two placeholders that {@link LdapFilters} substitutes at search time:
+ * {@code {login}} for the supplied user name and {@code {userDn}} for the resolved user entry DN.
+ * Placeholder values are always LDAP-escaped before substitution.</p>
+ */
+public enum LdapServerType {
+
+    /** Microsoft Active Directory. */
+    ACTIVE_DIRECTORY(
+            "(&(objectClass=user)(sAMAccountName={login}))",
+            "sAMAccountName",
+            "(&(objectClass=group)(member={userDn}))",
+            "cn",
+            "givenName",
+            "sn",
+            "mail"),
+
+    /** FreeIPA / Red Hat Identity Management (389 Directory Server based). */
+    FREE_IPA(
+            "(&(objectClass=person)(uid={login}))",
+            "uid",
+            "(&(objectClass=groupOfNames)(member={userDn}))",
+            "cn",
+            "givenName",
+            "sn",
+            "mail"),
+
+    /** Generic OpenLDAP using inetOrgPerson and groupOfNames. */
+    OPEN_LDAP(
+            "(&(objectClass=inetOrgPerson)(uid={login}))",
+            "uid",
+            "(&(objectClass=groupOfNames)(member={userDn}))",
+            "cn",
+            "givenName",
+            "sn",
+            "mail");
+
+    private final String defaultUserFilter;
+    private final String defaultLoginAttribute;
+    private final String defaultGroupFilter;
+    private final String defaultGroupNameAttribute;
+    private final String defaultFirstNameAttribute;
+    private final String defaultLastNameAttribute;
+    private final String defaultEmailAttribute;
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    LdapServerType(String userFilterIn, String loginAttributeIn, String groupFilterIn,
+                   String groupNameAttributeIn, String firstNameAttributeIn, String lastNameAttributeIn,
+                   String emailAttributeIn) {
+        this.defaultUserFilter = userFilterIn;
+        this.defaultLoginAttribute = loginAttributeIn;
+        this.defaultGroupFilter = groupFilterIn;
+        this.defaultGroupNameAttribute = groupNameAttributeIn;
+        this.defaultFirstNameAttribute = firstNameAttributeIn;
+        this.defaultLastNameAttribute = lastNameAttributeIn;
+        this.defaultEmailAttribute = emailAttributeIn;
+    }
+
+    /**
+     * @return default user search filter template (contains the {@code {login}} placeholder)
+     */
+    public String getDefaultUserFilter() {
+        return defaultUserFilter;
+    }
+
+    /**
+     * @return default attribute carrying the normalized login name
+     */
+    public String getDefaultLoginAttribute() {
+        return defaultLoginAttribute;
+    }
+
+    /**
+     * @return default group search filter template (contains the {@code {userDn}} placeholder)
+     */
+    public String getDefaultGroupFilter() {
+        return defaultGroupFilter;
+    }
+
+    /**
+     * @return default attribute carrying a group's external label
+     */
+    public String getDefaultGroupNameAttribute() {
+        return defaultGroupNameAttribute;
+    }
+
+    /**
+     * @return default attribute carrying the user's first (given) name
+     */
+    public String getDefaultFirstNameAttribute() {
+        return defaultFirstNameAttribute;
+    }
+
+    /**
+     * @return default attribute carrying the user's last (family) name
+     */
+    public String getDefaultLastNameAttribute() {
+        return defaultLastNameAttribute;
+    }
+
+    /**
+     * @return default attribute carrying the user's e-mail address
+     */
+    public String getDefaultEmailAttribute() {
+        return defaultEmailAttribute;
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapServiceException.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapServiceException.java
@@ -16,13 +16,17 @@ package com.suse.manager.ldap;
  * configuration problem, for example the directory is unreachable, the service account
  * bind fails, or a configured filter is malformed.
  *
+ * <p>Named {@code LdapServiceException} (not {@code LdapException}) to avoid confusion with
+ * UnboundID's {@code com.unboundid.ldap.sdk.LDAPException}, which is used internally as the
+ * SDK-level cause.</p>
+ *
  * <p>This is deliberately distinct from an authentication <em>decision</em>: a user who
  * simply supplied the wrong password, or who does not exist in the directory, is reported
  * as an empty result by {@link LdapAuthenticationService#authenticate(String, String)}
  * rather than by throwing. Callers should log the details of this exception for the
  * administrator while presenting only a generic message to the end user.</p>
  */
-public class LdapException extends Exception {
+public class LdapServiceException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
@@ -31,7 +35,7 @@ public class LdapException extends Exception {
      *
      * @param messageIn human readable description of the failure
      */
-    public LdapException(String messageIn) {
+    public LdapServiceException(String messageIn) {
         super(messageIn);
     }
 
@@ -41,7 +45,7 @@ public class LdapException extends Exception {
      * @param messageIn human readable description of the failure
      * @param causeIn the underlying cause
      */
-    public LdapException(String messageIn, Exception causeIn) {
+    public LdapServiceException(String messageIn, Exception causeIn) {
         super(messageIn, causeIn);
     }
 }

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapServiceFactory.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapServiceFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+/**
+ * Creates {@link LdapAuthenticationService} instances for a given server configuration.
+ */
+public interface LdapServiceFactory {
+
+    /**
+     * Creates a service that authenticates against the given directory server.
+     *
+     * @param configIn the directory server configuration
+     * @return a ready-to-use authentication service
+     */
+    LdapAuthenticationService getInstance(LdapServerConfig configIn);
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapTransport.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapTransport.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+/**
+ * Transport security mode used to reach a directory server.
+ */
+public enum LdapTransport {
+
+    /** Plain, unencrypted LDAP (typically port 389). For test and trusted-network use only. */
+    PLAIN(389, false),
+
+    /** LDAP over TLS, negotiated at connection time (LDAPS, typically port 636). */
+    LDAPS(636, true),
+
+    /** Plain LDAP upgraded to TLS via the StartTLS extended operation (typically port 389). */
+    STARTTLS(389, true);
+
+    private final int defaultPort;
+    private final boolean secure;
+
+    LdapTransport(int defaultPortIn, boolean secureIn) {
+        this.defaultPort = defaultPortIn;
+        this.secure = secureIn;
+    }
+
+    /**
+     * @return the default TCP port commonly associated with this transport
+     */
+    public int getDefaultPort() {
+        return defaultPort;
+    }
+
+    /**
+     * @return {@code true} if this transport encrypts traffic to the directory
+     */
+    public boolean isSecure() {
+        return secure;
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapUser.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapUser.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable description of a directory user that has successfully authenticated, together
+ * with the profile attributes and external group labels resolved during the bind/search/bind
+ * sequence.
+ *
+ * <p>This object intentionally carries no Uyuni domain types. It is the contract handed back
+ * to the login layer, which is responsible for just-in-time provisioning and for mapping
+ * {@link #groupLabels()} to Uyuni roles.</p>
+ *
+ * @param login the normalized login name as read from the configured login attribute
+ * @param distinguishedName the full DN of the authenticated entry
+ * @param firstName the user's first (given) name, may be {@code null}
+ * @param lastName the user's last (family) name, may be {@code null}
+ * @param email the user's e-mail address, may be {@code null}
+ * @param groupLabels the external group labels the user belongs to, never {@code null}
+ */
+public record LdapUser(
+        String login,
+        String distinguishedName,
+        String firstName,
+        String lastName,
+        String email,
+        List<String> groupLabels) {
+
+    public LdapUser {
+        Objects.requireNonNull(login, "login must not be null");
+        Objects.requireNonNull(distinguishedName, "distinguishedName must not be null");
+        groupLabels = groupLabels == null ? List.of() : List.copyOf(groupLabels);
+    }
+
+    /**
+     * @return the first name wrapped in an {@link Optional}
+     */
+    public Optional<String> firstNameOpt() {
+        return Optional.ofNullable(firstName);
+    }
+
+    /**
+     * @return the last name wrapped in an {@link Optional}
+     */
+    public Optional<String> lastNameOpt() {
+        return Optional.ofNullable(lastName);
+    }
+
+    /**
+     * @return the e-mail address wrapped in an {@link Optional}
+     */
+    public Optional<String> emailOpt() {
+        return Optional.ofNullable(email);
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/LdapUser.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/LdapUser.java
@@ -39,6 +39,10 @@ public record LdapUser(
         String email,
         List<String> groupLabels) {
 
+    /**
+     * Canonical constructor. Requires a login and a distinguished name, and defensively copies the
+     * group labels (treating {@code null} as an empty, immutable list).
+     */
     public LdapUser {
         Objects.requireNonNull(login, "login must not be null");
         Objects.requireNonNull(distinguishedName, "distinguishedName must not be null");

--- a/java/core/src/main/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationService.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationService.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import com.unboundid.ldap.sdk.Filter;
+import com.unboundid.ldap.sdk.LDAPConnection;
+import com.unboundid.ldap.sdk.LDAPConnectionPool;
+import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.ResultCode;
+import com.unboundid.ldap.sdk.SearchResult;
+import com.unboundid.ldap.sdk.SearchResultEntry;
+import com.unboundid.ldap.sdk.SearchScope;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@link LdapAuthenticationService} backed by the UnboundID LDAP SDK.
+ *
+ * <p>Implements the standard bind/search/bind sequence:</p>
+ * <ol>
+ *   <li>Bind a pooled connection as the service account (or anonymously, when allowed).</li>
+ *   <li>Search for the user under the base DN with the configured filter, requiring exactly one
+ *       match.</li>
+ *   <li>Reject an empty supplied password outright, then bind as the discovered user DN with the
+ *       supplied password on a separate connection.</li>
+ *   <li>Resolve the user's group memberships and normalize them to the configured label
+ *       attribute.</li>
+ *   <li>Return the login, profile attributes, and group labels.</li>
+ * </ol>
+ *
+ * <p>User input is never concatenated into a filter; see {@link LdapFilters}.</p>
+ */
+public class UnboundIdLdapAuthenticationService implements LdapAuthenticationService {
+
+    private static final Logger LOG = LogManager.getLogger(UnboundIdLdapAuthenticationService.class);
+
+    private final LdapServerConfig config;
+    private final LdapConnectionFactory connectionFactory;
+
+    /**
+     * @param configIn the server this service authenticates against
+     * @param connectionFactoryIn the factory used to open connections and the search pool
+     */
+    public UnboundIdLdapAuthenticationService(LdapServerConfig configIn,
+                                              LdapConnectionFactory connectionFactoryIn) {
+        this.config = configIn;
+        this.connectionFactory = connectionFactoryIn;
+    }
+
+    @Override
+    public Optional<LdapUser> authenticate(String login, String password) throws LdapException {
+        if (login == null || login.isBlank()) {
+            LOG.debug("Rejecting LDAP authentication with an empty login");
+            return Optional.empty();
+        }
+        // Reject an empty password before any bind. Many directories treat a bind with a valid
+        // DN and an empty password as a successful unauthenticated bind, which must never happen.
+        if (password == null || password.isEmpty()) {
+            LOG.debug("Rejecting LDAP authentication for [{}] because the password is empty", login);
+            return Optional.empty();
+        }
+
+        try (LDAPConnectionPool pool = connectionFactory.createServicePool(config)) {
+            SearchResultEntry entry = findUser(pool, login);
+            if (entry == null) {
+                LOG.info("LDAP authentication failed for [{}]: no matching directory entry", login);
+                return Optional.empty();
+            }
+
+            if (!credentialBindSucceeds(entry.getDN(), password)) {
+                LOG.info("LDAP authentication failed for [{}]: credential bind rejected", login);
+                return Optional.empty();
+            }
+
+            List<String> groups = findGroups(pool, entry.getDN(), login);
+            LdapUser user = toUser(login, entry, groups);
+            LOG.info("LDAP authentication succeeded for [{}] with {} group label(s)", login, groups.size());
+            return Optional.of(user);
+        }
+    }
+
+    private SearchResultEntry findUser(LDAPConnectionPool pool, String login) throws LdapException {
+        Filter filter = LdapFilters.userFilter(config.getUserFilter(), login);
+        try {
+            SearchResult result = pool.search(config.getUserBaseDn(), SearchScope.SUB, filter,
+                    config.getLoginAttribute(), config.getFirstNameAttribute(),
+                    config.getLastNameAttribute(), config.getEmailAttribute());
+            int count = result.getEntryCount();
+            if (count > 1) {
+                LOG.warn("LDAP authentication failed for [{}]: ambiguous user search (base DN={}, filter={}, "
+                        + "matched {} entries)", login, config.getUserBaseDn(), filter, count);
+                return null;
+            }
+            return count == 1 ? result.getSearchEntries().get(0) : null;
+        }
+        catch (LDAPException e) {
+            throw new LdapException("User search failed for [" + login + "]", e);
+        }
+    }
+
+    private boolean credentialBindSucceeds(String userDn, String password) {
+        LDAPConnection connection = null;
+        try {
+            connection = connectionFactory.openConnection(config);
+            ResultCode code = connection.bind(userDn, password).getResultCode();
+            return ResultCode.SUCCESS.equals(code);
+        }
+        catch (LDAPException e) {
+            // Wrong password (and similar) surface here as a normal, expected rejection.
+            return false;
+        }
+        catch (LdapException e) {
+            LOG.warn("Could not open a connection for the credential bind of [{}]", userDn, e);
+            return false;
+        }
+        finally {
+            if (connection != null) {
+                connection.close();
+            }
+        }
+    }
+
+    private List<String> findGroups(LDAPConnectionPool pool, String userDn, String login) {
+        Filter filter;
+        try {
+            filter = LdapFilters.groupFilter(config.getGroupFilter(), userDn);
+        }
+        catch (LdapException e) {
+            LOG.warn("LDAP group lookup skipped for [{}]: invalid group filter (user DN={})", login, userDn, e);
+            return List.of();
+        }
+        try {
+            SearchResult result = pool.search(config.getGroupBaseDn(), SearchScope.SUB, filter,
+                    config.getGroupNameAttribute());
+            List<String> labels = new ArrayList<>();
+            for (SearchResultEntry entry : result.getSearchEntries()) {
+                String label = entry.getAttributeValue(config.getGroupNameAttribute());
+                if (label != null && !label.isBlank()) {
+                    labels.add(label);
+                }
+            }
+            labels.sort(Comparator.naturalOrder());
+            return labels;
+        }
+        catch (LDAPException e) {
+            LOG.warn("LDAP group lookup failed for [{}] (base DN={}, filter={}): {}",
+                    login, config.getGroupBaseDn(), filter, e.getMessage(), e);
+            return List.of();
+        }
+    }
+
+    private LdapUser toUser(String login, SearchResultEntry entry, List<String> groups) {
+        String normalizedLogin = Optional.ofNullable(entry.getAttributeValue(config.getLoginAttribute()))
+                .filter(value -> !value.isBlank())
+                .orElse(login);
+        return new LdapUser(
+                normalizedLogin,
+                entry.getDN(),
+                entry.getAttributeValue(config.getFirstNameAttribute()),
+                entry.getAttributeValue(config.getLastNameAttribute()),
+                entry.getAttributeValue(config.getEmailAttribute()),
+                groups);
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationService.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationService.java
@@ -102,8 +102,8 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
                     config.getLastNameAttribute(), config.getEmailAttribute());
             int count = result.getEntryCount();
             if (count > 1) {
-                LOG.warn("LDAP authentication failed for [{}]: ambiguous user search (base DN={}, filter={}, "
-                        + "matched {} entries)", login, config.getUserBaseDn(), filter, count);
+                LOG.warn("LDAP authentication failed for [{}]: ambiguous user search (base DN={}, filter={}, " +
+                        "matched {} entries)", login, config.getUserBaseDn(), filter, count);
                 return null;
             }
             return count == 1 ? result.getSearchEntries().get(0) : null;
@@ -113,7 +113,7 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
         }
     }
 
-    private boolean credentialBindSucceeds(String userDn, String password) {
+    private boolean credentialBindSucceeds(String userDn, String password) throws LdapException {
         LDAPConnection connection = null;
         try {
             connection = connectionFactory.openConnection(config);
@@ -121,12 +121,14 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
             return ResultCode.SUCCESS.equals(code);
         }
         catch (LDAPException e) {
-            // Wrong password (and similar) surface here as a normal, expected rejection.
-            return false;
-        }
-        catch (LdapException e) {
-            LOG.warn("Could not open a connection for the credential bind of [{}]", userDn, e);
-            return false;
+            if (ResultCode.INVALID_CREDENTIALS.equals(e.getResultCode())) {
+                // A wrong password is a normal, expected authentication rejection.
+                return false;
+            }
+            // Any other result code (server unreachable, timeout, TLS failure, etc.) is an
+            // infrastructure problem the caller must be able to tell apart from a wrong password,
+            // so it is surfaced as an LdapException rather than silently reported as a failed login.
+            throw new LdapException("Credential bind failed for [" + userDn + "]", e);
         }
         finally {
             if (connection != null) {

--- a/java/core/src/main/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationService.java
+++ b/java/core/src/main/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationService.java
@@ -63,7 +63,7 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
     }
 
     @Override
-    public Optional<LdapUser> authenticate(String login, String password) throws LdapException {
+    public Optional<LdapUser> authenticate(String login, String password) throws LdapServiceException {
         if (login == null || login.isBlank()) {
             LOG.debug("Rejecting LDAP authentication with an empty login");
             return Optional.empty();
@@ -94,7 +94,7 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
         }
     }
 
-    private SearchResultEntry findUser(LDAPConnectionPool pool, String login) throws LdapException {
+    private SearchResultEntry findUser(LDAPConnectionPool pool, String login) throws LdapServiceException {
         Filter filter = LdapFilters.userFilter(config.getUserFilter(), login);
         try {
             SearchResult result = pool.search(config.getUserBaseDn(), SearchScope.SUB, filter,
@@ -109,11 +109,11 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
             return count == 1 ? result.getSearchEntries().get(0) : null;
         }
         catch (LDAPException e) {
-            throw new LdapException("User search failed for [" + login + "]", e);
+            throw new LdapServiceException("User search failed for [" + login + "]", e);
         }
     }
 
-    private boolean credentialBindSucceeds(String userDn, String password) throws LdapException {
+    private boolean credentialBindSucceeds(String userDn, String password) throws LdapServiceException {
         LDAPConnection connection = null;
         try {
             connection = connectionFactory.openConnection(config);
@@ -127,8 +127,8 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
             }
             // Any other result code (server unreachable, timeout, TLS failure, etc.) is an
             // infrastructure problem the caller must be able to tell apart from a wrong password,
-            // so it is surfaced as an LdapException rather than silently reported as a failed login.
-            throw new LdapException("Credential bind failed for [" + userDn + "]", e);
+            // so it is surfaced as an LdapServiceException rather than silently reported as a failed login.
+            throw new LdapServiceException("Credential bind failed for [" + userDn + "]", e);
         }
         finally {
             if (connection != null) {
@@ -142,7 +142,7 @@ public class UnboundIdLdapAuthenticationService implements LdapAuthenticationSer
         try {
             filter = LdapFilters.groupFilter(config.getGroupFilter(), userDn);
         }
-        catch (LdapException e) {
+        catch (LdapServiceException e) {
             LOG.warn("LDAP group lookup skipped for [{}]: invalid group filter (user DN={})", login, userDn, e);
             return List.of();
         }

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/login/LoginController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/login/LoginController.java
@@ -44,6 +44,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -197,26 +198,39 @@ public class LoginController {
     private String performLogin(Request request, Response response, boolean allowReadOnly) {
         Optional<String> errorMsg = Optional.empty();
         LoginCredentials creds = GSON.fromJson(request.body(), LoginCredentials.class);
-        User user = LoginHelper.checkExternalAuthentication(request.raw(), new ArrayList<>(), new ArrayList<>());
+        List<String> messages = new ArrayList<>();
+        User user = LoginHelper.checkExternalAuthentication(request.raw(), messages, new ArrayList<>());
 
-        // External-auth didn't return a user - try local-auth
+        // External-auth didn't return a user - try native LDAP, then local-auth
         if (user == null) {
             if (creds == null) {
                 Spark.halt(HttpServletResponse.SC_BAD_REQUEST);
             }
             else {
-                try {
-                    if (allowReadOnly) {
-                        user = UserManager.loginReadOnlyUser(creds.getLogin(), creds.getPassword());
-                    }
-                    else {
-                        user = UserManager.loginUser(creds.getLogin(), creds.getPassword());
-                    }
-                    LOGGER.info("LOCAL AUTH SUCCESS: [{}]", user.getLogin());
+                List<String> ldapErrors = new ArrayList<>();
+                user = LoginHelper.checkLdapAuthentication(creds.getLogin(), creds.getPassword(),
+                        allowReadOnly, true, messages, ldapErrors);
+                if (user != null) {
+                    LOGGER.info("LDAP AUTH SUCCESS: [{}]", user.getLogin());
                 }
-                catch (LoginException e) {
-                    LOGGER.error("LOCAL AUTH FAILURE: [{}]", creds.getLogin());
-                    errorMsg = Optional.of(LocalizationService.getInstance().getMessage(e.getMessage()));
+                else if (!ldapErrors.isEmpty()) {
+                    // Known LDAP user that failed authentication: reject, do not fall back.
+                    errorMsg = Optional.of(ldapErrors.get(0));
+                }
+                else {
+                    try {
+                        if (allowReadOnly) {
+                            user = UserManager.loginReadOnlyUser(creds.getLogin(), creds.getPassword());
+                        }
+                        else {
+                            user = UserManager.loginUser(creds.getLogin(), creds.getPassword());
+                        }
+                        LOGGER.info("LOCAL AUTH SUCCESS: [{}]", user.getLogin());
+                    }
+                    catch (LoginException e) {
+                        LOGGER.error("LOCAL AUTH FAILURE: [{}]", creds.getLogin());
+                        errorMsg = Optional.of(LocalizationService.getInstance().getMessage(e.getMessage()));
+                    }
                 }
             }
         }

--- a/java/core/src/main/java/com/suse/manager/webui/utils/LoginHelper.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/LoginHelper.java
@@ -47,7 +47,7 @@ import com.suse.manager.ldap.ConfigLdapAuthConfigProvider;
 import com.suse.manager.ldap.DefaultLdapServiceFactory;
 import com.suse.manager.ldap.LdapAuthConfigProvider;
 import com.suse.manager.ldap.LdapAuthServerSettings;
-import com.suse.manager.ldap.LdapException;
+import com.suse.manager.ldap.LdapServiceException;
 import com.suse.manager.ldap.LdapServiceFactory;
 import com.suse.manager.ldap.LdapUser;
 import com.suse.manager.utils.DBDiskCheckHelper;
@@ -452,7 +452,7 @@ public class LoginHelper {
         try {
             return ldapServiceFactory.getInstance(server.connectionConfig()).authenticate(login, password);
         }
-        catch (LdapException e) {
+        catch (LdapServiceException e) {
             if (log.isErrorEnabled()) {
                 log.error("LDAP directory could not be consulted for login {}: {}",
                         StringUtil.sanitizeLogInput(login), e.getMessage());

--- a/java/core/src/main/java/com/suse/manager/webui/utils/LoginHelper.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/LoginHelper.java
@@ -330,14 +330,18 @@ public class LoginHelper {
         LocalizationService ls = LocalizationService.getInstance();
         if (servers.isEmpty()) {
             // The user is bound to LDAP but LDAP is unavailable: reject, never try another backend.
-            log.error("LDAP user {} cannot be authenticated: native LDAP is disabled or unconfigured.",
-                    StringUtil.sanitizeLogInput(login));
+            if (log.isErrorEnabled()) {
+                log.error("LDAP user {} cannot be authenticated: native LDAP is disabled or unconfigured.",
+                        StringUtil.sanitizeLogInput(login));
+            }
             errors.add(ls.getMessage("error.invalid_login"));
             return null;
         }
         Optional<LdapUser> authenticated = authenticateAgainstServers(servers, login, password);
         if (authenticated.isEmpty()) {
-            log.warn("LDAP AUTH FAILURE: [{}]", StringUtil.sanitizeLogInput(login));
+            if (log.isWarnEnabled()) {
+                log.warn("LDAP AUTH FAILURE: [{}]", StringUtil.sanitizeLogInput(login));
+            }
             errors.add(ls.getMessage("error.invalid_login"));
             return null;
         }
@@ -369,8 +373,10 @@ public class LoginHelper {
                 continue;
             }
             if (!server.allowsJit()) {
-                log.info("LDAP user {} authenticated but just-in-time provisioning is disabled.",
-                        StringUtil.sanitizeLogInput(login));
+                if (log.isInfoEnabled()) {
+                    log.info("LDAP user {} authenticated but just-in-time provisioning is disabled.",
+                            StringUtil.sanitizeLogInput(login));
+                }
                 continue;
             }
             Org org = resolveLdapOrg(server);
@@ -447,8 +453,10 @@ public class LoginHelper {
             return ldapServiceFactory.getInstance(server.connectionConfig()).authenticate(login, password);
         }
         catch (LdapException e) {
-            log.error("LDAP directory could not be consulted for login {}: {}",
-                    StringUtil.sanitizeLogInput(login), e.getMessage());
+            if (log.isErrorEnabled()) {
+                log.error("LDAP directory could not be consulted for login {}: {}",
+                        StringUtil.sanitizeLogInput(login), e.getMessage());
+            }
             return Optional.empty();
         }
     }

--- a/java/core/src/main/java/com/suse/manager/webui/utils/LoginHelper.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/LoginHelper.java
@@ -33,6 +33,7 @@ import com.redhat.rhn.domain.org.usergroup.UserExtGroup;
 import com.redhat.rhn.domain.org.usergroup.UserGroupFactory;
 import com.redhat.rhn.domain.role.Role;
 import com.redhat.rhn.domain.server.ServerGroup;
+import com.redhat.rhn.domain.user.AuthType;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.frontend.events.UpdateErrataCacheEvent;
@@ -42,6 +43,13 @@ import com.redhat.rhn.manager.user.CreateUserCommand;
 import com.redhat.rhn.manager.user.UpdateUserCommand;
 import com.redhat.rhn.manager.user.UserManager;
 
+import com.suse.manager.ldap.ConfigLdapAuthConfigProvider;
+import com.suse.manager.ldap.DefaultLdapServiceFactory;
+import com.suse.manager.ldap.LdapAuthConfigProvider;
+import com.suse.manager.ldap.LdapAuthServerSettings;
+import com.suse.manager.ldap.LdapException;
+import com.suse.manager.ldap.LdapServiceFactory;
+import com.suse.manager.ldap.LdapUser;
 import com.suse.manager.utils.DBDiskCheckHelper;
 import com.suse.manager.utils.DiskCheckHelper;
 import com.suse.manager.utils.DiskCheckSeverity;
@@ -58,6 +66,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -70,6 +79,15 @@ public class LoginHelper {
 
     private static Logger log = LogManager.getLogger(LoginHelper.class);
     private static final String DEFAULT_KERB_USER_PASSWORD = "0";
+
+    /**
+     * Fixed prefix a directory group must carry to take part in Uyuni role mapping. Not
+     * configurable in v1; stripped before the external-group lookup.
+     */
+    private static final String LDAP_GROUP_PREFIX = "uyuni_";
+
+    private static LdapAuthConfigProvider ldapConfigProvider = new ConfigLdapAuthConfigProvider();
+    private static LdapServiceFactory ldapServiceFactory = new DefaultLdapServiceFactory();
     private static final Long MIN_PG_DB_VERSION = 160001L;
     private static final Long MAX_PG_DB_VERSION = 189999L;
     private static final String MIN_PG_DB_VERSION_STRING = "16";
@@ -157,27 +175,8 @@ public class LoginHelper {
         }
         if (newUserOrg != null) {
             Set<ServerGroup> sgs = getSgsFromExtGroups(extGroups, newUserOrg);
-            try {
-                CreateUserCommand createCmd = new CreateUserCommand();
-                createCmd.setLogin(remoteUserString);
-                // set a password, that cannot really be used
-                createCmd.setRawPassword(DEFAULT_KERB_USER_PASSWORD);
-                createCmd.setFirstNames(firstname);
-                createCmd.setLastName(lastname);
-                createCmd.setEmail(email);
-                createCmd.setOrg(newUserOrg);
-                createCmd.setTemporaryRoles(roles);
-                createCmd.setServerGroups(sgs);
-                createCmd.validate();
-                createCmd.storeNewUser();
-                remoteUser = createCmd.getUser();
-                log.warn("Externally authenticated login {} ({} {}) created in {}.", remoteUserString,
-                        firstname, lastname, newUserOrg.getName());
-            }
-            catch (WrappedSQLException wse) {
-                log.error("Creation of user failed with: {}", wse.getMessage());
-                HibernateFactory.rollbackTransaction();
-            }
+            remoteUser = createProvisionedUser(remoteUserString, firstname, lastname, email, roles, sgs,
+                    newUserOrg, AuthType.LOCAL);
         }
         if (remoteUser != null &&
                 remoteUser.getPassword().equals(DEFAULT_KERB_USER_PASSWORD)) {
@@ -186,6 +185,55 @@ public class LoginHelper {
                     "set your username and password in the user details page.");
         }
         return remoteUser;
+    }
+
+    /**
+     * Just-in-time provisioning shared by all external authentication backends (header-based
+     * {@code REMOTE_USER} and native LDAP). Creates a Uyuni account with a non-usable password and
+     * the given temporary roles. The caller is responsible for having resolved the target
+     * organization and, where relevant, server-group mappings.
+     *
+     * @param login the login name to create
+     * @param firstname the first name, may be {@code null}
+     * @param lastname the last name, may be {@code null}
+     * @param email the e-mail address, may be {@code null}
+     * @param roles the temporary roles to assign
+     * @param sgs the server groups to assign (may be empty)
+     * @param org the organization to create the user in
+     * @param authType the authentication backend to stamp on the new account
+     * @return the created user, or {@code null} if creation failed
+     */
+    private static User createProvisionedUser(String login, String firstname, String lastname, String email,
+                                              Set<Role> roles, Set<ServerGroup> sgs, Org org, AuthType authType) {
+        User created = null;
+        try {
+            CreateUserCommand createCmd = new CreateUserCommand();
+            createCmd.setLogin(login);
+            // set a password, that cannot really be used
+            createCmd.setRawPassword(DEFAULT_KERB_USER_PASSWORD);
+            createCmd.setFirstNames(firstname);
+            createCmd.setLastName(lastname);
+            createCmd.setEmail(email);
+            createCmd.setOrg(org);
+            createCmd.setTemporaryRoles(roles);
+            createCmd.setServerGroups(sgs);
+            createCmd.validate();
+            createCmd.storeNewUser();
+            created = createCmd.getUser();
+            if (authType != null && authType != AuthType.LOCAL) {
+                created.setAuthType(authType);
+                UserManager.storeUser(created);
+            }
+            log.warn("Externally authenticated login {} ({} {}) created in {} as {}.", login,
+                    firstname, lastname, org.getName(), authType);
+        }
+        catch (WrappedSQLException wse) {
+            log.error("Creation of user failed with: {}", wse.getMessage());
+            HibernateFactory.rollbackTransaction();
+            // The transaction was rolled back; never hand back a half-provisioned user.
+            created = null;
+        }
+        return created;
     }
 
     private static void updateRemoteUser(User remoteUser,
@@ -209,6 +257,219 @@ public class LoginHelper {
             log.warn("Externally authenticated login {} ({} {})",
                     StringUtil.sanitizeLogInput(remoteUser.getLogin()), firstname, lastname);
         }
+    }
+
+    /**
+     * Attempt to authenticate a password login against the configured LDAP directories.
+     *
+     * <p>This is the login-layer entry point for native LDAP. It mirrors
+     * {@link #checkExternalAuthentication} but for a supplied login and password rather than trusted
+     * request headers. It is called from every password entry point, but just-in-time provisioning
+     * is gated by {@code allowJit}: the Web UI / HTTP API path enables it, while the XML-RPC path
+     * only authenticates already-provisioned {@code auth_type = LDAP} users (RFC v1 decision).</p>
+     *
+     * <p>The three-way outcome tells the caller how to proceed:</p>
+     * <ul>
+     *   <li><b>non-{@code null} user</b> - LDAP handled the login; proceed to establish the session.</li>
+     *   <li><b>{@code null} and {@code errors} empty</b> - LDAP does not apply to this login (LDAP
+     *       disabled, a known non-LDAP user, or an unknown user when {@code allowJit} is
+     *       {@code false}); the caller should fall through to local/PAM auth.</li>
+     *   <li><b>{@code null} and {@code errors} non-empty</b> - the user is an LDAP user but
+     *       authentication failed; the caller should reject the login and must not fall back to
+     *       another backend.</li>
+     * </ul>
+     *
+     * @param login the supplied login name
+     * @param password the supplied password
+     * @param allowReadOnly whether a read-only account may log in on this entry point (the Web UI
+     *                      login passes {@code false}, the API entry points pass {@code true})
+     * @param allowJit whether unknown users may be provisioned just-in-time on this entry point
+     *                 (Web UI / HTTP API pass {@code true}; XML-RPC passes {@code false})
+     * @param messages informational messages to surface to the user
+     * @param errors error messages; a non-empty list means "reject, do not fall back"
+     * @return the authenticated (or just-provisioned) user, or {@code null} as described above
+     */
+    public static User checkLdapAuthentication(String login, String password, boolean allowReadOnly,
+            boolean allowJit, List<String> messages, List<String> errors) {
+        if (login == null) {
+            return null;
+        }
+        // Determine the configured servers up front. Routing by auth_type still happens even when
+        // LDAP is disabled, so that a known LDAP user can never silently fall back to local/PAM.
+        List<LdapAuthServerSettings> servers =
+                ldapConfigProvider.isEnabled() ? ldapConfigProvider.getServers() : List.of();
+
+        User existing;
+        try {
+            existing = UserFactory.lookupByLogin(login);
+        }
+        catch (LookupException le) {
+            existing = null;
+        }
+
+        if (existing != null) {
+            // Route strictly by auth_type. Non-LDAP users are not our concern; hand them back to the
+            // caller's local/PAM path. LDAP users are always handled here and never fall back.
+            if (existing.getAuthType() != AuthType.LDAP) {
+                return null;
+            }
+            return authenticateKnownLdapUser(existing, login, password, servers, allowReadOnly, errors);
+        }
+
+        // Unknown user. JIT provisioning runs on the Web UI / HTTP API path only; the XML-RPC path
+        // (allowJit == false) never creates accounts and lets the caller's local path reject the
+        // login as usual (RFC v1: JIT on Web UI only, XML-RPC authenticates existing users only).
+        if (!allowJit || servers.isEmpty()) {
+            return null;
+        }
+        return provisionUnknownLdapUser(login, password, servers, messages);
+    }
+
+    private static User authenticateKnownLdapUser(User existing, String login, String password,
+            List<LdapAuthServerSettings> servers, boolean allowReadOnly, List<String> errors) {
+        LocalizationService ls = LocalizationService.getInstance();
+        if (servers.isEmpty()) {
+            // The user is bound to LDAP but LDAP is unavailable: reject, never try another backend.
+            log.error("LDAP user {} cannot be authenticated: native LDAP is disabled or unconfigured.",
+                    StringUtil.sanitizeLogInput(login));
+            errors.add(ls.getMessage("error.invalid_login"));
+            return null;
+        }
+        Optional<LdapUser> authenticated = authenticateAgainstServers(servers, login, password);
+        if (authenticated.isEmpty()) {
+            log.warn("LDAP AUTH FAILURE: [{}]", StringUtil.sanitizeLogInput(login));
+            errors.add(ls.getMessage("error.invalid_login"));
+            return null;
+        }
+        // Credentials are valid; apply the same active/read-only gates as local login before granting
+        // a session (mirrors UserManager.loginUser).
+        if (existing.isDisabled()) {
+            errors.add(ls.getMessage("account.disabled"));
+            return null;
+        }
+        if (!allowReadOnly && existing.isReadOnly()) {
+            errors.add(ls.getMessage("error.user_readonly"));
+            return null;
+        }
+        LdapUser ldapUser = authenticated.get();
+        Set<Role> roles = getRolesFromExtGroups(toExtGroupLabels(ldapUser.groupLabels()));
+        updateRemoteUser(existing, ldapUser.firstName(), ldapUser.lastName(), ldapUser.email(), roles);
+        return existing;
+    }
+
+    private static User provisionUnknownLdapUser(String login, String password,
+            List<LdapAuthServerSettings> servers, List<String> messages) {
+        // Unknown user: probe the servers in priority order. A server that authenticates the
+        // credentials, allows just-in-time provisioning and resolves its organization creates the
+        // account as an LDAP user. If any of those steps fails, keep probing the remaining servers
+        // rather than giving up on the whole login.
+        for (LdapAuthServerSettings server : servers) {
+            Optional<LdapUser> authenticated = tryAuthenticate(server, login, password);
+            if (authenticated.isEmpty()) {
+                continue;
+            }
+            if (!server.allowsJit()) {
+                log.info("LDAP user {} authenticated but just-in-time provisioning is disabled.",
+                        StringUtil.sanitizeLogInput(login));
+                continue;
+            }
+            Org org = resolveLdapOrg(server);
+            if (org == null) {
+                continue;
+            }
+            LdapUser ldapUser = authenticated.get();
+            Set<Role> roles = getRolesFromExtGroups(toExtGroupLabels(ldapUser.groupLabels()));
+            User created = createProvisionedUser(ldapUser.login(), ldapUser.firstName(), ldapUser.lastName(),
+                    ldapUser.email(), roles, new HashSet<>(), org, AuthType.LDAP);
+            if (created != null) {
+                messages.add("You have logged in as an LDAP-authenticated user.");
+                return created;
+            }
+        }
+        return null;
+    }
+
+    private static Org resolveLdapOrg(LdapAuthServerSettings server) {
+        Long orgId = server.defaultOrgId();
+        Org org = orgId == null ? null : OrgFactory.lookupById(orgId);
+        if (org == null) {
+            log.error("Cannot provision LDAP user: organization with id {} not found.", orgId);
+        }
+        return org;
+    }
+
+    private static Optional<LdapUser> authenticateAgainstServers(List<LdapAuthServerSettings> servers,
+            String login, String password) {
+        for (LdapAuthServerSettings server : servers) {
+            Optional<LdapUser> authenticated = tryAuthenticate(server, login, password);
+            if (authenticated.isPresent()) {
+                return authenticated;
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Selects the directory groups that participate in role mapping and converts them to
+     * external-group labels.
+     *
+     * <p>Only groups whose name starts with {@link #LDAP_GROUP_PREFIX} are considered, and the
+     * prefix is stripped before the lookup, so directory group {@code uyuni_admins} is mapped
+     * through external group {@code admins}. Every other directory group is ignored, which keeps
+     * unrelated directory groups from accidentally matching an existing external-group mapping. The
+     * prefix is deliberately fixed rather than configurable for v1.</p>
+     *
+     * @param ldapGroupLabels the group names as returned by the directory
+     * @return the external-group labels to look up, prefix removed
+     */
+    private static Set<String> toExtGroupLabels(List<String> ldapGroupLabels) {
+        Set<String> labels = new HashSet<>();
+        for (String groupLabel : ldapGroupLabels) {
+            if (groupLabel == null) {
+                continue;
+            }
+            String trimmed = groupLabel.trim();
+            if (trimmed.length() > LDAP_GROUP_PREFIX.length() &&
+                    trimmed.regionMatches(true, 0, LDAP_GROUP_PREFIX, 0, LDAP_GROUP_PREFIX.length())) {
+                labels.add(trimmed.substring(LDAP_GROUP_PREFIX.length()));
+            }
+            else if (log.isDebugEnabled()) {
+                log.debug("Ignoring LDAP group '{}': it does not start with '{}'.",
+                        StringUtil.sanitizeLogInput(trimmed), LDAP_GROUP_PREFIX);
+            }
+        }
+        return labels;
+    }
+
+    private static Optional<LdapUser> tryAuthenticate(LdapAuthServerSettings server, String login,
+            String password) {
+        try {
+            return ldapServiceFactory.getInstance(server.connectionConfig()).authenticate(login, password);
+        }
+        catch (LdapException e) {
+            log.error("LDAP directory could not be consulted for login {}: {}",
+                    StringUtil.sanitizeLogInput(login), e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Overrides the LDAP configuration provider. Intended for tests.
+     *
+     * @param providerIn the provider to use
+     */
+    public static void setLdapConfigProvider(LdapAuthConfigProvider providerIn) {
+        ldapConfigProvider = providerIn;
+    }
+
+    /**
+     * Overrides the LDAP service factory. Intended for tests that point the login layer at an
+     * in-memory directory server.
+     *
+     * @param factoryIn the factory to use
+     */
+    public static void setLdapServiceFactory(LdapServiceFactory factoryIn) {
+        ldapServiceFactory = factoryIn;
     }
 
     private static String decodeFromIso88591(String string, String defaultString) {

--- a/java/core/src/test/java/com/redhat/rhn/domain/user/AuthTypeTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/user/AuthTypeTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.domain.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class AuthTypeTest {
+
+    @Test
+    public void resolvesKnownLabelsCaseInsensitively() {
+        assertEquals(AuthType.LOCAL, AuthType.fromLabel("LOCAL"));
+        assertEquals(AuthType.PAM, AuthType.fromLabel("pam"));
+        assertEquals(AuthType.LDAP, AuthType.fromLabel("  Ldap "));
+    }
+
+    @Test
+    public void fallsBackToLocalForBadValues() {
+        assertEquals(AuthType.LOCAL, AuthType.fromLabel(null));
+        assertEquals(AuthType.LOCAL, AuthType.fromLabel(""));
+        assertEquals(AuthType.LOCAL, AuthType.fromLabel("   "));
+        assertEquals(AuthType.LOCAL, AuthType.fromLabel("kerberos"));
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/ldap/ConfigLdapAuthConfigProviderTest.java
+++ b/java/core/src/test/java/com/suse/manager/ldap/ConfigLdapAuthConfigProviderTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ConfigLdapAuthConfigProviderTest {
+
+    private ConfigLdapAuthConfigProvider providerFor(Map<String, String> values) {
+        return new ConfigLdapAuthConfigProvider(
+                values::get,
+                key -> {
+                    String v = values.get(key);
+                    return "1".equals(v) || "true".equalsIgnoreCase(v) || "y".equalsIgnoreCase(v);
+                },
+                key -> {
+                    String v = values.get(key);
+                    if (v == null || v.isBlank()) {
+                        return 0;
+                    }
+                    return Integer.parseInt(v);
+                });
+    }
+
+    @Test
+    public void disabledByDefault() {
+        ConfigLdapAuthConfigProvider provider = providerFor(new HashMap<>());
+        assertFalse(provider.isEnabled());
+        assertTrue(provider.getServers().isEmpty());
+    }
+
+    @Test
+    public void enabledButMisconfiguredYieldsNoServers() {
+        Map<String, String> values = new HashMap<>();
+        values.put("ldap.auth_enabled", "1");
+        // No host / user_base_dn: misconfigured, must not throw and must not return a server.
+        ConfigLdapAuthConfigProvider provider = providerFor(values);
+        assertTrue(provider.isEnabled());
+        assertTrue(provider.getServers().isEmpty());
+    }
+
+    @Test
+    public void buildsSingleServerFromConfig() {
+        Map<String, String> values = new HashMap<>();
+        values.put("ldap.auth_enabled", "1");
+        values.put("ldap.server_type", "ACTIVE_DIRECTORY");
+        values.put("ldap.host", "ad.example.com");
+        values.put("ldap.transport", "LDAPS");
+        values.put("ldap.bind_dn", "CN=reader,DC=example,DC=com");
+        values.put("ldap.bind_password", "secret");
+        values.put("ldap.user_base_dn", "OU=Users,DC=example,DC=com");
+        values.put("ldap.provisioning_mode", "EXISTING_ONLY");
+        values.put("ldap.default_org_id", "3");
+
+        List<LdapAuthServerSettings> servers = providerFor(values).getServers();
+
+        assertEquals(1, servers.size());
+        LdapAuthServerSettings server = servers.get(0);
+        assertEquals("ad.example.com", server.connectionConfig().getHost());
+        assertEquals(LdapServerType.ACTIVE_DIRECTORY, server.connectionConfig().getServerType());
+        assertEquals(LdapTransport.LDAPS, server.connectionConfig().getTransport());
+        assertEquals(LdapProvisioningMode.EXISTING_ONLY, server.provisioningMode());
+        assertFalse(server.allowsJit());
+        assertEquals(3L, server.defaultOrgId());
+    }
+
+    @Test
+    public void defaultsProvisioningToJitAndOrgToOne() {
+        Map<String, String> values = new HashMap<>();
+        values.put("ldap.auth_enabled", "true");
+        values.put("ldap.host", "ldap.example.com");
+        values.put("ldap.bind_dn", "uid=reader,dc=example,dc=com");
+        values.put("ldap.bind_password", "secret");
+        values.put("ldap.user_base_dn", "ou=users,dc=example,dc=com");
+
+        List<LdapAuthServerSettings> servers = providerFor(values).getServers();
+
+        assertEquals(1, servers.size());
+        LdapAuthServerSettings server = servers.get(0);
+        assertEquals(LdapServerType.OPEN_LDAP, server.connectionConfig().getServerType());
+        assertTrue(server.allowsJit());
+        assertEquals(1L, server.defaultOrgId());
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/ldap/LdapFiltersTest.java
+++ b/java/core/src/test/java/com/suse/manager/ldap/LdapFiltersTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.unboundid.ldap.sdk.Filter;
+
+import org.junit.jupiter.api.Test;
+
+public class LdapFiltersTest {
+
+    @Test
+    public void buildsUserFilterFromTemplate() throws Exception {
+        Filter filter = LdapFilters.userFilter("(&(objectClass=inetOrgPerson)(uid={login}))", "alice");
+        assertEquals("(&(objectClass=inetOrgPerson)(uid=alice))", filter.toString());
+    }
+
+    @Test
+    public void buildsGroupFilterFromTemplate() throws Exception {
+        Filter filter = LdapFilters.groupFilter("(&(objectClass=groupOfNames)(member={userDn}))",
+                "uid=alice,ou=users,dc=uyuni,dc=test");
+        assertEquals("(&(objectClass=groupOfNames)(member=uid=alice,ou=users,dc=uyuni,dc=test))",
+                filter.toString());
+    }
+
+    @Test
+    public void escapesSpecialCharactersToPreventInjection() throws Exception {
+        Filter filter = LdapFilters.userFilter("(uid={login})", "a)(uid=*");
+        // The asterisk and parentheses must be escaped so the supplied value cannot widen the
+        // filter into a wildcard or inject extra clauses.
+        String rendered = filter.toString();
+        assertTrue(rendered.contains("\\2a"), "asterisk should be escaped: " + rendered);
+        assertTrue(rendered.contains("\\28") || rendered.contains("\\29"),
+                "parentheses should be escaped: " + rendered);
+        assertEquals("(uid=a\\29\\28uid=\\2a)", rendered);
+    }
+
+    @Test
+    public void rejectsTemplateWithoutPlaceholder() {
+        assertThrows(LdapException.class, () -> LdapFilters.userFilter("(uid=fixed)", "alice"));
+    }
+
+    @Test
+    public void rejectsEmptyValue() {
+        assertThrows(LdapException.class, () -> LdapFilters.userFilter("(uid={login})", ""));
+        assertThrows(LdapException.class, () -> LdapFilters.groupFilter("(member={userDn})", null));
+    }
+
+    @Test
+    public void rejectsMalformedTemplate() {
+        assertThrows(LdapException.class, () -> LdapFilters.userFilter("(&(uid={login})", "alice"));
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/ldap/LdapFiltersTest.java
+++ b/java/core/src/test/java/com/suse/manager/ldap/LdapFiltersTest.java
@@ -49,17 +49,17 @@ public class LdapFiltersTest {
 
     @Test
     public void rejectsTemplateWithoutPlaceholder() {
-        assertThrows(LdapException.class, () -> LdapFilters.userFilter("(uid=fixed)", "alice"));
+        assertThrows(LdapServiceException.class, () -> LdapFilters.userFilter("(uid=fixed)", "alice"));
     }
 
     @Test
     public void rejectsEmptyValue() {
-        assertThrows(LdapException.class, () -> LdapFilters.userFilter("(uid={login})", ""));
-        assertThrows(LdapException.class, () -> LdapFilters.groupFilter("(member={userDn})", null));
+        assertThrows(LdapServiceException.class, () -> LdapFilters.userFilter("(uid={login})", ""));
+        assertThrows(LdapServiceException.class, () -> LdapFilters.groupFilter("(member={userDn})", null));
     }
 
     @Test
     public void rejectsMalformedTemplate() {
-        assertThrows(LdapException.class, () -> LdapFilters.userFilter("(&(uid={login})", "alice"));
+        assertThrows(LdapServiceException.class, () -> LdapFilters.userFilter("(&(uid={login})", "alice"));
     }
 }

--- a/java/core/src/test/java/com/suse/manager/ldap/LdapServerConfigTest.java
+++ b/java/core/src/test/java/com/suse/manager/ldap/LdapServerConfigTest.java
@@ -48,6 +48,33 @@ public class LdapServerConfigTest {
     }
 
     @Test
+    public void transportSwitchUpdatesPortWhenNoExplicitPortIsSet() {
+        // Regression: selecting PLAIN without an explicit port must use the PLAIN default (389),
+        // not remain on the LDAPS default (636).
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "ldap.example.com", "ou=users,dc=example,dc=com")
+                .transport(LdapTransport.PLAIN)
+                .anonymousBind()
+                .build();
+
+        assertEquals(LdapTransport.PLAIN, config.getTransport());
+        assertEquals(389, config.getPort());
+    }
+
+    @Test
+    public void explicitPortSurvivesLaterTransportChange() {
+        // An explicitly chosen port must win even if the transport is set afterwards.
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "ldap.example.com", "ou=users,dc=example,dc=com")
+                .port(1636)
+                .transport(LdapTransport.PLAIN)
+                .anonymousBind()
+                .build();
+
+        assertEquals(1636, config.getPort());
+    }
+
+    @Test
     public void overridesAreHonored() {
         LdapServerConfig config = LdapServerConfig
                 .builder(LdapServerType.OPEN_LDAP, "ldap.example.com", "ou=users,dc=example,dc=com")

--- a/java/core/src/test/java/com/suse/manager/ldap/LdapServerConfigTest.java
+++ b/java/core/src/test/java/com/suse/manager/ldap/LdapServerConfigTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class LdapServerConfigTest {
+
+    @Test
+    public void appliesServerTypeDefaults() {
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.ACTIVE_DIRECTORY, "ad.example.com", "OU=Users,DC=example,DC=com")
+                .bind("CN=reader,DC=example,DC=com", "secret")
+                .build();
+
+        assertEquals("sAMAccountName", config.getLoginAttribute());
+        assertEquals("(&(objectClass=user)(sAMAccountName={login}))", config.getUserFilter());
+        assertEquals("cn", config.getGroupNameAttribute());
+        assertEquals("givenName", config.getFirstNameAttribute());
+        // group base DN defaults to the user base DN until overridden
+        assertEquals("OU=Users,DC=example,DC=com", config.getGroupBaseDn());
+    }
+
+    @Test
+    public void ldapsIsTheDefaultTransportWithItsDefaultPort() {
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.FREE_IPA, "ipa.example.com", "dc=example,dc=com")
+                .bind("uid=reader,dc=example,dc=com", "secret")
+                .build();
+
+        assertEquals(LdapTransport.LDAPS, config.getTransport());
+        assertEquals(636, config.getPort());
+        assertTrue(config.getTransport().isSecure());
+    }
+
+    @Test
+    public void overridesAreHonored() {
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "ldap.example.com", "ou=users,dc=example,dc=com")
+                .transport(LdapTransport.PLAIN)
+                .port(1389)
+                .bind("cn=admin,dc=example,dc=com", "admin")
+                .groupBaseDn("ou=groups,dc=example,dc=com")
+                .userFilter("(&(objectClass=posixAccount)(uid={login}))")
+                .build();
+
+        assertEquals(1389, config.getPort());
+        assertEquals(LdapTransport.PLAIN, config.getTransport());
+        assertFalse(config.getTransport().isSecure());
+        assertEquals("ou=groups,dc=example,dc=com", config.getGroupBaseDn());
+        assertEquals("(&(objectClass=posixAccount)(uid={login}))", config.getUserFilter());
+    }
+
+    @Test
+    public void anonymousBindIsAllowedWhenExplicit() {
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "ldap.example.com", "ou=users,dc=example,dc=com")
+                .anonymousBind()
+                .build();
+
+        assertTrue(config.isAllowAnonymousBind());
+        assertTrue(config.getBindDn().isEmpty());
+    }
+
+    @Test
+    public void rejectsMissingBindWithoutExplicitAnonymous() {
+        LdapServerConfig.Builder builder = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "ldap.example.com", "ou=users,dc=example,dc=com");
+        assertThrows(IllegalStateException.class, builder::build);
+    }
+
+    @Test
+    public void rejectsBindDnWithoutPassword() {
+        LdapServerConfig.Builder builder = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "ldap.example.com", "ou=users,dc=example,dc=com")
+                .bind("cn=admin,dc=example,dc=com", "");
+        assertThrows(IllegalStateException.class, builder::build);
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationServiceTest.java
+++ b/java/core/src/test/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationServiceTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.ldap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.unboundid.ldap.listener.InMemoryDirectoryServer;
+import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Integration test exercising the full bind/search/bind pipeline against an embedded
+ * {@link InMemoryDirectoryServer}. The directory is seeded with the same entries as the
+ * {@code tooling/dev-ldap} fixture so the test needs no external server or container.
+ */
+public class UnboundIdLdapAuthenticationServiceTest {
+
+    private static final String BASE_DN = "dc=uyuni,dc=test";
+    private static final String USERS_DN = "ou=users,dc=uyuni,dc=test";
+    private static final String GROUPS_DN = "ou=groups,dc=uyuni,dc=test";
+    private static final String ADMIN_DN = "cn=admin,dc=uyuni,dc=test";
+    private static final String ADMIN_PASSWORD = "admin";
+
+    private InMemoryDirectoryServer directory;
+
+    @BeforeEach
+    public void startDirectory() throws Exception {
+        InMemoryDirectoryServerConfig dsConfig = new InMemoryDirectoryServerConfig(BASE_DN);
+        dsConfig.addAdditionalBindCredentials(ADMIN_DN, ADMIN_PASSWORD);
+        directory = new InMemoryDirectoryServer(dsConfig);
+        seed();
+        directory.startListening();
+    }
+
+    @AfterEach
+    public void stopDirectory() {
+        if (directory != null) {
+            directory.shutDown(true);
+        }
+    }
+
+    private void seed() throws Exception {
+        directory.add("dn: " + BASE_DN, "objectClass: top", "objectClass: domain", "dc: uyuni");
+        directory.add("dn: " + USERS_DN, "objectClass: organizationalUnit", "ou: users");
+        directory.add("dn: " + GROUPS_DN, "objectClass: organizationalUnit", "ou: groups");
+
+        directory.add(
+                "dn: uid=alice," + USERS_DN,
+                "objectClass: inetOrgPerson",
+                "cn: Alice Anderson",
+                "givenName: Alice",
+                "sn: Anderson",
+                "uid: alice",
+                "mail: alice@uyuni.test",
+                "userPassword: alice123");
+        directory.add(
+                "dn: uid=bob," + USERS_DN,
+                "objectClass: inetOrgPerson",
+                "cn: Bob Brown",
+                "givenName: Bob",
+                "sn: Brown",
+                "uid: bob",
+                "mail: bob@uyuni.test",
+                "userPassword: bob123");
+
+        directory.add(
+                "dn: cn=uyuni-admins," + GROUPS_DN,
+                "objectClass: groupOfNames",
+                "cn: uyuni-admins",
+                "member: uid=alice," + USERS_DN);
+        directory.add(
+                "dn: cn=uyuni-users," + GROUPS_DN,
+                "objectClass: groupOfNames",
+                "cn: uyuni-users",
+                "member: uid=alice," + USERS_DN,
+                "member: uid=bob," + USERS_DN);
+    }
+
+    private LdapAuthenticationService service() {
+        return service(ADMIN_DN, ADMIN_PASSWORD);
+    }
+
+    private LdapAuthenticationService service(String bindDn, String bindPassword) {
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "127.0.0.1", USERS_DN)
+                .transport(LdapTransport.PLAIN)
+                .port(directory.getListenPort())
+                .bind(bindDn, bindPassword)
+                .groupBaseDn(GROUPS_DN)
+                .build();
+        return new DefaultLdapServiceFactory().getInstance(config);
+    }
+
+    @Test
+    public void authenticatesUserAndResolvesAllGroups() throws Exception {
+        Optional<LdapUser> result = service().authenticate("alice", "alice123");
+
+        assertTrue(result.isPresent());
+        LdapUser user = result.get();
+        assertEquals("alice", user.login());
+        assertEquals("uid=alice," + USERS_DN, user.distinguishedName());
+        assertEquals("Alice", user.firstName());
+        assertEquals("Anderson", user.lastName());
+        assertEquals("alice@uyuni.test", user.email());
+        assertEquals(List.of("uyuni-admins", "uyuni-users"), user.groupLabels());
+    }
+
+    @Test
+    public void authenticatesUserWithSubsetOfGroups() throws Exception {
+        Optional<LdapUser> result = service().authenticate("bob", "bob123");
+
+        assertTrue(result.isPresent());
+        assertEquals(List.of("uyuni-users"), result.get().groupLabels());
+    }
+
+    @Test
+    public void rejectsWrongPassword() throws Exception {
+        assertTrue(service().authenticate("alice", "wrong-password").isEmpty());
+    }
+
+    @Test
+    public void rejectsUnknownUser() throws Exception {
+        assertTrue(service().authenticate("carol", "whatever").isEmpty());
+    }
+
+    @Test
+    public void rejectsEmptyPasswordWithoutBinding() throws Exception {
+        // A valid DN with an empty password must never be treated as a successful bind.
+        assertTrue(service().authenticate("alice", "").isEmpty());
+    }
+
+    @Test
+    public void rejectsNullCredentials() throws Exception {
+        assertTrue(service().authenticate(null, "x").isEmpty());
+        assertTrue(service().authenticate("alice", null).isEmpty());
+    }
+
+    @Test
+    public void failedServiceBindRaisesLdapException() {
+        LdapAuthenticationService service = service(ADMIN_DN, "wrong-service-password");
+        assertThrows(LdapException.class, () -> service.authenticate("alice", "alice123"));
+    }
+
+    @Test
+    public void rejectsAmbiguousUserSearch() throws Exception {
+        directory.add(
+                "dn: uid=alice-dup," + USERS_DN,
+                "objectClass: inetOrgPerson",
+                "cn: Alice Duplicate",
+                "givenName: Alice",
+                "sn: Duplicate",
+                "uid: alice",
+                "mail: alice-dup@uyuni.test",
+                "userPassword: alice123");
+
+        assertTrue(service().authenticate("alice", "alice123").isEmpty());
+    }
+
+    @Test
+    public void authenticatesWhenGroupLookupFails() throws Exception {
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "127.0.0.1", USERS_DN)
+                .transport(LdapTransport.PLAIN)
+                .port(directory.getListenPort())
+                .bind(ADMIN_DN, ADMIN_PASSWORD)
+                .groupBaseDn("ou=missing," + BASE_DN)
+                .build();
+        LdapAuthenticationService brokenGroupService = new DefaultLdapServiceFactory().getInstance(config);
+
+        Optional<LdapUser> result = brokenGroupService.authenticate("alice", "alice123");
+
+        assertTrue(result.isPresent());
+        assertEquals("alice", result.get().login());
+        assertTrue(result.get().groupLabels().isEmpty());
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationServiceTest.java
+++ b/java/core/src/test/java/com/suse/manager/ldap/UnboundIdLdapAuthenticationServiceTest.java
@@ -153,9 +153,9 @@ public class UnboundIdLdapAuthenticationServiceTest {
     }
 
     @Test
-    public void failedServiceBindRaisesLdapException() {
+    public void failedServiceBindRaisesLdapServiceException() {
         LdapAuthenticationService service = service(ADMIN_DN, "wrong-service-password");
-        assertThrows(LdapException.class, () -> service.authenticate("alice", "alice123"));
+        assertThrows(LdapServiceException.class, () -> service.authenticate("alice", "alice123"));
     }
 
     @Test

--- a/java/core/src/test/java/com/suse/manager/webui/utils/LoginHelperLdapAuthenticationTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/utils/LoginHelperLdapAuthenticationTest.java
@@ -213,6 +213,12 @@ public class LoginHelperLdapAuthenticationTest extends BaseTestCaseWithUser {
         // RFC v1: only directory groups starting with "uyuni_" take part in role mapping, and the
         // prefix is stripped before the external-group lookup. A directory group without the prefix
         // must be ignored even when an external group of that exact name exists.
+        //
+        // UserTestUtils permanently grants IMPLIEDROLES (CHANNEL_ADMIN, CONFIG_ADMIN, ...).
+        // UserManager.resetTemporaryRoles skips any role the user already has, so those permanent
+        // grants would hide LDAP temporary-role updates. Strip them first so the temporary-role
+        // assertions below actually observe the mapping result.
+        UserFactory.IMPLIEDROLES.forEach(user::removePermanentRole);
         user.setAuthType(AuthType.LDAP);
         UserManager.storeUser(user);
         addGroup("uyuni_" + PREFIXED_EXT_GROUP, user.getLogin());
@@ -227,8 +233,6 @@ public class LoginHelperLdapAuthenticationTest extends BaseTestCaseWithUser {
 
         assertNotNull(result);
         assertTrue(errors.isEmpty());
-        // LDAP-derived roles are temporary. BaseTestCaseWithUser permanently grants the implied
-        // admin roles (including CONFIG_ADMIN), so hasRole() would always be true for those.
         assertTrue(result.getTemporaryRoles().contains(RoleFactory.CHANNEL_ADMIN),
                 "uyuni_-prefixed group should map through the stripped label");
         assertFalse(result.getTemporaryRoles().contains(RoleFactory.CONFIG_ADMIN),

--- a/java/core/src/test/java/com/suse/manager/webui/utils/LoginHelperLdapAuthenticationTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/utils/LoginHelperLdapAuthenticationTest.java
@@ -229,9 +229,9 @@ public class LoginHelperLdapAuthenticationTest extends BaseTestCaseWithUser {
         assertTrue(errors.isEmpty());
         // LDAP-derived roles are temporary. BaseTestCaseWithUser permanently grants the implied
         // admin roles (including CONFIG_ADMIN), so hasRole() would always be true for those.
-        assertTrue(result.hasTemporaryRole(RoleFactory.CHANNEL_ADMIN),
+        assertTrue(result.getTemporaryRoles().contains(RoleFactory.CHANNEL_ADMIN),
                 "uyuni_-prefixed group should map through the stripped label");
-        assertFalse(result.hasTemporaryRole(RoleFactory.CONFIG_ADMIN),
+        assertFalse(result.getTemporaryRoles().contains(RoleFactory.CONFIG_ADMIN),
                 "group without the uyuni_ prefix must be ignored");
     }
 

--- a/java/core/src/test/java/com/suse/manager/webui/utils/LoginHelperLdapAuthenticationTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/utils/LoginHelperLdapAuthenticationTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.webui.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.common.hibernate.LookupException;
+import com.redhat.rhn.domain.org.usergroup.UserExtGroup;
+import com.redhat.rhn.domain.org.usergroup.UserGroupFactory;
+import com.redhat.rhn.domain.role.Role;
+import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.domain.user.AuthType;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.domain.user.UserFactory;
+import com.redhat.rhn.manager.user.UserManager;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+
+import com.suse.manager.ldap.ConfigLdapAuthConfigProvider;
+import com.suse.manager.ldap.DefaultLdapServiceFactory;
+import com.suse.manager.ldap.LdapAuthConfigProvider;
+import com.suse.manager.ldap.LdapAuthServerSettings;
+import com.suse.manager.ldap.LdapProvisioningMode;
+import com.suse.manager.ldap.LdapServerConfig;
+import com.suse.manager.ldap.LdapServerType;
+import com.suse.manager.ldap.LdapTransport;
+
+import com.unboundid.ldap.listener.InMemoryDirectoryServer;
+import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Verifies the login-layer routing added in {@link LoginHelper#checkLdapAuthentication} against an
+ * embedded {@link InMemoryDirectoryServer}. Because this method is the single entry point shared by
+ * the Web UI, the HTTP API and the XML-RPC API, these tests cover the group synchronization that
+ * API-only users must also receive.
+ */
+public class LoginHelperLdapAuthenticationTest extends BaseTestCaseWithUser {
+
+    private static final String BASE_DN = "dc=uyuni,dc=test";
+    private static final String USERS_DN = "ou=users,dc=uyuni,dc=test";
+    private static final String GROUPS_DN = "ou=groups,dc=uyuni,dc=test";
+    private static final String ADMIN_DN = "cn=admin,dc=uyuni,dc=test";
+    private static final String ADMIN_PASSWORD = "admin";
+    private static final String JIT_LOGIN = "bob";
+    private static final String JIT_PASSWORD = "bob123";
+    private static final String PREFIXED_EXT_GROUP = "ldap-channel-admins";
+    private static final String UNPREFIXED_GROUP = "ldap-config-admins";
+
+    private InMemoryDirectoryServer directory;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        InMemoryDirectoryServerConfig dsConfig = new InMemoryDirectoryServerConfig(BASE_DN);
+        dsConfig.addAdditionalBindCredentials(ADMIN_DN, ADMIN_PASSWORD);
+        directory = new InMemoryDirectoryServer(dsConfig);
+        directory.add("dn: " + BASE_DN, "objectClass: top", "objectClass: domain", "dc: uyuni");
+        directory.add("dn: " + USERS_DN, "objectClass: organizationalUnit", "ou: users");
+        directory.add("dn: " + GROUPS_DN, "objectClass: organizationalUnit", "ou: groups");
+        // A directory entry matching the existing Uyuni user (whose login is randomly generated).
+        addUser(user.getLogin(), "existing-secret");
+        // A directory entry that has no Uyuni account yet, used for the JIT test.
+        addUser(JIT_LOGIN, JIT_PASSWORD);
+        directory.startListening();
+    }
+
+    @AfterEach
+    public void stopDirectory() {
+        if (directory != null) {
+            directory.shutDown(true);
+        }
+        // Restore the defaults so we do not leak configuration into other tests.
+        LoginHelper.setLdapConfigProvider(new ConfigLdapAuthConfigProvider());
+        LoginHelper.setLdapServiceFactory(new DefaultLdapServiceFactory());
+    }
+
+    private void addGroup(String cn, String... memberUids) throws Exception {
+        String[] entry = new String[3 + memberUids.length];
+        entry[0] = "dn: cn=" + cn + "," + GROUPS_DN;
+        entry[1] = "objectClass: groupOfNames";
+        entry[2] = "cn: " + cn;
+        for (int i = 0; i < memberUids.length; i++) {
+            entry[3 + i] = "member: uid=" + memberUids[i] + "," + USERS_DN;
+        }
+        directory.add(entry);
+    }
+
+    /**
+     * Maps an external group label to a single Uyuni role, as an administrator would through
+     * Users &gt; External groups.
+     */
+    private void mapExtGroupToRole(String label, Role role) {
+        UserExtGroup extGroup = new UserExtGroup();
+        extGroup.setLabel(label);
+        extGroup.setRoles(new HashSet<>(Set.of(role)));
+        UserGroupFactory.save(extGroup);
+    }
+
+    private void addUser(String uid, String password) throws Exception {
+        directory.add(
+                "dn: uid=" + uid + "," + USERS_DN,
+                "objectClass: inetOrgPerson",
+                "cn: " + uid,
+                "givenName: " + uid,
+                "sn: Directory",
+                "uid: " + uid,
+                "mail: " + uid + "@uyuni.test",
+                "userPassword: " + password);
+    }
+
+    private void enableLdap(LdapProvisioningMode mode) {
+        LdapServerConfig config = LdapServerConfig
+                .builder(LdapServerType.OPEN_LDAP, "127.0.0.1", USERS_DN)
+                .transport(LdapTransport.PLAIN)
+                .port(directory.getListenPort())
+                .bind(ADMIN_DN, ADMIN_PASSWORD)
+                .groupBaseDn(GROUPS_DN)
+                .build();
+        LdapAuthServerSettings settings =
+                new LdapAuthServerSettings(config, mode, user.getOrg().getId(), 0);
+        LoginHelper.setLdapConfigProvider(new StubProvider(true, List.of(settings)));
+        LoginHelper.setLdapServiceFactory(new DefaultLdapServiceFactory());
+    }
+
+    @Test
+    public void localUserIsNotApplicableWhenLdapDisabled() {
+        LoginHelper.setLdapConfigProvider(new StubProvider(false, List.of()));
+        List<String> errors = new ArrayList<>();
+        assertNull(LoginHelper.checkLdapAuthentication(user.getLogin(), "whatever",
+                true, true, new ArrayList<>(), errors));
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    public void knownLdapUserIsRejectedWhenLdapDisabled() {
+        // Regression: an AuthType.LDAP user must never fall back to local auth (placeholder password)
+        // when LDAP is turned off. Route by auth_type and reject.
+        user.setAuthType(AuthType.LDAP);
+        UserManager.storeUser(user);
+        LoginHelper.setLdapConfigProvider(new StubProvider(false, List.of()));
+
+        List<String> errors = new ArrayList<>();
+        User result = LoginHelper.checkLdapAuthentication(user.getLogin(), "0",
+                true, true, new ArrayList<>(), errors);
+
+        assertNull(result);
+        assertFalse(errors.isEmpty());
+    }
+
+    @Test
+    public void knownLocalUserIsNotHandledByLdap() {
+        enableLdap(LdapProvisioningMode.JIT);
+        // The base user defaults to AuthType.LOCAL, so LDAP must decline and let local auth run.
+        List<String> errors = new ArrayList<>();
+        assertNull(LoginHelper.checkLdapAuthentication(user.getLogin(), "existing-secret",
+                true, true, new ArrayList<>(), errors));
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    public void knownLdapUserAuthenticates() {
+        user.setAuthType(AuthType.LDAP);
+        UserManager.storeUser(user);
+        enableLdap(LdapProvisioningMode.JIT);
+
+        List<String> errors = new ArrayList<>();
+        User result = LoginHelper.checkLdapAuthentication(user.getLogin(), "existing-secret",
+                true, true, new ArrayList<>(), errors);
+
+        assertNotNull(result);
+        assertEquals(user.getId(), result.getId());
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    public void knownLdapUserWithWrongPasswordIsRejectedWithoutFallback() {
+        user.setAuthType(AuthType.LDAP);
+        UserManager.storeUser(user);
+        enableLdap(LdapProvisioningMode.JIT);
+
+        List<String> errors = new ArrayList<>();
+        User result = LoginHelper.checkLdapAuthentication(user.getLogin(), "wrong-password",
+                true, true, new ArrayList<>(), errors);
+
+        assertNull(result);
+        assertFalse(errors.isEmpty());
+    }
+
+    @Test
+    public void onlyPrefixedLdapGroupsAreMappedAndThePrefixIsStripped() throws Exception {
+        // RFC v1: only directory groups starting with "uyuni_" take part in role mapping, and the
+        // prefix is stripped before the external-group lookup. A directory group without the prefix
+        // must be ignored even when an external group of that exact name exists.
+        user.setAuthType(AuthType.LDAP);
+        UserManager.storeUser(user);
+        addGroup("uyuni_" + PREFIXED_EXT_GROUP, user.getLogin());
+        addGroup(UNPREFIXED_GROUP, user.getLogin());
+        mapExtGroupToRole(PREFIXED_EXT_GROUP, RoleFactory.CHANNEL_ADMIN);
+        mapExtGroupToRole(UNPREFIXED_GROUP, RoleFactory.CONFIG_ADMIN);
+        enableLdap(LdapProvisioningMode.JIT);
+
+        List<String> errors = new ArrayList<>();
+        User result = LoginHelper.checkLdapAuthentication(user.getLogin(), "existing-secret",
+                true, true, new ArrayList<>(), errors);
+
+        assertNotNull(result);
+        assertTrue(errors.isEmpty());
+        assertTrue(result.hasRole(RoleFactory.CHANNEL_ADMIN),
+                "uyuni_-prefixed group should map through the stripped label");
+        assertFalse(result.hasRole(RoleFactory.CONFIG_ADMIN),
+                "group without the uyuni_ prefix must be ignored");
+    }
+
+    @Test
+    public void unknownUserIsProvisionedJustInTime() {
+        enableLdap(LdapProvisioningMode.JIT);
+
+        List<String> messages = new ArrayList<>();
+        User result = LoginHelper.checkLdapAuthentication(JIT_LOGIN, JIT_PASSWORD, true,
+                true, messages, new ArrayList<>());
+
+        assertNotNull(result);
+        assertEquals(JIT_LOGIN, result.getLogin());
+        assertEquals(AuthType.LDAP, result.getAuthType());
+        assertNotNull(UserFactory.lookupByLogin(JIT_LOGIN));
+    }
+
+    @Test
+    public void unknownUserIsNotProvisionedWhenExistingOnly() {
+        enableLdap(LdapProvisioningMode.EXISTING_ONLY);
+
+        List<String> errors = new ArrayList<>();
+        User result = LoginHelper.checkLdapAuthentication(JIT_LOGIN, JIT_PASSWORD, true,
+                true, new ArrayList<>(), errors);
+
+        assertNull(result);
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    public void unknownUserIsNotProvisionedWhenJitDisallowedOnEntryPoint() {
+        // XML-RPC entry point (allowJit = false): even with JIT provisioning configured on the
+        // server, an unknown user must not be created; the call declines so local auth rejects it.
+        enableLdap(LdapProvisioningMode.JIT);
+
+        List<String> errors = new ArrayList<>();
+        User result = LoginHelper.checkLdapAuthentication(JIT_LOGIN, JIT_PASSWORD, true,
+                false, new ArrayList<>(), errors);
+
+        assertNull(result);
+        assertTrue(errors.isEmpty());
+        assertThrows(LookupException.class, () -> UserFactory.lookupByLogin(JIT_LOGIN));
+    }
+
+    /**
+     * Minimal in-test {@link LdapAuthConfigProvider} returning a fixed enabled flag and server list.
+     */
+    private static final class StubProvider implements LdapAuthConfigProvider {
+        private final boolean enabled;
+        private final List<LdapAuthServerSettings> servers;
+
+        private StubProvider(boolean enabledIn, List<LdapAuthServerSettings> serversIn) {
+            this.enabled = enabledIn;
+            this.servers = serversIn;
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        @Override
+        public List<LdapAuthServerSettings> getServers() {
+            return servers;
+        }
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/webui/utils/LoginHelperLdapAuthenticationTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/utils/LoginHelperLdapAuthenticationTest.java
@@ -70,10 +70,9 @@ public class LoginHelperLdapAuthenticationTest extends BaseTestCaseWithUser {
 
     private InMemoryDirectoryServer directory;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
+        // Parent @BeforeEach (setUpBaseTestCaseWithUser) already created `user`.
         InMemoryDirectoryServerConfig dsConfig = new InMemoryDirectoryServerConfig(BASE_DN);
         dsConfig.addAdditionalBindCredentials(ADMIN_DN, ADMIN_PASSWORD);
         directory = new InMemoryDirectoryServer(dsConfig);

--- a/java/core/src/test/java/com/suse/manager/webui/utils/LoginHelperLdapAuthenticationTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/utils/LoginHelperLdapAuthenticationTest.java
@@ -227,9 +227,11 @@ public class LoginHelperLdapAuthenticationTest extends BaseTestCaseWithUser {
 
         assertNotNull(result);
         assertTrue(errors.isEmpty());
-        assertTrue(result.hasRole(RoleFactory.CHANNEL_ADMIN),
+        // LDAP-derived roles are temporary. BaseTestCaseWithUser permanently grants the implied
+        // admin roles (including CONFIG_ADMIN), so hasRole() would always be true for those.
+        assertTrue(result.hasTemporaryRole(RoleFactory.CHANNEL_ADMIN),
                 "uyuni_-prefixed group should map through the stripped label");
-        assertFalse(result.hasRole(RoleFactory.CONFIG_ADMIN),
+        assertFalse(result.hasTemporaryRole(RoleFactory.CONFIG_ADMIN),
                 "group without the uyuni_ prefix must be ignored");
     }
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -310,6 +310,11 @@
                 <version>2.8.9</version>
             </dependency>
             <dependency>
+                <groupId>com.unboundid</groupId>
+                <artifactId>unboundid-ldapsdk</artifactId>
+                <version>7.0.4</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hibernate.orm</groupId>
                 <artifactId>hibernate-c3p0</artifactId>
                 <version>7.1.6.Final</version>

--- a/java/spacewalk-java.changes.suryas1306.native-ldap-login-wiring
+++ b/java/spacewalk-java.changes.suryas1306.native-ldap-login-wiring
@@ -1,0 +1,2 @@
+- Route logins by per-user authentication type and add native LDAP
+  authentication to the login layer

--- a/schema/spacewalk/common/tables/rhnUserInfo.sql
+++ b/schema/spacewalk/common/tables/rhnUserInfo.sql
@@ -56,6 +56,10 @@ CREATE TABLE rhnUserInfo
                                 DEFAULT ('N') NOT NULL
                                 CONSTRAINT rhn_user_info_pam_ck
                                     CHECK (use_pam_authentication in ('Y','N')),
+    auth_type               VARCHAR(16)
+                                DEFAULT ('LOCAL') NOT NULL
+                                CONSTRAINT rhn_user_info_auth_type_ck
+                                    CHECK (auth_type in ('LOCAL','PAM','LDAP')),
     last_logged_in          TIMESTAMPTZ,
     agreed_to_ws_terms      CHAR(1)
                                 CONSTRAINT rhn_user_info_ws_ck

--- a/schema/spacewalk/susemanager-schema.changes.suryas1306.native-ldap-login-wiring
+++ b/schema/spacewalk/susemanager-schema.changes.suryas1306.native-ldap-login-wiring
@@ -1,0 +1,1 @@
+- Add auth_type to rhnUserInfo and migrate PAM-flagged users to it

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.13-to-susemanager-schema-5.2.14/110-rhnuserinfo-auth-type.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.13-to-susemanager-schema-5.2.14/110-rhnuserinfo-auth-type.sql
@@ -1,0 +1,31 @@
+--
+-- Copyright (c) 2026 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+ALTER TABLE rhnUserInfo
+    ADD COLUMN IF NOT EXISTS auth_type VARCHAR(16) DEFAULT ('LOCAL') NOT NULL;
+
+-- Migrate existing users: those flagged for PAM become PAM, everyone else stays LOCAL.
+UPDATE rhnUserInfo
+    SET auth_type = 'PAM'
+    WHERE use_pam_authentication = 'Y' AND auth_type = 'LOCAL';
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+            WHERE conname = 'rhn_user_info_auth_type_ck'
+              AND conrelid = 'rhnuserinfo'::regclass
+    ) THEN
+        ALTER TABLE rhnUserInfo
+            ADD CONSTRAINT rhn_user_info_auth_type_ck
+            CHECK (auth_type in ('LOCAL','PAM','LDAP'));
+    END IF;
+END $$;

--- a/schema/spacewalk/upgrade/susemanager-schema-5.3.0-to-susemanager-schema-5.3.1/110-rhnuserinfo-auth-type.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.3.0-to-susemanager-schema-5.3.1/110-rhnuserinfo-auth-type.sql
@@ -9,10 +9,12 @@
 -- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 --
 
+-- Idempotent: safe if re-applied (ADD COLUMN IF NOT EXISTS + guarded constraint).
 ALTER TABLE rhnUserInfo
     ADD COLUMN IF NOT EXISTS auth_type VARCHAR(16) DEFAULT ('LOCAL') NOT NULL;
 
 -- Migrate existing users: those flagged for PAM become PAM, everyone else stays LOCAL.
+-- Guarded with auth_type = 'LOCAL' so a second run does not overwrite LDAP/PAM already set.
 UPDATE rhnUserInfo
     SET auth_type = 'PAM'
     WHERE use_pam_authentication = 'Y' AND auth_type = 'LOCAL';


### PR DESCRIPTION
## Summary
- Add per-user `auth_type` (`LOCAL` / `PAM` / `LDAP`) on `rhnUserInfo` with schema migration.
- Wire `LoginHelper.checkLdapAuthentication` into Web UI / HTTP API (`LoginController`) with JIT enabled.
- Wire XML-RPC (`AuthHandler`) with auth-only (no JIT), per RFC v1.
- Filter LDAP groups by fixed `uyuni_` prefix (strip before ext-group lookup).
- Interim `ldap.*` config via `ConfigLdapAuthConfigProvider` until Phase 4 UI/DB servers land.

Depends on / stacks on Phase 1 (native LDAP service layer). Opening in parallel per mentor guidance.

## Notes for reviewers
- `UserManager.loginUser` is not yet `auth_type`-aware; LDAP is handled at the login orchestration layer. Placeholder-password bypass for other callers (same shape as `REMOTE_USER`) is deferred — please confirm whether Phase 2 should harden `UserImpl.authenticate` / `loginUser` now or in a follow-up.
- JIT + role mapping are included here because they reuse the extracted `LoginHelper` lifecycle; RFC phasing listed them under Phase 3.

## Test plan
- [ ] CI checkstyle / Java tests green
- [ ] Schema migration applies cleanly
- [ ] LOCAL / PAM / REMOTE_USER login unchanged when LDAP disabled
- [ ] Known `auth_type=LDAP` user authenticates on Web UI and XML-RPC
- [ ] Unknown LDAP user: JIT on Web UI only; XML-RPC rejects (no account created)
- [ ] Only `uyuni_*` groups map to roles; prefix stripped