### PR TITLE
Add Salt package download benchmark

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -64,6 +64,17 @@ namespace :cucumber do
       end
       Rake::Task[task_name].enhance([watchdog_task])
     end
+    if filename == :kubernetes_package_download_benchmark
+      # Keep the normal per-scenario watchdog enabled for this benchmark, but allow the configured
+      # package-download timeout plus 30 minutes for preflight, cache reset, and verification.
+      # Invalid timeout values are rejected by the benchmark's first Cucumber step.
+      watchdog_task = :kubernetes_package_download_benchmark_bump_scenario_watchdog
+      task watchdog_task do
+        benchmark_timeout = ENV.fetch('UYUNI_BENCH_TIMEOUT_SECONDS', '14400').to_i
+        ENV['SCENARIO_HARD_LIMIT'] ||= (benchmark_timeout + 1800).to_s
+      end
+      Rake::Task[task_name].enhance([watchdog_task])
+    end
     # This block executes when the task runs and uses the exact same `html_results` path.
     # This file is used to expose the cucumber html report in Jenkins
     Rake::Task[task_name].enhance do

--- a/testsuite/features/build_validation/benchmarks/srv_salt_package_download_benchmark.feature
+++ b/testsuite/features/build_validation/benchmarks/srv_salt_package_download_benchmark.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@benchmark @long_running
+@benchmark
 Feature: Salt channel package download on configured minions
   In order to measure package storage performance
   As an operator of an existing Uyuni environment

--- a/testsuite/features/build_validation/benchmarks/srv_salt_package_download_benchmark.feature
+++ b/testsuite/features/build_validation/benchmarks/srv_salt_package_download_benchmark.feature
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@benchmark @long_running
+Feature: Salt channel package download on configured minions
+  In order to measure package storage performance
+  As an operator of an existing Uyuni environment
+  I want configured Salt minions to download every package in a configured channel
+
+  Scenario: Download every configured channel package on every configured minion
+    Given the Salt package download benchmark inputs are valid
+    And the initial configured channel package snapshot is valid
+    And a ready server pod is reachable from the benchmark controller
+    And the benchmark minions are ready for the configured channel
+    When I clear RPM payload caches on the benchmark minions outside the measurement
+    And I execute and record the channel package downloads
+    Then the package download result report should exist
+    And every configured minion should have downloaded every channel package

--- a/testsuite/features/build_validation/benchmarks/srv_salt_package_download_benchmark.feature
+++ b/testsuite/features/build_validation/benchmarks/srv_salt_package_download_benchmark.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 SUSE LLC
+# Copyright (c) 2026 Akash Kumar <meakash7902@gmail.com>
 # Licensed under the terms of the MIT license.
 
 @benchmark

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -7,152 +7,51 @@ require 'json'
 require 'shellwords'
 require 'time'
 
-PACKAGE_DOWNLOAD_BENCHMARK_DEFAULT_WORKLOAD_TIMEOUT = 14_400
-PACKAGE_DOWNLOAD_BENCHMARK_CONTROL_TIMEOUT = 600
-PACKAGE_DOWNLOAD_BENCHMARK_CACHE_ROOT = '/var/cache/zypp/packages'.freeze
-PACKAGE_DOWNLOAD_BENCHMARK_IDLE_POLL_SECONDS = 2
-PACKAGE_DOWNLOAD_BENCHMARK_SOURCE_ARCHES = %w[src nosrc source srcpackage].freeze
+PACKAGE_DOWNLOAD_DEFAULT_TIMEOUT = 14_400
+PACKAGE_DOWNLOAD_CONTROL_TIMEOUT = 600
+PACKAGE_DOWNLOAD_CACHE_ROOT = '/var/cache/zypp/packages'.freeze
+PACKAGE_DOWNLOAD_IDLE_POLL_SECONDS = 2
+PACKAGE_DOWNLOAD_SOURCE_ARCHES = %w[src nosrc source srcpackage].freeze
 
-# Parse one required JSON environment variable.
-def package_download_benchmark_json_env(name)
-  value = ENV.fetch(name, nil)
-  raise "#{name} must be set" if value.nil?
-
-  JSON.parse(value)
-rescue JSON::ParserError => e
-  raise "#{name} must contain valid JSON: #{e.message}"
-end
-
-# Return the validated Salt minion inventory.
-def package_download_benchmark_minions
-  minions = package_download_benchmark_json_env('UYUNI_BENCH_MINIONS')
+# Load the configured benchmark inputs.
+def package_download_inputs
+  minions = JSON.parse(ENV.fetch('UYUNI_BENCH_MINIONS', ''))
   raise 'UYUNI_BENCH_MINIONS must be a non-empty JSON array' unless minions.is_a?(Array) && !minions.empty?
 
-  minions.each do |minion|
-    valid = minion.is_a?(String) && !minion.empty? && !minion.start_with?('-') && !minion.match?(/[,\s[:cntrl:]]/)
-    raise "Invalid Salt minion ID: #{minion.inspect}" unless valid
-  end
-  raise 'UYUNI_BENCH_MINIONS must not contain duplicate IDs' unless minions.uniq.length == minions.length
+  valid_minions =
+    minions.all? do |minion|
+      minion.is_a?(String) &&
+        !minion.empty? &&
+        !minion.start_with?('-') &&
+        !minion.match?(/[,\s[:cntrl:]]/)
+    end
+  raise 'UYUNI_BENCH_MINIONS contains an invalid Salt ID' unless valid_minions
+  raise 'UYUNI_BENCH_MINIONS contains duplicate Salt IDs' unless minions.uniq.length == minions.length
 
-  minions
-end
+  channel = ENV.fetch('UYUNI_BENCH_CHANNEL', '')
+  raise 'UYUNI_BENCH_CHANNEL is invalid' unless channel.match?(/\A[A-Za-z0-9][A-Za-z0-9_.-]*\z/)
 
-# Return the validated Uyuni software channel label.
-def package_download_benchmark_channel
-  channel = ENV.fetch('UYUNI_BENCH_CHANNEL', nil)
-  raise 'UYUNI_BENCH_CHANNEL must be set' if channel.nil?
-
-  valid = channel.match?(/\A[A-Za-z0-9][A-Za-z0-9_.-]*\z/) && channel.length <= 128
-  raise 'UYUNI_BENCH_CHANNEL must be a valid software channel label' unless valid
-
-  channel
-end
-
-# Return the validated package-download workload timeout.
-def package_download_benchmark_workload_timeout
-  value = ENV.fetch('UYUNI_BENCH_TIMEOUT_SECONDS', PACKAGE_DOWNLOAD_BENCHMARK_DEFAULT_WORKLOAD_TIMEOUT.to_s)
-  timeout = Integer(value, 10)
+  timeout = Integer(ENV.fetch('UYUNI_BENCH_TIMEOUT_SECONDS', PACKAGE_DOWNLOAD_DEFAULT_TIMEOUT.to_s), 10)
   raise 'UYUNI_BENCH_TIMEOUT_SECONDS must be between 1 and 86400' unless timeout.between?(1, 86_400)
 
-  timeout
+  {
+    minions: minions,
+    channel: channel,
+    repo_alias: "susemanager:#{channel}",
+    storage_class: ENV.fetch('UYUNI_BENCH_STORAGE_CLASS', nil),
+    timeout_seconds: timeout
+  }
+rescue JSON::ParserError
+  raise 'UYUNI_BENCH_MINIONS must contain valid JSON'
 rescue ArgumentError
   raise 'UYUNI_BENCH_TIMEOUT_SECONDS must be an integer'
 end
 
-# Return the optional StorageClass result metadata.
-def package_download_benchmark_storage_class
-  value = ENV.fetch('UYUNI_BENCH_STORAGE_CLASS', nil)
-  return if value.nil?
-
-  raise 'UYUNI_BENCH_STORAGE_CLASS must not be empty' if value.empty?
-  raise 'UYUNI_BENCH_STORAGE_CLASS must not exceed 253 characters' if value.length > 253
-
-  value
-end
-
-# Load the complete benchmark input contract.
-def package_download_benchmark_inputs
-  {
-    minions: package_download_benchmark_minions,
-    channel: package_download_benchmark_channel,
-    storage_class: package_download_benchmark_storage_class,
-    timeout_seconds: package_download_benchmark_workload_timeout
-  }
-end
-
-# Return one required string field from a channel package API record.
-def package_download_benchmark_package_string(package, field, allow_blank: false)
-  value = package[field]
-  raise "Package #{package['id'].inspect} has invalid #{field}" unless value.is_a?(String)
-
-  value = value.strip
-  raise "Package #{package['id'].inspect} has blank #{field}" if !allow_blank && value.empty?
-
-  value
-end
-
-# Convert a channel package API record to the production package tuple.
-def package_download_benchmark_package(package)
-  raise "Invalid channel package record: #{package.inspect}" unless package.is_a?(Hash)
-
-  id = package['id']
-  raise "Channel package has invalid id: #{id.inspect}" unless id.is_a?(Integer) && id.positive?
-
-  name = package_download_benchmark_package_string(package, 'name')
-  version = package_download_benchmark_package_string(package, 'version')
-  release = package_download_benchmark_package_string(package, 'release', allow_blank: true)
-  epoch = package_download_benchmark_package_string(package, 'epoch', allow_blank: true)
-  api_arch = package_download_benchmark_package_string(package, 'arch_label')
-  checksum = package_download_benchmark_package_string(package, 'checksum')
-  checksum_type = package_download_benchmark_package_string(package, 'checksum_type')
-  arch = api_arch.sub(/-deb\z/, '')
-
-  raise "Package #{id} has an invalid retracted flag" unless [true, false, nil].include?(package['retracted'])
-  raise "Package #{id} has an invalid name" unless name.match?(/\A[A-Za-z0-9][A-Za-z0-9+_.-]*\z/)
-  raise "Package #{id} has an invalid architecture" unless arch.match?(/\A[A-Za-z0-9][A-Za-z0-9_.-]*\z/)
-  raise "Package #{id} is not a binary package (#{api_arch})" if PACKAGE_DOWNLOAD_BENCHMARK_SOURCE_ARCHES.include?(arch)
-  raise "Package #{id} has a non-numeric epoch" unless epoch.empty? || epoch.match?(/\A[0-9]+\z/)
-  raise "Package #{id} has an invalid checksum" unless checksum.match?(/\A[0-9A-Fa-f]+\z/)
-  raise "Package #{id} has an invalid checksum type" unless checksum_type.match?(/\A[A-Za-z0-9_-]+\z/)
-  raise "Package #{id} is not an RPM package (#{api_arch})" if api_arch.end_with?('-deb')
-
-  evr = +''
-  evr << "#{epoch}:" unless epoch.empty?
-  evr << version
-  evr << "-#{release}" unless release.empty? || release == 'X'
-  raise "Package #{id} has an invalid universal EVR" unless evr.match?(/\A[A-Za-z0-9][A-Za-z0-9+_.~:^%-]*\z/)
-
-  {
-    id: id,
-    name: name,
-    api_arch: api_arch,
-    arch: arch,
-    epoch: epoch,
-    version: version,
-    release: release,
-    evr: evr,
-    cache_evr: evr.sub(/\A0:/, ''),
-    checksum: checksum,
-    checksum_type: checksum_type,
-    retracted: package['retracted'],
-    tuple: [name, arch, evr]
-  }
-end
-
-# Raise when one value maps to more than one channel package.
-def package_download_benchmark_reject_duplicates(packages, description, &identity)
-  duplicates = packages.group_by(&identity).select { |_value, records| records.length > 1 }
-  return if duplicates.empty?
-
-  details = duplicates.map { |value, records| "#{value.inspect} (ids #{records.map { |record| record[:id] }.join(', ')})" }
-  raise "Channel contains duplicate #{description}: #{details.join('; ')}"
-end
-
-# Return a benchmark API client pointed at the configured Uyuni endpoint.
-def package_download_benchmark_api
-  @package_download_benchmark_api ||=
+# Return an API client for the configured Uyuni server.
+def package_download_api
+  @package_download_api ||=
     begin
-      host = ENV.fetch('SERVER', nil).strip
+      host = ENV.fetch('SERVER', '').strip
       raise 'SERVER must not be empty' if host.empty?
 
       if $api_test.is_a?(ApiTestXmlrpc)
@@ -164,86 +63,84 @@ def package_download_benchmark_api
     end
 end
 
-# Call a benchmark API method with the session key first for XML-RPC compatibility.
-def package_download_benchmark_api_call(name, params = {})
-  api = package_download_benchmark_api
-  api.call(name, { sessionKey: api.token }.merge(params))
-end
-
-# Validate and canonicalize one complete channel package response.
-def package_download_benchmark_api_packages(api_packages)
-  raise 'channel.software.listAllPackages did not return a non-empty array' unless api_packages.is_a?(Array) && !api_packages.empty?
-
+# Convert Uyuni package records to the RPM identities used by the benchmark.
+def package_download_packages(records)
   packages =
-    api_packages.map { |package| package_download_benchmark_package(package) }
-                .sort_by { |package| [package[:name], package[:cache_evr], package[:arch], package[:id]] }
-  package_download_benchmark_reject_duplicates(packages, 'package IDs') { |package| package[:id] }
-  packages
-end
+    records.filter_map do |package|
+      arch_label = package['arch_label']
+      arch = arch_label.sub(/-deb\z/, '')
+      next if arch_label.end_with?('-deb') || PACKAGE_DOWNLOAD_SOURCE_ARCHES.include?(arch)
 
-# Return the stable digest for one canonical channel package set.
-def package_download_benchmark_snapshot_digest(packages)
-  records = packages.map { |package| [package[:id], package[:tuple], package[:checksum_type], package[:checksum], package[:retracted]] }
-  Digest::SHA256.hexdigest(JSON.generate(records))
-end
+      epoch = package['epoch'].to_s
+      version = package['version'].to_s
+      release = package['release'].to_s
+      evr = +''
+      evr << "#{epoch}:" unless epoch.empty?
+      evr << version
+      evr << "-#{release}" unless release.empty? || release == 'X'
 
-# Map the configured Salt minion IDs to Uyuni system IDs.
-def package_download_benchmark_system_ids(minions)
-  id_map = package_download_benchmark_api_call('system.getMinionIdMap')
-  raise 'system.getMinionIdMap did not return an object' unless id_map.is_a?(Hash)
-
-  invalid = id_map.reject { |minion, system_id| minion.is_a?(String) && !minion.empty? && system_id.is_a?(Integer) && system_id.positive? }
-  raise "system.getMinionIdMap returned invalid entries: #{invalid.inspect}" unless invalid.empty?
-
-  missing = minions - id_map.keys
-  raise "Benchmark minions are not registered Salt systems: #{missing.join(', ')}" unless missing.empty?
-
-  minions.to_h { |minion| [minion, id_map[minion]] }
-end
-
-# Validate the initial all-package channel snapshot and configured subscriptions.
-def package_download_benchmark_snapshot(inputs)
-  api_packages = package_download_benchmark_api_call('channel.software.listAllPackages', channelLabel: inputs[:channel])
-  subscribed = package_download_benchmark_api_call('channel.software.listSubscribedSystems', channelLabel: inputs[:channel])
-  raise 'channel.software.listSubscribedSystems did not return an array' unless subscribed.is_a?(Array)
-
-  subscribed_ids =
-    subscribed.map do |system|
-      valid = system.is_a?(Hash) &&
-              system['id'].is_a?(Integer) &&
-              system['id'].positive? &&
-              system['name'].is_a?(String) &&
-              !system['name'].empty?
-      raise "Invalid subscribed system record: #{system.inspect}" unless valid
-
-      system['id']
+      {
+        id: package['id'],
+        name: package['name'],
+        arch: arch,
+        epoch: epoch,
+        version: version,
+        release: release,
+        evr: evr,
+        cache_evr: evr.sub(/\A0:/, ''),
+        checksum: package['checksum'].downcase,
+        checksum_type: package['checksum_type'],
+        retracted: package['retracted'],
+        tuple: [package['name'], arch, evr]
+      }
     end
-  raise 'The channel has duplicate subscribed system IDs' unless subscribed_ids.uniq.length == subscribed_ids.length
+  packages.sort_by { |package| [package[:name], package[:cache_evr], package[:arch], package[:id]] }
+end
 
-  system_ids = package_download_benchmark_system_ids(inputs[:minions])
-  missing_subscriptions = system_ids.reject { |_minion, system_id| subscribed_ids.include?(system_id) }
-  raise "Benchmark minions are not subscribed to #{inputs[:channel]}: #{missing_subscriptions.keys.join(', ')}" unless missing_subscriptions.empty?
+# Capture the channel packages and subscribed benchmark systems.
+def package_download_snapshot(inputs)
+  api = package_download_api
+  packages_response =
+    api.call(
+      'channel.software.listAllPackages',
+      sessionKey: api.token,
+      channelLabel: inputs[:channel]
+    )
+  subscribed =
+    api.call(
+      'channel.software.listSubscribedSystems',
+      sessionKey: api.token,
+      channelLabel: inputs[:channel]
+    )
+  id_map = api.call('system.getMinionIdMap', sessionKey: api.token)
 
-  packages = package_download_benchmark_api_packages(api_packages)
-  repo_alias = "susemanager:#{inputs[:channel]}"
+  packages = package_download_packages(packages_response)
+  raise 'The configured channel has no binary RPM packages' if packages.empty?
+
+  system_ids = inputs[:minions].to_h { |minion| [minion, id_map[minion]] }
+  unregistered = system_ids.select { |_minion, system_id| system_id.nil? }
+  raise "Salt minions are not registered in Uyuni: #{unregistered.keys.join(', ')}" unless unregistered.empty?
+
+  subscribed_ids = subscribed.map { |system| system['id'] }
+  missing = system_ids.reject { |_minion, system_id| subscribed_ids.include?(system_id) }
+  raise "Minions are not subscribed to #{inputs[:channel]}: #{missing.keys.join(', ')}" unless missing.empty?
+
+  snapshot_records =
+    packages.map do |package|
+      [package[:id], package[:tuple], package[:checksum_type], package[:checksum], package[:retracted]]
+    end
 
   inputs.merge(
     packages: packages,
-    repo_alias: repo_alias,
     system_ids: system_ids,
     snapshot_captured_at: Time.now.utc,
-    snapshot_digest: package_download_benchmark_snapshot_digest(packages),
+    snapshot_digest: Digest::SHA256.hexdigest(JSON.generate(snapshot_records.sort_by(&:first))),
     subscribed_system_count: subscribed_ids.length
   )
 end
 
