### PR TITLE
Prevent cascading package operations to checksums (bsc#1272392)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/rhnpackage/Package.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/rhnpackage/Package.java
@@ -140,7 +140,7 @@ public class Package extends BaseDomainHelper {
     @OneToMany(mappedBy = "pack", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Set<PackageFile> packageFiles = new HashSet<>();
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "checksum_id")
     private Checksum checksum;
 

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandlerTest.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.frontend.xmlrpc.packages;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -164,6 +165,28 @@ public class PackagesHandlerTest extends BaseHandlerTestCase {
         User user = new UserTestUtils.UserBuilder().orgId(admin.getOrg().getId()).build();
         Package pkg = PackageTest.createTestPackage(user.getOrg());
         handler.removePackage(admin, pkg.getId().intValue());
+    }
+
+    @Test
+    public void testRemoveOneOfMultiplePackageCopies() {
+        User user1 = new UserTestUtils.UserBuilder().orgId(admin.getOrg().getId()).build();
+        User user2 = UserTestUtils.createUser("user2", "anotherOrg");
+
+        Package pkg1 = PackageTest.createTestPackage(user1.getOrg());
+        PackageFactory.save(pkg1);
+
+        Package pkg2 = PackageTest.createTestPackage(user2.getOrg());
+        pkg2.setChecksum(pkg1.getChecksum());
+        PackageFactory.save(pkg2);
+        TestUtils.flushAndClearSession();
+
+        handler.removePackage(admin, pkg1.getId().intValue());
+        TestUtils.flushAndClearSession();
+
+        var pkg = PackageFactory.lookupByIdAndUser(pkg1.getId(), user1);
+        assertNull(pkg);
+        pkg = PackageFactory.lookupByIdAndUser(pkg2.getId(), user2);
+        assertEquals(pkg2, pkg);
     }
 
     @Test

--- a/java/spacewalk-java.changes.mcalmer.Manager-5.2-fix-pkgremove-checksum-error
+++ b/java/spacewalk-java.changes.mcalmer.Manager-5.2-fix-pkgremove-checksum-error
@@ -1,0 +1,1 @@
+- Prevent cascading package operations to checksums (bsc#1272392)


### PR DESCRIPTION
## What does this PR change?

Before migrating to hibernate 7 and using annotations the relation from package to checksum was defined without cascade option. This default to "none". With the hibernate migration to version 7 we have set now "all" for cascade which might cause the error when hibernate try to remove a checksum which is still used.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit test added

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/31482

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
