### PR TITLE
Align the containerized proxy checks

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -67,10 +67,17 @@ Feature: Setup containerized proxy
     And I wait until "uyuni-proxy-squid" service is active on "proxy"
     And I wait until "uyuni-proxy-ssh" service is active on "proxy"
     And I wait until "uyuni-proxy-tftpd" service is active on "proxy"
-    And I wait until port "8022" is listening on "proxy" container
-    And I wait until port "80" is listening on "proxy" container
-    And I wait until port "443" is listening on "proxy" container
+    And I check that "proxy" host is listening on TCP port "8022"
+    And I check that "proxy" host is listening on TCP port "80"
+    And I check that "proxy" host is listening on TCP port "443"
     And I visit "Proxy" endpoint of this "proxy"
+
+  Scenario: Podman containers are running on the proxy
+    Then podman container "uyuni-proxy-httpd" should be running on "proxy"
+    And podman container "uyuni-proxy-salt-broker" should be running on "proxy"
+    And podman container "uyuni-proxy-squid" should be running on "proxy"
+    And podman container "uyuni-proxy-ssh" should be running on "proxy"
+    And podman container "uyuni-proxy-tftpd" should be running on "proxy"
 
   Scenario: The containerized proxy should be registered automatically
     When I follow the left menu "Systems"

--- a/testsuite/features/proxy/proxy_container.feature
+++ b/testsuite/features/proxy/proxy_container.feature
@@ -66,6 +66,13 @@ Feature: Setup containerized proxy
     And I check that "proxy" host is listening on TCP port "443"
     And I visit "Proxy" endpoint of this "proxy"
 
+  Scenario: Podman containers are running on the proxy
+    Then podman container "uyuni-proxy-httpd" should be running on "proxy"
+    And podman container "uyuni-proxy-salt-broker" should be running on "proxy"
+    And podman container "uyuni-proxy-squid" should be running on "proxy"
+    And podman container "uyuni-proxy-ssh" should be running on "proxy"
+    And podman container "uyuni-proxy-tftpd" should be running on "proxy"
+
   Scenario: The containerized proxy should be registered automatically
     When I follow the left menu "Systems"
     And I wait until I see the name of "proxy", refreshing the page


### PR DESCRIPTION
## What does this PR change?

The sanity check verifies the podman containers on the server, but there is no
equivalent check for the proxy. This adds the same check for the containerized
proxy, reusing the existing `podman container "..." should be running on "..."`
step.

The five containers asserted are the ones `mgrpxy install podman` always creates
in the `uyuni-proxy-pod` pod: `uyuni-proxy-httpd`, `uyuni-proxy-salt-broker`,
`uyuni-proxy-squid`, `uyuni-proxy-ssh` and `uyuni-proxy-tftpd`.

A few notes on the placement and the scope:

* The check lives at the end of the containerized proxy setup, right after the
  `uyuni-proxy-*` services are confirmed active, and not in
  `features/core/allcli_sanity.feature` next to the server check. The sanity run
  set is executed straight after provisioning, before `mgrpxy install podman`
  runs in `Core - Proxy` / `init_clients`, so the proxy containers do not exist
  yet at that point.
* Only `should be running` is asserted, no `should be healthy`. None of the
  `containers/proxy-*-image` Dockerfiles declare a `HEALTHCHECK`, so
  `.State.Health` is empty for those containers.
* `uyuni-proxy-pod` is not asserted, since it is a pod and not a container.

The PR also aligns the proxy port check in the same feature files. The `lsof`
based check does not work with podman 6.0, where the port mapping is programmed
into nftables by netavark and nothing shows up as a listening socket where
`lsof` was looking. A real TCP connect works on both, so the change is
backwards compatible. This is the same change as
https://github.com/uyuni-project/uyuni/pull/12281, which reached
`features/proxy/proxy_container.feature` but not the build validation proxy
feature.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31523
Port(s): https://github.com/SUSE/spacewalk/pull/31528, https://github.com/SUSE/spacewalk/pull/31529

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

