### PR TITLE
Migrate to "mgr-libmod" to singlespec to fix issue on openSUSE Leap 16.0

### DIFF
--- a/susemanager-utils/mgr-libmod/mgr-libmod.changes.meaksh.master-singlespec
+++ b/susemanager-utils/mgr-libmod/mgr-libmod.changes.meaksh.master-singlespec
@@ -1,0 +1,1 @@
+- Migrate to singlespec to fix issues building on 16.0

--- a/susemanager-utils/mgr-libmod/mgr-libmod.spec
+++ b/susemanager-utils/mgr-libmod/mgr-libmod.spec
@@ -15,6 +15,7 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+%{?!python_module:%define python_module() python-%{**} python3-%{**}}
 
 Name:           mgr-libmod
 Version:        5.3.0
@@ -26,13 +27,14 @@ Group:          Applications/Internet
 URL:            https://github.com/uyuni-project/uyuni
 #!CreateArchive: %{name}
 Source:         %{name}-%{version}.tar.gz
-BuildRequires:  python3-pytest
-BuildRequires:  python3-rpm-macros
+BuildRequires:  %{python_module pytest}
+BuildRequires:  fdupes
+BuildRequires:  python-rpm-macros
 Requires:       python3-libmodulemd
 Requires(pre):  coreutils
 BuildArch:      noarch
 %if 0%{?rhel}
-BuildRequires:  python3-rpm-generators
+BuildRequires:  %{python_module rpm-generators}
 %endif
 
 %description
@@ -42,16 +44,17 @@ mgr-libmod
 %setup -q
 
 %build
-python3 setup.py build
+%python_build
 
 %install
-python3 setup.py install --skip-build --root %{buildroot}
+%python_install
+%python_expand %fdupes %{buildroot}%{$python_sitelib}
 mkdir -p %{buildroot}%{_bindir}
 cp -R scripts/* %{buildroot}%{_bindir}
 
 %files
-%{python3_sitelib}/mgrlibmod
-%{python3_sitelib}/mgrlibmod-%{version}*-info
+%{python_sitelib}/mgrlibmod
+%{python_sitelib}/mgrlibmod-%{version}*-info
 %{_bindir}/mgr-libmod
 %license LICENSE
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes the current issue building `mgr-libmod` on openSUSE Leap 16.0

See: https://build.opensuse.org/package/live_build_log/systemsmanagement:Uyuni:Master/mgr-libmod/openSUSE_Leap_16.0/x86_64

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
