### PR TITLE
Sync Rocky Linux 10 instead of Rocky 8 in the reference environments

### DIFF
--- a/testsuite/features/reposync/reference_srv_sync_products_extra.feature
+++ b/testsuite/features/reposync/reference_srv_sync_products_extra.feature
@@ -17,20 +17,20 @@ Feature: Synchronize extra products in the products page of the Setup Wizard
 
 @scc_credentials
 @susemanager
-  Scenario: Add Rocky 8 product with recommended sub-products
+  Scenario: Add Rocky 10 product with recommended sub-products
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "Rocky" as the filtered product description
-    And I wait until I see "Rocky Linux 8 x86_64" text
-    And I select "Rocky Linux 8 x86_64" as a product
-    Then I should see the "Rocky Linux 8 x86_64" selected
+    And I enter "Rocky Linux 10" as the filtered product description
+    And I wait until I see "Rocky Linux 10 x86_64" text
+    And I select "Rocky Linux 10 x86_64" as a product
+    Then I should see the "Rocky Linux 10 x86_64" selected
     When I click the Add Product button
-    And I wait until I see "Rocky Linux 8 x86_64" product has been added
+    And I wait until I see "Rocky Linux 10 x86_64" product has been added
 
 @uyuni
-  Scenario: Enable Rocky 8 Uyuni client tools for creating bootstrap repositories
-    When I use spacewalk-common-channel to add channel "rockylinux8 rockylinux8-appstream rockylinux8-uyuni-client" with arch "x86_64"
+  Scenario: Enable Rocky 10 Uyuni client tools for creating bootstrap repositories
+    When I use spacewalk-common-channel to add channel "rockylinux10 rockylinux10-appstream rockylinux10-uyuni-client" with arch "x86_64"
 
 @scc_credentials
 @susemanager


### PR DESCRIPTION
## What does this PR change?

Makes the reference environments sync the Rocky Linux 10 product instead of
Rocky Linux 8, in `features/reposync/reference_srv_sync_products_extra.feature`:

- `@susemanager`: add "Rocky Linux 10 x86_64" in the Setup Wizard products page
- `@uyuni`: add the `rockylinux10 rockylinux10-appstream rockylinux10-uyuni-client`
  common channels

The reference environments switch their RH-like client from Rocky 8 to Rocky 10.
Reference environments deliberately do not use the internal mirror, and the
Rocky 8 generic cloud image is 2.0 GB against 545 MB for Rocky 10, which made
`manager-5.2-infra-reference` build #2 fail with `context deadline exceeded`
while creating the `rocky8o` libvirt volume.

This feature is only used by `run_sets/reference_reposync.yml`, so no CI
acceptance test run is affected. It is the only place where the reference run
syncs the RH-like product, and `srv_create_bootstrap_repositories.feature` then
runs `mgr-create-bootstrap-repo --auto --force --with-custom-channels`: without
this change the reference server would have no EL10 bootstrap repository and
`features/init_clients/min_rhlike_salt.feature` would fail to bootstrap the
minion.

The product and channel strings are the ones already used and verified
elsewhere: "Rocky Linux 10" / "Rocky Linux 10 x86_64" come from the build
validation run (`features/build_validation/reposync/srv_sync_all_products.feature`),
and the three common channel names are the `rockylinux10`,
`rockylinux10-appstream` and `rockylinux10-uyuni-client` sections of
`utils/spacewalk-common-channels.ini`.

Registration itself is unaffected: the RH-like minion uses the
`fake-base-channel-rh-like` activation key and channel, so nothing else in the
reference run sets depends on the client version.

Environment side, done in susemanager-ci:

- `MLM-Head-refenv-NUE.tf` and `Uyuni-Master-refenv-NUE.tf` move to `rocky10o`
  in SUSE/susemanager-ci#2154, which must merge together with this PR
- `MLM-5.2-refenv-PRG.tf` moved to `rocky10o` in SUSE/susemanager-ci#2153
- `MLM-5.1-refenv-NUE.tf` moves to `rocky10o` in SUSE/susemanager-ci#2158

The 5.0 and 4.3 reference environments are not touched: they run their own
testsuite branches and keep syncing Rocky 8 (4.3 uses CentOS 7).

`features/reposync/reference_srv_check_reposync.feature` still names the Rocky 8
channels, but it is commented out in `run_sets/reference_reposync.yml` and is
left alone here.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31449
Ports:
Manager-5.2: SUSE/spacewalk#31451
Manager-5.1: SUSE/spacewalk#31462

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!


