### PR TITLE
Clarify software channel create page validation rules

### DIFF
--- a/java/core/src/main/resources/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8309,7 +8309,7 @@ Follow this url to see the full list of inactive systems:
         </context-group>
       </trans-unit>
       <trans-unit id="edit.channel.invalidchannelname.supportedregex" xml:space="preserve">
-        <source>Channel name must be at least 6 characters long, begin with a letter or digit and may contain only letters, digits, spaces, apostrophes (&apos;), hyphens ('-'), periods ('.'), underscores ('_'), parentheses and forward slashes ('/').</source>
+        <source>Channel name must be at least 6 characters long, begin with a letter or digit and may contain only letters, digits, whitespace, apostrophes (&apos;), hyphens ('-'), periods ('.'), underscores ('_'), parentheses and forward slashes ('/').</source>
       </trans-unit>
       <trans-unit id="edit.channel.invalidchannelname.redhat" xml:space="preserve">
         <source>@@VENDOR_NAME@@ channels require admin privileges</source>

--- a/java/core/src/main/resources/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8309,7 +8309,7 @@ Follow this url to see the full list of inactive systems:
         </context-group>
       </trans-unit>
       <trans-unit id="edit.channel.invalidchannelname.supportedregex" xml:space="preserve">
-        <source>Channel name must be at least 6 characters long, begin with a letter or digit and may contain letters, digits, spaces, hyphens ('-'), periods ('.'), underscores ('_'), parentheses and forward slashes ('/').</source>
+        <source>Channel name must be at least 6 characters long, begin with a letter or digit and may contain only letters, digits, spaces, apostrophes (&apos;), hyphens ('-'), periods ('.'), underscores ('_'), parentheses and forward slashes ('/').</source>
       </trans-unit>
       <trans-unit id="edit.channel.invalidchannelname.redhat" xml:space="preserve">
         <source>@@VENDOR_NAME@@ channels require admin privileges</source>

--- a/java/core/src/main/resources/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8309,7 +8309,7 @@ Follow this url to see the full list of inactive systems:
         </context-group>
       </trans-unit>
       <trans-unit id="edit.channel.invalidchannelname.supportedregex" xml:space="preserve">
-        <source>Channel name must be at least 6 characters long, begin with a letter and may contain only lowercase letters, hyphens ('-'), periods ('.'), underscores ('_'), numerals, spaces, parentheses and forward slashes ('/').</source>
+        <source>Channel name must be at least 6 characters long, begin with a letter or digit and may contain letters, digits, spaces, hyphens ('-'), periods ('.'), underscores ('_'), parentheses and forward slashes ('/').</source>
       </trans-unit>
       <trans-unit id="edit.channel.invalidchannelname.redhat" xml:space="preserve">
         <source>@@VENDOR_NAME@@ channels require admin privileges</source>
@@ -8360,7 +8360,7 @@ Follow this url to see the full list of inactive systems:
         </context-group>
       </trans-unit>
       <trans-unit id="edit.channel.invalidchannellabel.supportedregex" xml:space="preserve">
-        <source>Channel label must be at least 6 characters long, begin with a letter or digit and may contain only lowercase letters, hyphens ('-'), periods ('.'), underscores ('_'), and numerals.</source>
+        <source>Channel label must be at least 6 characters long, begin with a lowercase letter or digit and may contain only lowercase letters, hyphens ('-'), periods ('.'), underscores ('_'), and numerals.</source>
       </trans-unit>
       <trans-unit id="edit.channel.invalidchannellabel.redhat" xml:space="preserve">
         <source>@@VENDOR_NAME@@ channels require admin privileges</source>

--- a/java/core/src/main/resources/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -23313,7 +23313,7 @@ given channel.</source>
         &lt;p/&gt;
         Channel name and label are required.&lt;br&gt;
         Channel name must be 6 to 256 characters long and begin with a letter or digit.&lt;br&gt;
-        Channel name may contain only letters, digits, spaces, apostrophes (&apos;), hyphens ('-'), periods ('.'), underscores ('_'), parentheses (), and forward slashes ('/').&lt;br&gt;
+        Channel name may contain only letters, digits, whitespace, apostrophes (&apos;), hyphens ('-'), periods ('.'), underscores ('_'), parentheses (), and forward slashes ('/').&lt;br&gt;
         Channel label must be 6 to 128 characters long and begin with a lowercase letter or digit.&lt;br&gt;
         Channel label may contain only lowercase letters, digits, hyphens ('-'), periods ('.'), and underscores ('_').
         &lt;p/&gt;

--- a/java/core/src/main/resources/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -23312,12 +23312,10 @@ given channel.</source>
         Otherwise, the channel is a child of the specified channel.
         &lt;p/&gt;
         Channel name and label are required.&lt;br&gt;
