### PR TITLE
Use the TCP port check in the build validation proxy feature

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -67,9 +67,9 @@ Feature: Setup containerized proxy
     And I wait until "uyuni-proxy-squid" service is active on "proxy"
     And I wait until "uyuni-proxy-ssh" service is active on "proxy"
     And I wait until "uyuni-proxy-tftpd" service is active on "proxy"
-    And I wait until port "8022" is listening on "proxy" container
-    And I wait until port "80" is listening on "proxy" container
-    And I wait until port "443" is listening on "proxy" container
+    And I check that "proxy" host is listening on TCP port "8022"
+    And I check that "proxy" host is listening on TCP port "80"
+    And I check that "proxy" host is listening on TCP port "443"
     And I visit "Proxy" endpoint of this "proxy"
 
   Scenario: The containerized proxy should be registered automatically


### PR DESCRIPTION
## What does this PR change?

Follow-up to #12281, which replaced the `lsof` based port check with a real TCP
connect because with podman 6.0 the port mapping is programmed into nftables by
netavark and nothing shows up as a listening socket where `lsof` was looking.

That change was only applied to `features/proxy/proxy_container.feature`. The
build validation proxy feature carries the same three port checks in the old
form, so it will hit exactly the same failure once podman 6.0 reaches the
distributions build validation runs on. This applies the same replacement there.

The step used, `I check that "..." host is listening on TCP port "..."`, already
exists on this branch, so this is a feature file change only.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): https://github.com/SUSE/spacewalk/pull/31530

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
