### PR TITLE
Fix RBAC mappings for 'systems.profiles' namespace (bsc#1271963)

### DIFF
--- a/java/spacewalk-java.changes.cbbayburt.bsc1271963
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1271963
@@ -1,0 +1,1 @@
+- Fix Profile tab display in system details menu (bsc#1271963)

--- a/java/webapp/src/main/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/webapp/src/main/webapp/WEB-INF/nav/system_detail.xml
@@ -63,7 +63,7 @@
       <rhn-tab name="pkg.lock.menu" acl="authorized_for(systems.software.packages, W); system_feature(ftr_package_lock)">
         <rhn-tab-url>/rhn/systems/details/packages/LockPackages.do</rhn-tab-url>
       </rhn-tab>
-      <rhn-tab name="Profiles" acl="authorized_for(systems.software.packages.profiles); system_feature(ftr_profile_compare)">
+      <rhn-tab name="Profiles" acl="authorized_for(systems.profiles); system_feature(ftr_profile_compare)">
         <rhn-tab-url>/rhn/systems/details/packages/profiles/ShowProfiles.do</rhn-tab-url>
         <rhn-tab-url>/rhn/systems/details/packages/profiles/Create.do</rhn-tab-url>
         <rhn-tab-url>/rhn/systems/details/packages/profiles/CompareSystems.do</rhn-tab-url>

--- a/java/webapp/src/main/webapp/WEB-INF/pages/systems/details/packages/profiles/profiles.jsp
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/systems/details/packages/profiles/profiles.jsp
@@ -59,7 +59,7 @@
 
     <hr />
 
-    <rhn:require acl="authorized_for(systems.software.packages.profiles, W);">
+    <rhn:require acl="authorized_for(systems.profiles, W);">
         <div class="form-horizontal">
             <div class="row">
                 <div class="col-md-12">

--- a/schema/spacewalk/common/data/endpoint.sql
+++ b/schema/spacewalk/common/data/endpoint.sql
@@ -1731,6 +1731,15 @@ INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_re
     VALUES ('', '/systems/details/packages/profiles/CompareProfiles.do', 'GET', 'W', True)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('', '/systems/details/packages/profiles/CompareProfiles.do', 'POST', 'W', True)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('', '/systems/details/packages/profiles/CompareSystems.do', 'GET', 'W', True)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('', '/systems/details/packages/profiles/CompareSystems.do', 'POST', 'W', True)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('', '/ssm/PackageUpgrade.do', 'GET', 'W', True)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)

--- a/schema/spacewalk/common/data/endpointNamespace.sql
+++ b/schema/spacewalk/common/data/endpointNamespace.sql
@@ -2678,18 +2678,33 @@ INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
-    WHERE ns.namespace = 'systems.software.packages' AND ns.access_mode = 'R'
+    WHERE ns.namespace = 'systems.profiles' AND ns.access_mode = 'R'
     AND ep.endpoint = '/systems/details/packages/profiles/ShowProfiles.do' AND ep.http_method = 'GET'
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
-    WHERE ns.namespace = 'systems.software.packages' AND ns.access_mode = 'R'
+    WHERE ns.namespace = 'systems.profiles' AND ns.access_mode = 'R'
     AND ep.endpoint = '/systems/details/packages/profiles/ShowProfiles.do' AND ep.http_method = 'POST'
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
-    WHERE ns.namespace = 'systems.software.packages' AND ns.access_mode = 'R'
+    WHERE ns.namespace = 'systems.profiles' AND ns.access_mode = 'R'
     AND ep.endpoint = '/systems/details/packages/profiles/CompareProfiles.do' AND ep.http_method = 'GET'
+    ON CONFLICT DO NOTHING;
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'systems.profiles' AND ns.access_mode = 'R'
+    AND ep.endpoint = '/systems/details/packages/profiles/CompareProfiles.do' AND ep.http_method = 'POST'
+    ON CONFLICT DO NOTHING;
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'systems.profiles' AND ns.access_mode = 'R'
+    AND ep.endpoint = '/systems/details/packages/profiles/CompareSystems.do' AND ep.http_method = 'GET'
+    ON CONFLICT DO NOTHING;
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'systems.profiles' AND ns.access_mode = 'R'
+    AND ep.endpoint = '/systems/details/packages/profiles/CompareSystems.do' AND ep.http_method = 'POST'
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
@@ -2853,22 +2868,22 @@ INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
-    WHERE ns.namespace = 'systems.software.packages' AND ns.access_mode = 'W'
+    WHERE ns.namespace = 'systems.profiles' AND ns.access_mode = 'W'
     AND ep.endpoint = '/systems/details/packages/profiles/Create.do' AND ep.http_method = 'GET'
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
-    WHERE ns.namespace = 'systems.software.packages' AND ns.access_mode = 'W'
+    WHERE ns.namespace = 'systems.profiles' AND ns.access_mode = 'W'
     AND ep.endpoint = '/systems/details/packages/profiles/Create.do' AND ep.http_method = 'POST'
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
-    WHERE ns.namespace = 'systems.software.packages' AND ns.access_mode = 'W'
+    WHERE ns.namespace = 'systems.profiles' AND ns.access_mode = 'W'
     AND ep.endpoint = '/systems/details/packages/profiles/DeleteProfile.do' AND ep.http_method = 'GET'
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
-    WHERE ns.namespace = 'systems.software.packages' AND ns.access_mode = 'W'
+    WHERE ns.namespace = 'systems.profiles' AND ns.access_mode = 'W'
     AND ep.endpoint = '/systems/details/packages/profiles/DeleteProfile.do' AND ep.http_method = 'POST'
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)

