### PR TITLE
Fix SonarCloud: java rule S112: Generic exceptions should never be thrown (#9938) - Part 1

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/list/ColumnTag.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/list/ColumnTag.java
@@ -314,7 +314,7 @@ public class ColumnTag extends BodyTagSupport {
                         "You are probably using bound=true without an attr." +
                         " Either have both bound = true with " +
                             "an attr OR set bound=false.", headerKey);
-            throw new RuntimeException(msg);
+            throw new IllegalStateException(msg);
         }
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/list/ListTagUtil.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/list/ListTagUtil.java
@@ -454,7 +454,7 @@ public class ListTagUtil {
             String msg = String.format("Exception encounterd " +
                             "while accesing attribute = '%s' and bean class='%s'",
                                 attribute, bean.getClass().getName());
-            throw new RuntimeException(msg, e);
+            throw new IllegalStateException(msg, e);
         }
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/list/decorators/ElaborationDecorator.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/list/decorators/ElaborationDecorator.java
@@ -52,7 +52,7 @@ public class ElaborationDecorator extends BaseListDecorator {
                         " This is needed if you are using the ElaborationDecorator." +
                             " Check out TagHelper.bindElaboratorTo.." +
                             " for List -> " + getCurrentList().getUniqueName();
-            throw new RuntimeException(msg);
+            throw new IllegalStateException(msg);
         }
         elab.elaborate(data);
     }


### PR DESCRIPTION
Fixes #9938 (partially).

This PR addresses the SonarCloud rule S112 (Generic exceptions should never be thrown) by replacing instances of `RuntimeException` with more specific `IllegalStateException`s in the `com.redhat.rhn.frontend.taglibs.list` package. As requested in the issue, this task is split into a smaller chunk.

## What does this PR change?

Replaces generic `RuntimeException` throws with `IllegalStateException` in `com.redhat.rhn.frontend.taglibs.list` to comply with SonarCloud rule S112.

## End-User Impact & Release Notes

No end-user impact. This is purely an internal code quality refactoring.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered. This is a simple exception type replacement.

- [x] **DONE**

## Links

Issue(s): #9938
Port(s): 

- [x] **DONE**

## Changelogs

- [x] No changelog needed
