### PR TITLE
Fix typos in Java core comments

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/common/util/CryptHelper.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/util/CryptHelper.java
@@ -58,7 +58,7 @@ public class CryptHelper {
             salt = salt.substring(prefix.length());
         }
 
-        // If we recieve a string such as $1$salt$something else, we only want
+        // If we receive a string such as $1$salt$something else, we only want
         // to keep the salt portion of it
         int end = salt.indexOf('$');
         if (end != -1) {

--- a/java/core/src/main/java/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -739,7 +739,7 @@ public class FormulaFactory {
     }
 
     /**
-     * Check wether Grafana formula has reporting datasource enabled.
+     * Check whether Grafana formula has reporting datasource enabled.
      * @param formData data of the Grafana formula
      * @return true if datasource is enabled, otherwise false
      */

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/configuration/sdc/ViewModifyPathsAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/configuration/sdc/ViewModifyPathsAction.java
@@ -102,7 +102,7 @@ public class ViewModifyPathsAction extends RhnAction implements Listable<ConfigF
 
         //mapping.getParameter() is used to identify the type
         // channel we are trying to process..
-        // the struts-config has paramter set to
+        // the struts-config has parameter set to
         // either 'sandbox' or 'local' or 'central'
         request.setAttribute(mapping.getParameter(), Boolean.TRUE);
 

--- a/java/core/src/main/java/com/redhat/rhn/manager/BaseManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/BaseManager.java
@@ -96,7 +96,7 @@ public abstract class BaseManager {
 
     /**
      * Returns a DataResult for the given SelectMode with no bounds.  This
-     * can be usefull if you want a list without pagination controls.
+     * can be useful if you want a list without pagination controls.
      *
      * @param <T> the DataResults type
      * @param queryParams Named parameters for the driving query.

--- a/java/core/src/main/java/com/redhat/rhn/manager/audit/ScapManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/audit/ScapManager.java
@@ -105,7 +105,7 @@ public class ScapManager extends BaseManager {
 
     /**
      * Returns the given system is scap enabled.
-     * @param server The system for which to seach scap capability
+     * @param server The system for which to search scap capability
      * @param user The user requesting to view the system
      * @return true if the system is scap capable
      */


### PR DESCRIPTION
Fix five spelling mistakes in Java comments and Javadoc under `java/core`.

This is a comment only cleanup with no functional change.

No changelog needed: comment only cleanup.