### PR TITLE
Install python3 in the proxy-tftpd image

### DIFF
--- a/containers/proxy-tftpd-image/Dockerfile
+++ b/containers/proxy-tftpd-image/Dockerfile
@@ -6,6 +6,7 @@ FROM $BASE AS base
 
 # Main packages
 RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses \
+        python3 \
         python3-PyYAML \
         python3-fbtftp \
         python3-requests && \

--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes.ktsamis.tftpd-python3
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes.ktsamis.tftpd-python3
@@ -1,0 +1,3 @@
+- Install python3 to provide /usr/bin/python3 required by the
+  container entry point scripts on BCI 16.0
+  (gh#uyuni-project/uyuni#12368, bsc#1273343)


### PR DESCRIPTION
## What does this PR change?

Installs the `python3` package in the `proxy-tftpd` image.

Both entry point scripts of the image need `/usr/bin/python3` (`tftp_wrapper.py` uses `#!/usr/bin/env python3`, `uyuni-configure.py` uses `#!/usr/bin/python3`). Since the base moved to `registry.suse.com/bci/bci-base:16.0`, the `python3-PyYAML` / `python3-fbtftp` / `python3-requests` dependencies resolve to the 3.13 flavour, and in SLFO 16.0 the unversioned `/usr/bin/python3` moved out of `python313-base` into a new `python3-base` package that nothing in the `python313-*` chain requires or recommends. So nothing provides the unversioned name any more:

```
# podman run --rm .../uyuni/proxy-tftpd:latest sh -c 'ls -l /usr/bin/python3*; rpm -q python3'
-rwxr-xr-x. 1 root root 14448 Jun 17 13:00 /usr/bin/python3.13
package python3 is not installed
```

The container therefore exits with status 127 (`env: 'python3': No such file or directory`). Because `uyuni-tftp.service` is `Type=forking` with `Restart=on-failure`, systemd retries five times, hits the start limit and `ExecStopPost=podman rm -f` deletes the container, so `podman ps -a` shows nothing at all and the deployment still looks successful. The proxy is affected in the same way, since the default `CMD` is broken for the same reason.

The split happened between `python313-base` 3.13.13 and 3.13.14 and is specific to the SLFO build: Tumbleweed at the same upstream 3.13.14 still ships the symlink in `python313-base`, and the published SLE_BCI 16.0 repository is still on 3.13.13, which is why this only shows up in OBS-built images. Reported as bsc#1273343; details in #12368.

The other proxy images that run Python already install `python3` explicitly (`proxy-salt-broker-image`, `proxy-ssh-image`, `proxy-squid-image`); this aligns `proxy-tftpd-image` with them.

Verified on a running Uyuni master podman deployment: with `/usr/bin/python3` available and the unmodified `uyuni-tftp.service`, the container starts and stays up.

```
# systemctl is-active uyuni-tftp
active
# podman inspect --format '{{.State.Running}}' uyuni-tftpd
true
# podman logs uyuni-tftpd
INFO:root:Starting TFTP proxy:
INFO:root:HTTPS used for inproxy communication
```

Not affected: SUSE Multi-Linux Manager 5.2, which is still built on BCI 15.7.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

The Cucumber test suite already asserts this container is running, in `features/core/allcli_sanity.feature`:

```
And podman container "uyuni-tftpd" should be running on "server"
```

This is what caught the regression, in the `uyuni-master-dev-acceptance-tests-podman` pipeline.

- [x] **DONE**

## Links

Issue(s): #12368, bsc#1273343
Port(s): # no downstream port needed, SUSE Multi-Linux Manager 5.2 is built on BCI 15.7 and is not affected

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

