### PR TITLE
Proxy fqdn

### DIFF
--- a/containers/proxy-helm/proxy-helm.changes.nadvornik.proxy_fqdn
+++ b/containers/proxy-helm/proxy-helm.changes.nadvornik.proxy_fqdn
@@ -1,0 +1,1 @@
+- Support additional FQDNs

--- a/containers/proxy-helm/templates/ingress.yaml
+++ b/containers/proxy-helm/templates/ingress.yaml
@@ -32,8 +32,27 @@ spec:
               number: 80
         path: /
         pathType: Prefix
+  {{- if hasKey $config "additional_fqdns" }}
+  {{- range $config.additional_fqdns }}
+  - host: {{ . }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: web
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+  {{- end }}
+  {{- end }}
   tls:
   - hosts:
     - {{ $config.proxy_fqdn }}
+    {{- if hasKey $config "additional_fqdns" }}
+    {{- range $config.additional_fqdns }}
+    - {{ . }}
+    {{- end }}
+    {{- end }}
     secretName: proxy-cert
 {{- end }}

--- a/containers/proxy-helm/templates/routes.yaml
+++ b/containers/proxy-helm/templates/routes.yaml
@@ -19,6 +19,11 @@ spec:
       sectionName: {{ .Values.gateway.listeners.http.name }}
   hostnames:
     - {{ $config.proxy_fqdn | quote }}
+    {{- if hasKey $config "additional_fqdns" }}
+    {{- range $config.additional_fqdns }}
+    - {{ . | quote }}
+    {{- end }}
+    {{- end }}
   rules:
     - matches:
         - path: { type: PathPrefix, value: / }

--- a/containers/proxy-helm/tests/gateway_test.yaml
+++ b/containers/proxy-helm/tests/gateway_test.yaml
@@ -160,3 +160,30 @@ tests:
           namespace: myns
           any: true
         template: tcp-routes.yaml
+
+  - it: should render multiple hostnames in HTTPRoute
+    set:
+      global.config: |
+        max_cache_size_mb: 2048
+        server: parent.example.org
+        proxy_fqdn: proxy.example.org
+        email: foo@example.org
+        log_level: 2
+        additional_fqdns:
+          - alt1.example.org
+          - alt2.example.org
+      global.httpd: "httpd_content: test httpd"
+      global.ssh: "ssh_content: test ssh"
+      gateway:
+        enable: true
+    asserts:
+      - equal:
+          path: spec.hostnames
+          value:
+            - proxy.example.org
+            - alt1.example.org
+            - alt2.example.org
+        template: routes.yaml
+        documentSelector:
+          path: metadata.name
+          value: proxy-routes

--- a/containers/proxy-helm/tests/traefik_test.yaml
+++ b/containers/proxy-helm/tests/traefik_test.yaml
@@ -248,3 +248,51 @@ tests:
         documentSelector:
           path: metadata.name
           value: salt-request-router
+
+  - it: should render additional fqdns in ingress hosts and tls
+    set:
+      global.config: |
+        max_cache_size_mb: 2048
+        server: parent.example.org
+        proxy_fqdn: proxy.example.org
+        email: foo@example.org
+        log_level: 2
+        additional_fqdns:
+          - alt1.example.org
+          - alt2.example.org
+      global.httpd: "httpd_content: test httpd"
+      global.ssh: "ssh_content: test ssh"
+    release:
+      namespace: proxy1
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: proxy.example.org
+        template: ingress.yaml
+        documentSelector:
+          path: metadata.name
+          value: uyuni-proxy-ssl
+      - equal:
+          path: spec.rules[1].host
+          value: alt1.example.org
+        template: ingress.yaml
+        documentSelector:
+          path: metadata.name
+          value: uyuni-proxy-ssl
+      - equal:
+          path: spec.rules[2].host
+          value: alt2.example.org
+        template: ingress.yaml
+        documentSelector:
+          path: metadata.name
+          value: uyuni-proxy-ssl
+      - equal:
+          path: spec.tls[0].hosts
+          value:
+            - proxy.example.org
+            - alt1.example.org
+            - alt2.example.org
+        template: ingress.yaml
+        documentSelector:
+          path: metadata.name
+          value: uyuni-proxy-ssl

--- a/containers/proxy-httpd-image/proxy-httpd-image.changes.nadvornik.proxy_fqdn
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes.nadvornik.proxy_fqdn
@@ -1,0 +1,1 @@
+- Support additional FQDNs

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -198,6 +198,10 @@ with open(config_path + "httpd.yaml", encoding="utf-8") as httpdSource:
         smlm_conf.write(file_content)
         smlm_conf.truncate()
 
+    aliases = ""
+    if "additional_fqdns" in config and config["additional_fqdns"]:
+        aliases = "\n\tServerAlias " + " ".join(config["additional_fqdns"])
+
     with open("/etc/apache2/vhosts.d/ssl.conf", "w", encoding="utf-8") as file:
         file.write(f"""
 <IfDefine SSL>
@@ -205,7 +209,7 @@ with open(config_path + "httpd.yaml", encoding="utf-8") as httpdSource:
 <VirtualHost _default_:443>
 
 	DocumentRoot "/srv/www/htdocs"
-	ServerName {config["proxy_fqdn"]}
+	ServerName {config["proxy_fqdn"]}{aliases}
 
 	ErrorLog /proc/self/fd/2
 	TransferLog /proc/self/fd/1

--- a/java/core/src/main/java/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/server/MinionServer.java
@@ -315,8 +315,9 @@ public class MinionServer extends Server implements SaltConfigurable {
                 // the system is connected to a proxy
                 // check if serverPath already exists
                 Optional<ServerPath> path = ServerFactory.findServerPath(this, proxy.get());
-                if (path.isEmpty() || path.get().getPosition() != 0) {
-                    // proxy path does not exist -> create it
+                if (path.isEmpty() || path.get().getPosition() != 0 ||
+                        !path.get().getHostname().equals(hostname.orElse(proxy.get().getHostname()))) {
+                    // proxy path does not exist or hostname changed -> create it
                     Set<ServerPath> proxyPaths = ServerFactory.createServerPaths(this, proxy.get(),
                                                  hostname.orElse(proxy.get().getHostname()));
                     getServerPaths().clear();

--- a/java/core/src/main/java/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/server/MinionServer.java
@@ -110,6 +110,20 @@ public class MinionServer extends Server implements SaltConfigurable {
     }
 
     /**
+     * Return the name of the primary FQDN, falling back to the minion id if none is known.
+     *
+     * This is used for connection from proxy to minion for Salt SSH
+     *
+     * @return the primary FQDN name or the minion id
+     */
+    @Override
+    public String getPrimaryFqdnName() {
+        return Optional.ofNullable(findPrimaryFqdn())
+                .map(ServerFQDN::getName)
+                .orElseGet(this::getMinionId);
+    }
+
+    /**
      * Gets kernel live version.
      *
      * @return the kernel live version

--- a/java/core/src/main/java/com/redhat/rhn/domain/server/Server.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/server/Server.java
@@ -1233,6 +1233,35 @@ public class Server extends BaseDomainHelper implements Identifiable {
     }
 
     /**
+     * Return the name of the primary FQDN, falling back to the hostname if none is known.
+     *
+     * This is used for connection from proxy or server to minion or child proxy (Salt SSH or monitoring)
+     *
+     * @return the primary FQDN name or the hostname
+     */
+    public String getPrimaryFqdnName() {
+        return Optional.ofNullable(findPrimaryFqdn())
+                .map(ServerFQDN::getName)
+                .orElseGet(this::getHostname);
+    }
+
+    /**
+     * Return the names of all FQDNs except the primary one, sorted alphabetically.
+     *
+     * These fqdns can be used for Salt and http repo connecions from minion or child proxy to (parent) proxy.
+     *
+     * @return the additional (non-primary) FQDN names
+     */
+    public List<String> getAdditionalFqdnNames() {
+        String primary = getPrimaryFqdnName();
+        return this.fqdns.stream()
+                .map(ServerFQDN::getName)
+                .filter(fqdnName -> !fqdnName.equals(primary))
+                .sorted()
+                .toList();
+    }
+
+    /**
      * @param fqdnName The FQDN to be obtained
      * @return The fqdn with the specified name
      */

--- a/java/core/src/main/java/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/server/ServerFactory.java
@@ -360,9 +360,9 @@ public class ServerFactory extends HibernateFactory {
                 Server parentProxyServer = parentPath.getId().getProxyServer();
                 ServerPath newPath = new ServerPath();
                 newPath.setId(new ServerPathId(server, parentProxyServer));
-                newPath.setHostname(parentPath.getHostname());
                 return newPath;
             });
+            path.setHostname(parentPath.getHostname());
             path.setPosition(parentPath.getPosition() + 1);
             paths.add(path);
 
@@ -370,11 +370,11 @@ public class ServerFactory extends HibernateFactory {
         ServerPath path = findServerPath(server, proxyServer).orElseGet(() -> {
             ServerPath newPath = new ServerPath();
             newPath.setId(new ServerPathId(server, proxyServer));
-            // the first proxy is the one to which
-            // the server connects directly
-            newPath.setHostname(proxyHostname);
             return newPath;
         });
+        // the first proxy is the one to which
+        // the server connects directly
+        path.setHostname(proxyHostname);
         path.setPosition(0L);
         paths.add(path);
         return paths;

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
@@ -346,11 +346,9 @@ public class ProxyHandler extends BaseHandler {
                 throw new InvalidParameterException("Both proxyCrt and proxyKey need to be provided");
             }
 
-            List<String> fqdns = additionalFqdns != null ? additionalFqdns : List.of();
-
             return systemManager.createProxyContainerConfig(loggedInUser, proxyName, proxyPort, server,
                     maxCache.longValue(), email, rootCA, intermediateCAs, proxyCrtKey, null, null, null,
-                    new SSLCertManager(), fqdns);
+                    new SSLCertManager(), additionalFqdns);
         }
         catch (SSLCertGenerationException e) {
             LOG.error("Failed to generate SSL certificate", e);
@@ -409,9 +407,8 @@ public class ProxyHandler extends BaseHandler {
      */
     public byte[] containerConfig(User loggedInUser, String proxyName, Integer proxyPort, String server,
                                   Integer maxCache, String email, List<String> additionalFqdns) {
-        List<String> fqdns = additionalFqdns != null ? additionalFqdns : List.of();
         return systemManager.createProxyContainerConfig(loggedInUser, proxyName, proxyPort, server,
-                maxCache.longValue(), email, fqdns);
+                maxCache.longValue(), email, additionalFqdns);
     }
 
     /**
@@ -469,11 +466,9 @@ public class ProxyHandler extends BaseHandler {
             SSLCertData certData = new SSLCertData(nullable(proxyName), cnames, nullable(country),
                     nullable(state), nullable(city), nullable(org), nullable(orgUnit), nullable(sslEmail));
 
-            List<String> fqdns = cnames != null ? cnames : List.of();
-
             return systemManager.createProxyContainerConfig(loggedInUser, proxyName, proxyPort, server,
                     maxCache.longValue(), email, null, List.of(), null, caCrtKey, caPassword, certData,
-                    new SSLCertManager(), fqdns);
+                    new SSLCertManager(), cnames);
         }
         catch (SSLCertGenerationException e) {
             LOG.error("Failed to generate SSL certificate", e);

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
@@ -300,15 +300,57 @@ public class ProxyHandler extends BaseHandler {
     public byte[] containerConfig(User loggedInUser, String proxyName, Integer proxyPort, String server,
                                   Integer maxCache, String email,
                                   String rootCA, List<String> intermediateCAs, String proxyCrt, String proxyKey) {
+        return containerConfig(loggedInUser, proxyName, proxyPort, server, maxCache, email,
+                rootCA, intermediateCAs, proxyCrt, proxyKey, List.of());
+    }
+
+    /**
+     * Create and provide proxy container configuration.
+     *
+     * @param loggedInUser the current user
+     * @param proxyName  the FQDN of the proxy
+     * @param proxyPort the SSH port the proxy listens on
+     * @param server the FQDN of the server the proxy uses
+     * @param maxCache the maximum memory cache size
+     * @param email the email of proxy admin
+     * @param rootCA the root CA used to sign the SSL certificate in PEM format
+     * @param intermediateCAs intermediate CAs used to sign the SSL certificate in PEM format
+     * @param proxyCrt proxy CRT content in PEM format
+     * @param proxyKey proxy SSL private key in PEM format
+     * @param additionalFqdns additional FQDNs of the proxy
+     *
+     * @return the configuration file
+     *
+     * @apidoc.doc Compute and download the configuration for proxy containers
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("string", "proxyName", "The FQDN of the proxy")
+     * @apidoc.param #param_desc("int", "proxyPort", "The SSH port the proxy listens on")
+     * @apidoc.param #param_desc("string", "server", "The server FQDN the proxy will connect to")
+     * @apidoc.param #param_desc("int", "maxCache", "Max cache size in MB")
+     * @apidoc.param #param_desc("string", "email", "The proxy admin email")
+     * @apidoc.param #param_desc("string", "rootCA", "The root CA used to sign the SSL certificate in PEM format")
+     * @apidoc.param #array_single_desc("string", "intermediateCAs",
+     *                                  "intermediate CAs used to sign the SSL certificate in PEM format")
+     * @apidoc.param #param_desc("string", "proxyCrt", "proxy CRT content in PEM format")
+     * @apidoc.param #param_desc("string", "proxyKey", "proxy SSL private key in PEM format")
+     * @apidoc.param #array_single_desc("string", "additionalFqdns", "Additional FQDNs of the proxy")
+     *  @apidoc.returntype #array_single("byte", "binary object - package file")
+     */
+    public byte[] containerConfig(User loggedInUser, String proxyName, Integer proxyPort, String server,
+                                  Integer maxCache, String email,
+                                  String rootCA, List<String> intermediateCAs, String proxyCrt, String proxyKey,
+                                  List<String> additionalFqdns) {
         try {
             SSLCertPair proxyCrtKey = new SSLCertPair(proxyCrt, proxyKey);
             if (proxyCrtKey.isInvalid()) {
                 throw new InvalidParameterException("Both proxyCrt and proxyKey need to be provided");
             }
 
+            List<String> fqdns = additionalFqdns != null ? additionalFqdns : List.of();
+
             return systemManager.createProxyContainerConfig(loggedInUser, proxyName, proxyPort, server,
                     maxCache.longValue(), email, rootCA, intermediateCAs, proxyCrtKey, null, null, null,
-                    new SSLCertManager());
+                    new SSLCertManager(), fqdns);
         }
         catch (SSLCertGenerationException e) {
             LOG.error("Failed to generate SSL certificate", e);
@@ -339,8 +381,37 @@ public class ProxyHandler extends BaseHandler {
      */
     public byte[] containerConfig(User loggedInUser, String proxyName, Integer proxyPort, String server,
                                   Integer maxCache, String email) {
+        return containerConfig(loggedInUser, proxyName, proxyPort, server, maxCache, email, List.of());
+    }
+
+    /**
+     * Create and provide proxy container configuration without any SSL certificate and key, with additional FQDNs.
+     *
+     * @param loggedInUser the current user
+     * @param proxyName  the FQDN of the proxy
+     * @param proxyPort the SSH port the proxy listens on
+     * @param server the FQDN of the server the proxy uses
+     * @param maxCache the maximum memory cache size
+     * @param email the email of proxy admin
+     * @param additionalFqdns additional FQDNs of the proxy
+     * @return the configuration file
+     *
+     * @apidoc.doc Compute and download the configuration for proxy containers without adding the TLS certificate
+     *   for Apache. In such a case, the certificate files need to be deployed to the proxy in a different way.
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("string", "proxyName", "The FQDN of the proxy")
+     * @apidoc.param #param_desc("int", "proxyPort", "The SSH port the proxy listens on")
+     * @apidoc.param #param_desc("string", "server", "The server FQDN the proxy will connect to")
+     * @apidoc.param #param_desc("int", "maxCache", "Max cache size in MB")
+     * @apidoc.param #param_desc("string", "email", "The proxy admin email")
+     * @apidoc.param #array_single_desc("string", "additionalFqdns", "Additional FQDNs of the proxy")
+     * @apidoc.returntype #array_single("byte", "binary object - package file")
+     */
+    public byte[] containerConfig(User loggedInUser, String proxyName, Integer proxyPort, String server,
+                                  Integer maxCache, String email, List<String> additionalFqdns) {
+        List<String> fqdns = additionalFqdns != null ? additionalFqdns : List.of();
         return systemManager.createProxyContainerConfig(loggedInUser, proxyName, proxyPort, server,
-                maxCache.longValue(), email);
+                maxCache.longValue(), email, fqdns);
     }
 
     /**
@@ -397,9 +468,12 @@ public class ProxyHandler extends BaseHandler {
 
             SSLCertData certData = new SSLCertData(nullable(proxyName), cnames, nullable(country),
                     nullable(state), nullable(city), nullable(org), nullable(orgUnit), nullable(sslEmail));
+
+            List<String> fqdns = cnames != null ? cnames : List.of();
+
             return systemManager.createProxyContainerConfig(loggedInUser, proxyName, proxyPort, server,
                     maxCache.longValue(), email, null, List.of(), null, caCrtKey, caPassword, certData,
-                    new SSLCertManager());
+                    new SSLCertManager(), fqdns);
         }
         catch (SSLCertGenerationException e) {
             LOG.error("Failed to generate SSL certificate", e);

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -8612,6 +8612,48 @@ public class SystemHandler extends BaseHandler {
 
     /**
      * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
+     * Use Proxy FQDN instead of ID.
+     *
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link XmlRpcLoggingInvocationProcessor}
+     *
+     * @param user the current user
+     * @param host hostname or IP address of the target machine
+     * @param sshPort SSH port to be used on the target machine
+     * @param sshUser SSH user to be used on the target machine
+     * @param sshPassword SSH password of given user
+     * @param activationKey activation key to be used for registration
+     * @param proxyFqdn FQDN of proxy to use
+     * @param saltSSH manage system with Salt SSH
+     * @return 1 on success, 0 on failure
+     *
+     * @apidoc.doc Bootstrap a system for management via either Salt or Salt SSH. Use proxy FQDN instead of ID.
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("string", "host", "Hostname or IP address of target")
+     * @apidoc.param #param_desc("int", "sshPort", "SSH port on target machine")
+     * @apidoc.param #param_desc("string", "sshUser", "SSH user on target machine")
+     * @apidoc.param #param_desc("string", "sshPassword", "SSH password of given user")
+     * @apidoc.param #param_desc("string", "activationKey", "Activation key")
+     * @apidoc.param #param_desc("string", "proxyFqdn", "FQDN of proxy to use")
+     * @apidoc.param #param_desc("boolean", "saltSSH", "Manage system with Salt SSH")
+     * @apidoc.returntype #return_int_success()
+     */
+    public int bootstrapByProxyFqdn(User user, String host, Integer sshPort, String sshUser,
+            String sshPassword, String activationKey, String proxyFqdn, Boolean saltSSH) {
+        Optional<String> maybePassword = maybeString(sshPassword);
+        List<String> activationKeys = maybeActivationKeys(activationKey);
+        Optional<Server> proxy = ServerFactory.lookupProxyServer(proxyFqdn);
+        if (proxy.isEmpty()) {
+            throw new NoSuchSystemException("Proxy not found: " + proxyFqdn);
+        }
+        BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, maybePassword, activationKeys,
+                empty(), true, of(proxy.get().getId()));
+        params.setProxyFqdn(of(proxyFqdn));
+        log.debug("bootstrapByProxyFqdn called: {}", params);
+        return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
+    }
+
+    /**
+     * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
      * Use SSH private key for authentication.
      *
      * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link XmlRpcLoggingInvocationProcessor}
@@ -8647,6 +8689,51 @@ public class SystemHandler extends BaseHandler {
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
                 maybeString(sshPrivKeyPass), activationKeys, empty(), true, of(proxyId.longValue()));
         log.debug("bootstrapWithPrivateSshKey called with proxyId: {}", params);
+        return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
+    }
+
+    /**
+     * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
+     * Use SSH private key for authentication. Use Proxy FQDN instead of ID.
+     *
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link XmlRpcLoggingInvocationProcessor}
+     *
+     * @param user the current user
+     * @param host hostname or IP address of the target machine
+     * @param sshPort SSH port to be used on the target machine
+     * @param sshUser SSH user to be used on the target machine
+     * @param sshPrivKey SSH private key as a string in PEM format
+     * @param sshPrivKeyPass SSH passphrase for the key (use empty string for no passphrase)
+     * @param activationKey activation key to be used for registration
+     * @param proxyFqdn FQDN of proxy to use
+     * @param saltSSH manage system with Salt SSH
+     * @return 1 on success, 0 on failure
+     *
+     * @apidoc.doc Bootstrap a system for management via either Salt or Salt SSH. Use proxy FQDN instead of ID.
+     * Use SSH private key for authentication.
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("string", "host", "Hostname or IP address of target")
+     * @apidoc.param #param_desc("int", "sshPort", "SSH port on target machine")
+     * @apidoc.param #param_desc("string", "sshUser", "SSH user on target machine")
+     * @apidoc.param #param_desc("string", "sshPrivKey", "SSH private key as a string in PEM format")
+     * @apidoc.param #param_desc("string", "sshPrivKeyPass",
+     * "SSH passphrase for the key (use empty string for no passphrase)")
+     * @apidoc.param #param_desc("string", "activationKey", "Activation key")
+     * @apidoc.param #param_desc("string", "proxyFqdn", "FQDN of proxy to use")
+     * @apidoc.param #param_desc("boolean", "saltSSH", "Manage system with Salt SSH")
+     * @apidoc.returntype #return_int_success()
+     */
+    public int bootstrapWithPrivateSshKeyByProxyFqdn(User user, String host, Integer sshPort, String sshUser,
+            String sshPrivKey, String sshPrivKeyPass, String activationKey, String proxyFqdn, Boolean saltSSH) {
+        List<String> activationKeys = maybeActivationKeys(activationKey);
+        Optional<Server> proxy = ServerFactory.lookupProxyServer(proxyFqdn);
+        if (proxy.isEmpty()) {
+            throw new NoSuchSystemException("Proxy not found: " + proxyFqdn);
+        }
+        BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
+                maybeString(sshPrivKeyPass), activationKeys, empty(), true, of(proxy.get().getId()));
+        params.setProxyFqdn(of(proxyFqdn));
+        log.debug("bootstrapWithPrivateSshKeyByProxyFqdn called: {}", params);
         return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
     }
 
@@ -8767,6 +8854,50 @@ public class SystemHandler extends BaseHandler {
     }
 
     /**
+     * Bootstrap a system for management via either Salt (minion/master) or Salt SSH. Use proxy FQDN instead of ID.
+     *
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link XmlRpcLoggingInvocationProcessor}
+     *
+     * @param user the current user
+     * @param host hostname or IP address of the target machine
+     * @param sshPort SSH port to be used on the target machine
+     * @param sshUser SSH user to be used on the target machine
+     * @param sshPassword SSH password of given user
+     * @param activationKey activation key to be used for registration
+     * @param reactivationKey reactivation key to be used for registration
+     * @param proxyFqdn FQDN of proxy to use
+     * @param saltSSH manage system with Salt SSH
+     * @return 1 on success, 0 on failure
+     *
+     * @apidoc.doc Bootstrap a system for management via either Salt or Salt SSH. Use proxy FQDN instead of ID.
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("string", "host", "Hostname or IP address of target")
+     * @apidoc.param #param_desc("int", "sshPort", "SSH port on target machine")
+     * @apidoc.param #param_desc("string", "sshUser", "SSH user on target machine")
+     * @apidoc.param #param_desc("string", "sshPassword", "SSH password of given user")
+     * @apidoc.param #param_desc("string", "activationKey", "Activation key")
+     * @apidoc.param #param_desc("string", "reactivationKey", "Reactivation key")
+     * @apidoc.param #param_desc("string", "proxyFqdn", "FQDN of proxy to use")
+     * @apidoc.param #param_desc("boolean", "saltSSH", "Manage system with Salt SSH")
+     * @apidoc.returntype #return_int_success()
+     */
+    public int bootstrapByProxyFqdn(User user, String host, Integer sshPort, String sshUser,
+            String sshPassword, String activationKey, String reactivationKey, String proxyFqdn,
+            Boolean saltSSH) {
+        Optional<String> maybePassword = maybeString(sshPassword);
+        List<String> activationKeys = maybeActivationKeys(activationKey);
+        Optional<Server> proxy = ServerFactory.lookupProxyServer(proxyFqdn);
+        if (proxy.isEmpty()) {
+            throw new NoSuchSystemException("Proxy not found: " + proxyFqdn);
+        }
+        BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, maybePassword, activationKeys,
+                maybeString(reactivationKey), true, of(proxy.get().getId()));
+        params.setProxyFqdn(of(proxyFqdn));
+        log.debug("bootstrapByProxyFqdn called with reactivationKey: {}", params);
+        return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
+    }
+
+    /**
      * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
      * Use SSH private key for authentication.
      *
@@ -8807,6 +8938,55 @@ public class SystemHandler extends BaseHandler {
                 maybeString(sshPrivKeyPass), activationKeys, maybeString(reactivationKey), true,
                 of(proxyId.longValue()));
         log.debug("bootstrapWithPrivateSshKey called with reactivation key and proxyId: {}", params);
+        return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
+    }
+
+    /**
+     * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
+     * Use SSH private key for authentication. Use Proxy FQDN instead of ID.
+     *
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link XmlRpcLoggingInvocationProcessor}
+     *
+     * @param user the current user
+     * @param host hostname or IP address of the target machine
+     * @param sshPort SSH port to be used on the target machine
+     * @param sshUser SSH user to be used on the target machine
+     * @param sshPrivKey SSH private key as a string in PEM format
+     * @param sshPrivKeyPass SSH passphrase for the key (use empty string for no passphrase)
+     * @param activationKey activation key to be used for registration
+     * @param reactivationKey reactivation key to be used for registration
+     * @param proxyFqdn FQDN of proxy to use
+     * @param saltSSH manage system with Salt SSH
+     * @return 1 on success, 0 on failure
+     *
+     * @apidoc.doc Bootstrap a system for management via either Salt or Salt SSH. Use proxy FQDN instead of ID.
+     * Use SSH private key for authentication.
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("string", "host", "Hostname or IP address of target")
+     * @apidoc.param #param_desc("int", "sshPort", "SSH port on target machine")
+     * @apidoc.param #param_desc("string", "sshUser", "SSH user on target machine")
+     * @apidoc.param #param_desc("string", "sshPrivKey", "SSH private key as a string in PEM format")
+     * @apidoc.param #param_desc("string", "sshPrivKeyPass",
+     * "SSH passphrase for the key (use empty string for no passphrase)")
+     * @apidoc.param #param_desc("string", "activationKey", "Activation key")
+     * @apidoc.param #param_desc("string", "reactivationKey", "Reactivation key")
+     * @apidoc.param #param_desc("string", "proxyFqdn", "FQDN of proxy to use")
+     * @apidoc.param #param_desc("boolean", "saltSSH", "Manage system with Salt SSH")
+     * @apidoc.returntype #return_int_success()
+     */
+    public int bootstrapWithPrivateSshKeyByProxyFqdn(User user, String host, Integer sshPort, String sshUser,
+            String sshPrivKey, String sshPrivKeyPass, String activationKey, String reactivationKey,
+            String proxyFqdn, Boolean saltSSH) {
+        List<String> activationKeys = maybeActivationKeys(activationKey);
+        Optional<Server> proxy = ServerFactory.lookupProxyServer(proxyFqdn);
+        if (proxy.isEmpty()) {
+            throw new NoSuchSystemException("Proxy not found: " + proxyFqdn);
+        }
+        BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
+                maybeString(sshPrivKeyPass), activationKeys, maybeString(reactivationKey), true,
+                of(proxy.get().getId()));
+        params.setProxyFqdn(of(proxyFqdn));
+        log.debug("bootstrapWithPrivateSshKeyByProxyFqdn called with reactivation key and proxyFqdn: {}", params);
         return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/action/ActionManager.java
@@ -2090,6 +2090,21 @@ public class ActionManager extends BaseManager {
      */
     public static List<Long> changeProxy(User loggedInUser, List<Long> sysids, Long proxyId)
             throws TaskomaticApiException {
+        return changeProxy(loggedInUser, sysids, proxyId, null);
+    }
+
+    /**
+     * Connect given systems to another proxy.
+     *
+     * @param loggedInUser The current user
+     * @param sysids       A list of systems ids
+     * @param proxyId      Id of the proxy or 0 for direct connection to SUMA server
+     * @param proxyFqdn    Optional specific FQDN of the proxy to use
+     * @return Returns a list of scheduled action ids
+     *
+     */
+    public static List<Long> changeProxy(User loggedInUser, List<Long> sysids, Long proxyId, String proxyFqdn)
+            throws TaskomaticApiException {
         List<Long> visible = MinionServerFactory.lookupVisibleToUser(loggedInUser)
                 .map(Server::getId).collect(toList());
         if (!visible.containsAll(sysids)) {
@@ -2121,7 +2136,12 @@ public class ActionManager extends BaseManager {
                 .filter(minion -> ContactMethodUtil.isSSHPushContactMethod(minion.getContactMethod()))
                 .map(minion -> {
                     // handle SSH minions
-                    minion.updateServerPaths(proxyIdOpt);
+                    if (proxyFqdn != null && !proxyFqdn.isEmpty()) {
+                        minion.updateServerPaths(proxyFqdn);
+                    }
+                    else {
+                        minion.updateServerPaths(proxyIdOpt);
+                    }
                     ServerFactory.save(minion);
 
                     MinionPillarManager.INSTANCE.generatePillar(minion);
@@ -2148,7 +2168,9 @@ public class ActionManager extends BaseManager {
         if (!normalIds.isEmpty()) {
             // action for normal minions - update salt master, the channels will be updated after minion restart
             Map<String, Object> pillar = new HashMap<>();
-            pillar.put("mgr_server", proxy.map(Server::getHostname).orElse(ConfigDefaults.get().getJavaHostname()));
+            String mgrServer = (proxyFqdn != null && !proxyFqdn.isEmpty()) ? proxyFqdn :
+                    proxy.map(Server::getHostname).orElse(ConfigDefaults.get().getJavaHostname());
+            pillar.put("mgr_server", mgrServer);
 
             Action a = scheduleApplyStates(loggedInUser, normalIds,
                     Collections.singletonList(ApplyStatesEventMessage.SET_PROXY),

--- a/java/core/src/main/java/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/action/ActionManager.java
@@ -2131,12 +2131,13 @@ public class ActionManager extends BaseManager {
             });
         }
         Optional<Long> proxyIdOpt = proxy.map(Server::getId);
+        boolean hasProxyFqdn = proxyFqdn != null && !proxyFqdn.isEmpty();
 
         List<Long> sshIds = minions.stream()
                 .filter(minion -> ContactMethodUtil.isSSHPushContactMethod(minion.getContactMethod()))
                 .map(minion -> {
                     // handle SSH minions
-                    if (proxyFqdn != null && !proxyFqdn.isEmpty()) {
+                    if (hasProxyFqdn) {
                         minion.updateServerPaths(proxyFqdn);
                     }
                     else {
@@ -2168,7 +2169,7 @@ public class ActionManager extends BaseManager {
         if (!normalIds.isEmpty()) {
             // action for normal minions - update salt master, the channels will be updated after minion restart
             Map<String, Object> pillar = new HashMap<>();
-            String mgrServer = (proxyFqdn != null && !proxyFqdn.isEmpty()) ? proxyFqdn :
+            String mgrServer = hasProxyFqdn ? proxyFqdn :
                     proxy.map(Server::getHostname).orElse(ConfigDefaults.get().getJavaHostname());
             pillar.put("mgr_server", mgrServer);
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/SystemManager.java
@@ -2153,9 +2153,26 @@ public class SystemManager extends BaseManager {
      */
     public byte[] createProxyContainerConfig(User user, String proxyName, Integer proxyPort, String server,
                                              Long maxCache, String email) {
+        return createProxyContainerConfig(user, proxyName, proxyPort, server, maxCache, email, List.of());
+    }
+
+    /**
+     * Create and provide proxy container configuration with additional FQDNs without SSL.
+     *
+     * @param user            the current user
+     * @param proxyName       the FQDN of the proxy
+     * @param proxyPort       the SSH port the proxy listens on
+     * @param server          the FQDN of the server the proxy uses
+     * @param maxCache        the maximum memory cache size
+     * @param email           the email of proxy admin
+     * @param additionalFqdns the additional FQDNs for the proxy
+     * @return the tarball configuration file as a byte array
+     */
+    public byte[] createProxyContainerConfig(User user, String proxyName, Integer proxyPort, String server,
+                                             Long maxCache, String email, List<String> additionalFqdns) {
         return proxyContainerConfigCreateFacade.create(
                 saltApi, systemEntitlementManager, user, server, proxyName, proxyPort, maxCache, email,
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, new SSLCertManager(), additionalFqdns);
     }
 
 
@@ -2187,10 +2204,44 @@ public class SystemManager extends BaseManager {
                                              SSLCertPair caPair, String caPassword, SSLCertData certData,
                                              SSLCertManager certManager)
             throws SSLCertGenerationException {
+        return createProxyContainerConfig(user, proxyName, proxyPort, server, maxCache, email,
+                rootCA, intermediateCAs, proxyCertKey, caPair, caPassword, certData, certManager, List.of());
+    }
+
+    /**
+     * Create and provide proxy container configuration with additional FQDNs.
+     *
+     * @param user            the current user
+     * @param proxyName       the FQDN of the proxy
+     * @param proxyPort       the SSH port the proxy listens on
+     * @param server          the FQDN of the server the proxy uses
+     * @param maxCache        the maximum memory cache size
+     * @param email           the email of proxy admin
+     * @param rootCA          root CA used to sign the SSL certificate in PEM format
+     * @param intermediateCAs intermediate CAs used to sign the SSL certificate in PEM format
+     * @param proxyCertKey    proxy CRT and key pair
+     * @param caPair          the CA certificate and key used to sign the certificate to generate.
+     *                        Can be omitted if proxyCertKey is provided
+     * @param caPassword      the CA private key password.
+     *                        Can be omitted if proxyCertKey is provided
+     * @param certData        the data needed to generate the new proxy SSL certificate.
+     *                        Can be omitted if proxyCertKey is provided
+     * @param certManager     the SSLCertManager to use
+     * @param additionalFqdns the additional FQDNs for the proxy
+     * @return the tarball configuration file as a byte array
+     */
+    public byte[] createProxyContainerConfig(User user, String proxyName, Integer proxyPort, String server,
+                                             Long maxCache, String email,
+                                             String rootCA, List<String> intermediateCAs,
+                                             SSLCertPair proxyCertKey,
+                                             SSLCertPair caPair, String caPassword, SSLCertData certData,
+                                             SSLCertManager certManager,
+                                             List<String> additionalFqdns)
+            throws SSLCertGenerationException {
 
         return proxyContainerConfigCreateFacade.create(
                 saltApi, systemEntitlementManager, user, server, proxyName, proxyPort, maxCache, email,
-                rootCA, intermediateCAs, proxyCertKey, caPair, caPassword, certData, certManager);
+                rootCA, intermediateCAs, proxyCertKey, caPair, caPassword, certData, certManager, additionalFqdns);
     }
 
 
@@ -2227,10 +2278,50 @@ public class SystemManager extends BaseManager {
             SSLCertManager certManager,
             String sshPub, String sshPriv, String sshParent
     ) throws SSLCertGenerationException {
+        return createProxyContainerConfigFiles(user, proxyName, proxyPort, server, maxCache, email,
+                rootCA, intermediateCAs, proxyCertKey, caPair, caPassword, certData, certManager,
+                sshPub, sshPriv, sshParent, List.of());
+    }
+
+    /**
+     * Create and provide proxy container configuration files with additional FQDNs.
+     *
+     * @param user            the current user
+     * @param proxyName       the FQDN of the proxy
+     * @param proxyPort       the SSH port the proxy listens on
+     * @param server          the FQDN of the server the proxy uses
+     * @param maxCache        the maximum memory cache size
+     * @param email           the email of proxy admin
+     * @param rootCA          root CA used to sign the SSL certificate in PEM format
+     * @param intermediateCAs intermediate CAs used to sign the SSL certificate in PEM format
+     * @param proxyCertKey    proxy CRT and key pair
+     * @param caPair          the CA certificate and key used to sign the certificate to generate.
+     *                        Can be omitted if proxyCertKey is provided
+     * @param caPassword      the CA private key password.
+     *                        Can be omitted if proxyCertKey is provided
+     * @param certData        the data needed to generate the new proxy SSL certificate.
+     *                        Can be omitted if proxyCertKey is provided
+     * @param certManager     the SSLCertManager to use
+     * @param sshPub          the proxy SSH public key if known
+     * @param sshPriv         the proxy SSH private key if known
+     * @param sshParent       the parent SSH public key if known
+     * @param additionalFqdns the additional FQDNs for the proxy
+     * @return the configuration files as a map
+     */
+    public Map<String, Object> createProxyContainerConfigFiles(
+            User user, String proxyName, Integer proxyPort, String server,
+            Long maxCache, String email,
+            String rootCA, List<String> intermediateCAs,
+            SSLCertPair proxyCertKey,
+            SSLCertPair caPair, String caPassword, SSLCertData certData,
+            SSLCertManager certManager,
+            String sshPub, String sshPriv, String sshParent,
+            List<String> additionalFqdns
+    ) throws SSLCertGenerationException {
         return this.proxyContainerConfigCreateFacade.createFiles(
                 saltApi, systemEntitlementManager, user, server, proxyName, proxyPort, maxCache, email,
                 rootCA, intermediateCAs, proxyCertKey, caPair, caPassword, certData, certManager,
-                sshPub, sshPriv, sshParent
+                sshPub, sshPriv, sshParent, additionalFqdns
         );
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/SystemManager.java
@@ -2155,9 +2155,26 @@ public class SystemManager extends BaseManager {
      */
     public byte[] createProxyContainerConfig(User user, String proxyName, Integer proxyPort, String server,
                                              Long maxCache, String email) {
+        return createProxyContainerConfig(user, proxyName, proxyPort, server, maxCache, email, List.of());
+    }
+
+    /**
+     * Create and provide proxy container configuration with additional FQDNs without SSL.
+     *
+     * @param user            the current user
+     * @param proxyName       the FQDN of the proxy
+     * @param proxyPort       the SSH port the proxy listens on
+     * @param server          the FQDN of the server the proxy uses
+     * @param maxCache        the maximum memory cache size
+     * @param email           the email of proxy admin
+     * @param additionalFqdns the additional FQDNs for the proxy
+     * @return the tarball configuration file as a byte array
+     */
+    public byte[] createProxyContainerConfig(User user, String proxyName, Integer proxyPort, String server,
+                                             Long maxCache, String email, List<String> additionalFqdns) {
         return proxyContainerConfigCreateFacade.create(
                 saltApi, systemEntitlementManager, user, server, proxyName, proxyPort, maxCache, email,
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, new SSLCertManager(), additionalFqdns);
     }
 
 
@@ -2189,10 +2206,44 @@ public class SystemManager extends BaseManager {
                                              SSLCertPair caPair, String caPassword, SSLCertData certData,
                                              SSLCertManager certManager)
             throws SSLCertGenerationException {
+        return createProxyContainerConfig(user, proxyName, proxyPort, server, maxCache, email,
+                rootCA, intermediateCAs, proxyCertKey, caPair, caPassword, certData, certManager, List.of());
+    }
+
+    /**
+     * Create and provide proxy container configuration with additional FQDNs.
+     *
+     * @param user            the current user
+     * @param proxyName       the FQDN of the proxy
+     * @param proxyPort       the SSH port the proxy listens on
+     * @param server          the FQDN of the server the proxy uses
+     * @param maxCache        the maximum memory cache size
+     * @param email           the email of proxy admin
+     * @param rootCA          root CA used to sign the SSL certificate in PEM format
+     * @param intermediateCAs intermediate CAs used to sign the SSL certificate in PEM format
+     * @param proxyCertKey    proxy CRT and key pair
+     * @param caPair          the CA certificate and key used to sign the certificate to generate.
+     *                        Can be omitted if proxyCertKey is provided
+     * @param caPassword      the CA private key password.
+     *                        Can be omitted if proxyCertKey is provided
+     * @param certData        the data needed to generate the new proxy SSL certificate.
+     *                        Can be omitted if proxyCertKey is provided
+     * @param certManager     the SSLCertManager to use
+     * @param additionalFqdns the additional FQDNs for the proxy
+     * @return the tarball configuration file as a byte array
+     */
+    public byte[] createProxyContainerConfig(User user, String proxyName, Integer proxyPort, String server,
+                                             Long maxCache, String email,
+                                             String rootCA, List<String> intermediateCAs,
+                                             SSLCertPair proxyCertKey,
+                                             SSLCertPair caPair, String caPassword, SSLCertData certData,
+                                             SSLCertManager certManager,
+                                             List<String> additionalFqdns)
+            throws SSLCertGenerationException {
 
         return proxyContainerConfigCreateFacade.create(
                 saltApi, systemEntitlementManager, user, server, proxyName, proxyPort, maxCache, email,
-                rootCA, intermediateCAs, proxyCertKey, caPair, caPassword, certData, certManager);
+                rootCA, intermediateCAs, proxyCertKey, caPair, caPassword, certData, certManager, additionalFqdns);
     }
 
 
@@ -2229,10 +2280,50 @@ public class SystemManager extends BaseManager {
             SSLCertManager certManager,
             String sshPub, String sshPriv, String sshParent
     ) throws SSLCertGenerationException {
+        return createProxyContainerConfigFiles(user, proxyName, proxyPort, server, maxCache, email,
+                rootCA, intermediateCAs, proxyCertKey, caPair, caPassword, certData, certManager,
+                sshPub, sshPriv, sshParent, List.of());
+    }
+
+    /**
+     * Create and provide proxy container configuration files with additional FQDNs.
+     *
+     * @param user            the current user
+     * @param proxyName       the FQDN of the proxy
+     * @param proxyPort       the SSH port the proxy listens on
+     * @param server          the FQDN of the server the proxy uses
+     * @param maxCache        the maximum memory cache size
+     * @param email           the email of proxy admin
+     * @param rootCA          root CA used to sign the SSL certificate in PEM format
+     * @param intermediateCAs intermediate CAs used to sign the SSL certificate in PEM format
+     * @param proxyCertKey    proxy CRT and key pair
+     * @param caPair          the CA certificate and key used to sign the certificate to generate.
+     *                        Can be omitted if proxyCertKey is provided
+     * @param caPassword      the CA private key password.
+     *                        Can be omitted if proxyCertKey is provided
+     * @param certData        the data needed to generate the new proxy SSL certificate.
+     *                        Can be omitted if proxyCertKey is provided
+     * @param certManager     the SSLCertManager to use
+     * @param sshPub          the proxy SSH public key if known
+     * @param sshPriv         the proxy SSH private key if known
+     * @param sshParent       the parent SSH public key if known
+     * @param additionalFqdns the additional FQDNs for the proxy
+     * @return the configuration files as a map
+     */
+    public Map<String, Object> createProxyContainerConfigFiles(
+            User user, String proxyName, Integer proxyPort, String server,
+            Long maxCache, String email,
+            String rootCA, List<String> intermediateCAs,
+            SSLCertPair proxyCertKey,
+            SSLCertPair caPair, String caPassword, SSLCertData certData,
+            SSLCertManager certManager,
+            String sshPub, String sshPriv, String sshParent,
+            List<String> additionalFqdns
+    ) throws SSLCertGenerationException {
         return this.proxyContainerConfigCreateFacade.createFiles(
                 saltApi, systemEntitlementManager, user, server, proxyName, proxyPort, maxCache, email,
                 rootCA, intermediateCAs, proxyCertKey, caPair, caPassword, certData, certManager,
-                sshPub, sshPriv, sshParent
+                sshPub, sshPriv, sshParent, additionalFqdns
         );
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -100,9 +100,7 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
             }
         }
 
-        if (context.getAdditionalFqdns() != null) {
-            fqdns.addAll(context.getAdditionalFqdns());
-        }
+        fqdns.addAll(context.getAdditionalFqdns());
 
         Server proxySystem = getOrCreateProxySystem(
                 context.getSystemEntitlementManager(),
@@ -194,14 +192,7 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
 
             systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.PROXY);
 
-            if (parentProxy.isPresent()) {
-                Set<ServerPath> paths = ServerFactory.createServerPaths(server, parentProxy.get(), parentFqdn);
-                server.getServerPaths().clear();
-                server.getServerPaths().addAll(paths);
-            }
-            else {
-                server.getServerPaths().clear();
-            }
+            setParentPath(server, parentProxy, parentFqdn);
 
             ServerFactory.save(server);
             server.setPrimaryFQDNWithName(proxyName);
@@ -229,14 +220,7 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
         server.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
         server.updateServerInfo();
 
-        if (parentProxy.isPresent()) {
-            Set<ServerPath> paths = ServerFactory.createServerPaths(server, parentProxy.get(), parentFqdn);
-            server.getServerPaths().clear();
-            server.getServerPaths().addAll(paths);
-        }
-        else {
-            server.getServerPaths().clear();
-        }
+        setParentPath(server, parentProxy, parentFqdn);
 
         ServerFactory.save(server);
 
@@ -252,6 +236,20 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
         systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.PROXY);
         server.setPrimaryFQDNWithName(proxyName);
         return server;
+    }
+
+    /**
+     * Reset the proxy server's paths to reflect its parent. If the parent is another proxy the path
+     * chain leading to it is rebuilt, otherwise (direct connection to the server) the paths are cleared.
+     *
+     * @param server      the proxy server whose paths are updated
+     * @param parentProxy the parent proxy, or empty when connecting directly to the server
+     * @param parentFqdn  the FQDN used to reach the parent
+     */
+    private void setParentPath(Server server, Optional<Server> parentProxy, String parentFqdn) {
+        server.getServerPaths().clear();
+        parentProxy.ifPresent(parent ->
+                server.getServerPaths().addAll(ServerFactory.createServerPaths(server, parent, parentFqdn)));
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -207,6 +207,7 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
             }
 
             ServerFactory.save(server);
+            server.setPrimaryFQDNWithName(proxyName);
             return server;
         }
         Server server = ServerFactory.createServer();
@@ -252,6 +253,7 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
         // It will be called inside the method setBaseEntitlement. If we remove this line we need to manually call it
         systemEntitlementManager.setBaseEntitlement(server, EntitlementManager.FOREIGN);
         systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.PROXY);
+        server.setPrimaryFQDNWithName(proxyName);
         return server;
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -76,7 +76,8 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
         //config.yaml
         SSLCertPair proxyPair = context.getProxyCertKey();
         String rootCaCert = context.getRootCA();
-        if (ConfigDefaults.get().isSsl() && (proxyPair == null || !proxyPair.isComplete())) {
+        if (ConfigDefaults.get().isSsl() && (proxyPair == null || !proxyPair.isComplete()) &&
+                context.getCaPair() != null) {
             proxyPair = context.getCertManager().generateCertificate(
                     context.getCaPair(),
                     context.getCaPassword(),
@@ -105,6 +106,10 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
             catch (IllegalArgumentException err) {
                 throw new RhnRuntimeException("Certificate check failure: " + err.getMessage());
             }
+        }
+
+        if (context.getAdditionalFqdns() != null) {
+            fqdns.addAll(context.getAdditionalFqdns());
         }
 
         Server proxySystem = getOrCreateProxySystem(

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -76,7 +76,8 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
         //config.yaml
         SSLCertPair proxyPair = context.getProxyCertKey();
         String rootCaCert = context.getRootCA();
-        if (ConfigDefaults.get().isSsl() && (proxyPair == null || !proxyPair.isComplete())) {
+        if (ConfigDefaults.get().isSsl() && (proxyPair == null || !proxyPair.isComplete()) &&
+                context.getCaPair() != null) {
             proxyPair = context.getCertManager().generateCertificate(
                     context.getCaPair(),
                     context.getCaPassword(),
@@ -96,6 +97,10 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
             catch (IllegalArgumentException err) {
                 throw new RhnRuntimeException("Certificate check failure: " + err.getMessage());
             }
+        }
+
+        if (context.getAdditionalFqdns() != null) {
+            fqdns.addAll(context.getAdditionalFqdns());
         }
 
         Server proxySystem = getOrCreateProxySystem(

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -149,9 +149,15 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
             }
         }
 
-        Optional<Server> existing = ServerFactory.findByAnyFqdn(fqdns);
-        if (existing.isPresent()) {
-            Server server = existing.get();
+        List<Server> matchingServers = ServerFactory.listByAnyFqdn(fqdns);
+        if (matchingServers.size() > 1) {
+            throw raiseAndLog(this, "One or more of the requested FQDNs is already " +
+                    "registered on another system. Conflicting Server IDs: " +
+                    matchingServers.stream().map(Server::getId).toList()).get();
+        }
+
+        if (!matchingServers.isEmpty()) {
+            Server server = matchingServers.get(0);
             if (!(server.hasEntitlement(EntitlementManager.FOREIGN) ||
                     server.hasEntitlement(EntitlementManager.SALT))) {
                 throw new SystemsExistException(List.of(server.getId()));
@@ -276,8 +282,10 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
         Server serverServer = ServerFactory.findByFqdn(serverFqdn)
                 .map(s -> {
                     if (!s.getOrg().getId().equals(user.getOrg().getId())) {
-                        throw raiseAndLog(this, "Could not find specified server named " + serverFqdn +
-                                " in the organization (server is registered in organization " + s.getOrg().getName() + " [ID " + s.getOrg().getId() + "]).").get();
+                        throw raiseAndLog(this, "Could not find specified server named " +
+                                serverFqdn + " in the organization (server is registered in " +
+                                "organization " + s.getOrg().getName() + " [ID " +
+                                s.getOrg().getId() + "]).").get();
                     }
                     return s;
                 })

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -282,8 +282,14 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
             return serverSshKey.getPublicKey();
         }
 
-        Server serverServer = ServerFactory.lookupProxiesByOrg(user).stream()
-                .filter(proxy -> serverFqdn.equals(proxy.getName())).findFirst()
+        Server serverServer = ServerFactory.findByFqdn(serverFqdn)
+                .map(s -> {
+                    if (!s.getOrg().getId().equals(user.getOrg().getId())) {
+                        throw raiseAndLog(this, "Could not find specified server named " + serverFqdn +
+                                " in the organization (server is registered in organization " + s.getOrg().getName() + " [ID " + s.getOrg().getId() + "]).").get();
+                    }
+                    return s;
+                })
                 .orElseThrow(raiseAndLog(this, "Could not find specified server named " + serverFqdn +
                         " in the organization."));
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.domain.server.ProxyInfo;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFQDN;
 import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerPath;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
@@ -115,7 +116,7 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
         Server proxySystem = getOrCreateProxySystem(
                 context.getSystemEntitlementManager(),
                 context.getUser(), context.getProxyFqdn(), fqdns, context.getProxyPort(),
-                context.getProxySshKey().getPublicKey()
+                context.getProxySshKey().getPublicKey(), context.getServerFqdn()
         );
         SystemManager.updateSystemOverview(proxySystem);
         try {
@@ -139,12 +140,24 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
      * @param proxyName                the FQDN of the proxy system
      * @param port                     the SSH port of the proxy system
      * @param sshPublicKey             the SSH public key of the proxy system
+     * @param parentFqdn               the parent FQDN of the proxy system
      * @return the proxy system
      */
     private Server getOrCreateProxySystem(
             SystemEntitlementManager systemEntitlementManager,
-            User creator, String proxyName, Set<String> fqdns, Integer port, String sshPublicKey
+            User creator, String proxyName, Set<String> fqdns, Integer port, String sshPublicKey,
+            String parentFqdn
     ) {
+        Optional<Server> parentProxy = Optional.empty();
+        boolean isMainServer = parentFqdn.equals(ConfigDefaults.get().getJavaHostname()) ||
+                parentFqdn.equals(Config.get().getString(ConfigDefaults.SERVER_HOSTNAME));
+        if (!isMainServer) {
+            parentProxy = ServerFactory.lookupProxyServer(parentFqdn);
+            if (parentProxy.isEmpty()) {
+                throw new RhnRuntimeException("Parent proxy " + parentFqdn + " does not exist.");
+            }
+        }
+
         Optional<Server> existing = ServerFactory.findByAnyFqdn(fqdns);
         if (existing.isPresent()) {
             Server server = existing.get();
@@ -152,6 +165,19 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
                     server.hasEntitlement(EntitlementManager.SALT))) {
                 throw new SystemsExistException(List.of(server.getId()));
             }
+
+            Optional<ServerPath> currentParentPath = server.getFirstServerPath();
+            if (currentParentPath.isPresent()) {
+                Server currentParentProxy = currentParentPath.get().getId().getProxyServer();
+                boolean isMatch = currentParentProxy.getHostname().equals(parentFqdn) ||
+                        currentParentProxy.lookupFqdn(parentFqdn).isPresent();
+                if (!isMatch) {
+                    throw new RhnRuntimeException("The proxy " + proxyName +
+                            " is already registered and connected via " +
+                            currentParentProxy.getHostname() + ", but the requested parent is " + parentFqdn + ".");
+                }
+            }
+
             // The SSH key is going to change remove it from the known hosts
             SystemManagerUtils.removeSaltSSHKnownHosts(saltApi, server);
             ProxyInfo info = server.getProxyInfo();
@@ -170,6 +196,15 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
                     .map(fqdn -> new ServerFQDN(server, fqdn)).collect(Collectors.toList()));
 
             systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.PROXY);
+
+            if (parentProxy.isPresent()) {
+                Set<ServerPath> paths = ServerFactory.createServerPaths(server, parentProxy.get(), parentFqdn);
+                server.getServerPaths().clear();
+                server.getServerPaths().addAll(paths);
+            }
+            else {
+                server.getServerPaths().clear();
+            }
 
             ServerFactory.save(server);
             return server;
@@ -195,6 +230,16 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
         server.setLastBoot(System.currentTimeMillis() / 1000);
         server.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
         server.updateServerInfo();
+
+        if (parentProxy.isPresent()) {
+            Set<ServerPath> paths = ServerFactory.createServerPaths(server, parentProxy.get(), parentFqdn);
+            server.getServerPaths().clear();
+            server.getServerPaths().addAll(paths);
+        }
+        else {
+            server.getServerPaths().clear();
+        }
+
         ServerFactory.save(server);
 
         ProxyInfo info = new ProxyInfo();

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -273,8 +273,14 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
             return serverSshKey.getPublicKey();
         }
 
-        Server serverServer = ServerFactory.lookupProxiesByOrg(user).stream()
-                .filter(proxy -> serverFqdn.equals(proxy.getName())).findFirst()
+        Server serverServer = ServerFactory.findByFqdn(serverFqdn)
+                .map(s -> {
+                    if (!s.getOrg().getId().equals(user.getOrg().getId())) {
+                        throw raiseAndLog(this, "Could not find specified server named " + serverFqdn +
+                                " in the organization (server is registered in organization " + s.getOrg().getName() + " [ID " + s.getOrg().getId() + "]).").get();
+                    }
+                    return s;
+                })
                 .orElseThrow(raiseAndLog(this, "Could not find specified server named " + serverFqdn +
                         " in the organization."));
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -198,6 +198,7 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
             }
 
             ServerFactory.save(server);
+            server.setPrimaryFQDNWithName(proxyName);
             return server;
         }
         Server server = ServerFactory.createServer();
@@ -243,6 +244,7 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
         // It will be called inside the method setBaseEntitlement. If we remove this line we need to manually call it
         systemEntitlementManager.setBaseEntitlement(server, EntitlementManager.FOREIGN);
         systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.PROXY);
+        server.setPrimaryFQDNWithName(proxyName);
         return server;
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -158,9 +158,15 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
             }
         }
 
-        Optional<Server> existing = ServerFactory.findByAnyFqdn(fqdns);
-        if (existing.isPresent()) {
-            Server server = existing.get();
+        List<Server> matchingServers = ServerFactory.listByAnyFqdn(fqdns);
+        if (matchingServers.size() > 1) {
+            throw raiseAndLog(this, "One or more of the requested FQDNs is already " +
+                    "registered on another system. Conflicting Server IDs: " +
+                    matchingServers.stream().map(Server::getId).toList()).get();
+        }
+
+        if (!matchingServers.isEmpty()) {
+            Server server = matchingServers.get(0);
             if (!(server.hasEntitlement(EntitlementManager.FOREIGN) ||
                     server.hasEntitlement(EntitlementManager.SALT))) {
                 throw new SystemsExistException(List.of(server.getId()));
@@ -285,8 +291,10 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
         Server serverServer = ServerFactory.findByFqdn(serverFqdn)
                 .map(s -> {
                     if (!s.getOrg().getId().equals(user.getOrg().getId())) {
-                        throw raiseAndLog(this, "Could not find specified server named " + serverFqdn +
-                                " in the organization (server is registered in organization " + s.getOrg().getName() + " [ID " + s.getOrg().getId() + "]).").get();
+                        throw raiseAndLog(this, "Could not find specified server named " +
+                                serverFqdn + " in the organization (server is registered in " +
+                                "organization " + s.getOrg().getName() + " [ID " +
+                                s.getOrg().getId() + "]).").get();
                     }
                     return s;
                 })

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.domain.server.ProxyInfo;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFQDN;
 import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerPath;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
@@ -106,7 +107,7 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
         Server proxySystem = getOrCreateProxySystem(
                 context.getSystemEntitlementManager(),
                 context.getUser(), context.getProxyFqdn(), fqdns, context.getProxyPort(),
-                context.getProxySshKey().getPublicKey()
+                context.getProxySshKey().getPublicKey(), context.getServerFqdn()
         );
         SystemManager.updateSystemOverview(proxySystem);
         try {
@@ -130,12 +131,24 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
      * @param proxyName                the FQDN of the proxy system
      * @param port                     the SSH port of the proxy system
      * @param sshPublicKey             the SSH public key of the proxy system
+     * @param parentFqdn               the parent FQDN of the proxy system
      * @return the proxy system
      */
     private Server getOrCreateProxySystem(
             SystemEntitlementManager systemEntitlementManager,
-            User creator, String proxyName, Set<String> fqdns, Integer port, String sshPublicKey
+            User creator, String proxyName, Set<String> fqdns, Integer port, String sshPublicKey,
+            String parentFqdn
     ) {
+        Optional<Server> parentProxy = Optional.empty();
+        boolean isMainServer = parentFqdn.equals(ConfigDefaults.get().getJavaHostname()) ||
+                parentFqdn.equals(Config.get().getString(ConfigDefaults.SERVER_HOSTNAME));
+        if (!isMainServer) {
+            parentProxy = ServerFactory.lookupProxyServer(parentFqdn);
+            if (parentProxy.isEmpty()) {
+                throw new RhnRuntimeException("Parent proxy " + parentFqdn + " does not exist.");
+            }
+        }
+
         Optional<Server> existing = ServerFactory.findByAnyFqdn(fqdns);
         if (existing.isPresent()) {
             Server server = existing.get();
@@ -143,6 +156,19 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
                     server.hasEntitlement(EntitlementManager.SALT))) {
                 throw new SystemsExistException(List.of(server.getId()));
             }
+
+            Optional<ServerPath> currentParentPath = server.getFirstServerPath();
+            if (currentParentPath.isPresent()) {
+                Server currentParentProxy = currentParentPath.get().getId().getProxyServer();
+                boolean isMatch = currentParentProxy.getHostname().equals(parentFqdn) ||
+                        currentParentProxy.lookupFqdn(parentFqdn).isPresent();
+                if (!isMatch) {
+                    throw new RhnRuntimeException("The proxy " + proxyName +
+                            " is already registered and connected via " +
+                            currentParentProxy.getHostname() + ", but the requested parent is " + parentFqdn + ".");
+                }
+            }
+
             // The SSH key is going to change remove it from the known hosts
             SystemManagerUtils.removeSaltSSHKnownHosts(saltApi, server);
             ProxyInfo info = server.getProxyInfo();
@@ -161,6 +187,15 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
                     .map(fqdn -> new ServerFQDN(server, fqdn)).collect(Collectors.toList()));
 
             systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.PROXY);
+
+            if (parentProxy.isPresent()) {
+                Set<ServerPath> paths = ServerFactory.createServerPaths(server, parentProxy.get(), parentFqdn);
+                server.getServerPaths().clear();
+                server.getServerPaths().addAll(paths);
+            }
+            else {
+                server.getServerPaths().clear();
+            }
 
             ServerFactory.save(server);
             return server;
@@ -186,6 +221,16 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
         server.setLastBoot(System.currentTimeMillis() / 1000);
         server.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
         server.updateServerInfo();
+
+        if (parentProxy.isPresent()) {
+            Set<ServerPath> paths = ServerFactory.createServerPaths(server, parentProxy.get(), parentFqdn);
+            server.getServerPaths().clear();
+            server.getServerPaths().addAll(paths);
+        }
+        else {
+            server.getServerPaths().clear();
+        }
+
         ServerFactory.save(server);
 
         ProxyInfo info = new ProxyInfo();

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -22,6 +22,7 @@ import static com.suse.utils.Predicates.isAbsent;
 import com.redhat.rhn.common.RhnRuntimeException;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.ProxyInfo;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFQDN;
@@ -184,6 +185,13 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
             }
             info.setSshPort(port);
             info.setSshPublicKey(sshPublicKey.getBytes());
+
+            // For a foreign proxy, clear existing FQDNs before adding the newly specified ones.
+            // For standard Salt minion proxies (represented by MinionServer), we do not delete
+            // anything here because FQDNs are managed primarily by NetworkMapper during grains sync.
+            if (!(server instanceof MinionServer)) {
+                server.getFqdns().clear();
+            }
 
             // Add the FQDNs as some may not be already known
             server.getFqdns().addAll(fqdns.stream()

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateContext.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateContext.java
@@ -50,6 +50,7 @@ public class ProxyContainerConfigCreateContext {
     private final String caPassword;
     private final SSLCertData certData;
     private final SSLCertManager certManager;
+    private final List<String> additionalFqdns;
 
     // computed
     private MgrUtilRunner.SshKeygenResult proxySshKey;
@@ -69,7 +70,8 @@ public class ProxyContainerConfigCreateContext {
             SaltApi saltApiIn, User userIn, SystemEntitlementManager systemEntitlementManagerIn, String serverFqdnIn,
             String proxyFqdnIn, Integer proxyPortIn, Long maxCacheIn, String emailIn, String rootCAIn,
             List<String> intermediateCAsIn, SSLCertPair proxyCertKeyIn, SSLCertPair caPairIn, String caPasswordIn,
-            SSLCertData certDataIn, SSLCertManager certManagerIn, String sshPubIn, String sshPrivIn, String sshParentIn
+            SSLCertData certDataIn, SSLCertManager certManagerIn, String sshPubIn, String sshPrivIn, String sshParentIn,
+            List<String> additionalFqdnsIn
     ) {
         saltApi = saltApiIn;
         user = userIn;
@@ -87,9 +89,14 @@ public class ProxyContainerConfigCreateContext {
         certData = certDataIn;
         certManager = certManagerIn;
         serverSshPublicKey = sshParentIn;
+        additionalFqdns = additionalFqdnsIn != null ? additionalFqdnsIn : List.of();
         if (sshPubIn != null && sshPrivIn != null) {
             proxySshKey = new MgrUtilRunner.SshKeygenResult(sshPrivIn, sshPubIn);
         }
+    }
+
+    public List<String> getAdditionalFqdns() {
+        return additionalFqdns;
     }
 
     public SaltApi getSaltApi() {

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateFacade.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateFacade.java
@@ -49,13 +49,15 @@ public interface ProxyContainerConfigCreateFacade {
      * @param certData                 the data needed to generate the new proxy SSL certificate.
      *                                 Can be omitted if proxyCertKey is not provided
      * @param certManager              the SSLCertManager to use
+     * @param additionalFqdns          the additional FQDNs for the proxy
      * @return the tarball configuration file as a byte array
      */
     byte[] create(
             SaltApi saltApi, SystemEntitlementManager systemEntitlementManager, User user,
             String serverFqdn, String proxyFqdn, Integer proxyPort, Long maxCache, String email,
             String rootCA, List<String> intermediateCAs, SSLCertPair proxyCertKey,
-            SSLCertPair caPair, String caPassword, SSLCertData certData, SSLCertManager certManager
+            SSLCertPair caPair, String caPassword, SSLCertData certData, SSLCertManager certManager,
+            List<String> additionalFqdns
     );
 
     /**
@@ -82,6 +84,7 @@ public interface ProxyContainerConfigCreateFacade {
      * @param sshPub                   the proxy SSH public key if known
      * @param sshPriv                  the proxy SSH private key if known
      * @param sshParent                the parent SSH public key if known
+     * @param additionalFqdns          the additional FQDNs for the proxy
      * @return the configuration files as a map
      */
     Map<String, Object> createFiles(
@@ -89,7 +92,7 @@ public interface ProxyContainerConfigCreateFacade {
             String serverFqdn, String proxyFqdn, Integer proxyPort, Long maxCache, String email,
             String rootCA, List<String> intermediateCAs, SSLCertPair proxyCertKey,
             SSLCertPair caPair, String caPassword, SSLCertData certData, SSLCertManager certManager,
-            String sshPub, String sshPriv, String sshParent
+            String sshPub, String sshPriv, String sshParent, List<String> additionalFqdns
     );
 
 }

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateFacadeImpl.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateFacadeImpl.java
@@ -78,6 +78,7 @@ public class ProxyContainerConfigCreateFacadeImpl implements ProxyContainerConfi
      * @param certData                 the data needed to generate the new proxy SSL certificate.
      *                                 Can be omitted if proxyCertKey is not provided
      * @param certManager              the SSLCertManager to use
+     * @param additionalFqdns          the additional FQDNs for the proxy
      * @return the tarball configuration file as a byte array
      */
     @Override
@@ -85,11 +86,13 @@ public class ProxyContainerConfigCreateFacadeImpl implements ProxyContainerConfi
             SaltApi saltApi, SystemEntitlementManager systemEntitlementManager, User user,
             String serverFqdn, String proxyFqdn, Integer proxyPort, Long maxCache, String email,
             String rootCA, List<String> intermediateCAs, SSLCertPair proxyCertKey,
-            SSLCertPair caPair, String caPassword, SSLCertData certData, SSLCertManager certManager
+            SSLCertPair caPair, String caPassword, SSLCertData certData, SSLCertManager certManager,
+            List<String> additionalFqdns
     ) {
         ProxyContainerConfigCreateContext context = new ProxyContainerConfigCreateContext(
                 saltApi, user, systemEntitlementManager, serverFqdn, proxyFqdn, proxyPort, maxCache, email, rootCA,
-                intermediateCAs, proxyCertKey, caPair, caPassword, certData, certManager, null, null, null
+                intermediateCAs, proxyCertKey, caPair, caPassword, certData, certManager, null, null, null,
+                additionalFqdns
         );
         for (ProxyContainerConfigCreateContextHandler handler : contextHandlerChain) {
             handler.handle(context);
@@ -121,6 +124,7 @@ public class ProxyContainerConfigCreateFacadeImpl implements ProxyContainerConfi
      * @param sshPub                   the proxy SSH public key if known
      * @param sshPriv                  the proxy SSH private key if known
      * @param sshParent                the parent SSH public key if known
+     * @param additionalFqdns          the additional FQDNs for the proxy
      * @return the configuration files as a map
      */
     @Override
@@ -129,11 +133,12 @@ public class ProxyContainerConfigCreateFacadeImpl implements ProxyContainerConfi
             String serverFqdn, String proxyFqdn, Integer proxyPort, Long maxCache, String email,
             String rootCA, List<String> intermediateCAs, SSLCertPair proxyCertKey,
             SSLCertPair caPair, String caPassword, SSLCertData certData, SSLCertManager certManager,
-            String sshPub, String sshPriv, String sshParent
+            String sshPub, String sshPriv, String sshParent, List<String> additionalFqdns
     ) {
         ProxyContainerConfigCreateContext context = new ProxyContainerConfigCreateContext(
                 saltApi, user, systemEntitlementManager, serverFqdn, proxyFqdn, proxyPort, maxCache, email, rootCA,
-                intermediateCAs, proxyCertKey, caPair, caPassword, certData, certManager, sshPub, sshPriv, sshParent
+                intermediateCAs, proxyCertKey, caPair, caPassword, certData, certManager, sshPub, sshPriv, sshParent,
+                additionalFqdns
         );
 
         for (ProxyContainerConfigCreateContextHandler handler : contextHandlerChain) {

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateGenerateFileMaps.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateGenerateFileMaps.java
@@ -34,6 +34,7 @@ public class ProxyContainerConfigCreateGenerateFileMaps implements ProxyContaine
         context.getConfigMap().put("email", context.getEmail());
         context.getConfigMap().put("server_version", ConfigDefaults.get().getProductVersion());
         context.getConfigMap().put("proxy_fqdn", context.getProxyFqdn());
+        context.getConfigMap().put("additional_fqdns", context.getAdditionalFqdns());
         if (context.getRootCaCert() != null) {
             context.getConfigMap().put("ca_crt", context.getRootCaCert());
         }

--- a/java/core/src/main/java/com/suse/manager/reactor/hardware/network/NetworkMapper.java
+++ b/java/core/src/main/java/com/suse/manager/reactor/hardware/network/NetworkMapper.java
@@ -140,6 +140,13 @@ public class NetworkMapper {
                 .toList();
         serverFQDNs.retainAll(srvFqdnsObj);
         serverFQDNs.addAll(srvFqdnsObj);
+
+        if (serverFQDNs.stream().noneMatch(ServerFQDN::isPrimary)) {
+            String minionId = serverIn.getMinionId();
+            if (fqdns.contains(minionId)) {
+                serverIn.setPrimaryFQDNWithName(minionId);
+            }
+        }
     }
 
     /**
@@ -167,7 +174,7 @@ public class NetworkMapper {
 
         // Update interface properties
         networkInterface.setHwaddr(saltInterface.getHWAddr());
-        networkInterface.setModule(netModules.get(name).orElse(null));
+        networkInterface.setModule(netModules.getOrDefault(name, Optional.empty()).orElse(null));
 
         // Persist to get ID for IP address syncing
         networkInterface = ServerFactory.saveNetworkInterface(networkInterface);

--- a/java/core/src/main/java/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/core/src/main/java/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -599,7 +599,20 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             ServerFactory.save(minion);
 
             if (isSaltSSH) {
-                minion.updateServerPaths(saltSSHProxyId);
+                Optional<String> customProxyFqdn = MinionPendingRegistrationService.get(minionId)
+                        .flatMap(MinionPendingRegistrationService.PendingMinion::getProxyFqdn);
+                if (customProxyFqdn.isPresent()) {
+                    LOG.debug("RegisterMinionEventMessageAction: updating server path for minion {} " +
+                                    "with custom proxy FQDN {}",
+                            minionId, customProxyFqdn.get());
+                    minion.updateServerPaths(customProxyFqdn.get());
+                }
+                else {
+                    LOG.debug("RegisterMinionEventMessageAction: updating server path for minion {} " +
+                                    "with saltSSHProxyId: {}",
+                            minionId, saltSSHProxyId);
+                    minion.updateServerPaths(saltSSHProxyId);
+                }
                 minion.setSSHPushPort(sshPort.orElse(SaltSSHService.SSH_PUSH_PORT));
             }
             else {

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/MinionController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/MinionController.java
@@ -521,17 +521,8 @@ public class MinionController {
                             .collect(Collectors.toList());
                     entry.put("path", path);
 
-                    String primaryFqdn = java.util.Optional.ofNullable(proxy.findPrimaryFqdn())
-                            .map(com.redhat.rhn.domain.server.ServerFQDN::getName)
-                            .orElseGet(proxy::getHostname);
-                    entry.put("primaryFqdn", primaryFqdn);
-
-                    List<String> additional = proxy.getFqdns().stream()
-                            .map(com.redhat.rhn.domain.server.ServerFQDN::getName)
-                            .filter(name -> !name.equals(primaryFqdn))
-                            .sorted()
-                            .toList();
-                    entry.put("additionalFqdns", additional);
+                    entry.put("primaryFqdn", proxy.getPrimaryFqdnName());
+                    entry.put("additionalFqdns", proxy.getAdditionalFqdnNames());
 
                     return entry; })
                 .collect(Collectors.toList());

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/MinionController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/MinionController.java
@@ -520,6 +520,19 @@ public class MinionController {
                             .map(ServerPath::getHostname)
                             .collect(Collectors.toList());
                     entry.put("path", path);
+
+                    String primaryFqdn = java.util.Optional.ofNullable(proxy.findPrimaryFqdn())
+                            .map(com.redhat.rhn.domain.server.ServerFQDN::getName)
+                            .orElseGet(proxy::getHostname);
+                    entry.put("primaryFqdn", primaryFqdn);
+
+                    List<String> additional = proxy.getFqdns().stream()
+                            .map(com.redhat.rhn.domain.server.ServerFQDN::getName)
+                            .filter(name -> !name.equals(primaryFqdn))
+                            .sorted()
+                            .toList();
+                    entry.put("additionalFqdns", additional);
+
                     return entry; })
                 .collect(Collectors.toList());
         model.put("proxies", Json.GSON.toJson(proxies));

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/MinionsAPI.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/MinionsAPI.java
@@ -402,7 +402,7 @@ public class MinionsAPI {
 
         try {
              Map<String, Object> data = new TreeMap<>();
-             List<Long> actions = ActionManager.changeProxy(user, rq.getIds(), rq.getProxy());
+             List<Long> actions = ActionManager.changeProxy(user, rq.getIds(), rq.getProxy(), rq.getProxyFqdn());
              if (actions.isEmpty()) {
                  throw new IllegalStateException("No action in schedule result");
              }

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/ProxyController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/ProxyController.java
@@ -47,11 +47,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 import spark.ModelAndView;
 import spark.Request;
@@ -62,6 +63,29 @@ import spark.template.jade.JadeTemplateEngine;
  * Controller class providing backend code for proxy specific pages.
  */
 public class ProxyController {
+
+    private static class ParentRepresentation implements Comparable<ParentRepresentation> {
+        private final String primaryFqdn;
+        private final List<String> additionalFqdns;
+
+        ParentRepresentation(String primaryFqdnIn, List<String> additionalFqdnsIn) {
+            this.primaryFqdn = primaryFqdnIn;
+            this.additionalFqdns = additionalFqdnsIn;
+        }
+
+        String getPrimaryFqdn() {
+            return primaryFqdn;
+        }
+
+        List<String> getAdditionalFqdns() {
+            return additionalFqdns;
+        }
+
+        @Override
+        public int compareTo(ParentRepresentation o) {
+            return this.primaryFqdn.compareTo(o.primaryFqdn);
+        }
+    }
 
     private final SystemManager systemManager;
 
@@ -109,20 +133,45 @@ public class ProxyController {
 
         String localManagerFqdn = Config.get().getString(ConfigDefaults.SERVER_HOSTNAME);
         List<Server> proxies = ServerFactory.lookupProxiesByOrg(userIn);
-        Set<String> electableParents = proxies.stream()
-                .flatMap(s -> s.getFqdns().stream())
-                .map(ServerFQDN::getName)
-                .collect(Collectors.toSet());
 
+        List<ParentRepresentation> parentReps = new ArrayList<>();
         if (localManagerFqdn != null && !localManagerFqdn.isEmpty()) {
-            electableParents.add(localManagerFqdn);
+            parentReps.add(new ParentRepresentation(localManagerFqdn, Collections.emptyList()));
         }
         else {
             LOG.error("Could not determine the Server FQDN. Skipping it as a parent.");
         }
 
-        List<String> sortedParents = electableParents.stream().sorted().toList();
-        data.put("parents", GSON.toJson(sortedParents));
+        for (Server proxy : proxies) {
+            String primaryFqdn = Optional.ofNullable(proxy.findPrimaryFqdn())
+                    .map(ServerFQDN::getName)
+                    .orElseGet(proxy::getHostname);
+            List<String> additional = proxy.getFqdns().stream()
+                    .map(ServerFQDN::getName)
+                    .filter(name -> !name.equals(primaryFqdn))
+                    .sorted()
+                    .toList();
+            parentReps.add(new ParentRepresentation(primaryFqdn, additional));
+        }
+
+        Collections.sort(parentReps);
+
+        List<Map<String, String>> parentOptions = new ArrayList<>();
+        for (ParentRepresentation rep : parentReps) {
+            Map<String, String> primaryOpt = new HashMap<>();
+            primaryOpt.put("value", rep.getPrimaryFqdn());
+            primaryOpt.put("label", rep.getPrimaryFqdn());
+            parentOptions.add(primaryOpt);
+
+            for (String addFqdn : rep.getAdditionalFqdns()) {
+                Map<String, String> addOpt = new HashMap<>();
+                addOpt.put("value", addFqdn);
+                addOpt.put("label", "\u00A0\u00A0\u00A0\u00A0" + addFqdn);
+                parentOptions.add(addOpt);
+            }
+        }
+
+        data.put("parents", GSON.toJson(parentOptions));
 
         return new ModelAndView(data, "templates/proxy/container-config.jade");
     }

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/ProxyController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/ProxyController.java
@@ -121,7 +121,8 @@ public class ProxyController {
             byte[] config = systemManager.createProxyContainerConfig(user, data.getProxyFqdn(),
                     data.getProxyPort(), data.getServerFqdn(), data.getMaxCache(), data.getEmail(),
                     data.getRootCA(), data.getIntermediateCAs(), data.getProxyCertPair(),
-                    data.getCaPair(), data.getCaPassword(), data.getCertData(), new SSLCertManager());
+                    data.getCaPair(), data.getCaPassword(), data.getCertData(), new SSLCertManager(),
+                    data.getAdditionalFqdns());
             String filename = data.getProxyFqdn().split("\\.")[0];
             request.session().attribute(filename + "-config.tar.gz", config);
 

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/ProxyController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/ProxyController.java
@@ -24,7 +24,11 @@ import static spark.Spark.get;
 import static spark.Spark.post;
 
 import com.redhat.rhn.common.RhnRuntimeException;
+import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFQDN;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.SystemsExistException;
@@ -44,7 +48,10 @@ import org.apache.logging.log4j.Logger;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import spark.ModelAndView;
 import spark.Request;
@@ -99,6 +106,24 @@ public class ProxyController {
     public ModelAndView containerConfig(Request requestIn, Response responseIn, User userIn) {
         Map<String, Object> data = new HashMap<>();
         data.put("noSSL", !ConfigDefaults.get().isSsl());
+
+        String localManagerFqdn = Config.get().getString(ConfigDefaults.SERVER_HOSTNAME);
+        List<Server> proxies = ServerFactory.lookupProxiesByOrg(userIn);
+        Set<String> electableParents = proxies.stream()
+                .flatMap(s -> s.getFqdns().stream())
+                .map(ServerFQDN::getName)
+                .collect(Collectors.toSet());
+
+        if (localManagerFqdn != null && !localManagerFqdn.isEmpty()) {
+            electableParents.add(localManagerFqdn);
+        }
+        else {
+            LOG.error("Could not determine the Server FQDN. Skipping it as a parent.");
+        }
+
+        List<String> sortedParents = electableParents.stream().sorted().toList();
+        data.put("parents", GSON.toJson(sortedParents));
+
         return new ModelAndView(data, "templates/proxy/container-config.jade");
     }
 

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/ProxyController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/ProxyController.java
@@ -27,7 +27,6 @@ import com.redhat.rhn.common.RhnRuntimeException;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.server.Server;
-import com.redhat.rhn.domain.server.ServerFQDN;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.system.SystemManager;
@@ -52,7 +51,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import spark.ModelAndView;
 import spark.Request;
@@ -84,6 +82,23 @@ public class ProxyController {
         @Override
         public int compareTo(ParentRepresentation o) {
             return this.primaryFqdn.compareTo(o.primaryFqdn);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            ParentRepresentation other = (ParentRepresentation) obj;
+            return java.util.Objects.equals(this.primaryFqdn, other.primaryFqdn);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(primaryFqdn);
         }
     }
 
@@ -143,15 +158,7 @@ public class ProxyController {
         }
 
         for (Server proxy : proxies) {
-            String primaryFqdn = Optional.ofNullable(proxy.findPrimaryFqdn())
-                    .map(ServerFQDN::getName)
-                    .orElseGet(proxy::getHostname);
-            List<String> additional = proxy.getFqdns().stream()
-                    .map(ServerFQDN::getName)
-                    .filter(name -> !name.equals(primaryFqdn))
-                    .sorted()
-                    .toList();
-            parentReps.add(new ParentRepresentation(primaryFqdn, additional));
+            parentReps.add(new ParentRepresentation(proxy.getPrimaryFqdnName(), proxy.getAdditionalFqdnNames()));
         }
 
         Collections.sort(parentReps);

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
@@ -318,10 +318,11 @@ public abstract class AbstractMinionBootstrapper {
     protected Map<String, Object> createPillarData(User user, BootstrapParameters input,
                                                    String contactMethod) {
         Map<String, Object> pillarData = new HashMap<>();
-        String mgrServer = input.getProxyId()
-                .map(ServerFactory::lookupById)
-                .map(Server::getHostname)
-                .orElse(ConfigDefaults.get().getJavaHostname());
+        String mgrServer = input.getProxyFqdn()
+                .orElseGet(() -> input.getProxyId()
+                        .map(ServerFactory::lookupById)
+                        .map(Server::getHostname)
+                        .orElse(ConfigDefaults.get().getJavaHostname()));
 
         pillarData.put("mgr_server", mgrServer);
         if ("ssh-push-tunnel".equals(contactMethod)) {

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/bootstrap/SSHMinionBootstrapper.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/bootstrap/SSHMinionBootstrapper.java
@@ -111,7 +111,8 @@ public class SSHMinionBootstrapper extends AbstractMinionBootstrapper {
                         minionId,
                         result.getContactMethod().orElse(defaultContactMethod),
                         proxyPath,
-                        params.getPort().orElse(SSH_PUSH_PORT)
+                        params.getPort().orElse(SSH_PUSH_PORT),
+                        params.getProxyFqdn().orElse(null)
                 );
 
                 getRegisterAction().registerSSHMinion(minionId, params.getPort().orElse(SSH_PUSH_PORT),

--- a/java/core/src/main/java/com/suse/manager/webui/services/impl/MinionPendingRegistrationService.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/impl/MinionPendingRegistrationService.java
@@ -41,13 +41,14 @@ public class MinionPendingRegistrationService {
         private final User creator;
         private final List<String> proxyPath;
         private final Integer sshPushPort;
+        private final String proxyFqdn;
 
         /**
          * @param creatorIn user who accepted the key or bootstrapped the system
          * @param contactMethodIn the contact method
          */
         public PendingMinion(User creatorIn, String contactMethodIn) {
-            this(creatorIn, contactMethodIn, Collections.emptyList(), null);
+            this(creatorIn, contactMethodIn, Collections.emptyList(), null, null);
         }
 
         /**
@@ -57,10 +58,23 @@ public class MinionPendingRegistrationService {
          * @param portIn the ssh port
          */
         public PendingMinion(User creatorIn, String contactMethodIn, List<String> proxyPathIn, Integer portIn) {
+            this(creatorIn, contactMethodIn, proxyPathIn, portIn, null);
+        }
+
+        /**
+         * @param creatorIn user who accepted the key or bootstrapped the system
+         * @param contactMethodIn the contact method
+         * @param proxyPathIn the proxy path
+         * @param portIn the ssh port
+         * @param proxyFqdnIn the proxy custom FQDN
+         */
+        public PendingMinion(User creatorIn, String contactMethodIn,
+                List<String> proxyPathIn, Integer portIn, String proxyFqdnIn) {
             this.contactMethod = contactMethodIn;
             this.creator = creatorIn;
             this.proxyPath = proxyPathIn;
             this.sshPushPort = portIn;
+            this.proxyFqdn = proxyFqdnIn;
         }
 
         /**
@@ -89,6 +103,13 @@ public class MinionPendingRegistrationService {
          */
         public Optional<Integer> getSSHPushPort() {
             return Optional.ofNullable(sshPushPort);
+        }
+
+        /**
+         * @return an optional wrapping the proxy custom FQDN or empty if not supported.
+         */
+        public Optional<String> getProxyFqdn() {
+            return Optional.ofNullable(proxyFqdn);
         }
     }
 
@@ -122,6 +143,20 @@ public class MinionPendingRegistrationService {
     public static void addMinion(User creator, String minionId, String contactMethod, List<String> proxyPath,
                                  Integer sshPort) {
         minionIds.put(minionId, new PendingMinion(creator, contactMethod, proxyPath, sshPort));
+    }
+
+    /**
+     * Adds minion id to the database.
+     * @param creator user who accepted the key or bootstrapped the system
+     * @param minionId minion id to be added
+     * @param contactMethod the contact method of the minion
+     * @param proxyPath list of proxies hostnames in the order they connect through
+     * @param sshPort the ssh port for ssh only minions
+     * @param proxyFqdn the proxy custom FQDN
+     */
+    public static void addMinion(User creator, String minionId, String contactMethod, List<String> proxyPath,
+                                 Integer sshPort, String proxyFqdn) {
+        minionIds.put(minionId, new PendingMinion(creator, contactMethod, proxyPath, sshPort, proxyFqdn));
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -293,9 +293,7 @@ public class SaltSSHService {
                 MinionServerFactory.findByMinionId(mid).ifPresentOrElse(minion -> {
                     List<String> proxyPath = proxyPathToHostnames(minion.getServerPaths(), Optional.empty());
                     String contactMethodLabel = minion.getContactMethod().getLabel();
-                    String host = Optional.ofNullable(minion.findPrimaryFqdn())
-                            .map(ServerFQDN::getName)
-                            .orElse(minion.getMinionId());
+                    String host = minion.getPrimaryFqdnName();
 
                     roster.addHost(mid, host, getSSHUser(), Optional.empty(),
                             Opt.wrapFirstNonNull(minion.getSSHPushPort(), SSH_PUSH_PORT),
@@ -398,10 +396,7 @@ public class SaltSSHService {
                 .map(ProxyInfo::getSshPort)
                 .map(p -> ":" + p)
                 .orElse("");
-        String proxyHostname = Optional.ofNullable(proxy.findPrimaryFqdn())
-                .map(ServerFQDN::getName)
-                .orElse(proxy.getHostname());
-        return proxyPathToHostnames(proxy.getServerPaths(), Optional.of(proxyHostname + port));
+        return proxyPathToHostnames(proxy.getServerPaths(), Optional.of(proxy.getPrimaryFqdnName() + port));
     }
 
     /**
@@ -500,9 +495,7 @@ public class SaltSSHService {
         List<MinionServer> minions = MinionServerFactory.listSSHMinions();
         minions.forEach(minion -> {
             List<String> proxyPath = proxyPathToHostnames(minion.getServerPaths(), Optional.empty());
-            String host = Optional.ofNullable(minion.findPrimaryFqdn())
-                    .map(ServerFQDN::getName)
-                    .orElse(minion.getMinionId());
+            String host = minion.getPrimaryFqdnName();
             roster.addHost(minion.getMinionId(),
                     host,
                     getSSHUser(),
@@ -1069,9 +1062,7 @@ public class SaltSSHService {
         if (server == null || server.getServerPaths().isEmpty()) {
             return true;
         }
-        String hostname = Optional.ofNullable(server.findPrimaryFqdn())
-                .map(ServerFQDN::getName)
-                .orElse(server.getHostname());
+        String hostname = server.getPrimaryFqdnName();
         List<ServerPath> paths = sortServerPaths(server.getServerPaths());
         ServerPath last = paths.get(paths.size() - 1);
         Server proxy = last.getId().getProxyServer();

--- a/java/core/src/main/java/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.MinionSummary;
 import com.redhat.rhn.domain.server.ProxyInfo;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFQDN;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerPath;
 import com.redhat.rhn.domain.server.ServerPathId;
@@ -292,13 +293,16 @@ public class SaltSSHService {
                 MinionServerFactory.findByMinionId(mid).ifPresentOrElse(minion -> {
                     List<String> proxyPath = proxyPathToHostnames(minion.getServerPaths(), Optional.empty());
                     String contactMethodLabel = minion.getContactMethod().getLabel();
+                    String host = Optional.ofNullable(minion.findPrimaryFqdn())
+                            .map(ServerFQDN::getName)
+                            .orElse(minion.getMinionId());
 
-                    roster.addHost(mid, getSSHUser(), Optional.empty(),
+                    roster.addHost(mid, host, getSSHUser(), Optional.empty(),
                             Opt.wrapFirstNonNull(minion.getSSHPushPort(), SSH_PUSH_PORT),
                             remotePortForwarding(proxyPath, contactMethodLabel),
                             sshProxyCommandOption(proxyPath,
                                 contactMethodLabel,
-                                minion.getMinionId(),
+                                host,
                                 Optional.ofNullable(minion.getSSHPushPort()).orElse(SSH_PUSH_PORT)),
                             sshTimeout,
                             minionOpts(mid, contactMethodLabel)
@@ -394,7 +398,10 @@ public class SaltSSHService {
                 .map(ProxyInfo::getSshPort)
                 .map(p -> ":" + p)
                 .orElse("");
-        return proxyPathToHostnames(proxy.getServerPaths(), Optional.of(proxy.getHostname() + port));
+        String proxyHostname = Optional.ofNullable(proxy.findPrimaryFqdn())
+                .map(ServerFQDN::getName)
+                .orElse(proxy.getHostname());
+        return proxyPathToHostnames(proxy.getServerPaths(), Optional.of(proxyHostname + port));
     }
 
     /**
@@ -423,7 +430,11 @@ public class SaltSSHService {
                     if (port.isEmpty()) {
                         LOG.warn("Unable to identify port for proxy path {}. Using default.", path);
                     }
-                    return path.getHostname() + port;
+                    String proxyHostname = Optional.ofNullable(path.getId().getProxyServer())
+                            .map(Server::findPrimaryFqdn)
+                            .map(ServerFQDN::getName)
+                            .orElse(path.getHostname());
+                    return proxyHostname + port;
                 }).collect(Collectors.toList());
 
         lastProxy.ifPresent(hostnamePath::add);
@@ -489,14 +500,18 @@ public class SaltSSHService {
         List<MinionServer> minions = MinionServerFactory.listSSHMinions();
         minions.forEach(minion -> {
             List<String> proxyPath = proxyPathToHostnames(minion.getServerPaths(), Optional.empty());
+            String host = Optional.ofNullable(minion.findPrimaryFqdn())
+                    .map(ServerFQDN::getName)
+                    .orElse(minion.getMinionId());
             roster.addHost(minion.getMinionId(),
+                    host,
                     getSSHUser(),
                     Optional.empty(),
                     Opt.wrapFirstNonNull(minion.getSSHPushPort(), SSH_PUSH_PORT),
                     remotePortForwarding(proxyPath, minion.getContactMethod().getLabel()),
                     sshProxyCommandOption(proxyPath,
                         minion.getContactMethod().getLabel(),
-                        minion.getMinionId(),
+                        host,
                         Optional.ofNullable(minion.getSSHPushPort()).orElse(SSH_PUSH_PORT)),
                     getSshPushTimeout(),
                     minionOpts(minion.getMinionId(), minion.getContactMethod().getLabel()));
@@ -1054,7 +1069,9 @@ public class SaltSSHService {
         if (server == null || server.getServerPaths().isEmpty()) {
             return true;
         }
-        String hostname = server.getHostname();
+        String hostname = Optional.ofNullable(server.findPrimaryFqdn())
+                .map(ServerFQDN::getName)
+                .orElse(server.getHostname());
         List<ServerPath> paths = sortServerPaths(server.getServerPaths());
         ServerPath last = paths.get(paths.size() - 1);
         Server proxy = last.getId().getProxyServer();

--- a/java/core/src/main/java/com/suse/manager/webui/utils/SaltRoster.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/SaltRoster.java
@@ -41,6 +41,7 @@ public class SaltRoster {
     /**
      * Add host data to this roster.
      *
+     * @param minionId The minion ID/key in the roster
      * @param host The IP address or DNS name of the remote host
      * @param user The user to login as
      * @param passwd The password to login with
@@ -54,7 +55,7 @@ public class SaltRoster {
      * @param sshPreflightScriptPath The path to salt-ssh pre flight script
      * @param sshPreflightScriptArgs The list of arguments for salt-ssh pre flight script
      */
-    public void addHost(String host, String user, Optional<String> passwd,
+    public void addHost(String minionId, String host, String user, Optional<String> passwd,
             Optional<String> privKeyPath, Optional<String> privKeyPasswd,
             Optional<Integer> port, Optional<String> remotePortForwarding,
             Optional<List<String>> sshOption, Optional<Integer> timeout,
@@ -78,7 +79,55 @@ public class SaltRoster {
         if (sshPreflightScriptPath.isPresent()) {
             sshPreflightScriptArgs.ifPresent(value -> hostData.put("ssh_pre_flight_args", value));
         }
-        data.put(host, hostData);
+        data.put(minionId, hostData);
+    }
+
+    /**
+     * Add host data to this roster.
+     *
+     * @param host The IP address or DNS name of the remote host
+     * @param user The user to login as
+     * @param passwd The password to login with
+     * @param privKeyPath SSH private key absolute file path
+     * @param privKeyPasswd SSH private key passphrase
+     * @param port The target system's ssh port number
+     * @param remotePortForwarding SSH tunneling options
+     * @param sshOption Additional SSH option to pass to salt-ssh
+     * @param timeout SSH connect timeout
+     * @param minionOpts Minion configuration parameters
+     * @param sshPreflightScriptPath The path to salt-ssh pre flight script
+     * @param sshPreflightScriptArgs The list of arguments for salt-ssh pre flight script
+     */
+    public void addHost(String host, String user, Optional<String> passwd,
+            Optional<String> privKeyPath, Optional<String> privKeyPasswd,
+            Optional<Integer> port, Optional<String> remotePortForwarding,
+            Optional<List<String>> sshOption, Optional<Integer> timeout,
+            Optional<Map<String, Object>> minionOpts,
+            Optional<String> sshPreflightScriptPath,
+            Optional<List<Object>> sshPreflightScriptArgs) {
+        addHost(host, host, user, passwd, privKeyPath, privKeyPasswd, port, remotePortForwarding, sshOption, timeout,
+                minionOpts, sshPreflightScriptPath, sshPreflightScriptArgs);
+    }
+
+    /**
+     * Add host data to this roster.
+     *
+     * @param minionId The minion ID/key in the roster
+     * @param host The IP address or DNS name of the remote host
+     * @param user The user to login as
+     * @param passwd The password to login with
+     * @param port The target system's ssh port number
+     * @param remotePortForwarding SSH tunneling options
+     * @param sshOption Additional SSH option to pass to salt-ssh
+     * @param timeout SSH connect timeout
+     * @param minionOpts Minion configuration parameters
+     */
+    public void addHost(String minionId, String host, String user, Optional<String> passwd,
+            Optional<Integer> port, Optional<String> remotePortForwarding,
+            Optional<List<String>> sshOption, Optional<Integer> timeout,
+            Optional<Map<String, Object>> minionOpts) {
+        addHost(minionId, host, user, passwd, Optional.empty(), Optional.empty(), port, remotePortForwarding,
+                sshOption, timeout, minionOpts, Optional.empty(), Optional.empty());
     }
 
     /**
@@ -97,8 +146,7 @@ public class SaltRoster {
             Optional<Integer> port, Optional<String> remotePortForwarding,
             Optional<List<String>> sshOption, Optional<Integer> timeout,
             Optional<Map<String, Object>> minionOpts) {
-        addHost(host, user, passwd, Optional.empty(), Optional.empty(), port, remotePortForwarding, sshOption, timeout,
-                minionOpts, Optional.empty(), Optional.empty());
+        addHost(host, host, user, passwd, port, remotePortForwarding, sshOption, timeout, minionOpts);
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/webui/utils/gson/BootstrapHostsJson.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/gson/BootstrapHostsJson.java
@@ -41,6 +41,7 @@ public class BootstrapHostsJson {
     private String reactivationKey;
     private boolean ignoreHostKeys;
     private Long proxy;
+    private String proxyFqdn;
 
     /**
      * Authentication method for bootstrapping:
@@ -155,6 +156,20 @@ public class BootstrapHostsJson {
      */
     public Long getProxy() {
         return proxy;
+    }
+
+    /**
+     * @return the specific FQDN of the proxy
+     */
+    public String getProxyFqdn() {
+        return proxyFqdn;
+    }
+
+    /**
+     * @return an optional of the proxy FQDN
+     */
+    public Optional<String> maybeGetProxyFqdn() {
+        return ofNullable(proxyFqdn);
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/webui/utils/gson/BootstrapParameters.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/gson/BootstrapParameters.java
@@ -41,6 +41,7 @@ public class BootstrapParameters {
     private Optional<String> reactivationKey;
     private boolean ignoreHostKeys;
     private Optional<Long> proxyId;
+    private Optional<String> proxyFqdn = empty();
 
     /**
      * Create {@link BootstrapParameters} for password authentication.
@@ -127,23 +128,29 @@ public class BootstrapParameters {
      */
     public static BootstrapParameters createFromJson(BootstrapHostsJson json) {
         final BootstrapHostsJson.AuthMethod authMethod = json.maybeGetAuthMethod().orElse(AuthMethod.PASSWORD);
+        BootstrapParameters params;
         switch (authMethod) {
             case PASSWORD:
-                return new BootstrapParameters(json.getHost(), json.getPortInteger(), json.getUser(),
+                params = new BootstrapParameters(json.getHost(), json.getPortInteger(), json.getUser(),
                         json.maybeGetPassword(), json.getActivationKeys(), json.maybeGetReactivationKey(),
                         json.getIgnoreHostKeys(), Optional.ofNullable(json.getProxy()));
+                break;
             case SSH_KEY:
-                return new BootstrapParameters(json.getHost(), json.getPortInteger(), json.getUser(),
+                params = new BootstrapParameters(json.getHost(), json.getPortInteger(), json.getUser(),
                         json.getPrivKey(), json.maybeGetPrivKeyPwd(), json.getActivationKeys(),
                         json.maybeGetReactivationKey(), json.getIgnoreHostKeys(),
                         Optional.ofNullable(json.getProxy()));
+                break;
             case ANSIBLE_PREAUTH:
-                return new BootstrapParameters(json.getHost(), json.getPortInteger(), json.getUser(),
+                params = new BootstrapParameters(json.getHost(), json.getPortInteger(), json.getUser(),
                         json.getAnsibleInventoryId(), json.getActivationKeys(), json.maybeGetReactivationKey(),
                         json.getIgnoreHostKeys(), Optional.ofNullable(json.getProxy()));
+                break;
             default:
                 throw new UnsupportedOperationException("Unsupported auth method " + authMethod);
         }
+        params.setProxyFqdn(json.maybeGetProxyFqdn());
+        return params;
     }
 
     /**
@@ -319,6 +326,24 @@ public class BootstrapParameters {
      */
     public Optional<Long> getProxyId() {
         return proxyId;
+    }
+
+    /**
+     * Gets the proxy FQDN.
+     *
+     * @return proxyFqdn
+     */
+    public Optional<String> getProxyFqdn() {
+        return proxyFqdn;
+    }
+
+    /**
+     * Sets the proxy FQDN.
+     *
+     * @param proxyFqdnIn proxy FQDN
+     */
+    public void setProxyFqdn(Optional<String> proxyFqdnIn) {
+        this.proxyFqdn = proxyFqdnIn;
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/webui/utils/gson/ProxyContainerConfigJson.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/gson/ProxyContainerConfigJson.java
@@ -53,6 +53,8 @@ public class ProxyContainerConfigJson {
     private String caKey;
     private String caPassword;
     private List<String> cnames;
+    @SerializedName("additionalFQDNs")
+    private List<String> additionalFqdns;
     private String country;
     private String state;
     private String city;
@@ -171,5 +173,18 @@ public class ProxyContainerConfigJson {
             return new SSLCertData(proxyFqdn, cnames, country, state, city, org, orgUnit, sslEmail);
         }
         return null;
+    }
+
+    /**
+     * @return value of additionalFqdns
+     */
+    public List<String> getAdditionalFqdns() {
+        if (additionalFqdns != null && !additionalFqdns.isEmpty()) {
+            return additionalFqdns;
+        }
+        if (CREATE_SSL.equals(sslMode) && cnames != null) {
+            return cnames;
+        }
+        return List.of();
     }
 }

--- a/java/core/src/main/java/com/suse/manager/webui/utils/gson/ServerSetProxyJson.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/gson/ServerSetProxyJson.java
@@ -27,6 +27,8 @@ public class ServerSetProxyJson {
     /** The earliest execution date */
     private Long proxy;
 
+    private String proxyFqdn;
+
     /**
      * @return the server id
      */
@@ -39,6 +41,13 @@ public class ServerSetProxyJson {
      */
     public Long getProxy() {
         return proxy;
+    }
+
+    /**
+     * @return the proxy FQDN
+     */
+    public String getProxyFqdn() {
+        return proxyFqdn;
     }
 
 }

--- a/java/core/src/main/java/com/suse/proxy/get/formdata/ProxyConfigGetFormDataAcquisitor.java
+++ b/java/core/src/main/java/com/suse/proxy/get/formdata/ProxyConfigGetFormDataAcquisitor.java
@@ -30,6 +30,8 @@ import com.suse.proxy.model.ProxyConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -57,9 +59,9 @@ public class ProxyConfigGetFormDataAcquisitor implements ProxyConfigGetFormDataC
      * @param context the context
      */
     private void retrieveElectableParentsFqdn(ProxyConfigGetFormDataContext context) {
-        Set<String> parentFqdns = new java.util.HashSet<>();
+        Set<String> parentFqdns = new HashSet<>();
 
-        java.util.Optional<ServerPath> parentPath = context.getServer().getFirstServerPath();
+        Optional<ServerPath> parentPath = context.getServer().getFirstServerPath();
         if (parentPath.isPresent()) {
             Server parentProxy = parentPath.get().getId().getProxyServer();
             if (parentProxy != null) {

--- a/java/core/src/main/java/com/suse/proxy/get/formdata/ProxyConfigGetFormDataAcquisitor.java
+++ b/java/core/src/main/java/com/suse/proxy/get/formdata/ProxyConfigGetFormDataAcquisitor.java
@@ -16,14 +16,13 @@
 package com.suse.proxy.get.formdata;
 
 import static com.suse.utils.Predicates.allProvided;
-import static com.suse.utils.Predicates.isAbsent;
 import static com.suse.utils.Predicates.isProvided;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
-import com.redhat.rhn.common.db.datasource.DataResult;
-import com.redhat.rhn.frontend.dto.OrgProxyServer;
-import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFQDN;
+import com.redhat.rhn.domain.server.ServerPath;
 
 import com.suse.proxy.ProxyConfigUtils;
 import com.suse.proxy.model.ProxyConfig;
@@ -31,9 +30,7 @@ import com.suse.proxy.model.ProxyConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * This step acquires and maps the proxy configuration data and also the electable parents FQDNs
@@ -60,21 +57,30 @@ public class ProxyConfigGetFormDataAcquisitor implements ProxyConfigGetFormDataC
      * @param context the context
      */
     private void retrieveElectableParentsFqdn(ProxyConfigGetFormDataContext context) {
-        String localManagerFqdn = Config.get().getString(ConfigDefaults.SERVER_HOSTNAME);
+        Set<String> parentFqdns = new java.util.HashSet<>();
 
-        DataResult<OrgProxyServer> orgProxyServers = SystemManager.listProxies(context.getUser().getOrg());
-        Set<String> electableParents = orgProxyServers.stream()
-                .filter(s -> !Objects.equals(s.getId(), context.getServer().getId()))
-                .map(OrgProxyServer::getName)
-                .collect(Collectors.toSet());
-
-        if (isAbsent(localManagerFqdn)) {
-            LOG.error("Could not determine the Server FQDN. Skipping it as a parent.");
+        java.util.Optional<ServerPath> parentPath = context.getServer().getFirstServerPath();
+        if (parentPath.isPresent()) {
+            Server parentProxy = parentPath.get().getId().getProxyServer();
+            if (parentProxy != null) {
+                parentFqdns.addAll(parentProxy.getFqdns().stream()
+                        .map(ServerFQDN::getName)
+                        .toList());
+            }
+            else {
+                parentFqdns.add(parentPath.get().getHostname());
+            }
         }
         else {
-            electableParents.add(localManagerFqdn);
+            String localManagerFqdn = Config.get().getString(ConfigDefaults.SERVER_HOSTNAME);
+            if (isProvided(localManagerFqdn)) {
+                parentFqdns.add(localManagerFqdn);
+            }
+            else {
+                LOG.error("Could not determine the Server FQDN. Skipping it as a parent.");
+            }
         }
 
-        context.getElectableParentsFqdn().addAll(electableParents.stream().sorted().toList());
+        context.getElectableParentsFqdn().addAll(parentFqdns.stream().sorted().toList());
     }
 }

--- a/java/core/src/main/java/com/suse/proxy/get/formdata/ProxyConfigGetFormDefaults.java
+++ b/java/core/src/main/java/com/suse/proxy/get/formdata/ProxyConfigGetFormDefaults.java
@@ -15,6 +15,7 @@
 
 package com.suse.proxy.get.formdata;
 
+import static com.suse.proxy.ProxyConfigUtils.PARENT_FQDN_FIELD;
 import static com.suse.proxy.ProxyConfigUtils.REGISTRY_BASE_TAG;
 import static com.suse.proxy.ProxyConfigUtils.REGISTRY_BASE_URL;
 import static com.suse.proxy.ProxyConfigUtils.REGISTRY_MODE;
@@ -22,8 +23,10 @@ import static com.suse.proxy.ProxyConfigUtils.REGISTRY_MODE_SIMPLE;
 import static com.suse.proxy.ProxyConfigUtils.SOURCE_MODE_FIELD;
 import static com.suse.proxy.ProxyConfigUtils.SOURCE_MODE_RPM;
 
+import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.notification.types.ManagerVersion;
+import com.redhat.rhn.domain.server.ServerPath;
 
 import java.util.Map;
 
@@ -52,6 +55,11 @@ public class ProxyConfigGetFormDefaults implements ProxyConfigGetFormDataContext
 
         proxyConfigAsMap.put(SOURCE_MODE_FIELD, SOURCE_MODE_RPM);
         proxyConfigAsMap.put(REGISTRY_MODE, REGISTRY_MODE_SIMPLE);
+
+        String parentFqdn = context.getServer().getFirstServerPath()
+                .map(ServerPath::getHostname)
+                .orElse(Config.get().getString(ConfigDefaults.SERVER_HOSTNAME));
+        proxyConfigAsMap.put(PARENT_FQDN_FIELD, parentFqdn);
 
         if (version.isUyuni()) {
             proxyConfigAsMap.put(REGISTRY_BASE_URL, DEFAULT_UYUNI_REGISTRY_URL);

--- a/java/core/src/main/resources/com/suse/manager/webui/templates/proxy/container-config.jade
+++ b/java/core/src/main/resources/com/suse/manager/webui/templates/proxy/container-config.jade
@@ -8,6 +8,7 @@ script(type='text/javascript').
         .then(function(module) {
             module.renderer(
                 'container-config',
-                #{noSSL}
+                #{noSSL},
+                JSON.parse('!{parents}')
             )
         });

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandlerTest.java
@@ -198,7 +198,7 @@ public class ProxyHandlerTest extends MockObjectTestCase {
                     with(equal(email)), with(equal("ROOT_CA")), with(equal(List.of("CA1", "CA2"))),
                     with(equal(new SSLCertPair("PROXY_CERT", "PROXY_KEY"))),
                     with(aNull(SSLCertPair.class)), with(aNull(String.class)), with(aNull(SSLCertData.class)),
-                    with(any(SSLCertManager.class)));
+                    with(any(SSLCertManager.class)), with(equal(List.of())));
             will(returnValue(dummyConfig));
         }});
 
@@ -225,7 +225,7 @@ public class ProxyHandlerTest extends MockObjectTestCase {
                     with(equal(new SSLCertPair("CACert", "CAKey"))), with(equal("CAPass")),
                     with(equal(new SSLCertData(proxy, List.of("cname1", "cname2"), "DE", "Bayern",
                             "Nurnberg", "ACME", "ACME Tests", "coyote@acme.lab"))),
-                    with(any(SSLCertManager.class)));
+                    with(any(SSLCertManager.class)), with(equal(List.of("cname1", "cname2"))));
             will(returnValue(dummyConfig));
         }});
 
@@ -233,6 +233,27 @@ public class ProxyHandlerTest extends MockObjectTestCase {
                 .containerConfig(user, proxy, 22, server,
                 2048, email, "CACert", "CAKey", "CAPass", List.of("cname1", "cname2"),
                 "DE", "Bayern", "Nurnberg", "ACME", "ACME Tests", "coyote@acme.lab");
+        assertEquals(dummyConfig, actual);
+    }
+
+    @Test
+    public void testContainerConfigNoSsl() throws Exception {
+        User user = UserTestUtils.createUser();
+        byte[] dummyConfig = "Dummy config".getBytes();
+        String server = "srv.acme.lab";
+        String proxy = "proxy.acme.lab";
+        String email = "admin@acme.lab";
+
+        SystemManager mockSystemManager = mock(SystemManager.class);
+        context().checking(new Expectations() {{
+            allowing(mockSystemManager).createProxyContainerConfig(
+                    with(equal(user)), with(equal(proxy)), with(equal(8022)), with(equal(server)), with(equal(2048L)),
+                    with(equal(email)), with(equal(List.of("extra1.acme.lab", "extra2.acme.lab"))));
+            will(returnValue(dummyConfig));
+        }});
+
+        byte[] actual = new ProxyHandler(xmlRpcSystemHelper, mockSystemManager, proxyConfigUpdateFacade)
+                .containerConfig(user, proxy, 8022, server, 2048, email, List.of("extra1.acme.lab", "extra2.acme.lab"));
         assertEquals(dummyConfig, actual);
     }
 

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
@@ -2017,6 +2017,54 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
     }
 
     @Test
+    public void testCreateProxyContainerConfigWithAdditionalFqdns() throws InstantiationException, IOException {
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+
+        String proxyName = "pxy-fqdn.mgr.lab";
+        String serverName = Config.get().getString(ConfigDefaults.SERVER_HOSTNAME);
+        long maxCache = 4096;
+        String email = "admin@mgr.lab";
+        String rootCA = "Dummy Root CA";
+        List<String> otherCAs = List.of("CA 1", "CA 2");
+        String cert = "Dummy cert";
+        String key = "Dummy key";
+        String apacheCert = "Dummy cert for apache";
+        String sshKey = "DummySshKey";
+        String sshPubKey = "DummySshPubKey";
+        String sshPushKey = "DummySshPushKey";
+        String sshPushPubKey = "DummySshPushPubKey";
+
+        SSLCertManager certManager = mock(SSLCertManager.class);
+
+        context().checking(new Expectations() {{
+            allowing(saltServiceMock).generateSSHKey(with(equal(SaltSSHService.SSH_KEY_PATH)),
+                    with(equal(SaltSSHService.SUMA_SSH_PUB_KEY)));
+            will(returnValue(Optional.of(new MgrUtilRunner.SshKeygenResult(sshKey, sshPubKey))));
+            allowing(saltServiceMock).generateSSHKey(with(aNull(String.class)), with(aNull(String.class)));
+            will(returnValue(Optional.of(new MgrUtilRunner.SshKeygenResult(sshPushKey, sshPushPubKey))));
+            allowing(saltServiceMock)
+                    .checkSSLCert(with(equal(rootCA)), with(equal(new SSLCertPair(cert, key))), with(equal(otherCAs)));
+            will(returnValue(apacheCert));
+        }});
+
+        List<String> additionalFqdns = List.of("additional.fqdn.com", "additional2.fqdn.com");
+
+        byte[] actual = systemManager.createProxyContainerConfig(user, proxyName, 8022, serverName, maxCache, email,
+                rootCA, otherCAs, new SSLCertPair(cert, key), null, null, null, certManager, additionalFqdns);
+        Map<String, String> content = readTarData(actual);
+
+        Map<String, Object> configYaml = new Yaml().load(content.get("config.yaml"));
+        assertEquals(proxyName, configYaml.get("proxy_fqdn"));
+
+        Optional<Server> proxyServerOpt = ServerFactory.findByFqdn(proxyName);
+        assertTrue(proxyServerOpt.isPresent());
+        Server proxyServer = proxyServerOpt.get();
+        Set<String> fqdnNames = proxyServer.getFqdns().stream().map(ServerFQDN::getName).collect(Collectors.toSet());
+        assertTrue(fqdnNames.contains("additional.fqdn.com"));
+        assertTrue(fqdnNames.contains("additional2.fqdn.com"));
+    }
+
+    @Test
     public void testCreateProxyContainerConfigExisting() throws InstantiationException, IOException {
         // For some reason duplicating the ORG_ADMIN role setting is required
         user.addPermanentRole(RoleFactory.ORG_ADMIN);

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
@@ -2047,6 +2047,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
             allowing(saltServiceMock)
                     .checkSSLCert(with(equal(rootCA)), with(equal(new SSLCertPair(cert, key))), with(equal(otherCAs)));
             will(returnValue(apacheCert));
+            allowing(certManager).getNamesFromSslCert("Dummy cert");
+            will(returnValue(Set.of("pxy-fqdn.mgr.lab")));
         }});
 
         List<String> additionalFqdns = List.of("additional.fqdn.com", "additional2.fqdn.com");

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
@@ -92,6 +92,7 @@ import com.redhat.rhn.domain.server.ServerGroupTest;
 import com.redhat.rhn.domain.server.ServerHistoryEvent;
 import com.redhat.rhn.domain.server.ServerNetAddress4;
 import com.redhat.rhn.domain.server.ServerNetworkFactory;
+import com.redhat.rhn.domain.server.ServerPath;
 import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.ActivationKeyTest;
@@ -2252,6 +2253,116 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         SystemsOverviewUpdateWorker.doUpdate(sid);
 
         assertEquals(1, SystemsCollector.getNumberOfOutdatedSystems());
+    }
+
+    @Test
+    public void testCreateProxyContainerConfigParentNotExists() throws InstantiationException, IOException {
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+
+        String proxyName = "pxy.mgr.lab";
+        String invalidServerName = "invalid-parent.mgr.lab";
+        long maxCache = 4096;
+        String email = "admin@mgr.lab";
+        String rootCA = "Dummy Root CA";
+        List<String> otherCAs = List.of("CA 1", "CA 2");
+        String cert = "Dummy cert";
+        String key = "Dummy key";
+        String apacheCert = "Dummy cert for apache";
+        String sshKey = "DummySshKey";
+        String sshPubKey = "DummySshPubKey";
+        String sshPushKey = "DummySshPushKey";
+        String sshPushPubKey = "DummySshPushPubKey";
+
+        SSLCertManager certManager = mock(SSLCertManager.class);
+
+        context().checking(new Expectations() {{
+            allowing(saltServiceMock).generateSSHKey(with(equal(SaltSSHService.SSH_KEY_PATH)),
+                    with(equal(SaltSSHService.SUMA_SSH_PUB_KEY)));
+            will(returnValue(Optional.of(new MgrUtilRunner.SshKeygenResult(sshKey, sshPubKey))));
+            allowing(saltServiceMock).generateSSHKey(with(aNull(String.class)), with(aNull(String.class)));
+            will(returnValue(Optional.of(new MgrUtilRunner.SshKeygenResult(sshPushKey, sshPushPubKey))));
+            allowing(saltServiceMock)
+                    .checkSSLCert(with(equal(rootCA)), with(equal(new SSLCertPair(cert, key))), with(equal(otherCAs)));
+            will(returnValue(apacheCert));
+            allowing(certManager).getNamesFromSslCert("Dummy cert");
+            will(returnValue(Set.of("pxy.mgr.lab")));
+        }});
+
+        try {
+            systemManager.createProxyContainerConfig(user, proxyName, 8022, invalidServerName, maxCache, email,
+                    rootCA, otherCAs, new SSLCertPair(cert, key), null, null, null, certManager);
+            fail("Should throw RhnRuntimeException when parent proxy does not exist");
+        }
+        catch (com.redhat.rhn.common.RhnRuntimeException e) {
+            assertEquals("Parent proxy invalid-parent.mgr.lab does not exist.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateProxyContainerConfigParentMismatch() throws InstantiationException, IOException {
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+
+        String proxyName = "existing-proxy.mgr.lab";
+        String requestedParentName = "pxy1.mgr.lab";
+        long maxCache = 4096;
+        String email = "admin@mgr.lab";
+        String rootCA = "Dummy Root CA";
+        List<String> otherCAs = List.of("CA 1", "CA 2");
+        String cert = "Dummy cert";
+        String key = "Dummy key";
+        String apacheCert = "Dummy cert for apache";
+        String sshKey = "DummySshKey";
+        String sshPubKey = "DummySshPubKey";
+        String sshPushKey = "DummySshPushKey";
+        String sshPushPubKey = "DummySshPushPubKey";
+
+        SSLCertManager certManager = mock(SSLCertManager.class);
+
+        createTestProxy("pxy0.mgr.lab");
+        createTestProxy("pxy1.mgr.lab");
+
+        Server existingProxy = ServerFactoryTest.createUnentitledTestServer(
+                user, true, ServerFactoryTest.TYPE_SERVER_PROXY, new Date());
+        existingProxy.setName(proxyName);
+        existingProxy.setHostname(proxyName);
+        existingProxy.getFqdns().add(new ServerFQDN(existingProxy, proxyName));
+        existingProxy.getProxyInfo().setVersion(null);
+        existingProxy.getProxyInfo().setSshPort(8022);
+        existingProxy.getProxyInfo().setSshPublicKey(("SshPublicKey " + proxyName).getBytes());
+        systemEntitlementManager.setBaseEntitlement(existingProxy, EntitlementManager.FOREIGN);
+
+        Server pxy0 = ServerFactory.lookupProxyServer("pxy0.mgr.lab").get();
+        Set<ServerPath> paths = ServerFactory.createServerPaths(existingProxy, pxy0, "pxy0.mgr.lab");
+        existingProxy.getServerPaths().addAll(paths);
+
+        ServerFactory.save(existingProxy);
+        TestUtils.saveAndFlush(existingProxy);
+
+        context().checking(new Expectations() {{
+            allowing(saltServiceMock).generateSSHKey(with(equal(SaltSSHService.SSH_KEY_PATH)),
+                    with(equal(SaltSSHService.SUMA_SSH_PUB_KEY)));
+            will(returnValue(Optional.of(new MgrUtilRunner.SshKeygenResult(sshKey, sshPubKey))));
+            allowing(saltServiceMock).generateSSHKey(with(aNull(String.class)), with(aNull(String.class)));
+            will(returnValue(Optional.of(new MgrUtilRunner.SshKeygenResult(sshPushKey, sshPushPubKey))));
+            allowing(saltServiceMock)
+                    .checkSSLCert(with(equal(rootCA)), with(equal(new SSLCertPair(cert, key))), with(equal(otherCAs)));
+            will(returnValue(apacheCert));
+            allowing(certManager).getNamesFromSslCert("Dummy cert");
+            will(returnValue(Set.of("existing-proxy.mgr.lab")));
+            allowing(saltServiceMock).removeSaltSSHKnownHost(with(proxyName), with(8022));
+            will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
+        }});
+
+        try {
+            systemManager.createProxyContainerConfig(user, proxyName, 8022, requestedParentName, maxCache, email,
+                    rootCA, otherCAs, new SSLCertPair(cert, key), null, null, null, certManager);
+            fail("Should throw RhnRuntimeException when parent proxy does not match");
+        }
+        catch (com.redhat.rhn.common.RhnRuntimeException e) {
+            assertEquals("The proxy existing-proxy.mgr.lab is already registered " +
+                    "and connected via pxy0.mgr.lab, but the requested parent is pxy1.mgr.lab.",
+                    e.getMessage());
+        }
     }
 
     private void deleteAllMinionServers() {

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
@@ -2046,6 +2046,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
             allowing(saltServiceMock)
                     .checkSSLCert(with(equal(rootCA)), with(equal(new SSLCertPair(cert, key))), with(equal(otherCAs)));
             will(returnValue(apacheCert));
+            allowing(certManager).getNamesFromSslCert("Dummy cert");
+            will(returnValue(Set.of("pxy-fqdn.mgr.lab")));
         }});
 
         List<String> additionalFqdns = List.of("additional.fqdn.com", "additional2.fqdn.com");

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
@@ -2018,6 +2018,54 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
     }
 
     @Test
+    public void testCreateProxyContainerConfigWithAdditionalFqdns() throws InstantiationException, IOException {
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+
+        String proxyName = "pxy-fqdn.mgr.lab";
+        String serverName = Config.get().getString(ConfigDefaults.SERVER_HOSTNAME);
+        long maxCache = 4096;
+        String email = "admin@mgr.lab";
+        String rootCA = "Dummy Root CA";
+        List<String> otherCAs = List.of("CA 1", "CA 2");
+        String cert = "Dummy cert";
+        String key = "Dummy key";
+        String apacheCert = "Dummy cert for apache";
+        String sshKey = "DummySshKey";
+        String sshPubKey = "DummySshPubKey";
+        String sshPushKey = "DummySshPushKey";
+        String sshPushPubKey = "DummySshPushPubKey";
+
+        SSLCertManager certManager = mock(SSLCertManager.class);
+
+        context().checking(new Expectations() {{
+            allowing(saltServiceMock).generateSSHKey(with(equal(SaltSSHService.SSH_KEY_PATH)),
+                    with(equal(SaltSSHService.SUMA_SSH_PUB_KEY)));
+            will(returnValue(Optional.of(new MgrUtilRunner.SshKeygenResult(sshKey, sshPubKey))));
+            allowing(saltServiceMock).generateSSHKey(with(aNull(String.class)), with(aNull(String.class)));
+            will(returnValue(Optional.of(new MgrUtilRunner.SshKeygenResult(sshPushKey, sshPushPubKey))));
+            allowing(saltServiceMock)
+                    .checkSSLCert(with(equal(rootCA)), with(equal(new SSLCertPair(cert, key))), with(equal(otherCAs)));
+            will(returnValue(apacheCert));
+        }});
+
+        List<String> additionalFqdns = List.of("additional.fqdn.com", "additional2.fqdn.com");
+
+        byte[] actual = systemManager.createProxyContainerConfig(user, proxyName, 8022, serverName, maxCache, email,
+                rootCA, otherCAs, new SSLCertPair(cert, key), null, null, null, certManager, additionalFqdns);
+        Map<String, String> content = readTarData(actual);
+
+        Map<String, Object> configYaml = new Yaml().load(content.get("config.yaml"));
+        assertEquals(proxyName, configYaml.get("proxy_fqdn"));
+
+        Optional<Server> proxyServerOpt = ServerFactory.findByFqdn(proxyName);
+        assertTrue(proxyServerOpt.isPresent());
+        Server proxyServer = proxyServerOpt.get();
+        Set<String> fqdnNames = proxyServer.getFqdns().stream().map(ServerFQDN::getName).collect(Collectors.toSet());
+        assertTrue(fqdnNames.contains("additional.fqdn.com"));
+        assertTrue(fqdnNames.contains("additional2.fqdn.com"));
+    }
+
+    @Test
     public void testCreateProxyContainerConfigExisting() throws InstantiationException, IOException {
         // For some reason duplicating the ORG_ADMIN role setting is required
         user.addPermanentRole(RoleFactory.ORG_ADMIN);

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/SystemManagerTest.java
@@ -92,6 +92,7 @@ import com.redhat.rhn.domain.server.ServerGroupTest;
 import com.redhat.rhn.domain.server.ServerHistoryEvent;
 import com.redhat.rhn.domain.server.ServerNetAddress4;
 import com.redhat.rhn.domain.server.ServerNetworkFactory;
+import com.redhat.rhn.domain.server.ServerPath;
 import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.ActivationKeyTest;
@@ -2253,6 +2254,116 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         SystemsOverviewUpdateWorker.doUpdate(sid);
 
         assertEquals(1, SystemsCollector.getNumberOfOutdatedSystems());
+    }
+
+    @Test
+    public void testCreateProxyContainerConfigParentNotExists() throws InstantiationException, IOException {
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+
+        String proxyName = "pxy.mgr.lab";
+        String invalidServerName = "invalid-parent.mgr.lab";
+        long maxCache = 4096;
+        String email = "admin@mgr.lab";
+        String rootCA = "Dummy Root CA";
+        List<String> otherCAs = List.of("CA 1", "CA 2");
+        String cert = "Dummy cert";
+        String key = "Dummy key";
+        String apacheCert = "Dummy cert for apache";
+        String sshKey = "DummySshKey";
+        String sshPubKey = "DummySshPubKey";
+        String sshPushKey = "DummySshPushKey";
+        String sshPushPubKey = "DummySshPushPubKey";
+
+        SSLCertManager certManager = mock(SSLCertManager.class);
+
+        context().checking(new Expectations() {{
+            allowing(saltServiceMock).generateSSHKey(with(equal(SaltSSHService.SSH_KEY_PATH)),
+                    with(equal(SaltSSHService.SUMA_SSH_PUB_KEY)));
+            will(returnValue(Optional.of(new MgrUtilRunner.SshKeygenResult(sshKey, sshPubKey))));
+            allowing(saltServiceMock).generateSSHKey(with(aNull(String.class)), with(aNull(String.class)));
+            will(returnValue(Optional.of(new MgrUtilRunner.SshKeygenResult(sshPushKey, sshPushPubKey))));
+            allowing(saltServiceMock)
+                    .checkSSLCert(with(equal(rootCA)), with(equal(new SSLCertPair(cert, key))), with(equal(otherCAs)));
+            will(returnValue(apacheCert));
+            allowing(certManager).getNamesFromSslCert("Dummy cert");
+            will(returnValue(Set.of("pxy.mgr.lab")));
+        }});
+
+        try {
+            systemManager.createProxyContainerConfig(user, proxyName, 8022, invalidServerName, maxCache, email,
+                    rootCA, otherCAs, new SSLCertPair(cert, key), null, null, null, certManager);
+            fail("Should throw RhnRuntimeException when parent proxy does not exist");
+        }
+        catch (com.redhat.rhn.common.RhnRuntimeException e) {
+            assertEquals("Parent proxy invalid-parent.mgr.lab does not exist.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateProxyContainerConfigParentMismatch() throws InstantiationException, IOException {
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+
+        String proxyName = "existing-proxy.mgr.lab";
+        String requestedParentName = "pxy1.mgr.lab";
+        long maxCache = 4096;
+        String email = "admin@mgr.lab";
+        String rootCA = "Dummy Root CA";
+        List<String> otherCAs = List.of("CA 1", "CA 2");
+        String cert = "Dummy cert";
+        String key = "Dummy key";
+        String apacheCert = "Dummy cert for apache";
+        String sshKey = "DummySshKey";
+        String sshPubKey = "DummySshPubKey";
+        String sshPushKey = "DummySshPushKey";
+        String sshPushPubKey = "DummySshPushPubKey";
+
+        SSLCertManager certManager = mock(SSLCertManager.class);
+
+        createTestProxy("pxy0.mgr.lab");
+        createTestProxy("pxy1.mgr.lab");
+
+        Server existingProxy = ServerFactoryTest.createUnentitledTestServer(
+                user, true, ServerFactoryTest.TYPE_SERVER_PROXY, new Date());
+        existingProxy.setName(proxyName);
+        existingProxy.setHostname(proxyName);
+        existingProxy.getFqdns().add(new ServerFQDN(existingProxy, proxyName));
+        existingProxy.getProxyInfo().setVersion(null);
+        existingProxy.getProxyInfo().setSshPort(8022);
+        existingProxy.getProxyInfo().setSshPublicKey(("SshPublicKey " + proxyName).getBytes());
+        systemEntitlementManager.setBaseEntitlement(existingProxy, EntitlementManager.FOREIGN);
+
+        Server pxy0 = ServerFactory.lookupProxyServer("pxy0.mgr.lab").get();
+        Set<ServerPath> paths = ServerFactory.createServerPaths(existingProxy, pxy0, "pxy0.mgr.lab");
+        existingProxy.getServerPaths().addAll(paths);
+
+        ServerFactory.save(existingProxy);
+        TestUtils.saveAndFlush(existingProxy);
+
+        context().checking(new Expectations() {{
+            allowing(saltServiceMock).generateSSHKey(with(equal(SaltSSHService.SSH_KEY_PATH)),
+                    with(equal(SaltSSHService.SUMA_SSH_PUB_KEY)));
+            will(returnValue(Optional.of(new MgrUtilRunner.SshKeygenResult(sshKey, sshPubKey))));
+            allowing(saltServiceMock).generateSSHKey(with(aNull(String.class)), with(aNull(String.class)));
+            will(returnValue(Optional.of(new MgrUtilRunner.SshKeygenResult(sshPushKey, sshPushPubKey))));
+            allowing(saltServiceMock)
+                    .checkSSLCert(with(equal(rootCA)), with(equal(new SSLCertPair(cert, key))), with(equal(otherCAs)));
+            will(returnValue(apacheCert));
+            allowing(certManager).getNamesFromSslCert("Dummy cert");
+            will(returnValue(Set.of("existing-proxy.mgr.lab")));
+            allowing(saltServiceMock).removeSaltSSHKnownHost(with(proxyName), with(8022));
+            will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
+        }});
+
+        try {
+            systemManager.createProxyContainerConfig(user, proxyName, 8022, requestedParentName, maxCache, email,
+                    rootCA, otherCAs, new SSLCertPair(cert, key), null, null, null, certManager);
+            fail("Should throw RhnRuntimeException when parent proxy does not match");
+        }
+        catch (com.redhat.rhn.common.RhnRuntimeException e) {
+            assertEquals("The proxy existing-proxy.mgr.lab is already registered " +
+                    "and connected via pxy0.mgr.lab, but the requested parent is pxy1.mgr.lab.",
+                    e.getMessage());
+        }
     }
 
     private void deleteAllMinionServers() {

--- a/java/core/src/test/java/com/suse/manager/reactor/hardware/HardwareMapperTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/hardware/HardwareMapperTest.java
@@ -18,16 +18,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFQDN;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
 import com.suse.manager.reactor.utils.ValueMap;
+import com.suse.salt.netapi.calls.modules.Network;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 
 public class HardwareMapperTest extends BaseTestCaseWithUser {
@@ -86,6 +91,27 @@ public class HardwareMapperTest extends BaseTestCaseWithUser {
         assertNotNull(zhost);
         assertEquals("IBM Mainframe z12 2827 0000000000061A23", zhost.getName());
         assertEquals("z/VM", zhost.getOs());
+    }
+
+    @Test
+    public void testMapNetworkInfoSetsPrimaryFqdnFromMinionId() {
+        MinionServer testMinionServer = MinionServerFactoryTest.createTestMinionServer(user);
+        String minionId = testMinionServer.getMinionId();
+        assertNotNull(minionId);
+
+        HardwareMapper hwMapper = new HardwareMapper(testMinionServer, new ValueMap(new HashMap<>()));
+
+        List<String> fqdns = List.of(minionId, "other-fqdn.com");
+
+        Map<String, Network.Interface> interfaces = new HashMap<>();
+        Network.Interface iface = new Network.Interface();
+        interfaces.put("eth0", iface);
+
+        hwMapper.mapNetworkInfo(interfaces, Optional.empty(), new HashMap<>(), fqdns);
+
+        ServerFQDN primaryFqdn = testMinionServer.findPrimaryFqdn();
+        assertNotNull(primaryFqdn);
+        assertEquals(minionId, primaryFqdn.getName());
     }
 
 }

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/ProxyControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/ProxyControllerTest.java
@@ -62,7 +62,7 @@ public class ProxyControllerTest extends BaseControllerTestCase {
                     with(equal(2048L)), with(equal("coyote@acme.lab")), with(equal("Root CA")),
                     with(equal(List.of("CA1", "CA2"))), with(equal(new SSLCertPair("CERT", "KEY"))),
                     with(aNull(SSLCertPair.class)), with(aNull(String.class)), with(aNull(SSLCertData.class)),
-                    with(any(SSLCertManager.class)));
+                    with(any(SSLCertManager.class)), with(equal(List.of())));
             will(returnValue(data));
         }});
 
@@ -87,7 +87,7 @@ public class ProxyControllerTest extends BaseControllerTestCase {
                     with(equal(new SSLCertPair("CA CERT", "CA KEY"))), with(equal("secret")),
                     with(equal(new SSLCertData("pxy.acme.lab", List.of("cname1", "cname2"), "DE", "Bavaria", "Nurnberg",
                             "SUSE", "SUSE Unit", "roadrunner@acme.lab"))),
-                    with(any(SSLCertManager.class)));
+                    with(any(SSLCertManager.class)), with(equal(List.of("cname1", "cname2"))));
             will(returnValue(data));
         }});
 

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapperTestBase.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapperTestBase.java
@@ -115,6 +115,8 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
             will(returnValue(true));
             allowing(input).getProxy();
             will(returnValue(null));
+            allowing(input).maybeGetProxyFqdn();
+            will(returnValue(empty()));
         }});
         return input;
     }

--- a/java/core/src/test/java/com/suse/manager/webui/services/impl/SaltSSHServiceTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/impl/SaltSSHServiceTest.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.server.ProxyInfo;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFQDN;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerPath;
 import com.redhat.rhn.domain.server.ServerPathId;
@@ -152,5 +153,34 @@ public class SaltSSHServiceTest extends JMockBaseTestCaseWithUser {
 
         assertEquals(Collections.emptyList(),
                 SaltSSHService.proxyPathToHostnames(Collections.emptySet(), Optional.empty()));
+    }
+
+    @Test
+    public void testProxyPathToHostnamesChainWithPrimaryFqdn() throws Exception {
+        Server proxy0 = createTestProxyMinimal("proxy0-internal.local", 8022);
+        Server proxy1 = createTestProxyMinimal("proxy1-internal.local", 22);
+
+        // Add Primary FQDN to proxy0
+        ServerFQDN primaryFqdn0 = new ServerFQDN(proxy0, "proxy0-external.com");
+        primaryFqdn0.setPrimary(true);
+        proxy0.getFqdns().add(primaryFqdn0);
+        ServerFactory.save(proxy0);
+
+        // Add Primary FQDN to proxy1
+        ServerFQDN primaryFqdn1 = new ServerFQDN(proxy1, "proxy1-external.com");
+        primaryFqdn1.setPrimary(true);
+        proxy1.getFqdns().add(primaryFqdn1);
+        ServerFactory.save(proxy1);
+
+        // Chain proxy0 and proxy1
+        final Set<ServerPath> serverPaths = Set.of(
+                new ServerPath(new ServerPathId(proxy0, proxy1), 0L, "proxy1-internal.local")
+        );
+        proxy0.setServerPaths(serverPaths);
+
+        // Since both proxy0 and proxy1 have Primary FQDNs, the returned path should prioritize their Primary FQDNs.
+        // proxyPathToHostnames(proxy0) should return ["proxy1-external.com:22", "proxy0-external.com:8022"]
+        assertEquals(List.of("proxy1-external.com:22", "proxy0-external.com:8022"),
+                SaltSSHService.proxyPathToHostnames(proxy0));
     }
 }

--- a/java/core/src/test/java/com/suse/manager/webui/services/impl/SaltSSHServiceTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/impl/SaltSSHServiceTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.ProxyInfo;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFQDN;
@@ -119,6 +120,9 @@ public class SaltSSHServiceTest extends JMockBaseTestCaseWithUser {
     private Server createTestProxyMinimal(String hostname, Integer sshPort) throws Exception {
         Server srv = ServerTestUtils.createTestSystem();
         srv.setHostname(hostname);
+        if (srv instanceof MinionServer) {
+            ((MinionServer) srv).setMinionId(hostname);
+        }
         ProxyInfo info = new ProxyInfo();
         info.setServer(srv);
         info.setSshPort(sshPort);

--- a/java/core/src/test/java/com/suse/proxy/ProxyConfigGetFacadeImplTest.java
+++ b/java/core/src/test/java/com/suse/proxy/ProxyConfigGetFacadeImplTest.java
@@ -141,7 +141,8 @@ public class ProxyConfigGetFacadeImplTest extends BaseTestCaseWithUser {
     public void getFormDataWithWhenNewProxyConfiguration() throws Exception {
         final String expectedCurrentConfig = "{\"sourceMode\":\"rpm\",\"registryMode\":\"simple\"," +
                 "\"registryBaseTag\":\"99.98.97\",\"registryBaseURL\":" +
-                "\"registry.suse.com/suse/multi-linux-manager/99.98/x86_64\"}";
+                "\"registry.suse.com/suse/multi-linux-manager/99.98/x86_64\"," +
+                "\"parentFQDN\":\"" + Config.get().getString(ConfigDefaults.SERVER_HOSTNAME) + "\"}";
         final String expectedParents = "[\"" + Config.get().getString(ConfigDefaults.SERVER_HOSTNAME) + "\"]";
 
         Server server = ServerFactoryTest.createTestServer(user, false,

--- a/java/core/src/test/java/com/suse/proxy/ProxyConfigGetFormDataAcquisitorTest.java
+++ b/java/core/src/test/java/com/suse/proxy/ProxyConfigGetFormDataAcquisitorTest.java
@@ -31,8 +31,12 @@ import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerConstants;
+import com.redhat.rhn.domain.server.ServerFQDN;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerFactoryTest;
+import com.redhat.rhn.domain.server.ServerPath;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.proxy.get.formdata.ProxyConfigGetFormDataAcquisitor;
 import com.suse.proxy.get.formdata.ProxyConfigGetFormDataContext;
@@ -88,19 +92,25 @@ public class ProxyConfigGetFormDataAcquisitorTest extends BaseTestCaseWithUser {
         Server proxyA = ServerFactoryTest.createTestServer(user, true,
                 ServerConstants.getServerGroupTypeEnterpriseEntitled(),
                 ServerFactoryTest.TYPE_SERVER_PROXY);
+        proxyA.getFqdns().add(new ServerFQDN(proxyA, proxyA.getName()));
+        proxyA = ServerFactory.save(proxyA);
 
         Server proxyB = ServerFactoryTest.createTestServer(user, true,
                 ServerConstants.getServerGroupTypeEnterpriseEntitled(),
                 ServerFactoryTest.TYPE_SERVER_PROXY);
+        proxyB.getFqdns().add(new ServerFQDN(proxyB, proxyB.getName()));
+        proxyB = ServerFactory.save(proxyB);
 
         ServerFactoryTest.createTestServer(user, true,
                 ServerConstants.getServerGroupTypeEnterpriseEntitled(),
                 ServerFactoryTest.TYPE_SERVER_NORMAL);
 
+        Set<ServerPath> paths = ServerFactory.createServerPaths(testMinionServer, proxyA, proxyA.getName());
+        testMinionServer.getServerPaths().addAll(paths);
+        testMinionServer = TestUtils.saveAndFlush(testMinionServer);
+
         final String[] expectedElectableParentsFqdn = new String[]{
-                Config.get().getString(ConfigDefaults.SERVER_HOSTNAME),
                 proxyA.getName(),
-                proxyB.getName(),
         };
 
         ProxyConfigGetFormDataContext proxyConfigGetFormDataContext = new ProxyConfigGetFormDataContext(user,
@@ -118,6 +128,7 @@ public class ProxyConfigGetFormDataAcquisitorTest extends BaseTestCaseWithUser {
         Set<String> actualElectableParentsFqdn = new HashSet<>(proxyConfigGetFormDataContext.getElectableParentsFqdn());
         assertEquals(expectedElectableParentsFqdn.length, actualElectableParentsFqdn.size());
         assertTrue(actualElectableParentsFqdn.containsAll(Set.of(expectedElectableParentsFqdn)));
+        assertFalse(actualElectableParentsFqdn.contains(proxyB.getName()));
     }
 
 }

--- a/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateFileAcquisitorTest.java
+++ b/java/core/src/test/java/com/suse/proxy/ProxyConfigUpdateFileAcquisitorTest.java
@@ -223,7 +223,8 @@ public class ProxyConfigUpdateFileAcquisitorTest extends BaseTestCaseWithUser {
                         with(any(SSLCertManager.class)),
                         with(any(String.class)),
                         with(any(String.class)),
-                        with(any(String.class))
+                        with(any(String.class)),
+                        with(any(List.class))
                 );
                 will(throwException(new SSLCertGenerationException(expectedErrorMessage)));
             }});
@@ -296,7 +297,8 @@ public class ProxyConfigUpdateFileAcquisitorTest extends BaseTestCaseWithUser {
                         with(any(SSLCertManager.class)),
                         with(any(String.class)),
                         with(any(String.class)),
-                        with(any(String.class))
+                        with(any(String.class)),
+                        with(any(List.class))
                 );
                 will(returnValue(expectedProxyConfigFiles));
             }});

--- a/java/spacewalk-java.changes.nadvornik.proxy_fqdn
+++ b/java/spacewalk-java.changes.nadvornik.proxy_fqdn
@@ -1,0 +1,2 @@
+- Support additinal proxy FQDNs
+- Allow selecting a particular proxy FQDN

--- a/schema/spacewalk/common/data/endpoint.sql
+++ b/schema/spacewalk/common/data/endpoint.sql
@@ -5432,7 +5432,13 @@ INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_re
     VALUES ('com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.bootstrap', '/manager/api/system/bootstrap', 'POST', 'A', True)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.bootstrapByProxyFqdn', '/manager/api/system/bootstrapByProxyFqdn', 'POST', 'A', True)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.bootstrapWithPrivateSshKey', '/manager/api/system/bootstrapWithPrivateSshKey', 'POST', 'A', True)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.bootstrapWithPrivateSshKeyByProxyFqdn', '/manager/api/system/bootstrapWithPrivateSshKeyByProxyFqdn', 'POST', 'A', True)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.changeProxy', '/manager/api/system/changeProxy', 'POST', 'A', True)

--- a/schema/spacewalk/common/data/endpointNamespace.sql
+++ b/schema/spacewalk/common/data/endpointNamespace.sql
@@ -8646,8 +8646,18 @@ INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'api.system.bootstrap_by_proxy_fqdn' AND ns.access_mode = 'W'
+    AND ep.endpoint = '/manager/api/system/bootstrapByProxyFqdn' AND ep.http_method = 'POST'
+    ON CONFLICT DO NOTHING;
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
     WHERE ns.namespace = 'api.system.bootstrap_with_private_ssh_key' AND ns.access_mode = 'W'
     AND ep.endpoint = '/manager/api/system/bootstrapWithPrivateSshKey' AND ep.http_method = 'POST'
+    ON CONFLICT DO NOTHING;
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'api.system.bootstrap_with_private_ssh_key_by_proxy_fqdn' AND ns.access_mode = 'W'
+    AND ep.endpoint = '/manager/api/system/bootstrapWithPrivateSshKeyByProxyFqdn' AND ep.http_method = 'POST'
     ON CONFLICT DO NOTHING;
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep

--- a/schema/spacewalk/common/data/namespace.sql
+++ b/schema/spacewalk/common/data/namespace.sql
@@ -2481,7 +2481,13 @@ INSERT INTO access.namespace (namespace, access_mode, description)
     VALUES ('api.system.bootstrap', 'W', 'Bootstrap a system for management via either Salt or Salt SSH.')
     ON CONFLICT (namespace, access_mode) DO NOTHING;
 INSERT INTO access.namespace (namespace, access_mode, description)
+    VALUES ('api.system.bootstrap_by_proxy_fqdn', 'W', 'Bootstrap a system for management via either Salt or Salt SSH using a proxy FQDN.')
+    ON CONFLICT (namespace, access_mode) DO NOTHING;
+INSERT INTO access.namespace (namespace, access_mode, description)
     VALUES ('api.system.bootstrap_with_private_ssh_key', 'W', 'Bootstrap a system for management via either Salt or Salt SSH.')
+    ON CONFLICT (namespace, access_mode) DO NOTHING;
+INSERT INTO access.namespace (namespace, access_mode, description)
+    VALUES ('api.system.bootstrap_with_private_ssh_key_by_proxy_fqdn', 'W', 'Bootstrap a system for management via either Salt or Salt SSH with a private SSH key using a proxy FQDN.')
     ON CONFLICT (namespace, access_mode) DO NOTHING;
 INSERT INTO access.namespace (namespace, access_mode, description)
     VALUES ('api.system.change_proxy', 'W', 'Connect given systems to another proxy.')

--- a/schema/spacewalk/susemanager-schema.changes.nadvornik.proxy_fqdn
+++ b/schema/spacewalk/susemanager-schema.changes.nadvornik.proxy_fqdn
@@ -1,0 +1,1 @@
+- Add bootstrapByProxyFqdn endpoints

--- a/schema/spacewalk/upgrade/susemanager-schema-5.3.1-to-susemanager-schema-5.3.2/104-add-bootstrap-by-proxy-fqdn-endpoints.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.3.1-to-susemanager-schema-5.3.2/104-add-bootstrap-by-proxy-fqdn-endpoints.sql
@@ -1,0 +1,27 @@
+INSERT INTO access.namespace (namespace, access_mode, description)
+    SELECT 'api.system.bootstrap_by_proxy_fqdn', 'W', 'Bootstrap a system for management via either Salt or Salt SSH using a proxy FQDN.'
+    WHERE NOT EXISTS (SELECT 1 FROM access.namespace WHERE namespace = 'api.system.bootstrap_by_proxy_fqdn' AND access_mode = 'W');
+
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT 'com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.bootstrapByProxyFqdn', '/manager/api/system/bootstrapByProxyFqdn', 'POST', 'A', True
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/api/system/bootstrapByProxyFqdn' AND http_method = 'POST');
+
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'api.system.bootstrap_by_proxy_fqdn' AND ns.access_mode = 'W'
+    AND ep.endpoint = '/manager/api/system/bootstrapByProxyFqdn' AND ep.http_method = 'POST'
+    ON CONFLICT DO NOTHING;
+
+INSERT INTO access.namespace (namespace, access_mode, description)
+    SELECT 'api.system.bootstrap_with_private_ssh_key_by_proxy_fqdn', 'W', 'Bootstrap a system for management via either Salt or Salt SSH with a private SSH key using a proxy FQDN.'
+    WHERE NOT EXISTS (SELECT 1 FROM access.namespace WHERE namespace = 'api.system.bootstrap_with_private_ssh_key_by_proxy_fqdn' AND access_mode = 'W');
+
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT 'com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.bootstrapWithPrivateSshKeyByProxyFqdn', '/manager/api/system/bootstrapWithPrivateSshKeyByProxyFqdn', 'POST', 'A', True
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/api/system/bootstrapWithPrivateSshKeyByProxyFqdn' AND http_method = 'POST');
+
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'api.system.bootstrap_with_private_ssh_key_by_proxy_fqdn' AND ns.access_mode = 'W'
+    AND ep.endpoint = '/manager/api/system/bootstrapWithPrivateSshKeyByProxyFqdn' AND ep.http_method = 'POST'
+    ON CONFLICT DO NOTHING;

--- a/spacecmd/spacecmd.changes.nadvornik.proxy_fqdn
+++ b/spacecmd/spacecmd.changes.nadvornik.proxy_fqdn
@@ -1,0 +1,1 @@
+- Support --additional-fqdn in proxy container commands

--- a/spacecmd/src/spacecmd/proxy.py
+++ b/spacecmd/src/spacecmd/proxy.py
@@ -59,6 +59,7 @@ options:
   -p, --ssh-port SSH port the proxy listens one. Default: 8022
   -i, --intermediate-ca  Path to an intermediate CA used to sign the proxy
             certicate in PEM format. May be provided multiple times.
+  --additional-fqdn  additional FQDN of the proxy. Can be provided multiple times.
 
 examples:
   proxy_container_config -o config.zip proxy.lab server.lab 1024 proxy@acme.org root_ca.crt proxy.crt proxy.key
@@ -75,6 +76,9 @@ def do_proxy_container_config(self, args):
     arg_parser.add_argument("-k", "--key", default="")
     arg_parser.add_argument("-o", "--output", default="config.tar.gz")
     arg_parser.add_argument("-p", "--ssh-port", type=int, default=8022)
+    arg_parser.add_argument(
+        "--additional-fqdn", dest="additional_fqdns", action="append", default=[]
+    )
 
     args, options = parse_command_arguments(args, arg_parser)
 
@@ -100,6 +104,7 @@ def do_proxy_container_config(self, args):
         intermediate_cas,
         cert,
         key,
+        options.additional_fqdns,
     )
 
     with open(options.output, "wb") as fd:
@@ -127,6 +132,7 @@ parameters:
 options:
   -o, --output Path where to create the generated configuration. Default: 'config.tar.gz'
   -p, --ssh-port SSH port the proxy listens one. Default: 8022
+  --additional-fqdn  additional FQDN of the proxy. Can be provided multiple times.
 
 examples:
   proxy_container_config_nossl -o config.zip proxy.lab server.lab 51200 proxy@acme.org
@@ -139,13 +145,16 @@ def do_proxy_container_config_nossl(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument("-o", "--output", default="config.tar.gz")
     arg_parser.add_argument("-p", "--ssh-port", type=int, default=8022)
+    arg_parser.add_argument(
+        "--additional-fqdn", dest="additional_fqdns", action="append", default=[]
+    )
 
     args, options = parse_command_arguments(args, arg_parser)
 
     try:
         proxy_fqdn, server_fqdn, max_cache, email = args
     except ValueError:
-        self.help_proxy_container_config()
+        self.help_proxy_container_config_nossl()
         return
 
     config = self.client.proxy.container_config(
@@ -155,6 +164,7 @@ def do_proxy_container_config_nossl(self, args):
         server_fqdn,
         int(max_cache),
         email,
+        options.additional_fqdns,
     )
 
     with open(options.output, "wb") as fd:

--- a/susemanager-utils/susemanager-sls/modules/roster/uyuni.py
+++ b/susemanager-utils/susemanager-sls/modules/roster/uyuni.py
@@ -165,7 +165,9 @@ class UyuniRoster:
         tunnel=False,
         user=None,
         ssh_push_port=SSH_PUSH_PORT,
+        host=None,
     ):
+        target_host = host or minion_id
         proxy_command = []
         i = 0
         for proxy in proxies:
@@ -177,7 +179,7 @@ class UyuniRoster:
                     ssh_key_path=SSH_KEY_PATH if i == 0 else PROXY_SSH_PUSH_KEY,
                     ssh_push_user=PROXY_SSH_PUSH_USER,
                     in_out_forward=(
-                        f"-W {minion_id}:{ssh_push_port}"
+                        f"-W {target_host}:{ssh_push_port}"
                         if not tunnel and i == len(proxies) - 1
                         else ""
                     ),
@@ -196,7 +198,7 @@ class UyuniRoster:
                     pushPort=self.ssh_push_port_https,
                     proxy="localhost",
                     sslPort=SSL_PORT,
-                    minion=minion_id,
+                    minion=target_host,
                     # pylint: disable-next=consider-using-f-string
                     ownKey="{}{}".format(
                         # pylint: disable-next=consider-using-f-string
@@ -212,10 +214,15 @@ class UyuniRoster:
 
     # pylint: disable-next=dangerous-default-value
     def _get_ssh_minion(
-        self, minion_id=None, proxies=[], tunnel=False, ssh_push_port=SSH_PUSH_PORT
+        self,
+        minion_id=None,
+        proxies=[],
+        tunnel=False,
+        ssh_push_port=SSH_PUSH_PORT,
+        host=None,
     ):
         minion = {
-            "host": minion_id,
+            "host": host or minion_id,
             "user": self.ssh_push_sudo_user,
             "port": ssh_push_port,
             "timeout": self.ssh_connect_timeout,
@@ -242,6 +249,7 @@ class UyuniRoster:
                         tunnel=tunnel,
                         user=self.ssh_push_sudo_user,
                         ssh_push_port=ssh_push_port,
+                        host=host,
                     )
                 }
             )
@@ -260,14 +268,16 @@ class UyuniRoster:
         cache_data = self.cache.fetch("roster/uyuni", "minions")
         cache_fp = cache_data.get("fp", None)
         query = """
-            SELECT ENCODE(SHA256(FORMAT('%s|%s|%s|%s|%s|%s|%s',
+            SELECT ENCODE(SHA256(FORMAT('%s|%s|%s|%s|%s|%s|%s|%s|%s',
                           EXTRACT(EPOCH FROM MAX(S.modified)),
                           COUNT(S.id),
                           EXTRACT(EPOCH FROM MAX(SP.modified)),
                           COUNT(SP.proxy_server_id),
                           EXTRACT(EPOCH FROM MAX(SMI.modified)),
                           COUNT(SMI.server_id),
-                          EXTRACT(EPOCH FROM MAX(PI.modified))
+                          EXTRACT(EPOCH FROM MAX(PI.modified)),
+                          EXTRACT(EPOCH FROM MAX(F.modified)),
+                          COUNT(F.id)
                    )::bytea), 'hex') AS fp
                    FROM rhnServer AS S
                    INNER JOIN suseMinionInfo AS SMI ON
@@ -276,6 +286,8 @@ class UyuniRoster:
                         (SP.server_id=S.id)
                    LEFT JOIN rhnProxyInfo as PI ON
                         (SP.proxy_server_id = PI.server_id)
+                   LEFT JOIN rhnServerFQDN AS F ON
+                        (F.server_id = S.id OR F.server_id = SP.proxy_server_id)
                    WHERE S.contact_method_id IN (
                              SELECT SSCM.id
                              FROM suseServerContactMethod AS SSCM
@@ -312,8 +324,9 @@ class UyuniRoster:
                    SMI.minion_id AS minion_id,
                    SMI.ssh_push_port AS ssh_push_port,
                    SSCM.label='ssh-push-tunnel' AS tunnel,
-                   SP.hostname AS proxy_hostname,
-                   PI.ssh_port AS ssh_port
+                   COALESCE(PF.name, SP.hostname) AS proxy_hostname,
+                   PI.ssh_port AS ssh_port,
+                   COALESCE(MF.name, SMI.minion_id) AS minion_fqdn
             FROM rhnServer AS S
             INNER JOIN suseServerContactMethod AS SSCM ON
                   (SSCM.id=S.contact_method_id)
@@ -321,8 +334,12 @@ class UyuniRoster:
                   (SMI.server_id=S.id)
             LEFT JOIN rhnServerPath AS SP ON
                  (SP.server_id=S.id)
+            LEFT JOIN rhnServerFQDN AS PF ON
+                 (SP.proxy_server_id = PF.server_id AND PF.is_primary = 'Y')
             LEFT JOIN rhnProxyInfo as PI ON
                  (SP.proxy_server_id = PI.server_id)
+            LEFT JOIN rhnServerFQDN AS MF ON
+                 (S.id = MF.server_id AND MF.is_primary = 'Y')
             WHERE SSCM.label IN ('ssh-push', 'ssh-push-tunnel')
             ORDER BY S.id, SP.position DESC
         """
@@ -340,6 +357,7 @@ class UyuniRoster:
                     proxies=proxies,
                     tunnel=prow.tunnel,
                     ssh_push_port=int(prow.ssh_push_port or SSH_PUSH_PORT),
+                    host=prow.minion_fqdn,
                 )
             proxies = []
             if row is None:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.nadvornik.proxy_fqdn
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.nadvornik.proxy_fqdn
@@ -1,0 +1,1 @@
+- Use primary FQDNs in roster

--- a/web/html/src/manager/minion/proxy/proxy-config.tsx
+++ b/web/html/src/manager/minion/proxy/proxy-config.tsx
@@ -159,7 +159,7 @@ export function ProxyConfig({
             labelClass="col-md-3"
             divClass="col-md-6"
             options={parents}
-            isClearable={true}
+            isClearable={false}
           />
           <Text
             name="proxyPort"

--- a/web/html/src/manager/proxy/container-config.renderer.tsx
+++ b/web/html/src/manager/proxy/container-config.renderer.tsx
@@ -2,6 +2,9 @@ import SpaRenderer from "core/spa/spa-renderer";
 
 import { ProxyConfig } from "./container-config";
 
-export const renderer = (id: string, noSSL: boolean) => {
-  return SpaRenderer.renderNavigationReact(<ProxyConfig noSSL={noSSL} />, document.getElementById(id));
+export const renderer = (id: string, noSSL: boolean, parents: string[] = []) => {
+  return SpaRenderer.renderNavigationReact(
+    <ProxyConfig noSSL={noSSL} parents={parents} />,
+    document.getElementById(id)
+  );
 };

--- a/web/html/src/manager/proxy/container-config.renderer.tsx
+++ b/web/html/src/manager/proxy/container-config.renderer.tsx
@@ -1,8 +1,8 @@
 import SpaRenderer from "core/spa/spa-renderer";
 
-import { ProxyConfig } from "./container-config";
+import { ParentOption, ProxyConfig } from "./container-config";
 
-export const renderer = (id: string, noSSL: boolean, parents: any[] = []) => {
+export const renderer = (id: string, noSSL: boolean, parents: ParentOption[] = []) => {
   return SpaRenderer.renderNavigationReact(
     <ProxyConfig noSSL={noSSL} parents={parents} />,
     document.getElementById(id)

--- a/web/html/src/manager/proxy/container-config.renderer.tsx
+++ b/web/html/src/manager/proxy/container-config.renderer.tsx
@@ -2,7 +2,7 @@ import SpaRenderer from "core/spa/spa-renderer";
 
 import { ProxyConfig } from "./container-config";
 
-export const renderer = (id: string, noSSL: boolean, parents: string[] = []) => {
+export const renderer = (id: string, noSSL: boolean, parents: any[] = []) => {
   return SpaRenderer.renderNavigationReact(
     <ProxyConfig noSSL={noSSL} parents={parents} />,
     document.getElementById(id)

--- a/web/html/src/manager/proxy/container-config.tsx
+++ b/web/html/src/manager/proxy/container-config.tsx
@@ -22,7 +22,9 @@ enum SSLMode {
   CreateSSL = "create-ssl",
 }
 
-export function ProxyConfig({ noSSL, parents = [] }: { noSSL: boolean; parents?: any[] }) {
+export type ParentOption = { value: string; label: string };
+
+export function ProxyConfig({ noSSL, parents = [] }: { noSSL: boolean; parents?: ParentOption[] }) {
   const initialModel = {
     caCertificate: "",
     caKey: "",

--- a/web/html/src/manager/proxy/container-config.tsx
+++ b/web/html/src/manager/proxy/container-config.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { AsyncButton, SubmitButton } from "components/buttons";
+import { DEPRECATED_Select } from "components/input";
 import { Form } from "components/input/form/Form";
 import { FormMultiInput } from "components/input/form-multi-input/FormMultiInput";
 import { unflattenModel } from "components/input/form-utils";
@@ -21,7 +22,7 @@ enum SSLMode {
   CreateSSL = "create-ssl",
 }
 
-export function ProxyConfig({ noSSL }: { noSSL: boolean }) {
+export function ProxyConfig({ noSSL, parents = [] }: { noSSL: boolean; parents?: string[] }) {
   const initialModel = {
     caCertificate: "",
     caKey: "",
@@ -202,7 +203,7 @@ export function ProxyConfig({ noSSL }: { noSSL: boolean }) {
           validators={[Validation.matches(/^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*$/)]}
           invalidHint={t("Has to be a valid FQDN address")}
         />
-        <Text
+        <DEPRECATED_Select
           name="serverFQDN"
           label={t("Parent FQDN")}
           required
@@ -210,8 +211,8 @@ export function ProxyConfig({ noSSL }: { noSSL: boolean }) {
           hint={t("The FQDN of the parent (server or proxy) to connect to.")}
           labelClass="col-md-3"
           divClass="col-md-6"
-          validators={[Validation.matches(/^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*$/)]}
-          invalidHint={t("Has to be a valid FQDN address")}
+          options={parents}
+          isClearable={false}
         />
         <Text
           name="proxyPort"

--- a/web/html/src/manager/proxy/container-config.tsx
+++ b/web/html/src/manager/proxy/container-config.tsx
@@ -22,7 +22,7 @@ enum SSLMode {
   CreateSSL = "create-ssl",
 }
 
-export function ProxyConfig({ noSSL, parents = [] }: { noSSL: boolean; parents?: string[] }) {
+export function ProxyConfig({ noSSL, parents = [] }: { noSSL: boolean; parents?: any[] }) {
   const initialModel = {
     caCertificate: "",
     caKey: "",

--- a/web/html/src/manager/proxy/container-config.tsx
+++ b/web/html/src/manager/proxy/container-config.tsx
@@ -99,6 +99,9 @@ export function ProxyConfig({ noSSL, parents = [] }: { noSSL: boolean; parents?:
       };
 
       const cnamesData = Object.fromEntries(Object.entries(model).filter(([key]) => key.startsWith("cnames")));
+      const additionalFQDNsData = Object.fromEntries(
+        Object.entries(model).filter(([key]) => key.startsWith("additionalFQDNs"))
+      );
       const extraData =
         model.sslMode === SSLMode.CreateSSL
           ? Object.assign(
@@ -115,7 +118,7 @@ export function ProxyConfig({ noSSL, parents = [] }: { noSSL: boolean; parents?:
               cnamesData
             )
           : {};
-      const formData = unflattenModel(Object.assign({}, commonData, extraData, ...values));
+      const formData = unflattenModel(Object.assign({}, commonData, extraData, additionalFQDNsData, ...values));
       Network.post("/rhn/manager/api/proxy/container-config", formData).then(
         (data) => {
           setSuccess(data.success);
@@ -244,6 +247,28 @@ export function ProxyConfig({ noSSL, parents = [] }: { noSSL: boolean; parents?:
           labelClass="col-md-3"
           divClass="col-md-6"
         />
+        <FormMultiInput
+          id="additionalFQDNs"
+          title={t("Additional FQDNs")}
+          prefix="additionalFQDNs"
+          onAdd={onAddField("additionalFQDNs")}
+          onRemove={onRemoveField("additionalFQDNs")}
+          panelClassName="panel-default col-md-6 col-md-offset-3 offset-md-3 no-padding"
+          panelHeading="label"
+        >
+          {(index) => (
+            <Text
+              name={`additionalFQDNs${index}`}
+              label={t("Additional FQDN")}
+              className="col-md-11"
+              labelClass="col-md-3"
+              divClass="col-md-8"
+              placeholder={t("e.g., additional.domain.com")}
+              validators={[Validation.matches(/^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*$/)]}
+              invalidHint={t("Has to be a valid FQDN address")}
+            />
+          )}
+        </FormMultiInput>
         <Radio
           name="sslMode"
           label={t("SSL certificate")}

--- a/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
+++ b/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
@@ -10,6 +10,7 @@ import { Messages, MessageType, Utils as MessagesUtils } from "components/messag
 import { TopPanel } from "components/panels/TopPanel";
 
 import Network from "utils/network";
+import { ProxyOptions } from "../proxy";
 
 // See java/core/src/main/resources/com/suse/manager/webui/templates/minion/bootstrap.jade
 declare global {
@@ -265,11 +266,13 @@ class BootstrapMinions extends Component<Props, State> {
   };
 
   proxyChanged = (event) => {
-    const proxyId = parseInt(event.target.value, 10);
+    const val = event.target.value;
+    const parts = val.split(":");
+    const proxyId = parts[0] ? parseInt(parts[0], 10) : NaN;
     const proxy = this.props.proxies.find((p) => p.id === proxyId);
     const showWarn = proxy && proxy.hostname.indexOf(".") < 0;
     this.setState({
-      proxy: event.target.value,
+      proxy: val,
       showProxyHostnameWarn: showWarn,
     });
   };
@@ -308,7 +311,11 @@ class BootstrapMinions extends Component<Props, State> {
       formData["ansibleInventoryId"] = this.props.ansibleInventoryId;
     }
     if (this.state.proxy) {
-      formData["proxy"] = this.state.proxy;
+      const parts = this.state.proxy.split(":");
+      formData["proxy"] = parseInt(parts[0], 10);
+      if (parts.length > 1) {
+        formData["proxyFqdn"] = parts[1];
+      }
     }
 
     const request = Network.post(
@@ -622,15 +629,7 @@ class BootstrapMinions extends Component<Props, State> {
                 <option key="none" value="">
                   {t("None")}
                 </option>
-                {this.props.proxies.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.name}
-                    {p.path.reduce(
-                      (acc, val, idx) => acc + "\u2192 " + val + (idx === p.path.length - 1 ? "" : " "),
-                      ""
-                    )}
-                  </option>
-                ))}
+                <ProxyOptions proxies={this.props.proxies} />
               </select>
               <div>
                 <i

--- a/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
+++ b/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
@@ -10,7 +10,8 @@ import { Messages, MessageType, Utils as MessagesUtils } from "components/messag
 import { TopPanel } from "components/panels/TopPanel";
 
 import Network from "utils/network";
-import { ProxyOptions } from "../proxy";
+
+import { parseProxySelection, ProxyOptions } from "../proxy";
 
 // See java/core/src/main/resources/com/suse/manager/webui/templates/minion/bootstrap.jade
 declare global {
@@ -267,8 +268,7 @@ class BootstrapMinions extends Component<Props, State> {
 
   proxyChanged = (event) => {
     const val = event.target.value;
-    const parts = val.split(":");
-    const proxyId = parts[0] ? parseInt(parts[0], 10) : NaN;
+    const { proxyId } = parseProxySelection(val);
     const proxy = this.props.proxies.find((p) => p.id === proxyId);
     const showWarn = proxy && proxy.hostname.indexOf(".") < 0;
     this.setState({
@@ -311,10 +311,10 @@ class BootstrapMinions extends Component<Props, State> {
       formData["ansibleInventoryId"] = this.props.ansibleInventoryId;
     }
     if (this.state.proxy) {
-      const parts = this.state.proxy.split(":");
-      formData["proxy"] = parseInt(parts[0], 10);
-      if (parts.length > 1) {
-        formData["proxyFqdn"] = parts[1];
+      const { proxyId, proxyFqdn } = parseProxySelection(this.state.proxy);
+      formData["proxy"] = proxyId;
+      if (proxyFqdn) {
+        formData["proxyFqdn"] = proxyFqdn;
       }
     }
 

--- a/web/html/src/manager/systems/proxy.tsx
+++ b/web/html/src/manager/systems/proxy.tsx
@@ -12,7 +12,34 @@ type ProxyType = {
   id: number;
   name: string;
   path: string[];
+  primaryFqdn?: string;
+  additionalFqdns?: string[];
 };
+
+export function ProxyOptions({ proxies }: { proxies: ProxyType[] }) {
+  const arrow = " \u2192 ";
+  const optionsList: any[] = [];
+  proxies.forEach((p) => {
+    const primary = p.primaryFqdn || p.name;
+    const primaryValue = `${p.id}:${primary}`;
+    optionsList.push(
+      <option key={primaryValue} value={primaryValue}>
+        {[primary].concat(p.path).join(arrow)}
+      </option>
+    );
+    if (p.additionalFqdns && p.additionalFqdns.length > 0) {
+      p.additionalFqdns.forEach((add) => {
+        const addValue = `${p.id}:${add}`;
+        optionsList.push(
+          <option key={addValue} value={addValue}>
+            {"\u00A0\u00A0\u00A0\u00A0" + [add].concat(p.path).join(arrow)}
+          </option>
+        );
+      });
+    }
+  });
+  return <>{optionsList}</>;
+}
 
 // See java/core/src/main/resources/com/suse/manager/webui/templates/minion/proxy.jade
 declare global {
@@ -30,7 +57,7 @@ type Props = {
 
 type State = {
   messages: MessageType[];
-  proxy: number;
+  proxy: string;
 };
 
 class Proxy extends Component<Props, State> {
@@ -43,9 +70,16 @@ class Proxy extends Component<Props, State> {
           <span>{t("Please select a list of minions (not proxies or traditional clients).")}</span>
         );
 
+    let initialProxy = "0";
+    if (props.currentProxy) {
+      const p = props.proxies.find((px) => px.id === props.currentProxy);
+      const primary = p ? (p.primaryFqdn || p.name) : "";
+      initialProxy = p ? `${props.currentProxy}:${primary}` : String(props.currentProxy);
+    }
+
     this.state = {
       messages: msg,
-      proxy: props.currentProxy || 0,
+      proxy: initialProxy,
     };
   }
 
@@ -56,8 +90,19 @@ class Proxy extends Component<Props, State> {
   };
 
   onSet = () => {
+    let proxyId = 0;
+    let proxyFqdn = "";
+    if (this.state.proxy && this.state.proxy !== "0") {
+      const parts = String(this.state.proxy).split(":");
+      proxyId = parseInt(parts[0], 10);
+      if (parts.length > 1) {
+        proxyFqdn = parts[1];
+      }
+    }
+
     const request = Network.post("/rhn/manager/api/systems/proxy", {
-      proxy: this.state.proxy ? this.state.proxy : 0,
+      proxy: proxyId,
+      proxyFqdn: proxyFqdn || undefined,
       ids: window.minions?.map((m) => m.id),
     })
       .then((data) => {
@@ -104,13 +149,6 @@ class Proxy extends Component<Props, State> {
       />,
     ];
 
-    const arrow = " \u2192 ";
-    const proxies = this.props.proxies.map((p) => (
-      <option key={p.id} value={p.id}>
-        {[p.name].concat(p.path).join(arrow)}
-      </option>
-    ));
-
     return (
       <div>
         {messages}
@@ -123,7 +161,7 @@ class Proxy extends Component<Props, State> {
                   <option key="none" value="0">
                     {t("None")}
                   </option>
-                  {proxies}
+                  <ProxyOptions proxies={this.props.proxies} />
                 </select>
               </div>
             </div>

--- a/web/html/src/manager/systems/proxy.tsx
+++ b/web/html/src/manager/systems/proxy.tsx
@@ -16,9 +16,26 @@ type ProxyType = {
   additionalFqdns?: string[];
 };
 
+export type ProxySelection = { proxyId: number; proxyFqdn?: string };
+
+/**
+ * A proxy selection is encoded in a single <option> value as "<id>:<fqdn>" so that a proxy with
+ * several FQDNs can be offered as distinct choices. This parses that value back into its parts.
+ */
+export function parseProxySelection(value?: string): ProxySelection {
+  if (!value || value === "0") {
+    return { proxyId: 0 };
+  }
+  const sep = value.indexOf(":");
+  if (sep < 0) {
+    return { proxyId: parseInt(value, 10) };
+  }
+  return { proxyId: parseInt(value.slice(0, sep), 10), proxyFqdn: value.slice(sep + 1) };
+}
+
 export function ProxyOptions({ proxies }: { proxies: ProxyType[] }) {
   const arrow = " \u2192 ";
-  const optionsList: any[] = [];
+  const optionsList: JSX.Element[] = [];
   proxies.forEach((p) => {
     const primary = p.primaryFqdn || p.name;
     const primaryValue = `${p.id}:${primary}`;
@@ -73,7 +90,7 @@ class Proxy extends Component<Props, State> {
     let initialProxy = "0";
     if (props.currentProxy) {
       const p = props.proxies.find((px) => px.id === props.currentProxy);
-      const primary = p ? (p.primaryFqdn || p.name) : "";
+      const primary = p ? p.primaryFqdn || p.name : "";
       initialProxy = p ? `${props.currentProxy}:${primary}` : String(props.currentProxy);
     }
 
@@ -90,15 +107,7 @@ class Proxy extends Component<Props, State> {
   };
 
   onSet = () => {
-    let proxyId = 0;
-    let proxyFqdn = "";
-    if (this.state.proxy && this.state.proxy !== "0") {
-      const parts = String(this.state.proxy).split(":");
-      proxyId = parseInt(parts[0], 10);
-      if (parts.length > 1) {
-        proxyFqdn = parts[1];
-      }
-    }
+    const { proxyId, proxyFqdn } = parseProxySelection(this.state.proxy);
 
     const request = Network.post("/rhn/manager/api/systems/proxy", {
       proxy: proxyId,

--- a/web/spacewalk-web.changes.nadvornik.proxy_fqdn
+++ b/web/spacewalk-web.changes.nadvornik.proxy_fqdn
@@ -1,0 +1,1 @@
+- Support proxy selection with multiple FQDN choices


### PR DESCRIPTION
## What does this PR change?

Improved handling of proxy FQDNs

- Allow specifying additional fqdns when creating a proxy config - this is a alternative for the import from certificate (which has been dropped)
- Validate and update proxy connection path
  - Fixed updating on kubernetes
  - Specified proxy parent must exist in the database before - this ensures that proxy connection can't diverge from salt connection
- In UI the free text for parent has be changed to select
- On kubernetes all specified FQDNs are configured for Ingress and Traefik


Better control over used proxy FQDN

In environments where an intermediate Proxy server has both **internal** and **external** FQDNs:
- Internal minions must address the Proxy using its internal FQDN (e.g., `proxy-internal.local`).
- The central Uyuni Server (located externally) must address the Proxy using its external FQDN (e.g., `proxy-external.com`).

In this PR:
rhnServerPath.hostname contains the internal FQDN used by minion to connect the proxy or used by proxy to connect the parent

Primary FQDN is the external FQDN used for Salt SSH and for monitoring.

This cleanly decouples the network perspective of the internal minions from the network perspective of the external server, allowing both incoming minion connections and outgoing Salt-SSH tunnels to operate concurrently and correctly.

For compatibility, it sets the primary fqdn to minion ID by default - that is the FQDN used for bootstrapping of existing minions.

Bootstapping

This PR allows to choose particular proxy FQDN, that is used for minion->proxy connection.



## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

Before:
Proxy selector shows one random FQDN per proxy.

After:
Proxy selector shows primary FQDN followed by indented additional FQDNs.
It is possible to enter additional FQDNs when creating proxy config.

- [x] **DONE**

## Documentation
- TBD
- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30754
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
