### PR TITLE
Ensure su is installed in the DB migration image

### DIFF
--- a/containers/server-database-migration-image/Dockerfile
+++ b/containers/server-database-migration-image/Dockerfile
@@ -11,6 +11,7 @@ RUN useradd -r -s /usr/bin/bash -g postgres -d /var/lib/pgsql --uid 999 postgres
 
 # Main packages
 RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses --force-resolution \
+      util-linux \
       postgresql18-server \
       postgresql18-contrib \
       postgresql16-server \

--- a/containers/server-database-migration-image/server-database-migration-image.changes.cbosdo.db-migration-su
+++ b/containers/server-database-migration-image/server-database-migration-image.changes.cbosdo.db-migration-su
@@ -1,0 +1,1 @@
+- Ensure su is installed


### PR DESCRIPTION
## What does this PR change?

The DB migration image relies on `su` to be installed to run commands as the `postgres` user. Add the package containing it to those to install as in could go away from the base image (happened with the switch to 16).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: requires running postgresql migration

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