-# Build a safely serialized kubectl exec command for the Uyuni container.
-def package_download_benchmark_kubectl_command(pod, argv)
-  Shellwords.join(['kubectl', '--namespace', 'uyuni', 'exec', '--container', 'uyuni', pod, '--', *argv])
-end
-
-# Find one ready Uyuni server pod.
-def package_download_benchmark_server_pod
+# Find the ready Uyuni server pod.
+def package_download_server_pod
   command =
     Shellwords.join(
       [
@@ -265,28 +162,23 @@ def package_download_benchmark_server_pod
   raise "Unable to query the Uyuni server pod: #{stderr}" unless code.zero?
 
   pods = JSON.parse(stdout)['items']
-  raise 'The Uyuni server pod response did not contain an items array' unless pods.is_a?(Array)
-
-  ready_pods =
+  ready =
     pods.select do |pod|
       conditions = pod.dig('status', 'conditions')
       pod.dig('status', 'phase') == 'Running' &&
         conditions.is_a?(Array) &&
         conditions.any? { |condition| condition['type'] == 'Ready' && condition['status'] == 'True' }
     end
-  raise "Expected exactly one ready Uyuni server pod, found #{ready_pods.length}" unless ready_pods.length == 1
+  raise "Expected one ready Uyuni server pod, found #{ready.length}" unless ready.length == 1
 
-  pod_name = ready_pods.first.dig('metadata', 'name')
-  raise 'The ready Uyuni server pod has no metadata.name' unless pod_name.is_a?(String) && !pod_name.empty?
-
-  pod_name
-rescue JSON::ParserError, KeyError => e
-  raise "Unable to parse the Uyuni server pod response: #{e.message}"
+  ready.first['metadata']['name']
 end
 
-# Build one synchronous Salt list-target command with an explicit response timeout.
-def package_download_benchmark_salt(inputs, function, arguments, timeout_seconds:)
-  [
+# Run one Salt function on all benchmark minions.
+def package_download_run_salt(inputs, pod, function, arguments = [], context:, timeout_seconds: nil, remote_timeout: nil)
+  timeout_seconds ||= [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_CONTROL_TIMEOUT].min
+  remote_timeout ||= timeout_seconds + 60
+  salt = [
     'salt',
     '--static',
     '--out=json',
@@ -298,253 +190,172 @@ def package_download_benchmark_salt(inputs, function, arguments, timeout_seconds
     function,
     *arguments
   ]
-end
-
-# Parse the complete JSON result emitted by Salt in static mode.
-def package_download_benchmark_parse_salt(stdout, context)
-  output = JSON.parse(stdout)
-  raise "#{context} did not return a JSON object" unless output.is_a?(Hash)
-
-  output
-rescue JSON::ParserError => e
-  raise "#{context} did not return valid JSON: #{e.message}"
-end
-
-# Return missing and unexpected Salt targets.
-def package_download_benchmark_target_errors(output, expected_minions)
-  returned_minions = output.keys
-  errors = (expected_minions - returned_minions).map { |minion| "missing target #{minion}" }
-  errors.concat((returned_minions - expected_minions).map { |minion| "unexpected target #{minion}" })
-  errors
-end
-
-# Run and validate one structured Salt call outside the measurement.
-def package_download_benchmark_salt_call(inputs, pod, function, arguments, context, timeout_seconds: [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_BENCHMARK_CONTROL_TIMEOUT].min)
-  salt = package_download_benchmark_salt(inputs, function, arguments, timeout_seconds: timeout_seconds)
-  remote_timeout = timeout_seconds + 60
-  command = package_download_benchmark_kubectl_command(pod, salt)
+  command =
+    Shellwords.join(
+      ['kubectl', '--namespace', 'uyuni', 'exec', '--container', 'uyuni', pod, '--', *salt]
+    )
   stdout, stderr, code = get_target('localhost').run_local(
     command,
     separated_results: true,
     check_errors: false,
     timeout: remote_timeout
   )
-  raise "#{context} exited with #{code}: #{package_download_benchmark_excerpt(stderr)}" unless code.zero?
+  raise "#{context} exited with #{code}: #{stderr.to_s.byteslice(0, 4096)}" unless code.zero?
 
-  output = package_download_benchmark_parse_salt(stdout, context)
-  errors = package_download_benchmark_target_errors(output, inputs[:minions])
-  raise "#{context} returned invalid targets: #{errors.join('; ')}" unless errors.empty?
+  output = JSON.parse(stdout)
+  raise "#{context} returned invalid data" unless output.is_a?(Hash)
+
+  returned = output.keys.sort
+  expected = inputs[:minions].sort
+  raise "#{context} returned targets #{returned.inspect}, expected #{expected.inspect}" unless returned == expected
 
   output
+rescue JSON::ParserError
+  raise "#{context} did not return valid JSON"
 end
 
-# Return failed or malformed states from one Salt state.apply response.
-def package_download_benchmark_state_errors(state_output)
-  return ['malformed state.apply return'] unless state_output.is_a?(Hash)
-  return ['empty state.apply return'] if state_output.empty?
+# Wait until the benchmark minions have no running Salt jobs.
+def package_download_wait_for_idle(inputs, pod)
+  deadline =
+    Process.clock_gettime(Process::CLOCK_MONOTONIC) +
+    [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_CONTROL_TIMEOUT].min
+  idle_observations = 0
 
-  state_output.filter_map do |state_id, state|
-    next "#{state_id}: malformed state return" unless state.is_a?(Hash)
-    next if state['result'] == true
+  loop do
+    jobs =
+      package_download_run_salt(
+        inputs,
+        pod,
+        'saltutil.running',
+        context: 'Salt job check',
+        timeout_seconds: 30,
+        remote_timeout: 90
+      )
+    raise 'Salt job check returned invalid data' unless jobs.values.all?(Array)
 
-    comment = package_download_benchmark_excerpt(state['comment'].to_s)
-    "#{state_id}: result=#{state['result'].inspect}, comment=#{comment.inspect}"
+    idle_observations = jobs.values.all?(&:empty?) ? idle_observations + 1 : 0
+    return if idle_observations == 2
+    raise 'Salt minions did not become idle' if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+    sleep PACKAGE_DOWNLOAD_IDLE_POLL_SECONDS
   end
 end
 
-# Validate the exact enabled repository alias on every minion.
-def package_download_benchmark_validate_repositories(inputs, repos)
-  errors =
-    repos.filter_map do |minion, repo|
-      valid = repo.is_a?(Hash) &&
-              repo['alias'] == inputs[:repo_alias] &&
-              repo['name'].is_a?(String) &&
-              !repo['name'].empty? &&
-              repo['enabled'] == true
-      next if valid
+# Prepare the minions and repository for the download.
+def package_download_preflight(inputs, pod)
+  states =
+    package_download_run_salt(
+      inputs,
+      pod,
+      'state.apply',
+      ['channels'],
+      context: 'Channel state preflight'
+    )
+  failed_states = states.values.flat_map(&:values).reject { |state| state['result'] == true }
+  raise 'Channel state preflight failed' unless failed_states.empty?
 
-      "#{minion}: #{inputs[:repo_alias]} is missing or disabled"
-    end
-  raise "Channel repository preflight failed: #{errors.join('; ')}" unless errors.empty?
-
-  names = repos.values.map { |repo| repo['name'] }.uniq
-  raise "Channel repository preflight returned different names: #{names.join(', ')}" unless names.length == 1
-
-  names.first
-end
-
-# Refresh and validate all configured package repositories outside the measurement.
-def package_download_benchmark_refresh_repositories(inputs, pod)
-  refreshed = package_download_benchmark_salt_call(
-    inputs,
-    pod,
-    'pkg.refresh_db',
-    ['force=True', "repos=#{inputs[:repo_alias]}"],
-    'Repository metadata refresh'
-  )
-  errors =
-    refreshed.filter_map do |minion, repositories|
-      valid = repositories.is_a?(Hash) &&
-              repositories.keys == [inputs[:repo_name]] &&
-              [true, false].include?(repositories[inputs[:repo_name]])
-      "#{minion}: malformed selected-repository pkg.refresh_db return" unless valid
-    end
-  raise "Repository metadata refresh failed: #{errors.join('; ')}" unless errors.empty?
-end
-
-# Prove that every frozen package name and EVR is visible in the selected client repository.
-def package_download_benchmark_validate_available_packages(inputs, pod)
-  available = package_download_benchmark_salt_call(
-    inputs,
-    pod,
-    'pkg.list_repo_pkgs',
-    ["fromrepo=#{inputs[:repo_name]}"],
-    'Channel package availability preflight'
-  )
-  errors =
-    available.filter_map do |minion, packages|
-      unless packages.is_a?(Hash) &&
-             packages.all? { |name, versions| name.is_a?(String) && versions.is_a?(Array) && versions.all?(String) }
-
-        next "#{minion}: malformed pkg.list_repo_pkgs return"
-      end
-
-      missing = inputs[:packages].reject { |package| packages.fetch(package[:name], []).include?(package[:cache_evr]) }
-      next if missing.empty?
-
-      examples = missing.first(20).map { |package| "#{package[:id]}:#{package[:name]}-#{package[:evr]}" }
-      "#{minion}: #{missing.length} channel packages are unavailable (#{examples.join(', ')})"
-    end
-  raise "Channel package availability preflight failed: #{errors.join('; ')}" unless errors.empty?
-end
-
-# Apply channel configuration and validate client/provider compatibility.
-def package_download_benchmark_preflight(inputs, pod)
-  channel_states = package_download_benchmark_salt_call(inputs, pod, 'state.apply', ['channels'], 'Channel state preflight')
-  state_errors =
-    channel_states.flat_map do |minion, state_output|
-      package_download_benchmark_state_errors(state_output).map { |error| "#{minion}: #{error}" }
-    end
-  raise "Channel state preflight failed: #{state_errors.join('; ')}" unless state_errors.empty?
-
-  grains = package_download_benchmark_salt_call(inputs, pod, 'grains.item', %w[os_family osarch], 'Client grains preflight')
+  grains =
+    package_download_run_salt(
+      inputs,
+      pod,
+      'grains.item',
+      %w[os_family osarch],
+      context: 'Client grains preflight'
+    )
   client_details =
     inputs[:minions].map do |minion|
       value = grains[minion]
-      valid = value.is_a?(Hash) && value['os_family'].is_a?(String) && value['osarch'].is_a?(String)
-      raise "#{minion}: malformed os_family/osarch grains" unless valid
-
-      [minion, value['os_family'], value['osarch']]
+      [value['os_family'], value['osarch']]
     end
-  non_suse = client_details.reject { |_minion, os_family, _osarch| os_family == 'Suse' }
-  raise "Package download benchmark requires SUSE clients: #{non_suse.map(&:first).join(', ')}" unless non_suse.empty?
+  raise 'Package download benchmark requires SUSE clients' unless client_details.all? { |family, _arch| family == 'Suse' }
 
   osarches = client_details.map(&:last).uniq
-  raise "Package download benchmark requires one common client osarch, found #{osarches.join(', ')}" unless osarches.length == 1
+  raise "Package download benchmark requires one client architecture: #{osarches.join(', ')}" unless osarches.length == 1
 
-  osarch = osarches.first
+  repos =
+    package_download_run_salt(
+      inputs,
+      pod,
+      'pkg.get_repo',
+      [inputs[:repo_alias]],
+      context: 'Channel repository preflight'
+    )
+  repos_ok = repos.values.all? { |repo| repo['alias'] == inputs[:repo_alias] && repo['enabled'] == true }
+  raise "Repository is missing or disabled: #{inputs[:repo_alias]}" unless repos_ok
 
-  repos = package_download_benchmark_salt_call(inputs, pod, 'pkg.get_repo', [inputs[:repo_alias]], 'Channel repository preflight')
-  repo_name = package_download_benchmark_validate_repositories(inputs, repos)
-  inputs = inputs.merge(repo_name: repo_name)
-  package_download_benchmark_refresh_repositories(inputs, pod)
-  package_download_benchmark_validate_available_packages(inputs, pod)
+  repo_names = repos.values.map { |repo| repo['name'] }.uniq
+  raise 'Minions returned different repository names' unless repo_names.length == 1
 
-  inputs.merge(client_os_family: 'Suse', client_osarch: osarch)
-end
-
-# Return all Salt jobs currently active on the benchmark minions.
-def package_download_benchmark_running_jobs(inputs, pod)
-  output = package_download_benchmark_salt_call(
-    inputs,
-    pod,
-    'saltutil.running',
-    [],
-    'Salt job idle check',
-    timeout_seconds: 30
+  inputs = inputs.merge(
+    repo_name: repo_names.first,
+    client_os_family: 'Suse',
+    client_osarch: osarches.first
   )
-  output.each do |minion, jobs|
-    raise "#{minion}: saltutil.running returned malformed data" unless jobs.is_a?(Array)
+  refreshed =
+    package_download_run_salt(
+      inputs,
+      pod,
+      'pkg.refresh_db',
+      ['force=True', "repos=#{inputs[:repo_alias]}"],
+      context: 'Repository metadata refresh'
+    )
+  refresh_ok = refreshed.values.all? { |repositories| [true, false].include?(repositories[inputs[:repo_name]]) }
+  raise 'Repository metadata refresh failed' unless refresh_ok
 
-    invalid = jobs.reject { |job| job.is_a?(Hash) && job['fun'].is_a?(String) && !job['fun'].empty? }
-    raise "#{minion}: saltutil.running returned malformed jobs" unless invalid.empty?
+  available =
+    package_download_run_salt(
+      inputs,
+      pod,
+      'pkg.list_repo_pkgs',
+      ["fromrepo=#{inputs[:repo_name]}"],
+      context: 'Channel package availability'
+    )
+  available.each do |minion, packages|
+    raise "#{minion} returned an invalid package list" unless packages.is_a?(Hash)
+
+    missing =
+      inputs[:packages].count do |package|
+        !packages.fetch(package[:name], []).include?(package[:cache_evr])
+      end
+    raise "#{minion} cannot see #{missing} channel packages" unless missing.zero?
   end
-  output
+
+  inputs
 end
 
-# Require two consecutive complete observations with no active Salt jobs.
-def package_download_benchmark_wait_for_idle(inputs, pod)
-  wait_seconds = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_BENCHMARK_CONTROL_TIMEOUT].min
-  deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + wait_seconds
-  idle_observations = 0
-  latest = {}
-  loop do
-    latest = package_download_benchmark_running_jobs(inputs, pod)
-    idle_observations = latest.values.all?(&:empty?) ? idle_observations + 1 : 0
-    return if idle_observations >= 2
-
-    break if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
-
-    sleep PACKAGE_DOWNLOAD_BENCHMARK_IDLE_POLL_SECONDS
-  end
-
-  details =
-    latest.filter_map do |minion, jobs|
-      next if jobs.empty?
-
-      "#{minion}: #{jobs.map { |job| "#{job['fun']} (jid=#{job.fetch('jid', 'unknown')})" }.join(', ')}"
-    end
-  details << 'two consecutive idle observations were not completed' if details.empty?
-  raise "Salt minions did not become idle within #{wait_seconds} seconds: #{details.join('; ')}"
-end
-
-# Clear package payload caches on every benchmark minion outside the measurement.
-def package_download_benchmark_clear_cache(inputs, pod)
-  control_timeout = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_BENCHMARK_CONTROL_TIMEOUT].min
+# Clear downloaded RPMs before the measured workload.
+def package_download_clear_cache(inputs, pod)
+  package_download_wait_for_idle(inputs, pod)
+  control_timeout = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_CONTROL_TIMEOUT].min
   command_timeout = [control_timeout - 15, 1].max
   script = <<~SH
-    cache_root=#{PACKAGE_DOWNLOAD_BENCHMARK_CACHE_ROOT}
-    test -d "$cache_root" || { echo "Missing RPM payload cache: $cache_root" >&2; exit 10; }
+    cache_root=#{PACKAGE_DOWNLOAD_CACHE_ROOT}
+    test -d "$cache_root" || exit 10
     find "$cache_root" -type f -delete || exit 11
-    remaining=$(find "$cache_root" -type f -print -quit) || exit 12
-    test -z "$remaining" ||
-      { echo "Package payload cache is not empty" >&2; exit 12; }
+    test -z "$(find "$cache_root" -type f -print -quit)" || exit 12
   SH
-  package_download_benchmark_wait_for_idle(inputs, pod)
-  salt =
-    package_download_benchmark_salt(
+  output =
+    package_download_run_salt(
       inputs,
+      pod,
       'cmd.run_all',
       [script, 'python_shell=True', "timeout=#{command_timeout}"],
+      context: 'RPM cache reset',
       timeout_seconds: control_timeout
     )
-  remote_timeout = control_timeout + 60
-  command = package_download_benchmark_kubectl_command(pod, salt)
-  stdout, stderr, code = get_target('localhost').run_local(
-    command,
-    separated_results: true,
-    check_errors: false,
-    timeout: remote_timeout
-  )
-  raise "RPM cache reset exited with #{code}: #{stderr}" unless code.zero?
-
-  output = package_download_benchmark_parse_salt(stdout, 'RPM cache reset')
-  errors = package_download_benchmark_target_errors(output, inputs[:minions])
-  output.each do |minion, result|
-    if !result.is_a?(Hash)
-      errors << "#{minion}: malformed cmd.run_all return"
-    elsif result['retcode'] != 0
-      errors << "#{minion}: cache reset retcode=#{result['retcode'].inspect}, stderr=#{package_download_benchmark_excerpt(result['stderr'].to_s).inspect}"
+  failed =
+    output.filter_map do |minion, result|
+      minion unless result.is_a?(Hash) && result['retcode'].zero?
     end
-  end
-  raise "RPM cache reset failed: #{errors.join('; ')}" unless errors.empty?
+  raise "RPM cache reset failed on: #{failed.join(', ')}" unless failed.empty?
 
-  package_download_benchmark_wait_for_idle(inputs, pod)
+  package_download_wait_for_idle(inputs, pod)
 end
 
-# Return the argv used for the measured raw repository download.
-def package_download_benchmark_zypper_argv(inputs)
-  [
+# Run the measured package download on all minions.
+def package_download_workload(inputs, pod)
+  timeout = inputs[:timeout_seconds]
+  zypper = [
     'zypper',
     '--quiet',
     '--non-interactive',
@@ -555,145 +366,120 @@ def package_download_benchmark_zypper_argv(inputs)
     inputs[:repo_alias],
     '*'
   ]
-end
-
-# Return the safely serialized command passed to cmd.run_all.
-def package_download_benchmark_zypper_command(inputs)
-  Shellwords.join(package_download_benchmark_zypper_argv(inputs))
-end
-
-# Summarize the raw-download command returned by one minion.
-def package_download_benchmark_minion_result(minion, command_output)
-  result = {
-    id: minion,
-    status: 'failed',
-    retcode: nil,
-    pid: nil,
-    stdout: nil,
-    stderr: nil,
-    errors: []
-  }
-  unless command_output.is_a?(Hash)
-    result[:errors] << 'malformed cmd.run_all return'
-    return result
-  end
-
-  retcode = command_output['retcode']
-  stdout = command_output['stdout']
-  stderr = command_output['stderr']
-  result[:errors] << "invalid retcode #{retcode.inspect}" unless retcode.is_a?(Integer)
-  result[:errors] << "zypper download exited with #{retcode}" if retcode.is_a?(Integer) && !retcode.zero?
-  result[:errors] << 'malformed stdout' unless stdout.is_a?(String)
-  result[:errors] << 'malformed stderr' unless stderr.is_a?(String)
-  result.merge!(
-    status: result[:errors].empty? ? 'passed' : 'failed',
-    retcode: retcode,
-    pid: command_output['pid'],
-    stdout: package_download_benchmark_excerpt(stdout),
-    stderr: package_download_benchmark_excerpt(stderr)
-  )
-  result
-end
-
-# Return a bounded command-output excerpt for an actionable report.
-def package_download_benchmark_excerpt(value, limit = 4096)
-  return if value.nil?
-
-  text = value.to_s.scrub
-  return if text.empty?
-  return text if text.bytesize <= limit
-
-  "#{text.byteslice(0, limit).scrub}... [truncated]"
-end
-
-# Download every package from the selected repository on all minions concurrently.
-def package_download_benchmark_workload(inputs, pod)
-  timeout_seconds = inputs[:timeout_seconds]
-  command_timeout = [timeout_seconds - 30, 1].max
-  salt_timeout = [timeout_seconds - 15, 1].max
-  salt = package_download_benchmark_salt(
-    inputs,
-    'cmd.run_all',
-    [
-      package_download_benchmark_zypper_command(inputs),
-      'python_shell=False',
-      'output_loglevel=quiet',
-      "timeout=#{command_timeout}"
-    ],
-    timeout_seconds: salt_timeout
-  )
-  command = package_download_benchmark_kubectl_command(pod, salt)
   started_at = Time.now.utc
   started_monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  workload_error = nil
+  returns = {}
 
-  stdout = ''
-  stderr = ''
-  code = nil
-  exception = nil
   begin
-    stdout, stderr, code = get_target('localhost').run_local(
-      command,
-      separated_results: true,
-      check_errors: false,
-      timeout: timeout_seconds
-    )
+    returns =
+      package_download_run_salt(
+        inputs,
+        pod,
+        'cmd.run_all',
+        [
+          Shellwords.join(zypper),
+          'python_shell=False',
+          'output_loglevel=quiet',
+          "timeout=#{[timeout - 30, 1].max}"
+        ],
+        context: 'Package download workload',
+        timeout_seconds: [timeout - 15, 1].max,
+        remote_timeout: timeout
+      )
   rescue StandardError => e
-    exception = "#{e.class}: #{package_download_benchmark_excerpt(e.message)}"
+    workload_error = e.message
   end
 
   finished_at = Time.now.utc
-  duration_seconds = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_monotonic
-  errors = []
-  errors << "command raised #{exception}" unless exception.nil?
-  errors << "command exited with #{code.inspect}: #{package_download_benchmark_excerpt(stderr)}" unless code&.zero?
-
-  returns = {}
-  unless stdout.empty?
-    begin
-      returns = package_download_benchmark_parse_salt(stdout, 'Package download workload')
-    rescue StandardError => e
-      errors << e.message
+  duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_monotonic
+  per_minion =
+    inputs[:minions].map do |minion|
+      output = returns[minion]
+      output = {} unless output.is_a?(Hash)
+      errors = []
+      errors << "zypper exited with #{output['retcode'].inspect}" unless output['retcode']&.zero?
+      {
+        id: minion,
+        status: errors.empty? ? 'passed' : 'failed',
+        retcode: output['retcode'],
+        pid: output['pid'],
+        stdout: output['stdout'].to_s.byteslice(0, 4096),
+        stderr: output['stderr'].to_s.byteslice(0, 4096),
+        errors: errors
+      }
     end
-  end
-  target_errors = package_download_benchmark_target_errors(returns, inputs[:minions])
-  errors.concat(target_errors)
-
-  minions =
-    inputs[:minions].filter_map do |minion|
-      package_download_benchmark_minion_result(minion, returns[minion]) if returns.key?(minion)
-    end
-  failed_targets = minions.reject { |minion| minion[:status] == 'passed' }
-  errors << 'one or more minions failed the package download workload' unless failed_targets.empty?
-  successful_target_count = minions.count { |minion| minion[:status] == 'passed' }
-  no_return =
-    returns.values.any? do |value|
-      value.is_a?(String) && value.match?(/\A(?:Minion did not return(?:\. \[No response\])?|Timed out waiting for minion response)\z/i)
-    end
-  timed_out = code == 124 || no_return
-  uncertain_completion = !exception.nil? || timed_out || !target_errors.empty?
-
+  workload_errors = []
+  workload_errors << workload_error unless workload_error.nil?
+  workload_errors << 'one or more minions failed the package download' if per_minion.any? { |minion| minion[:status] == 'failed' }
   {
-    status: errors.empty? ? 'passed' : 'failed',
-    command: package_download_benchmark_zypper_argv(inputs),
-    timeout_seconds: timeout_seconds,
-    timed_out: timed_out,
-    uncertain_completion: uncertain_completion,
+    status: workload_errors.empty? ? 'passed' : 'failed',
+    command: zypper,
+    timeout_seconds: timeout,
+    timed_out: workload_error.to_s.include?('exited with 124'),
+    uncertain_completion: !workload_error.nil?,
     started_at: started_at.iso8601(6),
     finished_at: finished_at.iso8601(6),
-    duration_seconds: duration_seconds.round(6),
+    duration_seconds: duration.round(6),
     returned_target_count: returns.length,
-    successful_target_count: successful_target_count,
-    errors: errors,
-    per_minion: minions,
-    salt_exit_code: code,
-    salt_stderr: package_download_benchmark_excerpt(stderr),
-    raw_stdout: returns.empty? ? package_download_benchmark_excerpt(stdout) : nil
+    successful_target_count: per_minion.count { |minion| minion[:status] == 'passed' },
+    errors: workload_errors,
+    per_minion: per_minion,
+    salt_exit_code: workload_error.nil? ? 0 : nil,
+    salt_stderr: workload_error,
+    raw_stdout: nil
   }
 end
 
-# Return a Python program that emits every regular package-cache file as JSON.
-def package_download_benchmark_inventory_script
-  <<~PYTHON
+# Check one minion's downloaded RPM inventory.
+def package_download_verify_minion(inputs, minion, output)
+  raise "#{minion} cache inventory failed" unless output['retcode'].zero?
+
+  payloads = JSON.parse(output['stdout'])
+  expected_root = "#{PACKAGE_DOWNLOAD_CACHE_ROOT}/#{inputs[:repo_alias]}/"
+  valid_payloads =
+    payloads.select do |payload|
+      payload['size'].positive? &&
+        payload['path'].start_with?(expected_root)
+    end
+
+  expected = inputs[:packages].group_by { |package| package[:checksum] }
+  actual = valid_payloads.group_by { |payload| File.basename(File.dirname(payload['path'])).downcase }
+  missing = expected.keys - actual.keys
+  extra = actual.keys - expected.keys
+  duplicates = actual.reject { |_checksum, files| files.length == 1 }.keys
+  errors = []
+  errors << "#{payloads.length - valid_payloads.length} invalid payload entries" unless payloads.length == valid_payloads.length
+  errors << "#{missing.length} package payloads are missing" unless missing.empty?
+  errors << "#{extra.length} unexpected package payloads were downloaded" unless extra.empty?
+  errors << "#{duplicates.length} package checksums have multiple payloads" unless duplicates.empty?
+
+  verified_checksums = expected.keys & (actual.keys - duplicates)
+  verified_payloads = verified_checksums.flat_map { |checksum| actual[checksum] }
+  {
+    id: minion,
+    status: errors.empty? ? 'passed' : 'failed',
+    expected_package_count: inputs[:packages].length,
+    expected_payload_count: expected.length,
+    verified_package_count: verified_checksums.sum { |checksum| expected[checksum].length },
+    verified_payload_count: verified_payloads.length,
+    verified_payload_bytes: verified_payloads.sum { |payload| payload['size'] },
+    downloaded_payload_count: valid_payloads.length,
+    downloaded_payload_bytes: valid_payloads.sum { |payload| payload['size'] },
+    extra_payload_count: extra.sum { |checksum| actual[checksum].length },
+    extra_payload_bytes: extra.sum { |checksum| actual[checksum].sum { |payload| payload['size'] } },
+    missing_records: missing,
+    mismatched_records: duplicates,
+    extra_payloads: extra,
+    errors: errors
+  }
+end
+
+# Verify the downloaded RPMs and the channel snapshot.
+def package_download_verify(inputs, pod)
+  package_download_wait_for_idle(inputs, pod)
+  control_timeout = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_CONTROL_TIMEOUT].min
+  inventory_script = <<~PYTHON
     import json
     import os
     import stat
@@ -707,243 +493,108 @@ def package_download_benchmark_inventory_script
             metadata = os.lstat(path)
             if stat.S_ISREG(metadata.st_mode):
                 payloads.append({"path": path, "size": metadata.st_size})
-    print(json.dumps(sorted(payloads, key=lambda payload: payload["path"]), separators=(",", ":")))
+    print(json.dumps(sorted(payloads, key=lambda item: item["path"]), separators=(",", ":")))
   PYTHON
-end
-
-# Return the safely serialized cache-inventory command.
-def package_download_benchmark_inventory_command
-  Shellwords.join(['python3', '-c', package_download_benchmark_inventory_script, PACKAGE_DOWNLOAD_BENCHMARK_CACHE_ROOT])
-end
-
-# Parse one minion's structured cache-inventory command return.
-def package_download_benchmark_cache_payloads(command_output)
-  errors = []
-  return [[], ['malformed cache inventory cmd.run_all return']] unless command_output.is_a?(Hash)
-
-  retcode = command_output['retcode']
-  stdout = command_output['stdout']
-  errors << "cache inventory exited with #{retcode.inspect}" unless retcode&.zero?
-  errors << 'cache inventory returned malformed stdout' unless stdout.is_a?(String)
-  return [[], errors] unless errors.empty?
-
-  payloads = JSON.parse(stdout)
-  return [[], ['cache inventory did not return a JSON array']] unless payloads.is_a?(Array)
-
-  invalid =
-    payloads.reject do |payload|
-      payload.is_a?(Hash) &&
-        payload['path'].is_a?(String) &&
-        !payload['path'].empty? &&
-        payload['size'].is_a?(Integer)
-    end
-  errors << "#{invalid.length} malformed cache inventory entries" unless invalid.empty?
-  [payloads - invalid, errors]
-rescue JSON::ParserError => e
-  [[], ["cache inventory did not return valid JSON: #{e.message}"]]
-end
-
-# Return all integrity errors for one cached RPM.
-def package_download_benchmark_payload_errors(payload, repo_alias, checksum)
-  path = payload['path']
-  size = payload['size']
-  expanded_path = File.expand_path(path)
-  expected_root = "#{PACKAGE_DOWNLOAD_BENCHMARK_CACHE_ROOT}/#{repo_alias}/"
-  errors = []
-  errors << "invalid size #{size.inspect}" unless size.positive?
-  errors << "path is not canonical: #{path}" unless path == expanded_path
-  errors << "path is outside #{expected_root}" unless expanded_path.start_with?(expected_root)
-  errors << "path is not an RPM: #{path}" unless File.extname(expanded_path).casecmp?('.rpm')
-  checksum_directory = File.basename(File.dirname(expanded_path))
-  errors << "checksum directory is not #{checksum}" unless checksum_directory.casecmp?(checksum)
-  errors
-end
-
-# Return the compact frozen-package identity used in verification errors.
-def package_download_benchmark_package_reference(package)
-  {
-    package_id: package[:id],
-    name: package[:name],
-    arch: package[:arch],
-    evr: package[:evr],
-    checksum: package[:checksum]
-  }
-end
-
-# Match one frozen channel artifact to its checksum-named cache payload.
-def package_download_benchmark_verify_artifact(checksum, packages, candidates, repo_alias)
-  references = packages.map { |package| package_download_benchmark_package_reference(package) }
-  return [nil, references, nil] if candidates.empty?
-
-  candidate_errors =
-    candidates.map do |payload|
-      [payload, package_download_benchmark_payload_errors(payload, repo_alias, checksum)]
-    end
-  match = candidate_errors.find { |_payload, payload_errors| payload_errors.empty? }
-  return [match.first, [], nil] if candidates.length == 1 && match
-
-  mismatch = {
-    packages: references,
-    candidates: candidate_errors.map { |payload, payload_errors| payload.merge('errors' => payload_errors) }
-  }
-  [nil, [], mismatch]
-end
-
-# Verify every frozen channel artifact on one minion by its repository checksum path.
-def package_download_benchmark_verify_minion(minion, command_output, inputs)
-  payloads, errors = package_download_benchmark_cache_payloads(command_output)
-  expected = inputs[:packages].group_by { |package| package[:checksum].downcase }
-  actual = payloads.group_by { |payload| File.basename(File.dirname(payload['path'])).downcase }
-  verified_package_count = 0
-  verified_payloads = []
-  missing = []
-  mismatched = []
-  consumed_paths = {}
-
-  expected.each do |checksum, packages|
-    candidates = actual.fetch(checksum, [])
-    candidates.each { |payload| consumed_paths[payload['path']] = true }
-    verified, missing_records, mismatch =
-      package_download_benchmark_verify_artifact(checksum, packages, candidates, inputs[:repo_alias])
-    missing.concat(missing_records)
-    mismatched << mismatch if mismatch
-    if verified
-      verified_package_count += packages.length
-      verified_payloads << verified
-    end
-  end
-
-  extras = payloads.reject { |payload| consumed_paths.key?(payload['path']) }
-  errors << "#{missing.length} channel package records are missing" unless missing.empty?
-  errors << "#{mismatched.length} channel package artifacts are mismatched" unless mismatched.empty?
-  errors << "#{extras.length} unexpected package payloads were downloaded" unless extras.empty?
-
-  {
-    id: minion,
-    status: errors.empty? ? 'passed' : 'failed',
-    expected_package_count: inputs[:packages].length,
-    expected_payload_count: expected.length,
-    verified_package_count: verified_package_count,
-    verified_payload_count: verified_payloads.length,
-    verified_payload_bytes: verified_payloads.sum { |payload| payload['size'] },
-    downloaded_payload_count: payloads.length,
-    downloaded_payload_bytes: payloads.sum { |payload| payload['size'] },
-    extra_payload_count: extras.length,
-    extra_payload_bytes: extras.sum { |payload| payload['size'] },
-    missing_records: missing,
-    mismatched_records: mismatched,
-    extra_payloads: extras,
-    errors: errors
-  }
-end
-
-# Query and verify the structured downloaded-package inventory after timing.
-def package_download_benchmark_verify(inputs, pod)
-  control_timeout = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_BENCHMARK_CONTROL_TIMEOUT].min
-  command_timeout = [control_timeout - 15, 1].max
-  returns =
-    package_download_benchmark_salt_call(
+  inventory =
+    package_download_run_salt(
       inputs,
       pod,
       'cmd.run_all',
       [
-        package_download_benchmark_inventory_command,
+        Shellwords.join(['python3', '-c', inventory_script, PACKAGE_DOWNLOAD_CACHE_ROOT]),
         'python_shell=False',
         'output_loglevel=quiet',
-        "timeout=#{command_timeout}"
+        "timeout=#{[control_timeout - 15, 1].max}"
       ],
-      'Package cache verification',
+      context: 'Package cache verification',
       timeout_seconds: control_timeout
     )
   per_minion =
     inputs[:minions].map do |minion|
-      package_download_benchmark_verify_minion(minion, returns[minion], inputs)
+      package_download_verify_minion(inputs, minion, inventory[minion])
     end
-  errors = []
-  errors << 'one or more minions failed package cache verification' if per_minion.any? { |minion| minion[:status] == 'failed' }
-  expected_payloads_per_minion = inputs[:packages].map { |package| package[:checksum].downcase }.uniq.length
 
+  current_packages =
+    package_download_packages(
+      package_download_api.call(
+        'channel.software.listAllPackages',
+        sessionKey: package_download_api.token,
+        channelLabel: inputs[:channel]
+      )
+    )
+  current_records =
+    current_packages.map do |package|
+      [package[:id], package[:tuple], package[:checksum_type], package[:checksum], package[:retracted]]
+    end
+  current_digest = Digest::SHA256.hexdigest(JSON.generate(current_records.sort_by(&:first)))
+  snapshot_errors = current_digest == inputs[:snapshot_digest] ? [] : ['channel package snapshot changed']
+
+  expected_payloads = inputs[:packages].map { |package| package[:checksum] }.uniq.length
+  errors = per_minion.flat_map { |minion| minion[:errors].map { |error| "#{minion[:id]}: #{error}" } }
+  errors.concat(snapshot_errors.map { |error| "channel snapshot: #{error}" })
+  totals =
+    %i[
+      verified_package_count
+      verified_payload_count
+      verified_payload_bytes
+      downloaded_payload_count
+      downloaded_payload_bytes
+      extra_payload_count
+      extra_payload_bytes
+    ].to_h do |key|
+      [key, per_minion.sum { |minion| minion[key] }]
+    end
   {
     status: errors.empty? ? 'passed' : 'failed',
     expected_package_count: inputs[:minions].length * inputs[:packages].length,
-    expected_payload_count: inputs[:minions].length * expected_payloads_per_minion,
-    verified_package_count: per_minion.sum { |minion| minion[:verified_package_count] },
-    verified_payload_count: per_minion.sum { |minion| minion[:verified_payload_count] },
-    verified_payload_bytes: per_minion.sum { |minion| minion[:verified_payload_bytes] },
-    downloaded_payload_count: per_minion.sum { |minion| minion[:downloaded_payload_count] },
-    downloaded_payload_bytes: per_minion.sum { |minion| minion[:downloaded_payload_bytes] },
-    extra_payload_count: per_minion.sum { |minion| minion[:extra_payload_count] },
-    extra_payload_bytes: per_minion.sum { |minion| minion[:extra_payload_bytes] },
-    returned_target_count: returns.length,
+    expected_payload_count: inputs[:minions].length * expected_payloads,
+    verified_package_count: totals[:verified_package_count],
+    verified_payload_count: totals[:verified_payload_count],
+    verified_payload_bytes: totals[:verified_payload_bytes],
+    downloaded_payload_count: totals[:downloaded_payload_count],
+    downloaded_payload_bytes: totals[:downloaded_payload_bytes],
+    extra_payload_count: totals[:extra_payload_count],
+    extra_payload_bytes: totals[:extra_payload_bytes],
+    returned_target_count: inventory.length,
     successful_target_count: per_minion.count { |minion| minion[:status] == 'passed' },
     errors: errors,
-    per_minion: per_minion
+    per_minion: per_minion,
+    channel_snapshot: {
+      status: snapshot_errors.empty? ? 'passed' : 'failed',
+      checked_at: Time.now.utc.iso8601(6),
+      package_count: current_packages.length,
+      sha256: current_digest,
+      errors: snapshot_errors
+    }
   }
 rescue StandardError => e
-  package_download_benchmark_failed_verification(
-    inputs,
-    "cache verification raised #{e.class}: #{package_download_benchmark_excerpt(e.message)}"
-  )
-end
-
-# Confirm that channel membership did not change during the measured workload.
-def package_download_benchmark_verify_snapshot(inputs)
-  api_packages = package_download_benchmark_api_call('channel.software.listAllPackages', channelLabel: inputs[:channel])
-  packages = package_download_benchmark_api_packages(api_packages)
-  digest = package_download_benchmark_snapshot_digest(packages)
-  errors = []
-  errors << "package count changed from #{inputs[:packages].length} to #{packages.length}" unless packages.length == inputs[:packages].length
-  errors << "snapshot digest changed from #{inputs[:snapshot_digest]} to #{digest}" unless digest == inputs[:snapshot_digest]
-
-  {
-    status: errors.empty? ? 'passed' : 'failed',
-    checked_at: Time.now.utc.iso8601(6),
-    package_count: packages.length,
-    sha256: digest,
-    errors: errors
-  }
-rescue StandardError => e
+  expected_payloads = inputs[:packages].map { |package| package[:checksum] }.uniq.length
   {
     status: 'failed',
-    checked_at: Time.now.utc.iso8601(6),
-    package_count: nil,
-    sha256: nil,
-    errors: ["channel snapshot verification raised #{e.class}: #{package_download_benchmark_excerpt(e.message)}"]
+    expected_package_count: inputs[:minions].length * inputs[:packages].length,
+    expected_payload_count: inputs[:minions].length * expected_payloads,
+    verified_package_count: 0,
+    verified_payload_count: 0,
+    verified_payload_bytes: 0,
+    downloaded_payload_count: 0,
+    downloaded_payload_bytes: 0,
+    extra_payload_count: 0,
+    extra_payload_bytes: 0,
+    returned_target_count: 0,
+    successful_target_count: 0,
+    errors: ["verification failed: #{e.message}"],
+    per_minion: [],
+    channel_snapshot: nil
   }
 end
 
-# Verify both downloaded payloads and the frozen channel snapshot.
-def package_download_benchmark_complete_verification(inputs, pod)
-  verification = package_download_benchmark_verify(inputs, pod)
-  snapshot = package_download_benchmark_verify_snapshot(inputs)
-  verification[:channel_snapshot] = snapshot
-  verification[:errors].concat(snapshot[:errors].map { |error| "channel snapshot: #{error}" })
-  verification[:status] = 'failed' unless verification[:errors].empty?
-  verification
-end
+# Build the benchmark result from the workload and verification.
+def package_download_execute(inputs, pod)
+  workload = package_download_workload(inputs, pod)
+  verification = package_download_verify(inputs, pod)
 
-# Return the immutable channel package fields recorded with the result.
-def package_download_benchmark_report_package(package)
-  {
-    id: package[:id],
-    name: package[:name],
-    arch: package[:arch],
-    epoch: package[:epoch],
-    version: package[:version],
-    release: package[:release],
-    evr: package[:evr],
-    checksum: package[:checksum],
-    checksum_type: package[:checksum_type],
-    retracted: package[:retracted],
-    tuple: package[:tuple]
-  }
-end
-
-# Build schema version 2 result data from the measured workload and verification.
-def package_download_benchmark_result(inputs, pod, workload, verification)
   errors = workload[:errors].map { |error| "workload: #{error}" }
   errors.concat(verification[:errors].map { |error| "verification: #{error}" })
-
   {
     schema_version: 2,
     workload: 'zypper.download_all_matches',
@@ -971,7 +622,21 @@ def package_download_benchmark_result(inputs, pod, workload, verification)
       package_count: inputs[:packages].length,
       retracted_package_count: inputs[:packages].count { |package| package[:retracted] == true },
       subscribed_system_count: inputs[:subscribed_system_count],
-      packages: inputs[:packages].map { |package| package_download_benchmark_report_package(package) }
+      packages: inputs[:packages].map do |package|
+        package.slice(
+          :id,
+          :name,
+          :arch,
+          :epoch,
+          :version,
+          :release,
+          :evr,
+          :checksum,
+          :checksum_type,
+          :retracted,
+          :tuple
+        )
+      end
     },
     execution: workload,
     verification: verification,
@@ -979,45 +644,8 @@ def package_download_benchmark_result(inputs, pod, workload, verification)
   }
 end
 
-# Build a complete failure-shaped verification result.
-def package_download_benchmark_failed_verification(inputs, error)
-  expected_payloads_per_minion = inputs[:packages].map { |package| package[:checksum].downcase }.uniq.length
-  {
-    status: 'failed',
-    expected_package_count: inputs[:minions].length * inputs[:packages].length,
-    expected_payload_count: inputs[:minions].length * expected_payloads_per_minion,
-    verified_package_count: 0,
-    verified_payload_count: 0,
-    verified_payload_bytes: 0,
-    downloaded_payload_count: 0,
-    downloaded_payload_bytes: 0,
-    extra_payload_count: 0,
-    extra_payload_bytes: 0,
-    returned_target_count: 0,
-    successful_target_count: 0,
-    errors: [error],
-    per_minion: [],
-    channel_snapshot: nil
-  }
-end
-
-# Run one concurrent all-package download and verify every cached record.
-def package_download_benchmark_execute(inputs, pod)
-  workload = package_download_benchmark_workload(inputs, pod)
-  verification =
-    begin
-      package_download_benchmark_wait_for_idle(inputs, pod)
-      package_download_benchmark_complete_verification(inputs, pod)
-    rescue StandardError => e
-      message = package_download_benchmark_excerpt(e.message)
-      package_download_benchmark_failed_verification(inputs, "verification raised #{e.class}: #{message}")
-    end
-
-  package_download_benchmark_result(inputs, pod, workload, verification)
-end
-
-# Write one result document to the testsuite results directory.
-def package_download_benchmark_write_result(result)
+# Write the benchmark result to the testsuite results directory.
+def package_download_write_result(result)
   timestamp = Time.parse(result[:started_at]).strftime('%Y%m%dT%H%M%S.%6NZ')
   directory = File.expand_path("../../results/package-download/#{timestamp}-#{Process.pid}", __dir__)
   FileUtils.mkdir_p(directory)
@@ -1027,41 +655,37 @@ def package_download_benchmark_write_result(result)
 end
 
 Given('the Salt package download benchmark inputs are valid') do
-  @package_download_benchmark_inputs = package_download_benchmark_inputs
+  @package_download_inputs = package_download_inputs
 end
 
 Given('the initial configured channel package snapshot is valid') do
-  @package_download_benchmark_inputs = package_download_benchmark_snapshot(@package_download_benchmark_inputs)
+  @package_download_inputs = package_download_snapshot(@package_download_inputs)
 end
 
 Given('a ready server pod is reachable from the benchmark controller') do
-  @package_download_benchmark_pod = package_download_benchmark_server_pod
+  @package_download_pod = package_download_server_pod
 end
 
 Given('the benchmark minions are ready for the configured channel') do
-  @package_download_benchmark_inputs =
-    package_download_benchmark_preflight(@package_download_benchmark_inputs, @package_download_benchmark_pod)
+  @package_download_inputs = package_download_preflight(@package_download_inputs, @package_download_pod)
 end
 
 When('I clear RPM payload caches on the benchmark minions outside the measurement') do
-  package_download_benchmark_clear_cache(@package_download_benchmark_inputs, @package_download_benchmark_pod)
+  package_download_clear_cache(@package_download_inputs, @package_download_pod)
 end
 
 When('I execute and record the channel package downloads') do
-  @package_download_benchmark_result = package_download_benchmark_execute(
-    @package_download_benchmark_inputs,
-    @package_download_benchmark_pod
-  )
-  @package_download_benchmark_result_path = package_download_benchmark_write_result(@package_download_benchmark_result)
-  log "Package download result: #{@package_download_benchmark_result_path}"
+  @package_download_result = package_download_execute(@package_download_inputs, @package_download_pod)
+  @package_download_result_path = package_download_write_result(@package_download_result)
+  log "Package download result: #{@package_download_result_path}"
 end
 
 Then('the package download result report should exist') do
-  raise 'Package download result report was not written' unless File.file?(@package_download_benchmark_result_path)
+  raise 'Package download result report was not written' unless File.file?(@package_download_result_path)
 end
 
 Then('every configured minion should have downloaded every channel package') do
-  result = @package_download_benchmark_result
+  result = @package_download_result
   next if result[:status] == 'passed'
 
   details = result[:errors].dup

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -13,40 +13,6 @@ PACKAGE_DOWNLOAD_CACHE_ROOT = '/var/cache/zypp/packages'.freeze
 PACKAGE_DOWNLOAD_IDLE_POLL_SECONDS = 2
 PACKAGE_DOWNLOAD_SOURCE_ARCHES = %w[src nosrc source srcpackage].freeze
 
-# Load the configured benchmark inputs.
-def package_download_inputs
-  minions = JSON.parse(ENV.fetch('UYUNI_BENCH_MINIONS', ''))
-  raise 'UYUNI_BENCH_MINIONS must be a non-empty JSON array' unless minions.is_a?(Array) && !minions.empty?
-
-  valid_minions =
-    minions.all? do |minion|
-      minion.is_a?(String) &&
-        !minion.empty? &&
-        !minion.start_with?('-') &&
-        !minion.match?(/[,\s[:cntrl:]]/)
-    end
-  raise 'UYUNI_BENCH_MINIONS contains an invalid Salt ID' unless valid_minions
-  raise 'UYUNI_BENCH_MINIONS contains duplicate Salt IDs' unless minions.uniq.length == minions.length
-
-  channel = ENV.fetch('UYUNI_BENCH_CHANNEL', '')
-  raise 'UYUNI_BENCH_CHANNEL is invalid' unless channel.match?(/\A[A-Za-z0-9][A-Za-z0-9_.-]*\z/)
-
-  timeout = Integer(ENV.fetch('UYUNI_BENCH_TIMEOUT_SECONDS', PACKAGE_DOWNLOAD_DEFAULT_TIMEOUT.to_s), 10)
-  raise 'UYUNI_BENCH_TIMEOUT_SECONDS must be between 1 and 86400' unless timeout.between?(1, 86_400)
-
-  {
-    minions: minions,
-    channel: channel,
-    repo_alias: "susemanager:#{channel}",
-    storage_class: ENV.fetch('UYUNI_BENCH_STORAGE_CLASS', nil),
-    timeout_seconds: timeout
-  }
-rescue JSON::ParserError
-  raise 'UYUNI_BENCH_MINIONS must contain valid JSON'
-rescue ArgumentError
-  raise 'UYUNI_BENCH_TIMEOUT_SECONDS must be an integer'
-end
-
 # Return an API client for the configured Uyuni server.
 def package_download_api
   @package_download_api ||=
@@ -87,6 +53,7 @@ def package_download_packages(records)
         version: version,
         release: release,
         evr: evr,
+        # Salt's zypper provider omits a zero epoch from repository versions.
         cache_evr: evr.sub(/\A0:/, ''),
         checksum: package['checksum'].downcase,
         checksum_type: package['checksum_type'],
@@ -97,86 +64,15 @@ def package_download_packages(records)
   packages.sort_by { |package| [package[:name], package[:cache_evr], package[:arch], package[:id]] }
 end
 
-# Capture the channel packages and subscribed benchmark systems.
-def package_download_snapshot(inputs)
-  api = package_download_api
-  packages_response =
-    api.call(
-      'channel.software.listAllPackages',
-      sessionKey: api.token,
-      channelLabel: inputs[:channel]
-    )
-  subscribed =
-    api.call(
-      'channel.software.listSubscribedSystems',
-      sessionKey: api.token,
-      channelLabel: inputs[:channel]
-    )
-  id_map = api.call('system.getMinionIdMap', sessionKey: api.token)
-
-  packages = package_download_packages(packages_response)
-  raise 'The configured channel has no binary RPM packages' if packages.empty?
-
-  system_ids = inputs[:minions].to_h { |minion| [minion, id_map[minion]] }
-  unregistered = system_ids.select { |_minion, system_id| system_id.nil? }
-  raise "Salt minions are not registered in Uyuni: #{unregistered.keys.join(', ')}" unless unregistered.empty?
-
-  subscribed_ids = subscribed.map { |system| system['id'] }
-  missing = system_ids.reject { |_minion, system_id| subscribed_ids.include?(system_id) }
-  raise "Minions are not subscribed to #{inputs[:channel]}: #{missing.keys.join(', ')}" unless missing.empty?
-
-  snapshot_records =
-    packages.map do |package|
-      [package[:id], package[:tuple], package[:checksum_type], package[:checksum], package[:retracted]]
-    end
-
-  inputs.merge(
-    packages: packages,
-    system_ids: system_ids,
-    snapshot_captured_at: Time.now.utc,
-    snapshot_digest: Digest::SHA256.hexdigest(JSON.generate(snapshot_records.sort_by(&:first))),
-    subscribed_system_count: subscribed_ids.length
-  )
-end
-
-# Find the ready Uyuni server pod.
-def package_download_server_pod
-  command =
-    Shellwords.join(
-      [
-        'kubectl',
-        '--namespace',
-        'uyuni',
-        'get',
-        'pods',
-        '--selector',
-        'app.kubernetes.io/component=server',
-        '--output=json'
-      ]
-    )
-  stdout, stderr, code = get_target('localhost').run_local(
-    command,
-    separated_results: true,
-    check_errors: false
-  )
-  raise "Unable to query the Uyuni server pod: #{stderr}" unless code.zero?
-
-  pods = JSON.parse(stdout)['items']
-  ready =
-    pods.select do |pod|
-      conditions = pod.dig('status', 'conditions')
-      pod.dig('status', 'phase') == 'Running' &&
-        conditions.is_a?(Array) &&
-        conditions.any? { |condition| condition['type'] == 'Ready' && condition['status'] == 'True' }
-    end
-  raise "Expected one ready Uyuni server pod, found #{ready.length}" unless ready.length == 1
-
-  ready.first['metadata']['name']
-end
-
-# Run one Salt function on all benchmark minions.
+# Run Salt through kubectl from the testsuite controller.
 def package_download_run_salt(inputs, pod, function, arguments = [], context:, timeout_seconds: nil, remote_timeout: nil)
-  timeout_seconds ||= [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_CONTROL_TIMEOUT].min
+  if timeout_seconds.nil?
+    timeout_seconds = [
+      inputs[:timeout_seconds],
+      PACKAGE_DOWNLOAD_CONTROL_TIMEOUT
+    ].min
+  end
+  # Leave time for Salt's structured result to return after its own deadline.
   remote_timeout ||= timeout_seconds + 60
   salt = [
     'salt',
@@ -233,6 +129,7 @@ def package_download_wait_for_idle(inputs, pod)
       )
     raise 'Salt job check returned invalid data' unless jobs.values.all?(Array)
 
+    # Two empty polls avoid treating a brief gap between Salt jobs as idle.
     idle_observations = jobs.values.all?(&:empty?) ? idle_observations + 1 : 0
     return if idle_observations == 2
     raise 'Salt minions did not become idle' if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
@@ -241,8 +138,163 @@ def package_download_wait_for_idle(inputs, pod)
   end
 end
 
-# Prepare the minions and repository for the download.
-def package_download_preflight(inputs, pod)
+# Check one minion's downloaded RPM inventory.
+def package_download_verify_minion(inputs, minion, output)
+  raise "#{minion} cache inventory failed" unless output['retcode'].zero?
+
+  payloads = JSON.parse(output['stdout'])
+  expected_root = "#{PACKAGE_DOWNLOAD_CACHE_ROOT}/#{inputs[:repo_alias]}/"
+  valid_payloads =
+    payloads.select do |payload|
+      payload['size'].positive? &&
+        payload['path'].start_with?(expected_root)
+    end
+
+  expected = inputs[:packages].group_by { |package| package[:checksum] }
+  # Zypper stores each RPM under <repository>/<checksum>/<filename>.
+  actual = valid_payloads.group_by { |payload| File.basename(File.dirname(payload['path'])).downcase }
+  missing = expected.keys - actual.keys
+  extra = actual.keys - expected.keys
+  duplicates = actual.reject { |_checksum, files| files.length == 1 }.keys
+  errors = []
+  errors << "#{payloads.length - valid_payloads.length} invalid payload entries" unless payloads.length == valid_payloads.length
+  errors << "#{missing.length} package payloads are missing" unless missing.empty?
+  errors << "#{extra.length} unexpected package payloads were downloaded" unless extra.empty?
+  errors << "#{duplicates.length} package checksums have multiple payloads" unless duplicates.empty?
+
+  verified_checksums = expected.keys & (actual.keys - duplicates)
+  verified_payloads = verified_checksums.flat_map { |checksum| actual[checksum] }
+  {
+    id: minion,
+    status: errors.empty? ? 'passed' : 'failed',
+    expected_package_count: inputs[:packages].length,
+    expected_payload_count: expected.length,
+    verified_package_count: verified_checksums.sum { |checksum| expected[checksum].length },
+    verified_payload_count: verified_payloads.length,
+    verified_payload_bytes: verified_payloads.sum { |payload| payload['size'] },
+    downloaded_payload_count: valid_payloads.length,
+    downloaded_payload_bytes: valid_payloads.sum { |payload| payload['size'] },
+    extra_payload_count: extra.sum { |checksum| actual[checksum].length },
+    extra_payload_bytes: extra.sum { |checksum| actual[checksum].sum { |payload| payload['size'] } },
+    missing_records: missing,
+    mismatched_records: duplicates,
+    extra_payloads: extra,
+    errors: errors
+  }
+end
+
+Given('the Salt package download benchmark inputs are valid') do
+  minions = JSON.parse(ENV.fetch('UYUNI_BENCH_MINIONS', ''))
+  raise 'UYUNI_BENCH_MINIONS must be a non-empty JSON array' unless minions.is_a?(Array) && !minions.empty?
+
+  valid_minions =
+    minions.all? do |minion|
+      minion.is_a?(String) &&
+        !minion.empty? &&
+        !minion.start_with?('-') &&
+        !minion.match?(/[,\s[:cntrl:]]/)
+    end
+  raise 'UYUNI_BENCH_MINIONS contains an invalid Salt ID' unless valid_minions
+  raise 'UYUNI_BENCH_MINIONS contains duplicate Salt IDs' unless minions.uniq.length == minions.length
+
+  channel = ENV.fetch('UYUNI_BENCH_CHANNEL', '')
+  raise 'UYUNI_BENCH_CHANNEL is invalid' unless channel.match?(/\A[A-Za-z0-9][A-Za-z0-9_.-]*\z/)
+
+  timeout = Integer(ENV.fetch('UYUNI_BENCH_TIMEOUT_SECONDS', PACKAGE_DOWNLOAD_DEFAULT_TIMEOUT.to_s), 10)
+  raise 'UYUNI_BENCH_TIMEOUT_SECONDS must be between 1 and 86400' unless timeout.between?(1, 86_400)
+
+  @package_download_inputs = {
+    minions: minions,
+    channel: channel,
+    repo_alias: "susemanager:#{channel}",
+    storage_class: ENV.fetch('UYUNI_BENCH_STORAGE_CLASS', nil),
+    timeout_seconds: timeout
+  }
+rescue JSON::ParserError
+  raise 'UYUNI_BENCH_MINIONS must contain valid JSON'
+rescue ArgumentError
+  raise 'UYUNI_BENCH_TIMEOUT_SECONDS must be an integer'
+end
+
+Given('the initial configured channel package snapshot is valid') do
+  inputs = @package_download_inputs
+  api = package_download_api
+  packages_response =
+    api.call(
+      'channel.software.listAllPackages',
+      sessionKey: api.token,
+      channelLabel: inputs[:channel]
+    )
+  subscribed =
+    api.call(
+      'channel.software.listSubscribedSystems',
+      sessionKey: api.token,
+      channelLabel: inputs[:channel]
+    )
+  id_map = api.call('system.getMinionIdMap', sessionKey: api.token)
+
+  packages = package_download_packages(packages_response)
+  raise 'The configured channel has no binary RPM packages' if packages.empty?
+
+  system_ids = inputs[:minions].to_h { |minion| [minion, id_map[minion]] }
+  unregistered = system_ids.select { |_minion, system_id| system_id.nil? }
+  raise "Salt minions are not registered in Uyuni: #{unregistered.keys.join(', ')}" unless unregistered.empty?
+
+  subscribed_ids = subscribed.map { |system| system['id'] }
+  missing = system_ids.reject { |_minion, system_id| subscribed_ids.include?(system_id) }
+  raise "Minions are not subscribed to #{inputs[:channel]}: #{missing.keys.join(', ')}" unless missing.empty?
+
+  snapshot_records =
+    packages.map do |package|
+      [package[:id], package[:tuple], package[:checksum_type], package[:checksum], package[:retracted]]
+    end
+  @package_download_inputs = inputs.merge(
+    packages: packages,
+    system_ids: system_ids,
+    snapshot_captured_at: Time.now.utc,
+    snapshot_digest: Digest::SHA256.hexdigest(JSON.generate(snapshot_records.sort_by(&:first))),
+    subscribed_system_count: subscribed_ids.length
+  )
+end
+
+Given('a ready server pod is reachable from the benchmark controller') do
+  command =
+    Shellwords.join(
+      [
+        'kubectl',
+        '--namespace',
+        'uyuni',
+        'get',
+        'pods',
+        '--selector',
+        'app.kubernetes.io/component=server',
+        '--output=json'
+      ]
+    )
+  # The testsuite registers its controller as the 'localhost' target.
+  stdout, stderr, code = get_target('localhost').run_local(
+    command,
+    separated_results: true,
+    check_errors: false
+  )
+  raise "Unable to query the Uyuni server pod: #{stderr}" unless code.zero?
+
+  pods = JSON.parse(stdout)['items']
+  ready =
+    pods.select do |pod|
+      conditions = pod.dig('status', 'conditions')
+      pod.dig('status', 'phase') == 'Running' &&
+        conditions.is_a?(Array) &&
+        conditions.any? { |condition| condition['type'] == 'Ready' && condition['status'] == 'True' }
+    end
+  raise "Expected one ready Uyuni server pod, found #{ready.length}" unless ready.length == 1
+
+  @package_download_pod = ready.first['metadata']['name']
+end
+
+Given('the benchmark minions are ready for the configured channel') do
+  inputs = @package_download_inputs
+  pod = @package_download_pod
   states =
     package_download_run_salt(
       inputs,
@@ -320,11 +372,12 @@ def package_download_preflight(inputs, pod)
     raise "#{minion} cannot see #{missing} channel packages" unless missing.zero?
   end
 
-  inputs
+  @package_download_inputs = inputs
 end
 
-# Clear downloaded RPMs before the measured workload.
-def package_download_clear_cache(inputs, pod)
+When('I clear RPM payload caches on the benchmark minions outside the measurement') do
+  inputs = @package_download_inputs
+  pod = @package_download_pod
   package_download_wait_for_idle(inputs, pod)
   control_timeout = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_CONTROL_TIMEOUT].min
   command_timeout = [control_timeout - 15, 1].max
@@ -352,8 +405,9 @@ def package_download_clear_cache(inputs, pod)
   package_download_wait_for_idle(inputs, pod)
 end
 
-# Run the measured package download on all minions.
-def package_download_workload(inputs, pod)
+When('I execute and record the channel package downloads') do
+  inputs = @package_download_inputs
+  pod = @package_download_pod
   timeout = inputs[:timeout_seconds]
   zypper = [
     'zypper',
@@ -372,6 +426,7 @@ def package_download_workload(inputs, pod)
   returns = {}
 
   begin
+    # The minion command ends first, then Salt and SSH get 15 seconds each to return the result.
     returns =
       package_download_run_salt(
         inputs,
@@ -393,26 +448,26 @@ def package_download_workload(inputs, pod)
 
   finished_at = Time.now.utc
   duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_monotonic
-  per_minion =
+  workload_per_minion =
     inputs[:minions].map do |minion|
       output = returns[minion]
       output = {} unless output.is_a?(Hash)
-      errors = []
-      errors << "zypper exited with #{output['retcode'].inspect}" unless output['retcode']&.zero?
+      minion_errors = []
+      minion_errors << "zypper exited with #{output['retcode'].inspect}" unless output['retcode']&.zero?
       {
         id: minion,
-        status: errors.empty? ? 'passed' : 'failed',
+        status: minion_errors.empty? ? 'passed' : 'failed',
         retcode: output['retcode'],
         pid: output['pid'],
         stdout: output['stdout'].to_s.byteslice(0, 4096),
         stderr: output['stderr'].to_s.byteslice(0, 4096),
-        errors: errors
+        errors: minion_errors
       }
     end
   workload_errors = []
   workload_errors << workload_error unless workload_error.nil?
-  workload_errors << 'one or more minions failed the package download' if per_minion.any? { |minion| minion[:status] == 'failed' }
-  {
+  workload_errors << 'one or more minions failed the package download' if workload_per_minion.any? { |minion| minion[:status] == 'failed' }
+  workload = {
     status: workload_errors.empty? ? 'passed' : 'failed',
     command: zypper,
     timeout_seconds: timeout,
@@ -422,180 +477,133 @@ def package_download_workload(inputs, pod)
     finished_at: finished_at.iso8601(6),
     duration_seconds: duration.round(6),
     returned_target_count: returns.length,
-    successful_target_count: per_minion.count { |minion| minion[:status] == 'passed' },
+    successful_target_count: workload_per_minion.count { |minion| minion[:status] == 'passed' },
     errors: workload_errors,
-    per_minion: per_minion,
+    per_minion: workload_per_minion,
     salt_exit_code: workload_error.nil? ? 0 : nil,
     salt_stderr: workload_error,
     raw_stdout: nil
   }
-end
 
-# Check one minion's downloaded RPM inventory.
-def package_download_verify_minion(inputs, minion, output)
-  raise "#{minion} cache inventory failed" unless output['retcode'].zero?
+  verification =
+    begin
+      package_download_wait_for_idle(inputs, pod)
+      control_timeout = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_CONTROL_TIMEOUT].min
+      inventory_script = <<~PYTHON
+        import json
+        import os
+        import stat
+        import sys
 
-  payloads = JSON.parse(output['stdout'])
-  expected_root = "#{PACKAGE_DOWNLOAD_CACHE_ROOT}/#{inputs[:repo_alias]}/"
-  valid_payloads =
-    payloads.select do |payload|
-      payload['size'].positive? &&
-        payload['path'].start_with?(expected_root)
+        root = os.path.realpath(sys.argv[1])
+        payloads = []
+        for directory, _subdirectories, filenames in os.walk(root):
+            for filename in filenames:
+                path = os.path.join(directory, filename)
+                metadata = os.lstat(path)
+                if stat.S_ISREG(metadata.st_mode):
+                    payloads.append({"path": path, "size": metadata.st_size})
+        print(json.dumps(sorted(payloads, key=lambda item: item["path"]), separators=(",", ":")))
+      PYTHON
+      inventory =
+        package_download_run_salt(
+          inputs,
+          pod,
+          'cmd.run_all',
+          [
+            Shellwords.join(['python3', '-c', inventory_script, PACKAGE_DOWNLOAD_CACHE_ROOT]),
+            'python_shell=False',
+            'output_loglevel=quiet',
+            "timeout=#{[control_timeout - 15, 1].max}"
+          ],
+          context: 'Package cache verification',
+          timeout_seconds: control_timeout
+        )
+      verification_per_minion =
+        inputs[:minions].map do |minion|
+          package_download_verify_minion(inputs, minion, inventory[minion])
+        end
+
+      current_packages =
+        package_download_packages(
+          package_download_api.call(
+            'channel.software.listAllPackages',
+            sessionKey: package_download_api.token,
+            channelLabel: inputs[:channel]
+          )
+        )
+      current_records =
+        current_packages.map do |package|
+          [package[:id], package[:tuple], package[:checksum_type], package[:checksum], package[:retracted]]
+        end
+      current_digest = Digest::SHA256.hexdigest(JSON.generate(current_records.sort_by(&:first)))
+      snapshot_errors = current_digest == inputs[:snapshot_digest] ? [] : ['channel package snapshot changed']
+
+      expected_payloads = inputs[:packages].map { |package| package[:checksum] }.uniq.length
+      verification_errors =
+        verification_per_minion.flat_map do |minion|
+          minion[:errors].map { |error| "#{minion[:id]}: #{error}" }
+        end
+      verification_errors.concat(snapshot_errors.map { |error| "channel snapshot: #{error}" })
+      totals =
+        %i[
+          verified_package_count
+          verified_payload_count
+          verified_payload_bytes
+          downloaded_payload_count
+          downloaded_payload_bytes
+          extra_payload_count
+          extra_payload_bytes
+        ].to_h do |key|
+          [key, verification_per_minion.sum { |minion| minion[key] }]
+        end
+      {
+        status: verification_errors.empty? ? 'passed' : 'failed',
+        expected_package_count: inputs[:minions].length * inputs[:packages].length,
+        expected_payload_count: inputs[:minions].length * expected_payloads,
+        verified_package_count: totals[:verified_package_count],
+        verified_payload_count: totals[:verified_payload_count],
+        verified_payload_bytes: totals[:verified_payload_bytes],
+        downloaded_payload_count: totals[:downloaded_payload_count],
+        downloaded_payload_bytes: totals[:downloaded_payload_bytes],
+        extra_payload_count: totals[:extra_payload_count],
+        extra_payload_bytes: totals[:extra_payload_bytes],
+        returned_target_count: inventory.length,
+        successful_target_count: verification_per_minion.count { |minion| minion[:status] == 'passed' },
+        errors: verification_errors,
+        per_minion: verification_per_minion,
+        channel_snapshot: {
+          status: snapshot_errors.empty? ? 'passed' : 'failed',
+          checked_at: Time.now.utc.iso8601(6),
+          package_count: current_packages.length,
+          sha256: current_digest,
+          errors: snapshot_errors
+        }
+      }
+    rescue StandardError => e
+      expected_payloads = inputs[:packages].map { |package| package[:checksum] }.uniq.length
+      {
+        status: 'failed',
+        expected_package_count: inputs[:minions].length * inputs[:packages].length,
+        expected_payload_count: inputs[:minions].length * expected_payloads,
+        verified_package_count: 0,
+        verified_payload_count: 0,
+        verified_payload_bytes: 0,
+        downloaded_payload_count: 0,
+        downloaded_payload_bytes: 0,
+        extra_payload_count: 0,
+        extra_payload_bytes: 0,
+        returned_target_count: 0,
+        successful_target_count: 0,
+        errors: ["verification failed: #{e.message}"],
+        per_minion: [],
+        channel_snapshot: nil
+      }
     end
-
-  expected = inputs[:packages].group_by { |package| package[:checksum] }
-  actual = valid_payloads.group_by { |payload| File.basename(File.dirname(payload['path'])).downcase }
-  missing = expected.keys - actual.keys
-  extra = actual.keys - expected.keys
-  duplicates = actual.reject { |_checksum, files| files.length == 1 }.keys
-  errors = []
-  errors << "#{payloads.length - valid_payloads.length} invalid payload entries" unless payloads.length == valid_payloads.length
-  errors << "#{missing.length} package payloads are missing" unless missing.empty?
-  errors << "#{extra.length} unexpected package payloads were downloaded" unless extra.empty?
-  errors << "#{duplicates.length} package checksums have multiple payloads" unless duplicates.empty?
-
-  verified_checksums = expected.keys & (actual.keys - duplicates)
-  verified_payloads = verified_checksums.flat_map { |checksum| actual[checksum] }
-  {
-    id: minion,
-    status: errors.empty? ? 'passed' : 'failed',
-    expected_package_count: inputs[:packages].length,
-    expected_payload_count: expected.length,
-    verified_package_count: verified_checksums.sum { |checksum| expected[checksum].length },
-    verified_payload_count: verified_payloads.length,
-    verified_payload_bytes: verified_payloads.sum { |payload| payload['size'] },
-    downloaded_payload_count: valid_payloads.length,
-    downloaded_payload_bytes: valid_payloads.sum { |payload| payload['size'] },
-    extra_payload_count: extra.sum { |checksum| actual[checksum].length },
-    extra_payload_bytes: extra.sum { |checksum| actual[checksum].sum { |payload| payload['size'] } },
-    missing_records: missing,
-    mismatched_records: duplicates,
-    extra_payloads: extra,
-    errors: errors
-  }
-end
-
-# Verify the downloaded RPMs and the channel snapshot.
-def package_download_verify(inputs, pod)
-  package_download_wait_for_idle(inputs, pod)
-  control_timeout = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_CONTROL_TIMEOUT].min
-  inventory_script = <<~PYTHON
-    import json
-    import os
-    import stat
-    import sys
-
-    root = os.path.realpath(sys.argv[1])
-    payloads = []
-    for directory, _subdirectories, filenames in os.walk(root):
-        for filename in filenames:
-            path = os.path.join(directory, filename)
-            metadata = os.lstat(path)
-            if stat.S_ISREG(metadata.st_mode):
-                payloads.append({"path": path, "size": metadata.st_size})
-    print(json.dumps(sorted(payloads, key=lambda item: item["path"]), separators=(",", ":")))
-  PYTHON
-  inventory =
-    package_download_run_salt(
-      inputs,
-      pod,
-      'cmd.run_all',
-      [
-        Shellwords.join(['python3', '-c', inventory_script, PACKAGE_DOWNLOAD_CACHE_ROOT]),
-        'python_shell=False',
-        'output_loglevel=quiet',
-        "timeout=#{[control_timeout - 15, 1].max}"
-      ],
-      context: 'Package cache verification',
-      timeout_seconds: control_timeout
-    )
-  per_minion =
-    inputs[:minions].map do |minion|
-      package_download_verify_minion(inputs, minion, inventory[minion])
-    end
-
-  current_packages =
-    package_download_packages(
-      package_download_api.call(
-        'channel.software.listAllPackages',
-        sessionKey: package_download_api.token,
-        channelLabel: inputs[:channel]
-      )
-    )
-  current_records =
-    current_packages.map do |package|
-      [package[:id], package[:tuple], package[:checksum_type], package[:checksum], package[:retracted]]
-    end
-  current_digest = Digest::SHA256.hexdigest(JSON.generate(current_records.sort_by(&:first)))
-  snapshot_errors = current_digest == inputs[:snapshot_digest] ? [] : ['channel package snapshot changed']
-
-  expected_payloads = inputs[:packages].map { |package| package[:checksum] }.uniq.length
-  errors = per_minion.flat_map { |minion| minion[:errors].map { |error| "#{minion[:id]}: #{error}" } }
-  errors.concat(snapshot_errors.map { |error| "channel snapshot: #{error}" })
-  totals =
-    %i[
-      verified_package_count
-      verified_payload_count
-      verified_payload_bytes
-      downloaded_payload_count
-      downloaded_payload_bytes
-      extra_payload_count
-      extra_payload_bytes
-    ].to_h do |key|
-      [key, per_minion.sum { |minion| minion[key] }]
-    end
-  {
-    status: errors.empty? ? 'passed' : 'failed',
-    expected_package_count: inputs[:minions].length * inputs[:packages].length,
-    expected_payload_count: inputs[:minions].length * expected_payloads,
-    verified_package_count: totals[:verified_package_count],
-    verified_payload_count: totals[:verified_payload_count],
-    verified_payload_bytes: totals[:verified_payload_bytes],
-    downloaded_payload_count: totals[:downloaded_payload_count],
-    downloaded_payload_bytes: totals[:downloaded_payload_bytes],
-    extra_payload_count: totals[:extra_payload_count],
-    extra_payload_bytes: totals[:extra_payload_bytes],
-    returned_target_count: inventory.length,
-    successful_target_count: per_minion.count { |minion| minion[:status] == 'passed' },
-    errors: errors,
-    per_minion: per_minion,
-    channel_snapshot: {
-      status: snapshot_errors.empty? ? 'passed' : 'failed',
-      checked_at: Time.now.utc.iso8601(6),
-      package_count: current_packages.length,
-      sha256: current_digest,
-      errors: snapshot_errors
-    }
-  }
-rescue StandardError => e
-  expected_payloads = inputs[:packages].map { |package| package[:checksum] }.uniq.length
-  {
-    status: 'failed',
-    expected_package_count: inputs[:minions].length * inputs[:packages].length,
-    expected_payload_count: inputs[:minions].length * expected_payloads,
-    verified_package_count: 0,
-    verified_payload_count: 0,
-    verified_payload_bytes: 0,
-    downloaded_payload_count: 0,
-    downloaded_payload_bytes: 0,
-    extra_payload_count: 0,
-    extra_payload_bytes: 0,
-    returned_target_count: 0,
-    successful_target_count: 0,
-    errors: ["verification failed: #{e.message}"],
-    per_minion: [],
-    channel_snapshot: nil
-  }
-end
-
-# Build the benchmark result from the workload and verification.
-def package_download_execute(inputs, pod)
-  workload = package_download_workload(inputs, pod)
-  verification = package_download_verify(inputs, pod)
 
   errors = workload[:errors].map { |error| "workload: #{error}" }
   errors.concat(verification[:errors].map { |error| "verification: #{error}" })
-  {
+  @package_download_result = {
     schema_version: 2,
     workload: 'zypper.download_all_matches',
     status: errors.empty? ? 'passed' : 'failed',
@@ -642,41 +650,12 @@ def package_download_execute(inputs, pod)
     verification: verification,
     errors: errors
   }
-end
 
-# Write the benchmark result to the testsuite results directory.
-def package_download_write_result(result)
-  timestamp = Time.parse(result[:started_at]).strftime('%Y%m%dT%H%M%S.%6NZ')
+  timestamp = Time.parse(workload[:started_at]).strftime('%Y%m%dT%H%M%S.%6NZ')
   directory = File.expand_path("../../results/package-download/#{timestamp}-#{Process.pid}", __dir__)
   FileUtils.mkdir_p(directory)
-  path = File.join(directory, 'result.json')
-  File.write(path, "#{JSON.pretty_generate(result)}\n")
-  path
-end
-
-Given('the Salt package download benchmark inputs are valid') do
-  @package_download_inputs = package_download_inputs
-end
-
-Given('the initial configured channel package snapshot is valid') do
-  @package_download_inputs = package_download_snapshot(@package_download_inputs)
-end
-
-Given('a ready server pod is reachable from the benchmark controller') do
-  @package_download_pod = package_download_server_pod
-end
-
-Given('the benchmark minions are ready for the configured channel') do
-  @package_download_inputs = package_download_preflight(@package_download_inputs, @package_download_pod)
-end
-
-When('I clear RPM payload caches on the benchmark minions outside the measurement') do
-  package_download_clear_cache(@package_download_inputs, @package_download_pod)
-end
-
-When('I execute and record the channel package downloads') do
-  @package_download_result = package_download_execute(@package_download_inputs, @package_download_pod)
-  @package_download_result_path = package_download_write_result(@package_download_result)
+  @package_download_result_path = File.join(directory, 'result.json')
+  File.write(@package_download_result_path, "#{JSON.pretty_generate(@package_download_result)}\n")
   log "Package download result: #{@package_download_result_path}"
 end
 

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -213,15 +213,15 @@ rescue ArgumentError
 end
 
 # Prepare a fixed package snapshot before the benchmark:
-# 1. Read the channel packages, subscribed systems, and Salt-to-Uyuni system ID mapping.
-# 2. Keep the binary RPMs and verify that every selected minion is registered and subscribed.
-# 3. Save the package records and their SHA-256 digest for comparison after the download.
+# Read the channel packages, subscribed systems, and Salt-to-Uyuni system ID mapping.
+# Keep the binary RPMs and verify that every selected minion is registered and subscribed.
+# Save the package records and their SHA-256 digest for comparison after the download.
 # If the digest changes, the result is invalid because the tested package set was not stable.
 Given('the initial configured channel package snapshot is valid') do
   inputs = @package_download_inputs
   api = $api_test
 
-  # 1. Read the current channel state from the Uyuni API.
+  # Read the current channel state from the Uyuni API.
   packages_response =
     api.call(
       'channel.software.listAllPackages',
@@ -236,7 +236,7 @@ Given('the initial configured channel package snapshot is valid') do
     )
   id_map = api.call('system.getMinionIdMap', sessionKey: api.token)
 
-  # 2. Validate the packages and selected minions.
+  # Validate the packages and selected minions.
   packages = package_download_packages(packages_response)
   raise 'The configured channel has no binary RPM packages' if packages.empty?
 
@@ -248,7 +248,7 @@ Given('the initial configured channel package snapshot is valid') do
   missing = system_ids.reject { |_minion, system_id| subscribed_ids.include?(system_id) }
   raise "Minions are not subscribed to #{inputs[:channel]}: #{missing.keys.join(', ')}" unless missing.empty?
 
-  # 3. Save the initial package snapshot for the final comparison.
+  # Save the initial package snapshot for the final comparison.
   snapshot_records =
     packages.map do |package|
       [package[:id], package[:tuple], package[:checksum_type], package[:checksum], package[:retracted]]
@@ -302,16 +302,16 @@ Given('a ready server pod is reachable from the benchmark controller') do
 end
 
 # Check that every configured minion is ready before the measurement:
-# 1. Apply the Salt channels state to update the minion repository configuration.
-# 2. Read the OS family and architecture, then require matching SUSE clients.
-# 3. Verify that the configured Uyuni repository exists and is enabled.
-# 4. Refresh the repository metadata.
-# 5. Verify that every RPM from the initial snapshot is available to every minion.
+# Apply the Salt channels state to update the minion repository configuration.
+# Read the OS family and architecture, then require matching SUSE clients.
+# Verify that the configured Uyuni repository exists and is enabled.
+# Refresh the repository metadata.
+# Verify that every RPM from the initial snapshot is available to every minion.
 Given('the benchmark minions are ready for the configured channel') do
   inputs = @package_download_inputs
   pod = @package_download_pod
 
-  # 1. Run `state.apply channels` so Uyuni updates the assigned software channel
+  # Run `state.apply channels` so Uyuni updates the assigned software channel
   # repository configuration on every minion. The later `pkg.*` calls must use
   # this configuration instead of repository files left by an older run.
   states =
@@ -325,7 +325,7 @@ Given('the benchmark minions are ready for the configured channel') do
   failed_states = states.values.flat_map(&:values).reject { |state| state['result'] == true }
   raise 'Channel state preflight failed' unless failed_states.empty?
 
-  # 2. Read the `os_family` and `osarch` Salt grains. This workload uses zypper,
+  # Read the `os_family` and `osarch` Salt grains. This workload uses zypper,
   # so every target must be a SUSE client. Requiring one architecture also keeps
   # the visible RPM set and benchmark results comparable across all minions.
   grains =
@@ -346,7 +346,7 @@ Given('the benchmark minions are ready for the configured channel') do
   osarches = client_details.map(&:last).uniq
   raise "Package download benchmark requires one client architecture: #{osarches.join(', ')}" unless osarches.length == 1
 
-  # 3. Use `pkg.get_repo` to confirm that `susemanager:<channel>` exists and is
+  # Use `pkg.get_repo` to confirm that `susemanager:<channel>` exists and is
   # enabled on every minion. Save the common repository name returned by Salt;
   # `pkg.list_repo_pkgs` uses that name when it checks package availability.
   repos =
@@ -369,7 +369,7 @@ Given('the benchmark minions are ready for the configured channel') do
     client_osarch: osarches.first
   )
 
-  # 4. Force `pkg.refresh_db` for only the benchmark repository. This makes the
+  # Force `pkg.refresh_db` for only the benchmark repository. This makes the
   # package availability check use current zypper metadata instead of metadata
   # cached before the benchmark channel was prepared.
   refreshed =
@@ -383,7 +383,7 @@ Given('the benchmark minions are ready for the configured channel') do
   refresh_ok = refreshed.values.all? { |repositories| [true, false].include?(repositories[inputs[:repo_name]]) }
   raise 'Repository metadata refresh failed' unless refresh_ok
 
-  # 5. Use `pkg.list_repo_pkgs` to read the package versions each minion can see
+  # Use `pkg.list_repo_pkgs` to read the package versions each minion can see
   # in the benchmark repository, then compare them with the initial Uyuni
   # snapshot. Stop before measurement if any expected RPM is unavailable.
   available =

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -175,6 +175,14 @@ Given('the Salt package download benchmark inputs are valid') do
   minions = JSON.parse(ENV.fetch('UYUNI_BENCH_MINIONS', ''))
   raise 'UYUNI_BENCH_MINIONS must be a non-empty JSON array' unless minions.is_a?(Array) && !minions.empty?
 
+  # Salt's --list option accepts minion IDs as one comma-separated value.
+  # Each ID must be a non-empty String without commas, whitespace, control
+  # characters, or a leading hyphen that could look like a CLI option.
+  #
+  # Valid:   ["minion-1.tf.local", "minion-2.tf.local"]
+  # Invalid: ["minion 1"]           # contains whitespace
+  # Invalid: ["minion-1,minion-2"]  # contains Salt's list separator
+  # Invalid: ["-minion-1"]          # starts like a CLI option
   valid_minions =
     minions.all? do |minion|
       minion.is_a?(String) &&
@@ -204,9 +212,16 @@ rescue ArgumentError
   raise 'UYUNI_BENCH_TIMEOUT_SECONDS must be an integer'
 end
 
+# Prepare a fixed package snapshot before the benchmark:
+# 1. Read the channel packages, subscribed systems, and Salt-to-Uyuni system ID mapping.
+# 2. Keep the binary RPMs and verify that every selected minion is registered and subscribed.
+# 3. Save the package records and their SHA-256 digest for comparison after the download.
+# If the digest changes, the result is invalid because the tested package set was not stable.
 Given('the initial configured channel package snapshot is valid') do
   inputs = @package_download_inputs
   api = $api_test
+
+  # 1. Read the current channel state from the Uyuni API.
   packages_response =
     api.call(
       'channel.software.listAllPackages',
@@ -221,6 +236,7 @@ Given('the initial configured channel package snapshot is valid') do
     )
   id_map = api.call('system.getMinionIdMap', sessionKey: api.token)
 
+  # 2. Validate the packages and selected minions.
   packages = package_download_packages(packages_response)
   raise 'The configured channel has no binary RPM packages' if packages.empty?
 
@@ -232,6 +248,7 @@ Given('the initial configured channel package snapshot is valid') do
   missing = system_ids.reject { |_minion, system_id| subscribed_ids.include?(system_id) }
   raise "Minions are not subscribed to #{inputs[:channel]}: #{missing.keys.join(', ')}" unless missing.empty?
 
+  # 3. Save the initial package snapshot for the final comparison.
   snapshot_records =
     packages.map do |package|
       [package[:id], package[:tuple], package[:checksum_type], package[:checksum], package[:retracted]]

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -29,11 +29,11 @@ def package_download_api
     end
 end
 
-# Normalize Uyuni channel packages for:
-# - checking available versions on each minion;
-# - comparing the channel snapshot before and after the download;
-# - matching cached RPMs by checksum; and
-# - recording package details in result.json.
+# Convert Uyuni API package records into the values used by the benchmark:
+# - exclude source and Debian packages;
+# - build the RPM EVR used for repository checks;
+# - lowercase checksums used to match zypper cache directories; and
+# - retain stable fields for snapshot comparison and result.json.
 def package_download_packages(records)
   packages =
     records.filter_map do |package|

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -4,11 +4,11 @@
 require 'digest'
 require 'fileutils'
 require 'json'
-require 'open3'
 require 'shellwords'
 require 'time'
 
 PACKAGE_DOWNLOAD_BENCHMARK_DEFAULT_TIMEOUT = 14_400
+PACKAGE_DOWNLOAD_BENCHMARK_RUN_GRACE_SECONDS = 30
 PACKAGE_DOWNLOAD_BENCHMARK_CACHE_ROOT = '/var/cache/zypp/packages'.freeze
 PACKAGE_DOWNLOAD_BENCHMARK_IDLE_TIMEOUT = 600
 PACKAGE_DOWNLOAD_BENCHMARK_IDLE_POLL_SECONDS = 2
@@ -238,13 +238,9 @@ def package_download_benchmark_snapshot(inputs)
   )
 end
 
-# Run an argv-form command on the testsuite controller.
-def package_download_benchmark_run(argv, timeout:)
-  wrapped_argv = ['timeout', '--signal=TERM', '--kill-after=10s', "#{timeout}s", *argv]
-  stdout, stderr, status = Open3.capture3(*wrapped_argv)
-  exit_code = status.exitstatus
-  exit_code = status.termsig + 128 if exit_code.nil? && status.signaled?
-  [stdout, stderr, exit_code]
+# Build a safely serialized command with a process-level timeout.
+def package_download_benchmark_timeout_command(argv, timeout:)
+  Shellwords.join(['timeout', '--signal=TERM', '--kill-after=10s', "#{timeout}s", *argv])
 end
 
 # Build a kubectl exec command for the Uyuni container.
@@ -254,18 +250,27 @@ end
 
 # Find one ready Uyuni server pod.
 def package_download_benchmark_server_pod
-  stdout, stderr, code = package_download_benchmark_run(
-    [
-      'kubectl',
-      '--namespace',
-      'uyuni',
-      'get',
-      'pods',
-      '--selector',
-      'app.kubernetes.io/component=server',
-      '--output=json'
-    ],
-    timeout: 30
+  timeout = 30
+  command =
+    package_download_benchmark_timeout_command(
+      [
+        'kubectl',
+        '--namespace',
+        'uyuni',
+        'get',
+        'pods',
+        '--selector',
+        'app.kubernetes.io/component=server',
+        '--output=json'
+      ],
+      timeout: timeout
+    )
+  stdout, stderr, code = get_target('localhost').run(
+    command,
+    runs_in_container: false,
+    separated_results: true,
+    check_errors: false,
+    timeout: timeout + PACKAGE_DOWNLOAD_BENCHMARK_RUN_GRACE_SECONDS
   )
   raise "Unable to query the Uyuni server pod: #{stderr}" unless code.zero?
 
@@ -326,9 +331,14 @@ end
 # Run and validate one structured Salt call outside the measurement.
 def package_download_benchmark_salt_call(inputs, pod, function, arguments, context, timeout_seconds: inputs[:timeout_seconds])
   salt = package_download_benchmark_salt(inputs, function, arguments, timeout_seconds: timeout_seconds)
-  stdout, stderr, code = package_download_benchmark_run(
-    package_download_benchmark_kubectl(pod, salt),
-    timeout: timeout_seconds + 60
+  timeout = timeout_seconds + 60
+  command = package_download_benchmark_timeout_command(package_download_benchmark_kubectl(pod, salt), timeout: timeout)
+  stdout, stderr, code = get_target('localhost').run(
+    command,
+    runs_in_container: false,
+    separated_results: true,
+    check_errors: false,
+    timeout: timeout + PACKAGE_DOWNLOAD_BENCHMARK_RUN_GRACE_SECONDS
   )
   raise "#{context} exited with #{code}: #{package_download_benchmark_excerpt(stderr)}" unless code.zero?
 
@@ -517,9 +527,14 @@ def package_download_benchmark_clear_cache(inputs, pod)
       'cmd.run_all',
       [script, 'python_shell=True', "timeout=#{command_timeout}"]
     )
-  stdout, stderr, code = package_download_benchmark_run(
-    package_download_benchmark_kubectl(pod, salt),
-    timeout: inputs[:timeout_seconds] + 60
+  timeout = inputs[:timeout_seconds] + 60
+  command = package_download_benchmark_timeout_command(package_download_benchmark_kubectl(pod, salt), timeout: timeout)
+  stdout, stderr, code = get_target('localhost').run(
+    command,
+    runs_in_container: false,
+    separated_results: true,
+    check_errors: false,
+    timeout: timeout + PACKAGE_DOWNLOAD_BENCHMARK_RUN_GRACE_SECONDS
   )
   raise "RPM cache reset exited with #{code}: #{stderr}" unless code.zero?
 
@@ -626,7 +641,14 @@ def package_download_benchmark_workload(inputs, pod)
   code = nil
   exception = nil
   begin
-    stdout, stderr, code = package_download_benchmark_run(argv, timeout: timeout_seconds)
+    command = package_download_benchmark_timeout_command(argv, timeout: timeout_seconds)
+    stdout, stderr, code = get_target('localhost').run(
+      command,
+      runs_in_container: false,
+      separated_results: true,
+      check_errors: false,
+      timeout: timeout_seconds + PACKAGE_DOWNLOAD_BENCHMARK_RUN_GRACE_SECONDS
+    )
   rescue StandardError => e
     exception = "#{e.class}: #{package_download_benchmark_excerpt(e.message)}"
   end

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -7,9 +7,9 @@ require 'json'
 require 'shellwords'
 require 'time'
 
-PACKAGE_DOWNLOAD_BENCHMARK_DEFAULT_TIMEOUT = 14_400
+PACKAGE_DOWNLOAD_BENCHMARK_DEFAULT_WORKLOAD_TIMEOUT = 14_400
+PACKAGE_DOWNLOAD_BENCHMARK_CONTROL_TIMEOUT = 600
 PACKAGE_DOWNLOAD_BENCHMARK_CACHE_ROOT = '/var/cache/zypp/packages'.freeze
-PACKAGE_DOWNLOAD_BENCHMARK_IDLE_TIMEOUT = 600
 PACKAGE_DOWNLOAD_BENCHMARK_IDLE_POLL_SECONDS = 2
 PACKAGE_DOWNLOAD_BENCHMARK_SOURCE_ARCHES = %w[src nosrc source srcpackage].freeze
 
@@ -48,9 +48,9 @@ def package_download_benchmark_channel
   channel
 end
 
-# Return the validated Salt command timeout.
-def package_download_benchmark_timeout
-  value = ENV.fetch('UYUNI_BENCH_TIMEOUT_SECONDS', PACKAGE_DOWNLOAD_BENCHMARK_DEFAULT_TIMEOUT.to_s)
+# Return the validated package-download workload timeout.
+def package_download_benchmark_workload_timeout
+  value = ENV.fetch('UYUNI_BENCH_TIMEOUT_SECONDS', PACKAGE_DOWNLOAD_BENCHMARK_DEFAULT_WORKLOAD_TIMEOUT.to_s)
   timeout = Integer(value, 10)
   raise 'UYUNI_BENCH_TIMEOUT_SECONDS must be between 1 and 86400' unless timeout.between?(1, 86_400)
 
@@ -76,7 +76,7 @@ def package_download_benchmark_inputs
     minions: package_download_benchmark_minions,
     channel: package_download_benchmark_channel,
     storage_class: package_download_benchmark_storage_class,
-    timeout_seconds: package_download_benchmark_timeout
+    timeout_seconds: package_download_benchmark_workload_timeout
   }
 end
 
@@ -284,8 +284,8 @@ rescue JSON::ParserError, KeyError => e
   raise "Unable to parse the Uyuni server pod response: #{e.message}"
 end
 
-# Build one synchronous Salt list-target command.
-def package_download_benchmark_salt(inputs, function, arguments, timeout_seconds: inputs[:timeout_seconds])
+# Build one synchronous Salt list-target command with an explicit response timeout.
+def package_download_benchmark_salt(inputs, function, arguments, timeout_seconds:)
   [
     'salt',
     '--static',
@@ -319,15 +319,15 @@ def package_download_benchmark_target_errors(output, expected_minions)
 end
 
 # Run and validate one structured Salt call outside the measurement.
-def package_download_benchmark_salt_call(inputs, pod, function, arguments, context, timeout_seconds: inputs[:timeout_seconds])
+def package_download_benchmark_salt_call(inputs, pod, function, arguments, context, timeout_seconds: [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_BENCHMARK_CONTROL_TIMEOUT].min)
   salt = package_download_benchmark_salt(inputs, function, arguments, timeout_seconds: timeout_seconds)
-  timeout = timeout_seconds + 60
+  remote_timeout = timeout_seconds + 60
   command = package_download_benchmark_kubectl_command(pod, salt)
   stdout, stderr, code = get_target('localhost').run_local(
     command,
     separated_results: true,
     check_errors: false,
-    timeout: timeout
+    timeout: remote_timeout
   )
   raise "#{context} exited with #{code}: #{package_download_benchmark_excerpt(stderr)}" unless code.zero?
 
@@ -474,7 +474,7 @@ end
 
 # Require two consecutive complete observations with no active Salt jobs.
 def package_download_benchmark_wait_for_idle(inputs, pod)
-  wait_seconds = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_BENCHMARK_IDLE_TIMEOUT].min
+  wait_seconds = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_BENCHMARK_CONTROL_TIMEOUT].min
   deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + wait_seconds
   idle_observations = 0
   latest = {}
@@ -500,7 +500,8 @@ end
 
 # Clear package payload caches on every benchmark minion outside the measurement.
 def package_download_benchmark_clear_cache(inputs, pod)
-  command_timeout = [inputs[:timeout_seconds] - 15, 1].max
+  control_timeout = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_BENCHMARK_CONTROL_TIMEOUT].min
+  command_timeout = [control_timeout - 15, 1].max
   script = <<~SH
     cache_root=#{PACKAGE_DOWNLOAD_BENCHMARK_CACHE_ROOT}
     test -d "$cache_root" || { echo "Missing RPM payload cache: $cache_root" >&2; exit 10; }
@@ -514,15 +515,16 @@ def package_download_benchmark_clear_cache(inputs, pod)
     package_download_benchmark_salt(
       inputs,
       'cmd.run_all',
-      [script, 'python_shell=True', "timeout=#{command_timeout}"]
+      [script, 'python_shell=True', "timeout=#{command_timeout}"],
+      timeout_seconds: control_timeout
     )
-  timeout = inputs[:timeout_seconds] + 60
+  remote_timeout = control_timeout + 60
   command = package_download_benchmark_kubectl_command(pod, salt)
   stdout, stderr, code = get_target('localhost').run_local(
     command,
     separated_results: true,
     check_errors: false,
-    timeout: timeout
+    timeout: remote_timeout
   )
   raise "RPM cache reset exited with #{code}: #{stderr}" unless code.zero?
 
@@ -837,8 +839,8 @@ end
 
 # Query and verify the structured downloaded-package inventory after timing.
 def package_download_benchmark_verify(inputs, pod)
-  inventory_timeout = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_BENCHMARK_IDLE_TIMEOUT].min
-  command_timeout = [inventory_timeout - 15, 1].max
+  control_timeout = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_BENCHMARK_CONTROL_TIMEOUT].min
+  command_timeout = [control_timeout - 15, 1].max
   returns =
     package_download_benchmark_salt_call(
       inputs,
@@ -851,7 +853,7 @@ def package_download_benchmark_verify(inputs, pod)
         "timeout=#{command_timeout}"
       ],
       'Package cache verification',
