### PR TITLE
Fix gpgverify signature file check for file object

### DIFF
--- a/python/spacewalk/common/gpgverify.py
+++ b/python/spacewalk/common/gpgverify.py
@@ -188,7 +188,9 @@ def verify_file(
 
     if detached_signature_file:
         # check for file object
-        if hasattr(detached_signature_file, "name"):
+        if hasattr(detached_signature_file, "name") and not isinstance(
+            detached_signature_file, (os.PathLike, str)
+        ):
             detached_signature_fname = typing.cast(str, detached_signature_file.name)
         else:
             detached_signature_fname = detached_signature_file

--- a/python/spacewalk/spacewalk-backend.changes.mczernek.gpgverify-fix-ubuntu
+++ b/python/spacewalk/spacewalk-backend.changes.mczernek.gpgverify-fix-ubuntu
@@ -1,0 +1,1 @@
+- Fix gpgverify signature file check for file object (bsc#1273131)


### PR DESCRIPTION
## What does this PR change?

Previously, `gpgverify` assumed that if a parameter has the `name` attribute, it's a file object. However, `Path`-like objects also have the `name` attribute, though with completely different meaning:

```
>>> f = open('/tmp/a')
>>> f.name
'/tmp/a'
>>> from pathlib import Path
>>> p = Path('/tmp/a')
>>> p.name
'a'
```

This caused an error when trying to reposync Debian repositories.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): bsc#1273131
Port(s):  https://github.com/SUSE/spacewalk/pull/31478

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
