### PR TITLE
feat(openapi): migrate packages.search handler to OpenAPI contract

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/search/PackagesSearchHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/search/PackagesSearchHandler.java
@@ -54,7 +54,7 @@ import redstone.xmlrpc.XmlRpcFault;
  * @apidoc.namespace packages.search
  * @apidoc.doc Methods to interface to package search capabilities in search server..
  */
-public class PackagesSearchHandler extends BaseHandler {
+public class PackagesSearchHandler extends BaseHandler implements PackagesSearchHandlerApi {
 
     private static Logger log = LogManager.getLogger(PackagesSearchHandler.class);
 

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/search/PackagesSearchHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/search/PackagesSearchHandlerApi.java
@@ -110,11 +110,12 @@ public interface PackagesSearchHandlerApi {
     @ApiEndpointDoc(
         summary = "Advanced method to search lucene indexes with a passed in query written " +
                   "in Lucene Query Parser syntax.",
-        description = "Lucene Query Parser syntax is defined at lucene.apache.org " +
-                      "(http://lucene.apache.org/java/3_5_0/queryparsersyntax.html).\n" +
-                      "Fields searchable for Packages: name, epoch, version, release, arch, " +
-                      "description, summary.\n" +
-                      "Lucene Query Example: \"name:kernel AND version:2.6.18 AND -description:devel\"",
+        description = """
+            Lucene Query Parser syntax is defined at lucene.apache.org \
+            (http://lucene.apache.org/java/3_5_0/queryparsersyntax.html).
+            Fields searchable for Packages: name, epoch, version, release, arch, description, summary.
+            Lucene Query Example: "name:kernel AND version:2.6.18 AND -description:devel"\
+            """,
         method = HttpMethod.get,
         responseClass = PackageOverviewListResponse.class
     )
@@ -140,11 +141,12 @@ public interface PackagesSearchHandlerApi {
         summary = "Advanced method to search lucene indexes with a passed in query written " +
                   "in Lucene Query Parser syntax, additionally this method will limit results " +
                   "to those which are in the passed in channel label.",
-        description = "Lucene Query Parser syntax is defined at lucene.apache.org " +
-                      "(http://lucene.apache.org/java/3_5_0/queryparsersyntax.html).\n" +
-                      "Fields searchable for Packages: name, epoch, version, release, arch, " +
-                      "description, summary.\n" +
-                      "Lucene Query Example: \"name:kernel AND version:2.6.18 AND -description:devel\"",
+        description = """
+            Lucene Query Parser syntax is defined at lucene.apache.org \
+            (http://lucene.apache.org/java/3_5_0/queryparsersyntax.html).
+            Fields searchable for Packages: name, epoch, version, release, arch, description, summary.
+            Lucene Query Example: "name:kernel AND version:2.6.18 AND -description:devel"\
+            """,
         method = HttpMethod.get,
         responseClass = PackageOverviewListResponse.class
     )
@@ -176,11 +178,12 @@ public interface PackagesSearchHandlerApi {
         summary = "Advanced method to search lucene indexes with a passed in query written " +
                   "in Lucene Query Parser syntax, additionally this method will limit results " +
                   "to those which are associated with a given activation key.",
-        description = "Lucene Query Parser syntax is defined at lucene.apache.org " +
-                      "(http://lucene.apache.org/java/3_5_0/queryparsersyntax.html).\n" +
-                      "Fields searchable for Packages: name, epoch, version, release, arch, " +
-                      "description, summary.\n" +
-                      "Lucene Query Example: \"name:kernel AND version:2.6.18 AND -description:devel\"",
+        description = """
+            Lucene Query Parser syntax is defined at lucene.apache.org \
+            (http://lucene.apache.org/java/3_5_0/queryparsersyntax.html).
+            Fields searchable for Packages: name, epoch, version, release, arch, description, summary.
+            Lucene Query Example: "name:kernel AND version:2.6.18 AND -description:devel"\
+            """,
         method = HttpMethod.get,
         responseClass = PackageOverviewListResponse.class
     )

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/search/PackagesSearchHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/search/PackagesSearchHandlerApi.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.packages.search;
+
+import com.redhat.rhn.frontend.dto.PackageOverview;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import spark.route.HttpMethod;
+
+/**
+ * API contract for {@link PackagesSearchHandler}.
+ */
+@Tag(name = "packages.search",
+     description = "Methods to interface to package search capabilities in search server.")
+public interface PackagesSearchHandlerApi {
+
+    /**
+     * Searches the package indexes by package name.
+     *
+     * @param sessionKey the session key
+     * @param name the package name to search for
+     * @return the matching packages
+     */
+    @ApiEndpointDoc(
+        summary = "Search the lucene package indexes for all packages which match the given name.",
+        method = HttpMethod.get,
+        responseClass = PackageOverviewListResponse.class
+    )
+    List<PackageOverview> name(
+        @Parameter(hidden = true) String sessionKey,
+        @Parameter(
+            name = "name",
+            description = "package name to search for",
+            in = ParameterIn.QUERY,
+            required = true
+        ) String name
+    );
+
+    /**
+     * Searches the package indexes by name or description.
+     *
+     * @param sessionKey the session key
+     * @param query the text to match
+     * @return the matching packages
+     */
+    @ApiEndpointDoc(
+        summary = "Search the lucene package indexes for all packages which match the given query " +
+                  "in name or description",
+        method = HttpMethod.get,
+        responseClass = PackageOverviewListResponse.class
+    )
+    List<PackageOverview> nameAndDescription(
+        @Parameter(hidden = true) String sessionKey,
+        @Parameter(
+            name = "query",
+            description = "text to match in package name or description",
+            in = ParameterIn.QUERY,
+            required = true
+        ) String query
+    );
+
+    /**
+     * Searches the package indexes by name or summary.
+     *
+     * @param sessionKey the session key
+     * @param query the text to match
+     * @return the matching packages
+     */
+    @ApiEndpointDoc(
+        summary = "Search the lucene package indexes for all packages which match the given query " +
+                  "in name or summary.",
+        method = HttpMethod.get,
+        responseClass = PackageOverviewListResponse.class
+    )
+    List<PackageOverview> nameAndSummary(
+        @Parameter(hidden = true) String sessionKey,
+        @Parameter(
+            name = "query",
+            description = "text to match in package name or summary",
+            in = ParameterIn.QUERY,
+            required = true
+        ) String query
+    );
+
+    /**
+     * Searches the package indexes with a Lucene Query Parser syntax query.
+     *
+     * @param sessionKey the session key
+     * @param luceneQuery the query
+     * @return the matching packages
+     */
+    @ApiEndpointDoc(
+        summary = "Advanced method to search lucene indexes with a passed in query written " +
+                  "in Lucene Query Parser syntax.",
+        description = "Lucene Query Parser syntax is defined at lucene.apache.org " +
+                      "(http://lucene.apache.org/java/3_5_0/queryparsersyntax.html).\n" +
+                      "Fields searchable for Packages: name, epoch, version, release, arch, " +
+                      "description, summary.\n" +
+                      "Lucene Query Example: \"name:kernel AND version:2.6.18 AND -description:devel\"",
+        method = HttpMethod.get,
+        responseClass = PackageOverviewListResponse.class
+    )
+    List<PackageOverview> advanced(
+        @Parameter(hidden = true) String sessionKey,
+        @Parameter(
+            name = "luceneQuery",
+            description = "a query written in the form of Lucene QueryParser Syntax",
+            in = ParameterIn.QUERY,
+            required = true
+        ) String luceneQuery
+    );
+
+    /**
+     * Searches the package indexes with a Lucene query, limited to a channel.
+     *
+     * @param sessionKey the session key
+     * @param luceneQuery the query
+     * @param channelLabel the channel label
+     * @return the matching packages
+     */
+    @ApiEndpointDoc(
+        summary = "Advanced method to search lucene indexes with a passed in query written " +
+                  "in Lucene Query Parser syntax, additionally this method will limit results " +
+                  "to those which are in the passed in channel label.",
+        description = "Lucene Query Parser syntax is defined at lucene.apache.org " +
+                      "(http://lucene.apache.org/java/3_5_0/queryparsersyntax.html).\n" +
+                      "Fields searchable for Packages: name, epoch, version, release, arch, " +
+                      "description, summary.\n" +
+                      "Lucene Query Example: \"name:kernel AND version:2.6.18 AND -description:devel\"",
+        method = HttpMethod.get,
+        responseClass = PackageOverviewListResponse.class
+    )
+    List<PackageOverview> advancedWithChannel(
+        @Parameter(hidden = true) String sessionKey,
+        @Parameter(
+            name = "luceneQuery",
+            description = "a query written in the form of Lucene QueryParser Syntax",
+            in = ParameterIn.QUERY,
+            required = true
+        ) String luceneQuery,
+        @Parameter(
+            name = "channelLabel",
+            description = "the channel Label",
+            in = ParameterIn.QUERY,
+            required = true
+        ) String channelLabel
+    );
+
+    /**
+     * Searches the package indexes with a Lucene query, limited to an activation key.
+     *
+     * @param sessionKey the session key
+     * @param luceneQuery the query
+     * @param activationKey the activation key
+     * @return the matching packages
+     */
+    @ApiEndpointDoc(
+        summary = "Advanced method to search lucene indexes with a passed in query written " +
+                  "in Lucene Query Parser syntax, additionally this method will limit results " +
+                  "to those which are associated with a given activation key.",
+        description = "Lucene Query Parser syntax is defined at lucene.apache.org " +
+                      "(http://lucene.apache.org/java/3_5_0/queryparsersyntax.html).\n" +
+                      "Fields searchable for Packages: name, epoch, version, release, arch, " +
+                      "description, summary.\n" +
+                      "Lucene Query Example: \"name:kernel AND version:2.6.18 AND -description:devel\"",
+        method = HttpMethod.get,
+        responseClass = PackageOverviewListResponse.class
+    )
+    List<PackageOverview> advancedWithActKey(
+        @Parameter(hidden = true) String sessionKey,
+        @Parameter(
+            name = "luceneQuery",
+            description = "a query written in the form of Lucene QueryParser Syntax",
+            in = ParameterIn.QUERY,
+            required = true
+        ) String luceneQuery,
+        @Parameter(
+            name = "activationKey",
+            description = "activation key to look for packages in",
+            in = ParameterIn.QUERY,
+            required = true
+        ) String activationKey
+    );
+
+    @Schema(name = "PackageOverview")
+    @JsonPropertyOrder({"id", "name", "summary", "description", "version", "release", "arch",
+                        "epoch", "provider"})
+    interface PackageOverviewDoc {
+
+        /**
+         * @return the package identifier
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Long getId();
+
+        /**
+         * @return the package name
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the package summary
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSummary();
+
+        /**
+         * @return the package description
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getDescription();
+
+        /**
+         * @return the package version
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getVersion();
+
+        /**
+         * @return the package release
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getRelease();
+
+        /**
+         * @return the package architecture
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getArch();
+
+        /**
+         * @return the package epoch
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getEpoch();
+
+        /**
+         * @return the package provider
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getProvider();
+    }
+
+    @Schema(name = "ApiResponsePackageOverviewList")
+    interface PackageOverviewListResponse extends ApiResponseWrapper<List<PackageOverviewDoc>> { }
+}

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.frontend.xmlrpc.api.ApiHandler;
 import com.redhat.rhn.frontend.xmlrpc.channel.access.ChannelAccessHandler;
 import com.redhat.rhn.frontend.xmlrpc.distchannel.DistChannelHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.snippet.SnippetHandler;
+import com.redhat.rhn.frontend.xmlrpc.packages.search.PackagesSearchHandler;
 import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
 import com.redhat.rhn.frontend.xmlrpc.saltkey.SaltKeyHandler;
 import com.redhat.rhn.frontend.xmlrpc.subscriptionmatching.PinnedSubscriptionHandler;
@@ -112,6 +113,7 @@ public final class OpenApiConfig {
         handlers.put("channel.access", ChannelAccessHandler.class);
         handlers.put("distchannel", DistChannelHandler.class);
         handlers.put("kickstart.snippet", SnippetHandler.class);
+        handlers.put("packages.search", PackagesSearchHandler.class);
         handlers.put("preferences.locale", PreferencesLocaleHandler.class);
         handlers.put("saltkey", SaltKeyHandler.class);
         handlers.put("subscriptionmatching.pinnedsubscription", PinnedSubscriptionHandler.class);

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/PackagesSearchHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/PackagesSearchHandlerContractTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.frontend.dto.PackageOverview;
+import com.redhat.rhn.frontend.xmlrpc.packages.search.PackagesSearchHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class PackagesSearchHandlerContractTest extends BaseOpenApiTest {
+
+    private static final String SESSION_KEY = "fake-session";
+
+    @Override
+    protected String getApiNamespace() {
+        return "packages.search";
+    }
+
+    @Override
+    protected Class<PackagesSearchHandler> getHandlerClass() {
+        return PackagesSearchHandler.class;
+    }
+
+    private PackagesSearchHandler handler() {
+        return (PackagesSearchHandler) handlerMock;
+    }
+
+    /**
+     * Builds a package overview serialized by the registered PackageOverviewSerializer, so the
+     * response is validated against the documented schema.
+     */
+    private PackageOverview packageOverview() {
+        PackageOverview overview = new PackageOverview();
+        overview.setId(1000L);
+        overview.setPackageName("kernel");
+        overview.setSummary("The Linux kernel");
+        overview.setDescription("The kernel package contains the Linux kernel.");
+        overview.setVersion("6.4.0");
+        overview.setRelease("150600.1.1");
+        overview.setPackageArch("x86_64");
+        overview.setEpoch("1");
+        overview.setProvider("SUSE");
+        return overview;
+    }
+
+    @Test
+    public void testName() throws Exception {
+        String name = "kernel";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).name(with(SESSION_KEY), with(name));
+            will(returnValue(List.of(packageOverview())));
+        }});
+
+        validateApiContract("/packages.search/name", "GET")
+                .withParams(Map.of("name", new String[] {name}))
+                .onHandlerMethod("name", String.class, String.class);
+    }
+
+    @Test
+    public void testNameAndDescription() throws Exception {
+        String query = "kernel";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).nameAndDescription(with(SESSION_KEY), with(query));
+            will(returnValue(List.of(packageOverview())));
+        }});
+
+        validateApiContract("/packages.search/nameAndDescription", "GET")
+                .withParams(Map.of("query", new String[] {query}))
+                .onHandlerMethod("nameAndDescription", String.class, String.class);
+    }
+
+    @Test
+    public void testNameAndSummary() throws Exception {
+        String query = "kernel";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).nameAndSummary(with(SESSION_KEY), with(query));
+            will(returnValue(List.of(packageOverview())));
+        }});
+
+        validateApiContract("/packages.search/nameAndSummary", "GET")
+                .withParams(Map.of("query", new String[] {query}))
+                .onHandlerMethod("nameAndSummary", String.class, String.class);
+    }
+
+    @Test
+    public void testAdvanced() throws Exception {
+        String luceneQuery = "name:kernel AND version:6.4.0";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).advanced(with(SESSION_KEY), with(luceneQuery));
+            will(returnValue(List.of(packageOverview())));
+        }});
+
+        validateApiContract("/packages.search/advanced", "GET")
+                .withParams(Map.of("luceneQuery", new String[] {luceneQuery}))
+                .onHandlerMethod("advanced", String.class, String.class);
+    }
+
+    @Test
+    public void testAdvancedWithChannel() throws Exception {
+        String luceneQuery = "name:kernel";
+        String channelLabel = "sle-product-sles15-sp6-pool-x86_64";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).advancedWithChannel(with(SESSION_KEY), with(luceneQuery), with(channelLabel));
+            will(returnValue(List.of(packageOverview())));
+        }});
+
+        validateApiContract("/packages.search/advancedWithChannel", "GET")
+                .withParams(Map.of(
+                        "luceneQuery", new String[] {luceneQuery},
+                        "channelLabel", new String[] {channelLabel}
+                ))
+                .onHandlerMethod("advancedWithChannel", String.class, String.class, String.class);
+    }
+
+    @Test
+    public void testAdvancedWithActKey() throws Exception {
+        String luceneQuery = "name:kernel";
+        String activationKey = "1-my-activation-key";
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).advancedWithActKey(with(SESSION_KEY), with(luceneQuery), with(activationKey));
+            will(returnValue(List.of(packageOverview())));
+        }});
+
+        validateApiContract("/packages.search/advancedWithActKey", "GET")
+                .withParams(Map.of(
+                        "luceneQuery", new String[] {luceneQuery},
+                        "activationKey", new String[] {activationKey}
+                ))
+                .onHandlerMethod("advancedWithActKey", String.class, String.class, String.class);
+    }
+}


### PR DESCRIPTION
Migrates the `packages.search` XML-RPC handler to the OpenAPI contract approach
(`name`, `nameAndDescription`, `nameAndSummary`, `advanced`, `advancedWithChannel`,
`advancedWithActKey`).


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Unit tests were added: `PackagesSearchHandlerContractTest` validates the generated OpenAPI
  schema against the handler responses for all six methods, covering the query-parameter `GET`
  paths and the `String sessionKey` argument injection.

- [x] **DONE**

## Links

Tracks: GSoC 2026 OpenAPI migration

- [x] **DONE**

## Changelogs

- [x] No changelog needed