-      timeout_seconds: inventory_timeout
+      timeout_seconds: control_timeout
     )
   per_minion =
     inputs[:minions].map do |minion|

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -285,16 +285,20 @@ Given('a ready server pod is reachable from the benchmark controller') do
   raise "Unable to query the Uyuni server pod: #{stderr}" unless code.zero?
 
   pods = JSON.parse(stdout)['items']
-  ready =
+  ready_pods =
     pods.select do |pod|
-      conditions = pod.dig('status', 'conditions')
-      pod.dig('status', 'phase') == 'Running' &&
-        conditions.is_a?(Array) &&
-        conditions.any? { |condition| condition['type'] == 'Ready' && condition['status'] == 'True' }
-    end
-  raise "Expected one ready Uyuni server pod, found #{ready.length}" unless ready.length == 1
+      status = pod.fetch('status', {})
+      running = status['phase'] == 'Running'
+      ready =
+        Array(status['conditions']).any? do |condition|
+          condition['type'] == 'Ready' && condition['status'] == 'True'
+        end
 
-  @package_download_pod = ready.first['metadata']['name']
+      running && ready
+    end
+  raise "Expected one ready Uyuni server pod, found #{ready_pods.length}" unless ready_pods.length == 1
+
+  @package_download_pod = ready_pods.first['metadata']['name']
 end
 
 Given('the benchmark minions are ready for the configured channel') do

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -301,9 +301,19 @@ Given('a ready server pod is reachable from the benchmark controller') do
   @package_download_pod = ready_pods.first['metadata']['name']
 end
 
