### PR TITLE
feat(openapi): migrate kickstart.snippet handler to OpenAPI contract

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/kickstart/snippet/SnippetHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/kickstart/snippet/SnippetHandler.java
@@ -30,7 +30,7 @@ import java.util.List;
  * @apidoc.namespace kickstart.snippet
  * @apidoc.doc Provides methods to create kickstart files
  */
-public class SnippetHandler extends BaseHandler {
+public class SnippetHandler extends BaseHandler implements SnippetHandlerApi {
 
     /**
      * list all cobbler snippets for a user.  Includes default and custom snippets

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/kickstart/snippet/SnippetHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/kickstart/snippet/SnippetHandlerApi.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.kickstart.snippet;
+
+import com.redhat.rhn.domain.kickstart.cobbler.CobblerSnippet;
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import spark.route.HttpMethod;
+
+/**
+ * API contract for {@link SnippetHandler}.
+ */
+@Tag(name = "kickstart.snippet", description = "Provides methods to create kickstart files")
+public interface SnippetHandlerApi {
+
+    /**
+     * Lists all cobbler snippets for the logged in user.
+     *
+     * @param loggedInUser the current user
+     * @return the list of cobbler snippets
+     */
+    @ApiEndpointDoc(
+        summary = "List all cobbler snippets for the logged in user",
+        method = HttpMethod.get,
+        responseClass = SnippetListResponse.class
+    )
+    List<CobblerSnippet> listAll(@Parameter(hidden = true) User loggedInUser);
+
+    /**
+     * Lists only the custom snippets for the logged in user.
+     *
+     * @param loggedInUser the current user
+     * @return the list of custom cobbler snippets
+     */
+    @ApiEndpointDoc(
+        summary = "List only custom snippets for the logged in user. These snippets are editable.",
+        method = HttpMethod.get,
+        responseClass = SnippetListResponse.class
+    )
+    List<CobblerSnippet> listCustom(@Parameter(hidden = true) User loggedInUser);
+
+    /**
+     * Lists only the pre-made default snippets for the logged in user.
+     *
+     * @param loggedInUser the current user
+     * @return the list of default cobbler snippets
+     */
+    @ApiEndpointDoc(
+        summary = "List only pre-made default snippets for the logged in user. These snippets are not editable.",
+        method = HttpMethod.get,
+        responseClass = SnippetListResponse.class
+    )
+    List<CobblerSnippet> listDefault(@Parameter(hidden = true) User loggedInUser);
+
+    /**
+     * Creates a snippet, or updates it when it already exists.
+     *
+     * @param loggedInUser the current user
+     * @param name the name of the snippet
+     * @param contents the contents of the snippet
+     * @return the created or updated snippet
+     */
+    @ApiEndpointDoc(
+        summary = "Will create a snippet with the given name and contents if it doesn't exist. " +
+                  "If it does exist, the existing snippet will be updated.",
+        requestClass = CreateOrUpdateRequest.class,
+        responseClass = SnippetResponse.class
+    )
+    CobblerSnippet createOrUpdate(User loggedInUser, String name, String contents);
+
+    /**
+     * Deletes the specified snippet.
+     *
+     * @param loggedInUser the current user
+     * @param name the name of the snippet
+     * @return 1 on success, 0 if the snippet is not found
+     */
+    @ApiEndpointDoc(
+        summary = "Delete the specified snippet. If the snippet is not found, 0 is returned.",
+        requestClass = DeleteRequest.class,
+        isIntegerResponse = true
+    )
+    int delete(User loggedInUser, String name);
+
+    @Schema(name = "CreateOrUpdateSnippetRequest")
+    @JsonPropertyOrder({"name", "contents"})
+    interface CreateOrUpdateRequest {
+
+        /**
+         * @return the name of the snippet
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the contents of the snippet
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getContents();
+    }
+
+    @Schema(name = "DeleteSnippetRequest")
+    interface DeleteRequest {
+
+        /**
+         * @return the name of the snippet
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+    }
+
+    @Schema(name = "Snippet")
+    @JsonPropertyOrder({"name", "contents", "fragment", "file"})
+    interface SnippetDoc {
+
+        /**
+         * @return the name of the snippet
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the contents of the snippet
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getContents();
+
+        /**
+         * @return the string to include in a kickstart file that will generate this snippet
+         */
+        @Schema(description = "the string to include in a kickstart file that will generate this snippet",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getFragment();
+
+        /**
+         * @return the local path to the file containing this snippet
+         */
+        @Schema(description = "the local path to the file containing this snippet",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getFile();
+    }
+
+    @Schema(name = "ApiResponseSnippet")
+    interface SnippetResponse extends ApiResponseWrapper<SnippetDoc> { }
+
+    @Schema(name = "ApiResponseSnippetList")
+    interface SnippetListResponse extends ApiResponseWrapper<List<SnippetDoc>> { }
+}

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.frontend.xmlrpc.admin.ssh.AdminSshHandler;
 import com.redhat.rhn.frontend.xmlrpc.api.ApiHandler;
 import com.redhat.rhn.frontend.xmlrpc.channel.access.ChannelAccessHandler;
 import com.redhat.rhn.frontend.xmlrpc.distchannel.DistChannelHandler;
+import com.redhat.rhn.frontend.xmlrpc.kickstart.snippet.SnippetHandler;
 import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
 import com.redhat.rhn.frontend.xmlrpc.saltkey.SaltKeyHandler;
 import com.redhat.rhn.frontend.xmlrpc.subscriptionmatching.PinnedSubscriptionHandler;
@@ -110,6 +111,7 @@ public final class OpenApiConfig {
         handlers.put("api", ApiHandler.class);
         handlers.put("channel.access", ChannelAccessHandler.class);
         handlers.put("distchannel", DistChannelHandler.class);
+        handlers.put("kickstart.snippet", SnippetHandler.class);
         handlers.put("preferences.locale", PreferencesLocaleHandler.class);
         handlers.put("saltkey", SaltKeyHandler.class);
         handlers.put("subscriptionmatching.pinnedsubscription", PinnedSubscriptionHandler.class);

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/SnippetHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/SnippetHandlerContractTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.kickstart.cobbler.CobblerSnippet;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.kickstart.snippet.SnippetHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+public class SnippetHandlerContractTest extends BaseOpenApiTest {
+
+    @Override
+    protected String getApiNamespace() {
+        return "kickstart.snippet";
+    }
+
+    @Override
+    protected Class<SnippetHandler> getHandlerClass() {
+        return SnippetHandler.class;
+    }
+
+    private SnippetHandler handler() {
+        return (SnippetHandler) handlerMock;
+    }
+
+    /**
+     * Builds a snippet serialized by the registered SnippetSerializer, so the response is
+     * validated against the documented schema. CobblerSnippet has no public constructor and
+     * its getters read from the cobbler snippets directory, so it is mocked instead.
+     */
+    private CobblerSnippet snippet() {
+        CobblerSnippet snippet = context.mock(CobblerSnippet.class, "snippet");
+        context.checking(new Expectations() {{
+            allowing(snippet).getName();
+            will(returnValue("test-snippet"));
+            allowing(snippet).getContents();
+            will(returnValue("echo test"));
+            allowing(snippet).getFragment();
+            will(returnValue("$SNIPPET('spacewalk/1/test-snippet')"));
+            allowing(snippet).getPath();
+            will(returnValue(new File("/var/lib/cobbler/snippets/spacewalk/1/test-snippet")));
+        }});
+        return snippet;
+    }
+
+    @Test
+    public void testListAll() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listAll(with(mockUser));
+            will(returnValue(List.of(snippet())));
+        }});
+
+        validateApiContract("/kickstart.snippet/listAll", "GET")
+                .onHandlerMethod("listAll", User.class);
+    }
+
+    @Test
+    public void testListCustom() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listCustom(with(mockUser));
+            will(returnValue(List.of(snippet())));
+        }});
+
+        validateApiContract("/kickstart.snippet/listCustom", "GET")
+                .onHandlerMethod("listCustom", User.class);
+    }
+
+    @Test
+    public void testListDefault() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listDefault(with(mockUser));
+            will(returnValue(List.of(snippet())));
+        }});
+
+        validateApiContract("/kickstart.snippet/listDefault", "GET")
+                .onHandlerMethod("listDefault", User.class);
+    }
+
+    @Test
+    public void testCreateOrUpdate() throws Exception {
+        String name = "test-snippet";
+        String contents = "echo test";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).createOrUpdate(with(mockUser), with(name), with(contents));
+            will(returnValue(snippet()));
+        }});
+
+        validateApiContract("/kickstart.snippet/createOrUpdate", "POST")
+                .withBody(Map.of("name", name, "contents", contents))
+                .onHandlerMethod("createOrUpdate", User.class, String.class, String.class);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        String name = "test-snippet";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).delete(with(mockUser), with(name));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.snippet/delete", "POST")
+                .withBody(Map.of("name", name))
+                .onHandlerMethod("delete", User.class, String.class);
+    }
+}


### PR DESCRIPTION
Migrates the `kickstart.snippet` XML-RPC handler to the OpenAPI contract approach
(`listAll`, `listCustom`, `listDefault`, `createOrUpdate`, `delete`).


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Unit tests were added: `SnippetHandlerContractTest` validates the generated OpenAPI schema
  against the handler responses for all five methods, covering both the `GET` list paths and
  the `POST` request-body paths.

- [x] **DONE**

## Links

Tracks: GSoC 2026 OpenAPI migration

- [x] **DONE**

## Changelogs

- [x] No changelog needed
