### PR TITLE
Use Channel equality even for ClonedChannel (bsc#1272621)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/channel/ClonedChannel.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/channel/ClonedChannel.java
@@ -17,9 +17,6 @@ package com.redhat.rhn.domain.channel;
 
 import com.redhat.rhn.domain.common.ChecksumType;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-
 import java.util.Optional;
 
 import jakarta.persistence.Entity;
@@ -33,7 +30,10 @@ import jakarta.persistence.Table;
 
 /**
  * ClonedChannel
+ *
+ * Suppressed warning about not overloaded "equals" which would cause problems with HibernateProxy objects.
  */
+@SuppressWarnings("java:S2160")
 @Entity
 @Table(name = "rhnChannelCloned")
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -91,30 +91,5 @@ public class ClonedChannel extends Channel {
         }
         return super.getChecksumType();
 
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean equals(final Object other) {
-        if (other instanceof SelectableChannel castOther) {
-            return this.equals(castOther.getChannel());
-        }
-        if (!(other instanceof ClonedChannel castOther)) {
-            return false;
-        }
-        return new EqualsBuilder()
-                .appendSuper(super.equals(other))
-                .append(isCloned(), castOther.isCloned())
-                .isEquals();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder().appendSuper(super.hashCode()).append(isCloned()).toHashCode();
     }
 }

--- a/java/core/src/test/java/com/redhat/rhn/domain/channel/ChannelTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/channel/ChannelTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactoryTest;
 import com.redhat.rhn.domain.rhnpackage.Package;
@@ -36,6 +37,7 @@ import com.redhat.rhn.testing.TestUtils;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.Hibernate;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
@@ -123,6 +125,21 @@ public class ChannelTest extends BaseTestCaseWithUser {
         testSet.add(c2);
         testSet.add(c3);
         assertEquals(2, testSet.size());
+    }
+
+    @Test
+    public void testClonedChannelEqualsWithProxy() throws Exception {
+        Channel original = ChannelFactoryTest.createTestChannel(user);
+        Channel clonedChannel = ChannelFactoryTest.createTestClonedChannel(original, user);
+
+        TestUtils.flushAndEvict(clonedChannel);
+
+        // Fetch a proxy of the cloned channel
+        Channel proxy = HibernateFactory.getSession().getReference(Channel.class, clonedChannel.getId());
+        assertFalse(Hibernate.isInitialized(proxy));
+
+        assertEquals(clonedChannel, proxy);
+        assertEquals(proxy, clonedChannel);
     }
 
     @Test

--- a/java/spacewalk-java.changes.oholecek.bsc1272621
+++ b/java/spacewalk-java.changes.oholecek.bsc1272621
@@ -1,0 +1,2 @@
+- Use Channel equality even for ClonedChannel
+  (bsc#1272621)


### PR DESCRIPTION
## What does this PR change?

Using ClonedChannel.equal does not work with Hibernate proxy objects. Channel.equal already checks for isCloned property so can be used for both Channel and derived ClonedChannel objects.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31436
Port(s): https://github.com/SUSE/spacewalk/pull/31471

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