+# Check that every configured minion is ready before the measurement:
+# 1. Apply the Salt channels state to update the minion repository configuration.
+# 2. Read the OS family and architecture, then require matching SUSE clients.
+# 3. Verify that the configured Uyuni repository exists and is enabled.
+# 4. Refresh the repository metadata.
+# 5. Verify that every RPM from the initial snapshot is available to every minion.
 Given('the benchmark minions are ready for the configured channel') do
   inputs = @package_download_inputs
   pod = @package_download_pod
+
+  # 1. Run `state.apply channels` so Uyuni updates the assigned software channel
+  # repository configuration on every minion. The later `pkg.*` calls must use
+  # this configuration instead of repository files left by an older run.
   states =
     package_download_run_salt(
       inputs,
@@ -315,6 +325,9 @@ Given('the benchmark minions are ready for the configured channel') do
   failed_states = states.values.flat_map(&:values).reject { |state| state['result'] == true }
   raise 'Channel state preflight failed' unless failed_states.empty?
 
+  # 2. Read the `os_family` and `osarch` Salt grains. This workload uses zypper,
+  # so every target must be a SUSE client. Requiring one architecture also keeps
+  # the visible RPM set and benchmark results comparable across all minions.
   grains =
     package_download_run_salt(
       inputs,
@@ -333,6 +346,9 @@ Given('the benchmark minions are ready for the configured channel') do
   osarches = client_details.map(&:last).uniq
   raise "Package download benchmark requires one client architecture: #{osarches.join(', ')}" unless osarches.length == 1
 
+  # 3. Use `pkg.get_repo` to confirm that `susemanager:<channel>` exists and is
+  # enabled on every minion. Save the common repository name returned by Salt;
+  # `pkg.list_repo_pkgs` uses that name when it checks package availability.
   repos =
     package_download_run_salt(
       inputs,
@@ -352,6 +368,10 @@ Given('the benchmark minions are ready for the configured channel') do
     client_os_family: 'Suse',
     client_osarch: osarches.first
   )
+
+  # 4. Force `pkg.refresh_db` for only the benchmark repository. This makes the
+  # package availability check use current zypper metadata instead of metadata
+  # cached before the benchmark channel was prepared.
   refreshed =
     package_download_run_salt(
       inputs,
@@ -363,6 +383,9 @@ Given('the benchmark minions are ready for the configured channel') do
   refresh_ok = refreshed.values.all? { |repositories| [true, false].include?(repositories[inputs[:repo_name]]) }
   raise 'Repository metadata refresh failed' unless refresh_ok
 
+  # 5. Use `pkg.list_repo_pkgs` to read the package versions each minion can see
+  # in the benchmark repository, then compare them with the initial Uyuni
+  # snapshot. Stop before measurement if any expected RPM is unavailable.
   available =
     package_download_run_salt(
       inputs,

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -13,22 +13,6 @@ PACKAGE_DOWNLOAD_CACHE_ROOT = '/var/cache/zypp/packages'.freeze
 PACKAGE_DOWNLOAD_IDLE_POLL_SECONDS = 2
 PACKAGE_DOWNLOAD_SOURCE_ARCHES = %w[src nosrc source srcpackage].freeze
 
-# Return an API client for the configured Uyuni server.
-def package_download_api
-  @package_download_api ||=
-    begin
-      host = ENV.fetch('SERVER', '').strip
-      raise 'SERVER must not be empty' if host.empty?
-
-      if $api_test.is_a?(ApiTestXmlrpc)
-        ApiTestXmlrpc.new(host)
-      else
-        ssl_verify = $api_protocol == 'http' ? false : !$is_gh_validation
-        ApiTestHttp.new(host, ssl_verify)
-      end
-    end
-end
-
 # Convert Uyuni API package records into the values used by the benchmark:
 # - exclude source and Debian packages;
 # - build the RPM EVR used for repository checks;
@@ -222,7 +206,7 @@ end
 
 Given('the initial configured channel package snapshot is valid') do
   inputs = @package_download_inputs
-  api = package_download_api
+  api = $api_test
   packages_response =
     api.call(
       'channel.software.listAllPackages',
@@ -530,9 +514,9 @@ When('I execute and record the channel package downloads') do
 
       current_packages =
         package_download_packages(
-          package_download_api.call(
+          $api_test.call(
             'channel.software.listAllPackages',
-            sessionKey: package_download_api.token,
+            sessionKey: $api_test.token,
             channelLabel: inputs[:channel]
           )
         )

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -29,7 +29,11 @@ def package_download_api
     end
 end
 
-# Convert Uyuni package records to the RPM identities used by the benchmark.
+# Normalize Uyuni channel packages for:
+# - checking available versions on each minion;
+# - comparing the channel snapshot before and after the download;
+# - matching cached RPMs by checksum; and
+# - recording package details in result.json.
 def package_download_packages(records)
   packages =
     records.filter_map do |package|

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -503,7 +503,6 @@ When('I execute and record the channel package downloads') do
     status: workload_errors.empty? ? 'passed' : 'failed',
     command: zypper,
     timeout_seconds: timeout,
-    timed_out: workload_error.to_s.include?('exited with 124'),
     uncertain_completion: !workload_error.nil?,
     started_at: started_at.iso8601(6),
     finished_at: finished_at.iso8601(6),

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 SUSE LLC.
+# Copyright (c) 2026 Akash Kumar <meakash7902@gmail.com>
 # Licensed under the terms of the MIT license.
 
 require 'digest'

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -1,0 +1,1065 @@
+# Copyright (c) 2026 SUSE LLC.
+# Licensed under the terms of the MIT license.
+
+require 'digest'
+require 'fileutils'
+require 'json'
+require 'open3'
+require 'shellwords'
+require 'time'
+
+PACKAGE_DOWNLOAD_BENCHMARK_DEFAULT_TIMEOUT = 14_400
+PACKAGE_DOWNLOAD_BENCHMARK_CACHE_ROOT = '/var/cache/zypp/packages'.freeze
+PACKAGE_DOWNLOAD_BENCHMARK_IDLE_TIMEOUT = 600
+PACKAGE_DOWNLOAD_BENCHMARK_IDLE_POLL_SECONDS = 2
+PACKAGE_DOWNLOAD_BENCHMARK_SOURCE_ARCHES = %w[src nosrc source srcpackage].freeze
+
+# Parse one required JSON environment variable.
+def package_download_benchmark_json_env(name)
+  value = ENV.fetch(name, nil)
+  raise "#{name} must be set" if value.nil?
+
+  JSON.parse(value)
+rescue JSON::ParserError => e
+  raise "#{name} must contain valid JSON: #{e.message}"
+end
+
+# Return the validated Salt minion inventory.
+def package_download_benchmark_minions
+  minions = package_download_benchmark_json_env('UYUNI_BENCH_MINIONS')
+  raise 'UYUNI_BENCH_MINIONS must be a non-empty JSON array' unless minions.is_a?(Array) && !minions.empty?
+
+  minions.each do |minion|
+    valid = minion.is_a?(String) && !minion.empty? && !minion.start_with?('-') && !minion.match?(/[,\s[:cntrl:]]/)
+    raise "Invalid Salt minion ID: #{minion.inspect}" unless valid
+  end
+  raise 'UYUNI_BENCH_MINIONS must not contain duplicate IDs' unless minions.uniq.length == minions.length
+
+  minions
+end
+
+# Return the validated Uyuni software channel label.
+def package_download_benchmark_channel
+  channel = ENV.fetch('UYUNI_BENCH_CHANNEL', nil)
+  raise 'UYUNI_BENCH_CHANNEL must be set' if channel.nil?
+
+  valid = channel.match?(/\A[A-Za-z0-9][A-Za-z0-9_.-]*\z/) && channel.length <= 128
+  raise 'UYUNI_BENCH_CHANNEL must be a valid software channel label' unless valid
+
+  channel
+end
+
+# Return the validated Salt command timeout.
+def package_download_benchmark_timeout
+  value = ENV.fetch('UYUNI_BENCH_TIMEOUT_SECONDS', PACKAGE_DOWNLOAD_BENCHMARK_DEFAULT_TIMEOUT.to_s)
+  timeout = Integer(value, 10)
+  raise 'UYUNI_BENCH_TIMEOUT_SECONDS must be between 1 and 86400' unless timeout.between?(1, 86_400)
+
+  timeout
+rescue ArgumentError
+  raise 'UYUNI_BENCH_TIMEOUT_SECONDS must be an integer'
+end
+
+# Return the optional StorageClass result metadata.
+def package_download_benchmark_storage_class
+  value = ENV.fetch('UYUNI_BENCH_STORAGE_CLASS', nil)
+  return if value.nil?
+
+  raise 'UYUNI_BENCH_STORAGE_CLASS must not be empty' if value.empty?
+  raise 'UYUNI_BENCH_STORAGE_CLASS must not exceed 253 characters' if value.length > 253
+
+  value
+end
+
+# Load the complete benchmark input contract.
+def package_download_benchmark_inputs
+  {
+    minions: package_download_benchmark_minions,
+    channel: package_download_benchmark_channel,
+    storage_class: package_download_benchmark_storage_class,
+    timeout_seconds: package_download_benchmark_timeout
+  }
+end
+
+# Return one required string field from a channel package API record.
+def package_download_benchmark_package_string(package, field, allow_blank: false)
+  value = package[field]
+  raise "Package #{package['id'].inspect} has invalid #{field}" unless value.is_a?(String)
+
+  value = value.strip
+  raise "Package #{package['id'].inspect} has blank #{field}" if !allow_blank && value.empty?
+
+  value
+end
+
+# Convert a channel package API record to the production package tuple.
+def package_download_benchmark_package(package)
+  raise "Invalid channel package record: #{package.inspect}" unless package.is_a?(Hash)
+
+  id = package['id']
+  raise "Channel package has invalid id: #{id.inspect}" unless id.is_a?(Integer) && id.positive?
+
+  name = package_download_benchmark_package_string(package, 'name')
+  version = package_download_benchmark_package_string(package, 'version')
+  release = package_download_benchmark_package_string(package, 'release', allow_blank: true)
+  epoch = package_download_benchmark_package_string(package, 'epoch', allow_blank: true)
+  api_arch = package_download_benchmark_package_string(package, 'arch_label')
+  checksum = package_download_benchmark_package_string(package, 'checksum')
+  checksum_type = package_download_benchmark_package_string(package, 'checksum_type')
+  arch = api_arch.sub(/-deb\z/, '')
+
+  raise "Package #{id} has an invalid retracted flag" unless [true, false, nil].include?(package['retracted'])
+  raise "Package #{id} has an invalid name" unless name.match?(/\A[A-Za-z0-9][A-Za-z0-9+_.-]*\z/)
+  raise "Package #{id} has an invalid architecture" unless arch.match?(/\A[A-Za-z0-9][A-Za-z0-9_.-]*\z/)
+  raise "Package #{id} is not a binary package (#{api_arch})" if PACKAGE_DOWNLOAD_BENCHMARK_SOURCE_ARCHES.include?(arch)
+  raise "Package #{id} has a non-numeric epoch" unless epoch.empty? || epoch.match?(/\A[0-9]+\z/)
+  raise "Package #{id} has an invalid checksum" unless checksum.match?(/\A[0-9A-Fa-f]+\z/)
+  raise "Package #{id} has an invalid checksum type" unless checksum_type.match?(/\A[A-Za-z0-9_-]+\z/)
+  raise "Package #{id} is not an RPM package (#{api_arch})" if api_arch.end_with?('-deb')
+
+  evr = +''
+  evr << "#{epoch}:" unless epoch.empty?
+  evr << version
+  evr << "-#{release}" unless release.empty? || release == 'X'
+  raise "Package #{id} has an invalid universal EVR" unless evr.match?(/\A[A-Za-z0-9][A-Za-z0-9+_.~:^%-]*\z/)
+
+  {
+    id: id,
+    name: name,
+    api_arch: api_arch,
+    arch: arch,
+    epoch: epoch,
+    version: version,
+    release: release,
+    evr: evr,
+    cache_evr: evr.sub(/\A0:/, ''),
+    checksum: checksum,
+    checksum_type: checksum_type,
+    retracted: package['retracted'],
+    tuple: [name, arch, evr]
+  }
+end
+
+# Raise when one value maps to more than one channel package.
+def package_download_benchmark_reject_duplicates(packages, description, &identity)
+  duplicates = packages.group_by(&identity).select { |_value, records| records.length > 1 }
+  return if duplicates.empty?
+
+  details = duplicates.map { |value, records| "#{value.inspect} (ids #{records.map { |record| record[:id] }.join(', ')})" }
+  raise "Channel contains duplicate #{description}: #{details.join('; ')}"
+end
+
+# Return a benchmark API client pointed at the configured Uyuni endpoint.
+def package_download_benchmark_api
+  @package_download_benchmark_api ||=
+    begin
+      host = ENV.fetch('SERVER', nil).strip
+      raise 'SERVER must not be empty' if host.empty?
+
+      if $api_test.is_a?(ApiTestXmlrpc)
+        ApiTestXmlrpc.new(host)
+      else
+        ssl_verify = $api_protocol == 'http' ? false : !$is_gh_validation
+        ApiTestHttp.new(host, ssl_verify)
+      end
+    end
+end
+
+# Call a benchmark API method with the session key first for XML-RPC compatibility.
+def package_download_benchmark_api_call(name, params = {})
+  api = package_download_benchmark_api
+  api.call(name, { sessionKey: api.token }.merge(params))
+end
+
+# Validate and canonicalize one complete channel package response.
+def package_download_benchmark_api_packages(api_packages)
+  raise 'channel.software.listAllPackages did not return a non-empty array' unless api_packages.is_a?(Array) && !api_packages.empty?
+
+  packages =
+    api_packages.map { |package| package_download_benchmark_package(package) }
+                .sort_by { |package| [package[:name], package[:cache_evr], package[:arch], package[:id]] }
+  package_download_benchmark_reject_duplicates(packages, 'package IDs') { |package| package[:id] }
+  packages
+end
+
+# Return the stable digest for one canonical channel package set.
+def package_download_benchmark_snapshot_digest(packages)
+  records = packages.map { |package| [package[:id], package[:tuple], package[:checksum_type], package[:checksum], package[:retracted]] }
+  Digest::SHA256.hexdigest(JSON.generate(records))
+end
+
+# Map the configured Salt minion IDs to Uyuni system IDs.
+def package_download_benchmark_system_ids(minions)
+  id_map = package_download_benchmark_api_call('system.getMinionIdMap')
+  raise 'system.getMinionIdMap did not return an object' unless id_map.is_a?(Hash)
+
+  invalid = id_map.reject { |minion, system_id| minion.is_a?(String) && !minion.empty? && system_id.is_a?(Integer) && system_id.positive? }
+  raise "system.getMinionIdMap returned invalid entries: #{invalid.inspect}" unless invalid.empty?
+
+  missing = minions - id_map.keys
+  raise "Benchmark minions are not registered Salt systems: #{missing.join(', ')}" unless missing.empty?
+
+  minions.to_h { |minion| [minion, id_map[minion]] }
+end
+
+# Validate the initial all-package channel snapshot and configured subscriptions.
+def package_download_benchmark_snapshot(inputs)
+  api_packages = package_download_benchmark_api_call('channel.software.listAllPackages', channelLabel: inputs[:channel])
+  subscribed = package_download_benchmark_api_call('channel.software.listSubscribedSystems', channelLabel: inputs[:channel])
+  raise 'channel.software.listSubscribedSystems did not return an array' unless subscribed.is_a?(Array)
+
+  subscribed_ids =
+    subscribed.map do |system|
+      valid = system.is_a?(Hash) &&
+              system['id'].is_a?(Integer) &&
+              system['id'].positive? &&
+              system['name'].is_a?(String) &&
+              !system['name'].empty?
+      raise "Invalid subscribed system record: #{system.inspect}" unless valid
+
+      system['id']
+    end
+  raise 'The channel has duplicate subscribed system IDs' unless subscribed_ids.uniq.length == subscribed_ids.length
+
+  system_ids = package_download_benchmark_system_ids(inputs[:minions])
+  missing_subscriptions = system_ids.reject { |_minion, system_id| subscribed_ids.include?(system_id) }
+  raise "Benchmark minions are not subscribed to #{inputs[:channel]}: #{missing_subscriptions.keys.join(', ')}" unless missing_subscriptions.empty?
+
+  packages = package_download_benchmark_api_packages(api_packages)
+  repo_alias = "susemanager:#{inputs[:channel]}"
+
+  inputs.merge(
+    packages: packages,
+    repo_alias: repo_alias,
+    system_ids: system_ids,
+    snapshot_captured_at: Time.now.utc,
+    snapshot_digest: package_download_benchmark_snapshot_digest(packages),
+    subscribed_system_count: subscribed_ids.length
+  )
+end
+
+# Run an argv-form command on the testsuite controller.
+def package_download_benchmark_run(argv, timeout:)
+  wrapped_argv = ['timeout', '--signal=TERM', '--kill-after=10s', "#{timeout}s", *argv]
+  stdout, stderr, status = Open3.capture3(*wrapped_argv)
+  exit_code = status.exitstatus
+  exit_code = status.termsig + 128 if exit_code.nil? && status.signaled?
+  [stdout, stderr, exit_code]
+end
+
+# Build a kubectl exec command for the Uyuni container.
+def package_download_benchmark_kubectl(pod, argv)
+  ['kubectl', '--namespace', 'uyuni', 'exec', '--container', 'uyuni', pod, '--', *argv]
+end
+
+# Find one ready Uyuni server pod.
+def package_download_benchmark_server_pod
+  stdout, stderr, code = package_download_benchmark_run(
+    [
+      'kubectl',
+      '--namespace',
+      'uyuni',
+      'get',
+      'pods',
+      '--selector',
+      'app.kubernetes.io/component=server',
+      '--output=json'
+    ],
+    timeout: 30
+  )
+  raise "Unable to query the Uyuni server pod: #{stderr}" unless code.zero?
+
+  pods = JSON.parse(stdout)['items']
+  raise 'The Uyuni server pod response did not contain an items array' unless pods.is_a?(Array)
+
+  ready_pods =
+    pods.select do |pod|
+      conditions = pod.dig('status', 'conditions')
+      pod.dig('status', 'phase') == 'Running' &&
+        conditions.is_a?(Array) &&
+        conditions.any? { |condition| condition['type'] == 'Ready' && condition['status'] == 'True' }
+    end
+  raise "Expected exactly one ready Uyuni server pod, found #{ready_pods.length}" unless ready_pods.length == 1
+
+  pod_name = ready_pods.first.dig('metadata', 'name')
+  raise 'The ready Uyuni server pod has no metadata.name' unless pod_name.is_a?(String) && !pod_name.empty?
+
+  pod_name
+rescue JSON::ParserError, KeyError => e
+  raise "Unable to parse the Uyuni server pod response: #{e.message}"
+end
+
+# Build one synchronous Salt list-target command.
+def package_download_benchmark_salt(inputs, function, arguments, timeout_seconds: inputs[:timeout_seconds])
+  [
+    'salt',
+    '--static',
+    '--out=json',
+    '--no-color',
+    '--timeout',
+    timeout_seconds.to_s,
+    '--list',
+    inputs[:minions].join(','),
+    function,
+    *arguments
+  ]
+end
+
+# Parse the complete JSON result emitted by Salt in static mode.
+def package_download_benchmark_parse_salt(stdout, context)
+  output = JSON.parse(stdout)
+  raise "#{context} did not return a JSON object" unless output.is_a?(Hash)
+
+  output
+rescue JSON::ParserError => e
+  raise "#{context} did not return valid JSON: #{e.message}"
+end
+
+# Return missing and unexpected Salt targets.
+def package_download_benchmark_target_errors(output, expected_minions)
+  returned_minions = output.keys
+  errors = (expected_minions - returned_minions).map { |minion| "missing target #{minion}" }
+  errors.concat((returned_minions - expected_minions).map { |minion| "unexpected target #{minion}" })
+  errors
+end
+
+# Run and validate one structured Salt call outside the measurement.
+def package_download_benchmark_salt_call(inputs, pod, function, arguments, context, timeout_seconds: inputs[:timeout_seconds])
+  salt = package_download_benchmark_salt(inputs, function, arguments, timeout_seconds: timeout_seconds)
+  stdout, stderr, code = package_download_benchmark_run(
+    package_download_benchmark_kubectl(pod, salt),
+    timeout: timeout_seconds + 60
+  )
+  raise "#{context} exited with #{code}: #{package_download_benchmark_excerpt(stderr)}" unless code.zero?
+
+  output = package_download_benchmark_parse_salt(stdout, context)
+  errors = package_download_benchmark_target_errors(output, inputs[:minions])
+  raise "#{context} returned invalid targets: #{errors.join('; ')}" unless errors.empty?
+
+  output
+end
+
+# Return failed or malformed states from one Salt state.apply response.
+def package_download_benchmark_state_errors(state_output)
+  return ['malformed state.apply return'] unless state_output.is_a?(Hash)
+  return ['empty state.apply return'] if state_output.empty?
+
+  state_output.filter_map do |state_id, state|
+    next "#{state_id}: malformed state return" unless state.is_a?(Hash)
+    next if state['result'] == true
+
+    comment = package_download_benchmark_excerpt(state['comment'].to_s)
+    "#{state_id}: result=#{state['result'].inspect}, comment=#{comment.inspect}"
+  end
+end
+
+# Validate the exact enabled repository alias on every minion.
+def package_download_benchmark_validate_repositories(inputs, repos)
+  errors =
+    repos.filter_map do |minion, repo|
+      valid = repo.is_a?(Hash) &&
+              repo['alias'] == inputs[:repo_alias] &&
+              repo['name'].is_a?(String) &&
+              !repo['name'].empty? &&
+              repo['enabled'] == true
+      next if valid
+
+      "#{minion}: #{inputs[:repo_alias]} is missing or disabled"
+    end
+  raise "Channel repository preflight failed: #{errors.join('; ')}" unless errors.empty?
+
+  names = repos.values.map { |repo| repo['name'] }.uniq
+  raise "Channel repository preflight returned different names: #{names.join(', ')}" unless names.length == 1
+
+  names.first
+end
+
+# Refresh and validate all configured package repositories outside the measurement.
+def package_download_benchmark_refresh_repositories(inputs, pod)
+  refreshed = package_download_benchmark_salt_call(
+    inputs,
+    pod,
+    'pkg.refresh_db',
+    ['force=True', "repos=#{inputs[:repo_alias]}"],
+    'Repository metadata refresh'
+  )
+  errors =
+    refreshed.filter_map do |minion, repositories|
+      valid = repositories.is_a?(Hash) &&
+              repositories.keys == [inputs[:repo_name]] &&
+              [true, false].include?(repositories[inputs[:repo_name]])
+      "#{minion}: malformed selected-repository pkg.refresh_db return" unless valid
+    end
+  raise "Repository metadata refresh failed: #{errors.join('; ')}" unless errors.empty?
+end
+
+# Prove that every frozen package name and EVR is visible in the selected client repository.
+def package_download_benchmark_validate_available_packages(inputs, pod)
+  available = package_download_benchmark_salt_call(
+    inputs,
+    pod,
+    'pkg.list_repo_pkgs',
+    ["fromrepo=#{inputs[:repo_name]}"],
+    'Channel package availability preflight'
+  )
+  errors =
+    available.filter_map do |minion, packages|
+      unless packages.is_a?(Hash) &&
+             packages.all? { |name, versions| name.is_a?(String) && versions.is_a?(Array) && versions.all?(String) }
+
+        next "#{minion}: malformed pkg.list_repo_pkgs return"
+      end
+
+      missing = inputs[:packages].reject { |package| packages.fetch(package[:name], []).include?(package[:cache_evr]) }
+      next if missing.empty?
+
+      examples = missing.first(20).map { |package| "#{package[:id]}:#{package[:name]}-#{package[:evr]}" }
+      "#{minion}: #{missing.length} channel packages are unavailable (#{examples.join(', ')})"
+    end
+  raise "Channel package availability preflight failed: #{errors.join('; ')}" unless errors.empty?
+end
+
+# Apply channel configuration and validate client/provider compatibility.
+def package_download_benchmark_preflight(inputs, pod)
+  channel_states = package_download_benchmark_salt_call(inputs, pod, 'state.apply', ['channels'], 'Channel state preflight')
+  state_errors =
+    channel_states.flat_map do |minion, state_output|
+      package_download_benchmark_state_errors(state_output).map { |error| "#{minion}: #{error}" }
+    end
+  raise "Channel state preflight failed: #{state_errors.join('; ')}" unless state_errors.empty?
+
+  grains = package_download_benchmark_salt_call(inputs, pod, 'grains.item', %w[os_family osarch], 'Client grains preflight')
+  client_details =
+    inputs[:minions].map do |minion|
+      value = grains[minion]
+      valid = value.is_a?(Hash) && value['os_family'].is_a?(String) && value['osarch'].is_a?(String)
+      raise "#{minion}: malformed os_family/osarch grains" unless valid
+
+      [minion, value['os_family'], value['osarch']]
+    end
+  non_suse = client_details.reject { |_minion, os_family, _osarch| os_family == 'Suse' }
+  raise "Package download benchmark requires SUSE clients: #{non_suse.map(&:first).join(', ')}" unless non_suse.empty?
+
+  osarches = client_details.map(&:last).uniq
+  raise "Package download benchmark requires one common client osarch, found #{osarches.join(', ')}" unless osarches.length == 1
+
+  osarch = osarches.first
+
+  repos = package_download_benchmark_salt_call(inputs, pod, 'pkg.get_repo', [inputs[:repo_alias]], 'Channel repository preflight')
+  repo_name = package_download_benchmark_validate_repositories(inputs, repos)
+  inputs = inputs.merge(repo_name: repo_name)
+  package_download_benchmark_refresh_repositories(inputs, pod)
+  package_download_benchmark_validate_available_packages(inputs, pod)
+
+  inputs.merge(client_os_family: 'Suse', client_osarch: osarch)
+end
+
+# Return all Salt jobs currently active on the benchmark minions.
+def package_download_benchmark_running_jobs(inputs, pod)
+  output = package_download_benchmark_salt_call(
+    inputs,
+    pod,
+    'saltutil.running',
+    [],
+    'Salt job idle check',
+    timeout_seconds: 30
+  )
+  output.each do |minion, jobs|
+    raise "#{minion}: saltutil.running returned malformed data" unless jobs.is_a?(Array)
+
+    invalid = jobs.reject { |job| job.is_a?(Hash) && job['fun'].is_a?(String) && !job['fun'].empty? }
+    raise "#{minion}: saltutil.running returned malformed jobs" unless invalid.empty?
+  end
+  output
+end
+
+# Require two consecutive complete observations with no active Salt jobs.
+def package_download_benchmark_wait_for_idle(inputs, pod)
+  wait_seconds = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_BENCHMARK_IDLE_TIMEOUT].min
+  deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + wait_seconds
+  idle_observations = 0
+  latest = {}
+  loop do
+    latest = package_download_benchmark_running_jobs(inputs, pod)
+    idle_observations = latest.values.all?(&:empty?) ? idle_observations + 1 : 0
+    return if idle_observations >= 2
+
+    break if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+    sleep PACKAGE_DOWNLOAD_BENCHMARK_IDLE_POLL_SECONDS
+  end
+
+  details =
+    latest.filter_map do |minion, jobs|
+      next if jobs.empty?
+
+      "#{minion}: #{jobs.map { |job| "#{job['fun']} (jid=#{job.fetch('jid', 'unknown')})" }.join(', ')}"
+    end
+  details << 'two consecutive idle observations were not completed' if details.empty?
+  raise "Salt minions did not become idle within #{wait_seconds} seconds: #{details.join('; ')}"
+end
+
+# Clear package payload caches on every benchmark minion outside the measurement.
+def package_download_benchmark_clear_cache(inputs, pod)
+  command_timeout = [inputs[:timeout_seconds] - 15, 1].max
+  script = <<~SH
+    cache_root=#{PACKAGE_DOWNLOAD_BENCHMARK_CACHE_ROOT}
+    test -d "$cache_root" || { echo "Missing RPM payload cache: $cache_root" >&2; exit 10; }
+    find "$cache_root" -type f -delete || exit 11
+    remaining=$(find "$cache_root" -type f -print -quit) || exit 12
+    test -z "$remaining" ||
+      { echo "Package payload cache is not empty" >&2; exit 12; }
+  SH
+  package_download_benchmark_wait_for_idle(inputs, pod)
+  salt =
+    package_download_benchmark_salt(
+      inputs,
+      'cmd.run_all',
+      [script, 'python_shell=True', "timeout=#{command_timeout}"]
+    )
+  stdout, stderr, code = package_download_benchmark_run(
+    package_download_benchmark_kubectl(pod, salt),
+    timeout: inputs[:timeout_seconds] + 60
+  )
+  raise "RPM cache reset exited with #{code}: #{stderr}" unless code.zero?
+
+  output = package_download_benchmark_parse_salt(stdout, 'RPM cache reset')
+  errors = package_download_benchmark_target_errors(output, inputs[:minions])
+  output.each do |minion, result|
+    if !result.is_a?(Hash)
+      errors << "#{minion}: malformed cmd.run_all return"
+    elsif result['retcode'] != 0
+      errors << "#{minion}: cache reset retcode=#{result['retcode'].inspect}, stderr=#{package_download_benchmark_excerpt(result['stderr'].to_s).inspect}"
+    end
+  end
+  raise "RPM cache reset failed: #{errors.join('; ')}" unless errors.empty?
+
+  package_download_benchmark_wait_for_idle(inputs, pod)
+end
+
+# Return the argv used for the measured raw repository download.
+def package_download_benchmark_zypper_argv(inputs)
+  [
+    'zypper',
+    '--quiet',
+    '--non-interactive',
+    '--no-refresh',
+    'download',
+    '--all-matches',
+    '--repo',
+    inputs[:repo_alias],
+    '*'
+  ]
+end
+
+# Return the safely serialized command passed to cmd.run_all.
+def package_download_benchmark_zypper_command(inputs)
+  Shellwords.join(package_download_benchmark_zypper_argv(inputs))
+end
+
+# Summarize the raw-download command returned by one minion.
+def package_download_benchmark_minion_result(minion, command_output)
+  result = {
+    id: minion,
+    status: 'failed',
+    retcode: nil,
+    pid: nil,
+    stdout: nil,
+    stderr: nil,
+    errors: []
+  }
+  unless command_output.is_a?(Hash)
+    result[:errors] << 'malformed cmd.run_all return'
+    return result
+  end
+
+  retcode = command_output['retcode']
+  stdout = command_output['stdout']
+  stderr = command_output['stderr']
+  result[:errors] << "invalid retcode #{retcode.inspect}" unless retcode.is_a?(Integer)
+  result[:errors] << "zypper download exited with #{retcode}" if retcode.is_a?(Integer) && !retcode.zero?
+  result[:errors] << 'malformed stdout' unless stdout.is_a?(String)
+  result[:errors] << 'malformed stderr' unless stderr.is_a?(String)
+  result.merge!(
+    status: result[:errors].empty? ? 'passed' : 'failed',
+    retcode: retcode,
+    pid: command_output['pid'],
+    stdout: package_download_benchmark_excerpt(stdout),
+    stderr: package_download_benchmark_excerpt(stderr)
+  )
+  result
+end
+
+# Return a bounded command-output excerpt for an actionable report.
+def package_download_benchmark_excerpt(value, limit = 4096)
+  return if value.nil?
+
+  text = value.to_s.scrub
+  return if text.empty?
+  return text if text.bytesize <= limit
+
+  "#{text.byteslice(0, limit).scrub}... [truncated]"
+end
+
+# Download every package from the selected repository on all minions concurrently.
+def package_download_benchmark_workload(inputs, pod)
+  timeout_seconds = inputs[:timeout_seconds]
+  command_timeout = [timeout_seconds - 30, 1].max
+  salt_timeout = [timeout_seconds - 15, 1].max
+  salt = package_download_benchmark_salt(
+    inputs,
+    'cmd.run_all',
+    [
+      package_download_benchmark_zypper_command(inputs),
+      'python_shell=False',
+      'output_loglevel=quiet',
+      "timeout=#{command_timeout}"
+    ],
+    timeout_seconds: salt_timeout
+  )
+  argv = package_download_benchmark_kubectl(pod, salt)
+  started_at = Time.now.utc
+  started_monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+  stdout = ''
+  stderr = ''
+  code = nil
+  exception = nil
+  begin
+    stdout, stderr, code = package_download_benchmark_run(argv, timeout: timeout_seconds)
+  rescue StandardError => e
+    exception = "#{e.class}: #{package_download_benchmark_excerpt(e.message)}"
+  end
+
+  finished_at = Time.now.utc
+  duration_seconds = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_monotonic
+  errors = []
+  errors << "command raised #{exception}" unless exception.nil?
+  errors << "command exited with #{code.inspect}: #{package_download_benchmark_excerpt(stderr)}" unless code&.zero?
+
+  returns = {}
+  unless stdout.empty?
+    begin
+      returns = package_download_benchmark_parse_salt(stdout, 'Package download workload')
+    rescue StandardError => e
+      errors << e.message
+    end
+  end
+  target_errors = package_download_benchmark_target_errors(returns, inputs[:minions])
+  errors.concat(target_errors)
+
+  minions =
+    inputs[:minions].filter_map do |minion|
+      package_download_benchmark_minion_result(minion, returns[minion]) if returns.key?(minion)
+    end
+  failed_targets = minions.reject { |minion| minion[:status] == 'passed' }
+  errors << 'one or more minions failed the package download workload' unless failed_targets.empty?
+  successful_target_count = minions.count { |minion| minion[:status] == 'passed' }
+  no_return =
+    returns.values.any? do |value|
+      value.is_a?(String) && value.match?(/\A(?:Minion did not return(?:\. \[No response\])?|Timed out waiting for minion response)\z/i)
+    end
+  timed_out = [124, 137].include?(code) || no_return
+  uncertain_completion = !exception.nil? || timed_out || !target_errors.empty?
+
+  {
+    status: errors.empty? ? 'passed' : 'failed',
+    command: package_download_benchmark_zypper_argv(inputs),
+    timeout_seconds: timeout_seconds,
+    timed_out: timed_out,
+    uncertain_completion: uncertain_completion,
+    started_at: started_at.iso8601(6),
+    finished_at: finished_at.iso8601(6),
+    duration_seconds: duration_seconds.round(6),
+    returned_target_count: returns.length,
+    successful_target_count: successful_target_count,
+    errors: errors,
+    per_minion: minions,
+    salt_exit_code: code,
+    salt_stderr: package_download_benchmark_excerpt(stderr),
+    raw_stdout: returns.empty? ? package_download_benchmark_excerpt(stdout) : nil
+  }
+end
+
+# Return a Python program that emits every regular package-cache file as JSON.
+def package_download_benchmark_inventory_script
+  <<~PYTHON
+    import json
+    import os
+    import stat
+    import sys
+
+    root = os.path.realpath(sys.argv[1])
+    payloads = []
+    for directory, _subdirectories, filenames in os.walk(root):
+        for filename in filenames:
+            path = os.path.join(directory, filename)
+            metadata = os.lstat(path)
+            if stat.S_ISREG(metadata.st_mode):
+                payloads.append({"path": path, "size": metadata.st_size})
+    print(json.dumps(sorted(payloads, key=lambda payload: payload["path"]), separators=(",", ":")))
+  PYTHON
+end
+
+# Return the safely serialized cache-inventory command.
+def package_download_benchmark_inventory_command
+  Shellwords.join(['python3', '-c', package_download_benchmark_inventory_script, PACKAGE_DOWNLOAD_BENCHMARK_CACHE_ROOT])
+end
+
+# Parse one minion's structured cache-inventory command return.
+def package_download_benchmark_cache_payloads(command_output)
+  errors = []
+  return [[], ['malformed cache inventory cmd.run_all return']] unless command_output.is_a?(Hash)
+
+  retcode = command_output['retcode']
+  stdout = command_output['stdout']
+  errors << "cache inventory exited with #{retcode.inspect}" unless retcode&.zero?
+  errors << 'cache inventory returned malformed stdout' unless stdout.is_a?(String)
+  return [[], errors] unless errors.empty?
+
+  payloads = JSON.parse(stdout)
+  return [[], ['cache inventory did not return a JSON array']] unless payloads.is_a?(Array)
+
+  invalid =
+    payloads.reject do |payload|
+      payload.is_a?(Hash) &&
+        payload['path'].is_a?(String) &&
+        !payload['path'].empty? &&
+        payload['size'].is_a?(Integer)
+    end
+  errors << "#{invalid.length} malformed cache inventory entries" unless invalid.empty?
+  [payloads - invalid, errors]
+rescue JSON::ParserError => e
+  [[], ["cache inventory did not return valid JSON: #{e.message}"]]
+end
+
+# Return all integrity errors for one cached RPM.
+def package_download_benchmark_payload_errors(payload, repo_alias, checksum)
+  path = payload['path']
+  size = payload['size']
+  expanded_path = File.expand_path(path)
+  expected_root = "#{PACKAGE_DOWNLOAD_BENCHMARK_CACHE_ROOT}/#{repo_alias}/"
+  errors = []
+  errors << "invalid size #{size.inspect}" unless size.positive?
+  errors << "path is not canonical: #{path}" unless path == expanded_path
+  errors << "path is outside #{expected_root}" unless expanded_path.start_with?(expected_root)
+  errors << "path is not an RPM: #{path}" unless File.extname(expanded_path).casecmp?('.rpm')
+  checksum_directory = File.basename(File.dirname(expanded_path))
+  errors << "checksum directory is not #{checksum}" unless checksum_directory.casecmp?(checksum)
+  errors
+end
+
+# Return the compact frozen-package identity used in verification errors.
+def package_download_benchmark_package_reference(package)
+  {
+    package_id: package[:id],
+    name: package[:name],
+    arch: package[:arch],
+    evr: package[:evr],
+    checksum: package[:checksum]
+  }
+end
+
+# Match one frozen channel artifact to its checksum-named cache payload.
+def package_download_benchmark_verify_artifact(checksum, packages, candidates, repo_alias)
+  references = packages.map { |package| package_download_benchmark_package_reference(package) }
+  return [nil, references, nil] if candidates.empty?
+
+  candidate_errors =
+    candidates.map do |payload|
+      [payload, package_download_benchmark_payload_errors(payload, repo_alias, checksum)]
+    end
+  match = candidate_errors.find { |_payload, payload_errors| payload_errors.empty? }
+  return [match.first, [], nil] if candidates.length == 1 && match
+
+  mismatch = {
+    packages: references,
+    candidates: candidate_errors.map { |payload, payload_errors| payload.merge('errors' => payload_errors) }
+  }
+  [nil, [], mismatch]
+end
+
+# Verify every frozen channel artifact on one minion by its repository checksum path.
+def package_download_benchmark_verify_minion(minion, command_output, inputs)
+  payloads, errors = package_download_benchmark_cache_payloads(command_output)
+  expected = inputs[:packages].group_by { |package| package[:checksum].downcase }
+  actual = payloads.group_by { |payload| File.basename(File.dirname(payload['path'])).downcase }
+  verified_package_count = 0
+  verified_payloads = []
+  missing = []
+  mismatched = []
+  consumed_paths = {}
+
+  expected.each do |checksum, packages|
+    candidates = actual.fetch(checksum, [])
+    candidates.each { |payload| consumed_paths[payload['path']] = true }
+    verified, missing_records, mismatch =
+      package_download_benchmark_verify_artifact(checksum, packages, candidates, inputs[:repo_alias])
+    missing.concat(missing_records)
+    mismatched << mismatch if mismatch
+    if verified
+      verified_package_count += packages.length
+      verified_payloads << verified
+    end
+  end
+
+  extras = payloads.reject { |payload| consumed_paths.key?(payload['path']) }
+  errors << "#{missing.length} channel package records are missing" unless missing.empty?
+  errors << "#{mismatched.length} channel package artifacts are mismatched" unless mismatched.empty?
+  errors << "#{extras.length} unexpected package payloads were downloaded" unless extras.empty?
+
+  {
+    id: minion,
+    status: errors.empty? ? 'passed' : 'failed',
+    expected_package_count: inputs[:packages].length,
+    expected_payload_count: expected.length,
+    verified_package_count: verified_package_count,
+    verified_payload_count: verified_payloads.length,
+    verified_payload_bytes: verified_payloads.sum { |payload| payload['size'] },
+    downloaded_payload_count: payloads.length,
+    downloaded_payload_bytes: payloads.sum { |payload| payload['size'] },
+    extra_payload_count: extras.length,
+    extra_payload_bytes: extras.sum { |payload| payload['size'] },
+    missing_records: missing,
+    mismatched_records: mismatched,
+    extra_payloads: extras,
+    errors: errors
+  }
+end
+
+# Query and verify the structured downloaded-package inventory after timing.
+def package_download_benchmark_verify(inputs, pod)
+  inventory_timeout = [inputs[:timeout_seconds], PACKAGE_DOWNLOAD_BENCHMARK_IDLE_TIMEOUT].min
+  command_timeout = [inventory_timeout - 15, 1].max
+  returns =
+    package_download_benchmark_salt_call(
+      inputs,
+      pod,
+      'cmd.run_all',
+      [
+        package_download_benchmark_inventory_command,
+        'python_shell=False',
+        'output_loglevel=quiet',
+        "timeout=#{command_timeout}"
+      ],
+      'Package cache verification',
+      timeout_seconds: inventory_timeout
+    )
+  per_minion =
+    inputs[:minions].map do |minion|
+      package_download_benchmark_verify_minion(minion, returns[minion], inputs)
+    end
+  errors = []
+  errors << 'one or more minions failed package cache verification' if per_minion.any? { |minion| minion[:status] == 'failed' }
+  expected_payloads_per_minion = inputs[:packages].map { |package| package[:checksum].downcase }.uniq.length
+
+  {
+    status: errors.empty? ? 'passed' : 'failed',
+    expected_package_count: inputs[:minions].length * inputs[:packages].length,
+    expected_payload_count: inputs[:minions].length * expected_payloads_per_minion,
+    verified_package_count: per_minion.sum { |minion| minion[:verified_package_count] },
+    verified_payload_count: per_minion.sum { |minion| minion[:verified_payload_count] },
+    verified_payload_bytes: per_minion.sum { |minion| minion[:verified_payload_bytes] },
+    downloaded_payload_count: per_minion.sum { |minion| minion[:downloaded_payload_count] },
+    downloaded_payload_bytes: per_minion.sum { |minion| minion[:downloaded_payload_bytes] },
+    extra_payload_count: per_minion.sum { |minion| minion[:extra_payload_count] },
+    extra_payload_bytes: per_minion.sum { |minion| minion[:extra_payload_bytes] },
+    returned_target_count: returns.length,
+    successful_target_count: per_minion.count { |minion| minion[:status] == 'passed' },
+    errors: errors,
+    per_minion: per_minion
+  }
+rescue StandardError => e
+  package_download_benchmark_failed_verification(
+    inputs,
+    "cache verification raised #{e.class}: #{package_download_benchmark_excerpt(e.message)}"
+  )
+end
+
+# Confirm that channel membership did not change during the measured workload.
+def package_download_benchmark_verify_snapshot(inputs)
+  api_packages = package_download_benchmark_api_call('channel.software.listAllPackages', channelLabel: inputs[:channel])
+  packages = package_download_benchmark_api_packages(api_packages)
+  digest = package_download_benchmark_snapshot_digest(packages)
+  errors = []
+  errors << "package count changed from #{inputs[:packages].length} to #{packages.length}" unless packages.length == inputs[:packages].length
+  errors << "snapshot digest changed from #{inputs[:snapshot_digest]} to #{digest}" unless digest == inputs[:snapshot_digest]
+
+  {
+    status: errors.empty? ? 'passed' : 'failed',
+    checked_at: Time.now.utc.iso8601(6),
+    package_count: packages.length,
+    sha256: digest,
+    errors: errors
+  }
+rescue StandardError => e
+  {
+    status: 'failed',
+    checked_at: Time.now.utc.iso8601(6),
+    package_count: nil,
+    sha256: nil,
+    errors: ["channel snapshot verification raised #{e.class}: #{package_download_benchmark_excerpt(e.message)}"]
+  }
+end
+
+# Verify both downloaded payloads and the frozen channel snapshot.
+def package_download_benchmark_complete_verification(inputs, pod)
+  verification = package_download_benchmark_verify(inputs, pod)
+  snapshot = package_download_benchmark_verify_snapshot(inputs)
+  verification[:channel_snapshot] = snapshot
+  verification[:errors].concat(snapshot[:errors].map { |error| "channel snapshot: #{error}" })
+  verification[:status] = 'failed' unless verification[:errors].empty?
+  verification
+end
+
+# Return the immutable channel package fields recorded with the result.
+def package_download_benchmark_report_package(package)
+  {
+    id: package[:id],
+    name: package[:name],
+    arch: package[:arch],
+    epoch: package[:epoch],
+    version: package[:version],
+    release: package[:release],
+    evr: package[:evr],
+    checksum: package[:checksum],
+    checksum_type: package[:checksum_type],
+    retracted: package[:retracted],
+    tuple: package[:tuple]
+  }
+end
+
+# Build schema version 2 result data from the measured workload and verification.
+def package_download_benchmark_result(inputs, pod, workload, verification)
+  errors = workload[:errors].map { |error| "workload: #{error}" }
+  errors.concat(verification[:errors].map { |error| "verification: #{error}" })
+
+  {
+    schema_version: 2,
+    workload: 'zypper.download_all_matches',
+    status: errors.empty? ? 'passed' : 'failed',
+    storage_class: inputs[:storage_class],
+    server_pod: pod,
+    api_server: ENV.fetch('SERVER', nil),
+    channel: inputs[:channel],
+    repo_alias: inputs[:repo_alias],
+    repo_name: inputs[:repo_name],
+    client_os_family: inputs[:client_os_family],
+    client_osarch: inputs[:client_osarch],
+    timeout_seconds: inputs[:timeout_seconds],
+    timeout_scope: 'single_concurrent_all_minion_download',
+    started_at: workload[:started_at],
+    finished_at: workload[:finished_at],
+    duration_seconds: workload[:duration_seconds],
+    target_ids: inputs[:minions],
+    target_system_ids: inputs[:system_ids],
+    expected_target_count: inputs[:minions].length,
+    snapshot: {
+      kind: 'initial_frozen_channel_binary_rpms',
+      captured_at: inputs[:snapshot_captured_at].iso8601(6),
+      sha256: inputs[:snapshot_digest],
+      package_count: inputs[:packages].length,
+      retracted_package_count: inputs[:packages].count { |package| package[:retracted] == true },
+      subscribed_system_count: inputs[:subscribed_system_count],
+      packages: inputs[:packages].map { |package| package_download_benchmark_report_package(package) }
+    },
+    execution: workload,
+    verification: verification,
+    errors: errors
+  }
+end
+
+# Build a complete failure-shaped verification result.
+def package_download_benchmark_failed_verification(inputs, error)
+  expected_payloads_per_minion = inputs[:packages].map { |package| package[:checksum].downcase }.uniq.length
+  {
+    status: 'failed',
+    expected_package_count: inputs[:minions].length * inputs[:packages].length,
+    expected_payload_count: inputs[:minions].length * expected_payloads_per_minion,
+    verified_package_count: 0,
+    verified_payload_count: 0,
+    verified_payload_bytes: 0,
+    downloaded_payload_count: 0,
+    downloaded_payload_bytes: 0,
+    extra_payload_count: 0,
+    extra_payload_bytes: 0,
+    returned_target_count: 0,
+    successful_target_count: 0,
+    errors: [error],
+    per_minion: [],
+    channel_snapshot: nil
+  }
+end
+
+# Run one concurrent all-package download and verify every cached record.
+def package_download_benchmark_execute(inputs, pod)
+  workload = package_download_benchmark_workload(inputs, pod)
+  verification =
+    begin
+      package_download_benchmark_wait_for_idle(inputs, pod)
+      package_download_benchmark_complete_verification(inputs, pod)
+    rescue StandardError => e
+      message = package_download_benchmark_excerpt(e.message)
+      package_download_benchmark_failed_verification(inputs, "verification raised #{e.class}: #{message}")
+    end
+
+  package_download_benchmark_result(inputs, pod, workload, verification)
+end
+
+# Write one result document to the testsuite results directory.
+def package_download_benchmark_write_result(result)
+  timestamp = Time.parse(result[:started_at]).strftime('%Y%m%dT%H%M%S.%6NZ')
+  directory = File.expand_path("../../results/package-download/#{timestamp}-#{Process.pid}", __dir__)
+  FileUtils.mkdir_p(directory)
+  path = File.join(directory, 'result.json')
+  File.write(path, "#{JSON.pretty_generate(result)}\n")
+  path
+end
+
+Given('the Salt package download benchmark inputs are valid') do
+  @package_download_benchmark_inputs = package_download_benchmark_inputs
+end
+
+Given('the initial configured channel package snapshot is valid') do
+  @package_download_benchmark_inputs = package_download_benchmark_snapshot(@package_download_benchmark_inputs)
+end
+
+Given('a ready server pod is reachable from the benchmark controller') do
+  @package_download_benchmark_pod = package_download_benchmark_server_pod
+end
+
+Given('the benchmark minions are ready for the configured channel') do
+  @package_download_benchmark_inputs =
+    package_download_benchmark_preflight(@package_download_benchmark_inputs, @package_download_benchmark_pod)
+end
+
+When('I clear RPM payload caches on the benchmark minions outside the measurement') do
+  package_download_benchmark_clear_cache(@package_download_benchmark_inputs, @package_download_benchmark_pod)
+end
+
+When('I execute and record the channel package downloads') do
+  @package_download_benchmark_result = package_download_benchmark_execute(
+    @package_download_benchmark_inputs,
+    @package_download_benchmark_pod
+  )
+  @package_download_benchmark_result_path = package_download_benchmark_write_result(@package_download_benchmark_result)
+  log "Package download result: #{@package_download_benchmark_result_path}"
+end
+
+Then('the package download result report should exist') do
+  raise 'Package download result report was not written' unless File.file?(@package_download_benchmark_result_path)
+end
+
+Then('every configured minion should have downloaded every channel package') do
+  result = @package_download_benchmark_result
+  next if result[:status] == 'passed'
+
+  details = result[:errors].dup
+  result[:execution][:per_minion].each do |minion|
+    details << "#{minion[:id]} workload: #{minion[:errors].join('; ')}" unless minion[:errors].empty?
+  end
+  result[:verification][:per_minion].each do |minion|
+    details << "#{minion[:id]} verification: #{minion[:errors].join('; ')}" unless minion[:errors].empty?
+  end
+  raise "Package download benchmark failed: #{details.join(' | ')}"
+end

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -213,9 +213,9 @@ rescue ArgumentError
 end
 
 # Prepare a fixed package snapshot before the benchmark:
-# Read the channel packages, subscribed systems, and Salt-to-Uyuni system ID mapping.
-# Keep the binary RPMs and verify that every selected minion is registered and subscribed.
-# Save the package records and their SHA-256 digest for comparison after the download.
+# - Read the channel packages, subscribed systems, and Salt-to-Uyuni system ID mapping.
+# - Keep the binary RPMs and verify that every selected minion is registered and subscribed.
+# - Save the package records and their SHA-256 digest for comparison after the download.
 # If the digest changes, the result is invalid because the tested package set was not stable.
 Given('the initial configured channel package snapshot is valid') do
   inputs = @package_download_inputs
@@ -302,11 +302,11 @@ Given('a ready server pod is reachable from the benchmark controller') do
 end
 
 # Check that every configured minion is ready before the measurement:
-# Apply the Salt channels state to update the minion repository configuration.
-# Read the OS family and architecture, then require matching SUSE clients.
-# Verify that the configured Uyuni repository exists and is enabled.
-# Refresh the repository metadata.
-# Verify that every RPM from the initial snapshot is available to every minion.
+# - Apply the Salt channels state to update the minion repository configuration.
+# - Read the OS family and architecture, then require matching SUSE clients.
+# - Verify that the configured Uyuni repository exists and is enabled.
+# - Refresh the repository metadata.
+# - Verify that every RPM from the initial snapshot is available to every minion.
 Given('the benchmark minions are ready for the configured channel') do
   inputs = @package_download_inputs
   pod = @package_download_pod

--- a/testsuite/features/step_definitions/package_download_benchmark_steps.rb
+++ b/testsuite/features/step_definitions/package_download_benchmark_steps.rb
@@ -8,7 +8,6 @@ require 'shellwords'
 require 'time'
 
 PACKAGE_DOWNLOAD_BENCHMARK_DEFAULT_TIMEOUT = 14_400
-PACKAGE_DOWNLOAD_BENCHMARK_RUN_GRACE_SECONDS = 30
 PACKAGE_DOWNLOAD_BENCHMARK_CACHE_ROOT = '/var/cache/zypp/packages'.freeze
 PACKAGE_DOWNLOAD_BENCHMARK_IDLE_TIMEOUT = 600
 PACKAGE_DOWNLOAD_BENCHMARK_IDLE_POLL_SECONDS = 2
@@ -238,21 +237,15 @@ def package_download_benchmark_snapshot(inputs)
   )
 end
 
-# Build a safely serialized command with a process-level timeout.
-def package_download_benchmark_timeout_command(argv, timeout:)
-  Shellwords.join(['timeout', '--signal=TERM', '--kill-after=10s', "#{timeout}s", *argv])
-end
-
-# Build a kubectl exec command for the Uyuni container.
-def package_download_benchmark_kubectl(pod, argv)
-  ['kubectl', '--namespace', 'uyuni', 'exec', '--container', 'uyuni', pod, '--', *argv]
+# Build a safely serialized kubectl exec command for the Uyuni container.
+def package_download_benchmark_kubectl_command(pod, argv)
+  Shellwords.join(['kubectl', '--namespace', 'uyuni', 'exec', '--container', 'uyuni', pod, '--', *argv])
 end
 
 # Find one ready Uyuni server pod.
 def package_download_benchmark_server_pod
-  timeout = 30
   command =
-    package_download_benchmark_timeout_command(
+    Shellwords.join(
       [
         'kubectl',
         '--namespace',
@@ -262,15 +255,12 @@ def package_download_benchmark_server_pod
         '--selector',
         'app.kubernetes.io/component=server',
         '--output=json'
-      ],
-      timeout: timeout
+      ]
     )
-  stdout, stderr, code = get_target('localhost').run(
+  stdout, stderr, code = get_target('localhost').run_local(
     command,
-    runs_in_container: false,
     separated_results: true,
-    check_errors: false,
-    timeout: timeout + PACKAGE_DOWNLOAD_BENCHMARK_RUN_GRACE_SECONDS
+    check_errors: false
   )
   raise "Unable to query the Uyuni server pod: #{stderr}" unless code.zero?
 
@@ -332,13 +322,12 @@ end
 def package_download_benchmark_salt_call(inputs, pod, function, arguments, context, timeout_seconds: inputs[:timeout_seconds])
   salt = package_download_benchmark_salt(inputs, function, arguments, timeout_seconds: timeout_seconds)
   timeout = timeout_seconds + 60
-  command = package_download_benchmark_timeout_command(package_download_benchmark_kubectl(pod, salt), timeout: timeout)
-  stdout, stderr, code = get_target('localhost').run(
+  command = package_download_benchmark_kubectl_command(pod, salt)
+  stdout, stderr, code = get_target('localhost').run_local(
     command,
-    runs_in_container: false,
     separated_results: true,
     check_errors: false,
-    timeout: timeout + PACKAGE_DOWNLOAD_BENCHMARK_RUN_GRACE_SECONDS
+    timeout: timeout
   )
   raise "#{context} exited with #{code}: #{package_download_benchmark_excerpt(stderr)}" unless code.zero?
 
@@ -528,13 +517,12 @@ def package_download_benchmark_clear_cache(inputs, pod)
       [script, 'python_shell=True', "timeout=#{command_timeout}"]
     )
   timeout = inputs[:timeout_seconds] + 60
-  command = package_download_benchmark_timeout_command(package_download_benchmark_kubectl(pod, salt), timeout: timeout)
-  stdout, stderr, code = get_target('localhost').run(
+  command = package_download_benchmark_kubectl_command(pod, salt)
+  stdout, stderr, code = get_target('localhost').run_local(
     command,
-    runs_in_container: false,
     separated_results: true,
     check_errors: false,
-    timeout: timeout + PACKAGE_DOWNLOAD_BENCHMARK_RUN_GRACE_SECONDS
+    timeout: timeout
   )
   raise "RPM cache reset exited with #{code}: #{stderr}" unless code.zero?
 
@@ -632,7 +620,7 @@ def package_download_benchmark_workload(inputs, pod)
     ],
     timeout_seconds: salt_timeout
   )
-  argv = package_download_benchmark_kubectl(pod, salt)
+  command = package_download_benchmark_kubectl_command(pod, salt)
   started_at = Time.now.utc
   started_monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
@@ -641,13 +629,11 @@ def package_download_benchmark_workload(inputs, pod)
   code = nil
   exception = nil
   begin
-    command = package_download_benchmark_timeout_command(argv, timeout: timeout_seconds)
-    stdout, stderr, code = get_target('localhost').run(
+    stdout, stderr, code = get_target('localhost').run_local(
       command,
-      runs_in_container: false,
       separated_results: true,
       check_errors: false,
-      timeout: timeout_seconds + PACKAGE_DOWNLOAD_BENCHMARK_RUN_GRACE_SECONDS
+      timeout: timeout_seconds
     )
   rescue StandardError => e
     exception = "#{e.class}: #{package_download_benchmark_excerpt(e.message)}"
@@ -681,7 +667,7 @@ def package_download_benchmark_workload(inputs, pod)
     returns.values.any? do |value|
       value.is_a?(String) && value.match?(/\A(?:Minion did not return(?:\. \[No response\])?|Timed out waiting for minion response)\z/i)
     end
-  timed_out = [124, 137].include?(code) || no_return
+  timed_out = code == 124 || no_return
   uncertain_completion = !exception.nil? || timed_out || !target_errors.empty?
 
   {

--- a/testsuite/features/support/network_utils.rb
+++ b/testsuite/features/support/network_utils.rb
@@ -26,7 +26,6 @@ def ssh_command(command, host, port: 22, timeout: DEFAULT_TIMEOUT, buffer_size: 
     end
   rescue Timeout::Error
     stderr = "SSH operation timed out after #{timeout} seconds."
-    exit_code = 124
     puts stderr
   rescue Net::SSH::ConnectionTimeout, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ECONNRESET
     puts "Unable to reach the SSH server at #{host}:#{port}"

--- a/testsuite/features/support/network_utils.rb
+++ b/testsuite/features/support/network_utils.rb
@@ -21,11 +21,13 @@ def ssh_command(command, host, port: 22, timeout: DEFAULT_TIMEOUT, buffer_size: 
   begin
     Timeout.timeout(timeout) do # Enforce timeout on the entire SSH operation
       Net::SSH.start(host, nil, port: port, verify_host_key: :never, timeout: timeout, keepalive: true, max_pkt_size: buffer_size, config: true) do |ssh|
-        stdout, stderr, exit_code = ssh_exec!(ssh, command, timeout: DEFAULT_TIMEOUT)
+        stdout, stderr, exit_code = ssh_exec!(ssh, command, timeout: timeout)
       end
     end
   rescue Timeout::Error
-    puts "SSH operation timed out after #{timeout} seconds."
+    stderr = "SSH operation timed out after #{timeout} seconds."
+    exit_code = 124
+    puts stderr
   rescue Net::SSH::ConnectionTimeout, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ECONNRESET
     puts "Unable to reach the SSH server at #{host}:#{port}"
   rescue Net::SSH::AuthenticationFailed

--- a/testsuite/run_sets/kubernetes_package_download_benchmark.yml
+++ b/testsuite/run_sets/kubernetes_package_download_benchmark.yml
@@ -1,0 +1,1 @@
+- features/build_validation/benchmarks/srv_salt_package_download_benchmark.feature


### PR DESCRIPTION
## What does this PR change?

Adds an opt-in Cucumber benchmark that downloads every binary RPM from one Uyuni software channel on a configured set of Salt minions.

### Benchmark flow

1. Read the channel label and Salt minion IDs from environment variables.
2. Capture the channel's binary-RPM snapshot through the Uyuni API and confirm that every minion is registered and subscribed.
3. Find the ready Uyuni server pod.
4. Prepare the minions with:
   - `state.apply channels`
   - `grains.item os_family osarch`
   - `pkg.get_repo`
   - `pkg.refresh_db`
   - `pkg.list_repo_pkgs`
5. Clear the RPM payload cache outside the measured interval.
6. Run one concurrent Salt `cmd.run_all` workload on all selected minions:

   ```console
   zypper --quiet --non-interactive --no-refresh download \
     --all-matches \
     --repo susemanager:<channel-label> \
     '*'
   ```

7. Inventory the downloaded RPMs, match them to the channel checksums, and confirm that the channel snapshot remained unchanged.
8. Write a structured JSON result.

Commands follow this path:

```text
testsuite controller
  -> get_target('localhost').run_local
  -> kubectl exec into the Uyuni server pod
  -> salt --list <minions>
  -> Salt minions
```

Only the package download workload is timed. Setup, cache cleanup, and verification run outside the measured interval. The RPMs are downloaded into each minion's zypper package cache and are not installed.

The benchmark expects an existing channel and existing subscriptions. It does not create channels, subscribe systems, install a Helm release, or configure a StorageClass.

## Configuration

### Prerequisites

- The testsuite controller can reach the Kubernetes cluster with `kubectl`.
- The Uyuni server pod is running and ready in the `uyuni` namespace.
- The selected Salt minions are registered, reachable, and subscribed to the configured channel.
- The selected minions are SUSE systems with the same architecture.
- The channel contains binary RPM packages and is available on every selected minion.
- #12240 is present so a run set without Cobbler scenarios does not initialize the Cobbler client during Cucumber startup.

### Required inputs

| Variable | Description | Example |
| --- | --- | --- |
| `UYUNI_BENCH_MINIONS` | JSON array containing the exact Salt minion IDs | `["minion-1.example.test","minion-2.example.test"]` |
| `UYUNI_BENCH_CHANNEL` | Uyuni software channel label | `uyuni-bench-channel` |

The normal testsuite environment must also provide `SERVER` and its API configuration.

### Optional inputs

| Variable | Default | Description |
| --- | --- | --- |
| `UYUNI_BENCH_TIMEOUT_SECONDS` | `14400` | Timeout for the measured all-minion download workload |
| `UYUNI_BENCH_STORAGE_CLASS` | unset | StorageClass name recorded as result metadata |
| `SCENARIO_HARD_LIMIT` | workload timeout + 1800 seconds | Overall Cucumber scenario watchdog override |

Control operations use a maximum timeout of 600 seconds. `UYUNI_BENCH_STORAGE_CLASS` does not select or configure storage.

## How to run

Run the dedicated Rake task from a configured testsuite controller:

```bash
source /root/.bashrc
cd /root/spacewalk/testsuite

export UYUNI_BENCH_MINIONS='["minion-1.example.test","minion-2.example.test"]'
export UYUNI_BENCH_CHANNEL='uyuni-bench-channel'
export UYUNI_BENCH_TIMEOUT_SECONDS=14400
export UYUNI_BENCH_STORAGE_CLASS='nfs-csi'

bundle exec rake cucumber:kubernetes_package_download_benchmark
```

If StorageClass metadata is not needed, omit `UYUNI_BENCH_STORAGE_CLASS`.

Results are written to:

```text
testsuite/results/package-download/<timestamp>-<pid>/result.json
```

The result contains the measured duration, per-minion command status, package and payload counts, downloaded bytes, channel snapshot digest, and verification errors.

## Codespace

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- The configuration and run instructions are included in this PR description.

- [x] **DONE**

## Test coverage

Validated with:

- Ruby syntax checks for the benchmark steps and Rakefile;
- RuboCop for the benchmark step definitions;
- focused checks for API snapshot mapping and the Salt preflight sequence;
- focused checks for controller target selection, `kubectl exec` serialization, Salt arguments, zypper arguments, and timeout values;
- focused checks for RPM cache verification and result schema;
- run-set linkage validation;
- `git diff --check`.

- [x] **DONE**

## Links

Issue(s): openSUSE/mentoring#252  
Related: #12077  
Depends on: #12240  
Related Sumaform storage work: uyuni-project/sumaform#2246  
Port(s): none

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
