### PR TITLE
Fix reference-sync watchdog timeout + missing sync verification for Rocky/Ubuntu

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -47,6 +47,23 @@ namespace :cucumber do
       # Cucumber is now configured to use the consistent path/timestamp
       t.cucumber_opts = cucumber_opts + features unless features.nil?
     end
+    if filename == :reference_reposync
+      # The SLES 15 SP7 product-sync scenario in this run set waits on ~19 channels sequentially;
+      # individual channel syncs have been observed taking up to 1110s, so the default 2400s
+      # per-scenario watchdog (env.rb SCENARIO_HARD_LIMIT) trips before the sync finishes and kills
+      # the browser mid-run. Bump it to 5400s (90 min) for this job only, via a prerequisite task
+      # that sets the env var right before this task's cucumber process starts - other run_sets
+      # (e.g. core.yml, which also runs srv_sync_products.feature) are unaffected since their task
+      # never invokes this prerequisite. `||=` still lets an explicit external override win.
+      # NOTE: the prerequisite is declared with a bare symbol (not "cucumber:...") so Rake's
+      # namespace macro prefixes it exactly once; it's then attached via Rake::Task[task_name],
+      # which does a direct lookup on the already fully-qualified name instead of re-scoping it.
+      watchdog_task = :"#{filename}_bump_scenario_watchdog"
+      task watchdog_task do
+        ENV['SCENARIO_HARD_LIMIT'] ||= '5400'
+      end
+      Rake::Task[task_name].enhance([watchdog_task])
+    end
     # This block executes when the task runs and uses the exact same `html_results` path.
     # This file is used to expose the cucumber html report in Jenkins
     Rake::Task[task_name].enhance do

--- a/testsuite/features/reposync/reference_srv_sync_products_extra.feature
+++ b/testsuite/features/reposync/reference_srv_sync_products_extra.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 SUSE LLC
+# Copyright (c) 2023-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Synchronize extra products in the products page of the Setup Wizard
@@ -27,6 +27,7 @@ Feature: Synchronize extra products in the products page of the Setup Wizard
     Then I should see the "Rocky Linux 10 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Rocky Linux 10 x86_64" product has been added
+    And I wait until all synchronized channels for "rockylinux10" have finished
 
 @uyuni
   Scenario: Enable Rocky 10 Uyuni client tools for creating bootstrap repositories
@@ -45,6 +46,7 @@ Feature: Synchronize extra products in the products page of the Setup Wizard
     Then I should see the "Ubuntu 24.04" selected
     When I click the Add Product button
     And I wait until I see "Ubuntu 24.04" product has been added
+    And I wait until all synchronized channels for "ubuntu-2404" have finished
 
 @uyuni
   Scenario: Enable Ubuntu 24.04 Uyuni client tools for creating bootstrap repositories

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -44,6 +44,11 @@ end
 # Context per feature
 $context = {}
 
+# Set by the Layer 3 watchdog (see the Around hook below) when it has force-torn-down the browser
+# session. Once true, every remaining scenario in the run is skipped with one clear reason instead
+# of failing individually with confusing Playwright::Transport::AlreadyDisconnectedError traces.
+$watchdog_run_aborted = false
+
 # Other global variables
 $pxeboot_mac = ENV.fetch('PXEBOOT_MAC', nil)
 $pxeboot_image = ENV.fetch('PXEBOOT_IMAGE', nil) || 'sles15sp7o'
@@ -366,6 +371,11 @@ Around do |scenario, block|
       warn "WATCHDOG: scenario '#{scenario.name}' exceeded its hard limit of #{limit}s - " \
            'tearing down the browser session to unblock the run'
       unblock_wedged_browser
+      # capybara/cucumber's own After hook calls driver.reset! unconditionally, which tries to talk
+      # to the browser process we just killed and raises again - it does not rebuild a fresh one.
+      # Without this flag every remaining scenario would fail one-by-one with confusing
+      # Playwright::Transport::AlreadyDisconnectedError traces instead of a single clear reason.
+      $watchdog_run_aborted = true
     end
 
   begin
@@ -374,6 +384,12 @@ Around do |scenario, block|
     finished = true
     watchdog.kill
   end
+end
+
+# Must be the first unconditional Before hook in the suite (registered here, right after the
+# watchdog) so it runs before any hook that touches the browser. See $watchdog_run_aborted above.
+Before do
+  skip_this_scenario if $watchdog_run_aborted
 end
 
 Before('@skip') do


### PR DESCRIPTION
## What does this PR change?

Fix reference-sync watchdog timeout + missing sync verification for Rocky/Ubuntu

The reference-sync job (rake cucumber:reference_reposync) was hitting the default 2400s per-scenario watchdog mid-sync of SLES 15 SP7 (individual channels observed taking up to 1110s), force-killing the browser and cascading into ~79 unrelated failures for the rest of the run.

- Rakefile: bump SCENARIO_HARD_LIMIT to 5400s via a Rake prerequisite scoped to the reference_reposync task only — other run_sets (e.g. core.yml, which shares srv_sync_products.feature) are unaffected.
- env.rb: skip all remaining scenarios with one clear reason once the watchdog fires, instead of letting capybara/cucumber's reset! hook fail repeatedly against the dead browser with confusing AlreadyDisconnectedError traces.
- reference_srv_sync_products_extra.feature: add the missing I wait until all synchronized channels for "..." have finished step after adding Rocky Linux 10 and Ubuntu 24.04, so their sync is actually verified instead of silently possibly hanging/failing later.

Testing: https://jenkins.mgr.suse.de/job/manager-5.2-infra-reference/8/

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): 
Port(s):
 - 5.2: https://github.com/SUSE/spacewalk/pull/31518
 - 5.1: https://github.com/SUSE/spacewalk/pull/31524
 - 4.3: https://github.com/SUSE/spacewalk/pull/31525

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