-        They each must be at least 6 characters in length.&lt;br&gt;
-        Channel name must not be longer than 256 characters and channel label must not be longer than 128 characters.&lt;br&gt;
-        Channel name and label may begin with a letter or digit.&lt;br&gt;
-        They each must not begin with rhn, redhat or red hat.&lt;br&gt;
-        They each must contain only lowercase letters, hyphens ('-'), periods ('.'), underscores ('_'), and numerals.&lt;br&gt;
-        Channel name may also contain spaces, parentheses () and forward slashes ('/').
+        Channel name must be 6 to 256 characters long, begin with a letter or digit, and must not begin with rhn, redhat or red hat.&lt;br&gt;
+        Channel name may contain letters, digits, spaces, hyphens ('-'), periods ('.'), underscores ('_'), parentheses (), and forward slashes ('/').&lt;br&gt;
+        Channel label must be 6 to 128 characters long, begin with a lowercase letter or digit, and must not begin with rhn, redhat or red hat.&lt;br&gt;
+        Channel label may contain lowercase letters, digits, hyphens ('-'), periods ('.'), and underscores ('_').
         &lt;p/&gt;
         Channel summary is also required and must not exceed 500 characters.
         </source>

--- a/java/core/src/main/resources/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -23312,10 +23312,10 @@ given channel.</source>
         Otherwise, the channel is a child of the specified channel.
         &lt;p/&gt;
         Channel name and label are required.&lt;br&gt;
-        Channel name must be 6 to 256 characters long, begin with a letter or digit, and must not begin with rhn, redhat or red hat.&lt;br&gt;
-        Channel name may contain letters, digits, spaces, hyphens ('-'), periods ('.'), underscores ('_'), parentheses (), and forward slashes ('/').&lt;br&gt;
-        Channel label must be 6 to 128 characters long, begin with a lowercase letter or digit, and must not begin with rhn, redhat or red hat.&lt;br&gt;
-        Channel label may contain lowercase letters, digits, hyphens ('-'), periods ('.'), and underscores ('_').
+        Channel name must be 6 to 256 characters long and begin with a letter or digit.&lt;br&gt;
+        Channel name may contain only letters, digits, spaces, apostrophes (&apos;), hyphens ('-'), periods ('.'), underscores ('_'), parentheses (), and forward slashes ('/').&lt;br&gt;
+        Channel label must be 6 to 128 characters long and begin with a lowercase letter or digit.&lt;br&gt;
+        Channel label may contain only lowercase letters, digits, hyphens ('-'), periods ('.'), and underscores ('_').
         &lt;p/&gt;
         Channel summary is also required and must not exceed 500 characters.
         </source>

--- a/java/core/src/test/java/com/redhat/rhn/manager/channel/CreateChannelCommandRegexTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/channel/CreateChannelCommandRegexTest.java
@@ -28,6 +28,7 @@ public class CreateChannelCommandRegexTest {
 
         assertTrue(channelNamePattern.matcher("Uppercase Channel Name").matches());
         assertTrue(channelNamePattern.matcher("0Starts With Digit").matches());
+        assertTrue(channelNamePattern.matcher("O'Reilly Channel").matches());
     }
 
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/manager/channel/CreateChannelCommandRegexTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/channel/CreateChannelCommandRegexTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.manager.channel;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
+
+/**
+ * CreateChannelCommandRegexTest
+ */
+public class CreateChannelCommandRegexTest {
+
+    @Test
+    public void testChannelNameRegexAllowsUppercaseAndLeadingDigit() {
+        Pattern channelNamePattern = Pattern.compile(CreateChannelCommand.CHANNEL_NAME_REGEX);
+
+        assertTrue(channelNamePattern.matcher("Uppercase Channel Name").matches());
+        assertTrue(channelNamePattern.matcher("0Starts With Digit").matches());
+    }
+
+    @Test
+    public void testChannelLabelRegexAllowsLeadingDigitButRejectsUppercase() {
+        Pattern channelLabelPattern = Pattern.compile(CreateChannelCommand.CHANNEL_LABEL_REGEX);
+
+        assertTrue(channelLabelPattern.matcher("0starts-with-digit").matches());
+        assertFalse(channelLabelPattern.matcher("Uppercase-label").matches());
+    }
+}


### PR DESCRIPTION
## What does this PR change?

This PR updates the Create Software Channel help text on `/rhn/channels/manage/Edit.do` so it matches the current validation rules.

It separates the channel name and channel label restrictions, fixes the incorrect lowercase only statement for channel names, updates the related invalid name and label messages, and adds a focused regression test for the regex rules behind those messages.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

Before:
- The help text mixed channel name and channel label rules together and incorrectly said both fields only allowed lowercase letters.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/32c46c39-fa5f-4424-9ca8-b72923c6db99" />

After:
- The help text lists the channel name and channel label rules separately and matches the backend validation rules.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/dfd08d56-4742-4600-a90c-85768260b857" />

- [x] **DONE**

## Documentation
- No documentation needed: this only corrects inline help text on an existing page and does not change product behavior or documented workflows.

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): #7965
Port(s): none

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