--- a/schema/spacewalk/common/data/namespace.sql
+++ b/schema/spacewalk/common/data/namespace.sql
@@ -666,10 +666,10 @@ INSERT INTO access.namespace (namespace, access_mode, description)
     VALUES ('systems.activation_keys.delete', 'W', NULL)
     ON CONFLICT (namespace, access_mode) DO NOTHING;
 INSERT INTO access.namespace (namespace, access_mode, description)
-    VALUES ('systems.profiles', 'R', NULL)
+    VALUES ('systems.profiles', 'R', 'View/compare package profiles')
     ON CONFLICT (namespace, access_mode) DO NOTHING;
 INSERT INTO access.namespace (namespace, access_mode, description)
-    VALUES ('systems.profiles', 'W', NULL)
+    VALUES ('systems.profiles', 'W', 'Create/edit package profiles')
     ON CONFLICT (namespace, access_mode) DO NOTHING;
 INSERT INTO access.namespace (namespace, access_mode, description)
     VALUES ('systems.custom_data', 'R', NULL)

--- a/schema/spacewalk/susemanager-schema.changes.cbbayburt.bsc1271963
+++ b/schema/spacewalk/susemanager-schema.changes.cbbayburt.bsc1271963
@@ -1,0 +1,2 @@
+- RBAC: add missing endpoints to 'systems.profiles' namespace
+  (bsc#1271963)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.3.1-to-susemanager-schema-5.3.2/110-rbac-package-profiles.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.3.1-to-susemanager-schema-5.3.2/110-rbac-package-profiles.sql
@@ -1,0 +1,67 @@
+--
+-- Copyright (c) 2026 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+-- Add namespace descriptions
+UPDATE access.namespace SET description = 'View/compare package profiles'
+    WHERE namespace = 'systems.profiles' AND access_mode = 'R';
+
+UPDATE access.namespace SET description = 'Create/edit package profiles'
+    WHERE namespace = 'systems.profiles' AND access_mode = 'W';
+
+-- Move package profile related (view) endpoints to 'systems.profiles' namespace
+UPDATE access.endpointNamespace
+    SET namespace_id =
+        (SELECT id FROM access.namespace WHERE namespace = 'systems.profiles' AND access_mode = 'R')
+    WHERE endpoint_id IN
+        (SELECT id FROM access.endpoint WHERE endpoint IN (
+            '/systems/details/packages/profiles/ShowProfiles.do',
+            '/systems/details/packages/profiles/CompareProfiles.do'));
+
+-- Move package profile related (modify) endpoints to 'systems.profiles' namespace
+UPDATE access.endpointNamespace
+    SET namespace_id =
+        (SELECT id FROM access.namespace WHERE namespace = 'systems.profiles' AND access_mode = 'W')
+    WHERE endpoint_id IN
+        (SELECT id FROM access.endpoint WHERE endpoint IN (
+            '/systems/details/packages/profiles/Create.do',
+            '/systems/details/packages/profiles/DeleteProfile.do'));
+
+-- Insert missing profile endpoints
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/systems/details/packages/profiles/CompareProfiles.do', 'POST', 'W', True
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/systems/details/packages/profiles/CompareProfiles.do' AND http_method = 'POST');
+
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/systems/details/packages/profiles/CompareSystems.do', 'GET', 'W', True
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/systems/details/packages/profiles/CompareSystems.do' AND http_method = 'GET');
+
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/systems/details/packages/profiles/CompareSystems.do', 'POST', 'W', True
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/systems/details/packages/profiles/CompareSystems.do' AND http_method = 'POST');
+
+-- Add new profiles to 'systems.profiles' namespace
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'systems.profiles' AND ns.access_mode = 'R'
+    AND ep.endpoint = '/systems/details/packages/profiles/CompareProfiles.do' AND ep.http_method = 'POST'
+    ON CONFLICT DO NOTHING;
+
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'systems.profiles' AND ns.access_mode = 'R'
+    AND ep.endpoint = '/systems/details/packages/profiles/CompareSystems.do' AND ep.http_method = 'GET'
+    ON CONFLICT DO NOTHING;
+
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'systems.profiles' AND ns.access_mode = 'R'
+    AND ep.endpoint = '/systems/details/packages/profiles/CompareSystems.do' AND ep.http_method = 'POST'
+    ON CONFLICT DO NOTHING;


### PR DESCRIPTION
This PR fixes RBAC mappings for the `systems.profiles` namespace:

- Add missing endpoints
- Collect all related endpoints into `systems.profiles`
- Fix conditional rendering of 'Profiles' tab in the system details menu

## Documentation
- No documentation needed: Bugfix

## Test coverage
- No tests: RBAC mappings are not covered

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31292
Port: https://github.com/SUSE/spacewalk/pull/31392

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
