### PR TITLE
feat(openapi): document struct parameters and legacy parameter types

### DIFF
--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -284,7 +284,7 @@ public class OpenApiToAsciidocParser {
         }
 
         if ("array".equals(schema.getType()) && schema.getItems() != null) {
-            writeArrayReturn(writer, schema, responseLabel);
+            writeArrayReturn(writer, schema, responseLabel, legacyDocResponse.name());
             return;
         }
 
@@ -315,7 +315,8 @@ public class OpenApiToAsciidocParser {
         return value instanceof String stringValue ? stringValue : "";
     }
 
-    private void writeArrayReturn(PrintWriter writer, Schema<?> schema, String responseLabel) {
+    private void writeArrayReturn(PrintWriter writer, Schema<?> schema, String responseLabel,
+                                  String legacyStructLabel) {
         Schema<?> itemSchema = schema.getItems();
         Schema<?> resolved = resolveSchemaReference(itemSchema);
         String itemRefName = itemSchema.get$ref() != null ? extractRefName(itemSchema.get$ref()) : "";
@@ -326,7 +327,8 @@ public class OpenApiToAsciidocParser {
         }
 
         writer.println("* [.array]#array# :");
-        writer.printf("    * [.struct]#struct#  %s%n", itemRefName);
+        writer.printf("    * [.struct]#struct#  %s%n",
+                legacyStructLabel.isEmpty() ? itemRefName : legacyStructLabel);
         printStructProperties(writer, resolved);
         writer.println();
     }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -196,26 +196,53 @@ public class OpenApiToAsciidocParser {
         for (String paramName : entry.activeParams()) {
             Schema schema = allProps.get(paramName);
             if (schema != null) {
-                String type;
-                if ("array".equals(schema.getType())) {
-                    type = "[.array]#string array#";
-                }
-                else {
-                    type = "[." + displayType(schema) + "]#" + displayType(schema) + "#";
-                }
-                String descriptionText = findDescription(schema);
-                writer.printf(
-                        "* %s  %s%s%n%n",
-                        type,
-                        paramName,
-                        descriptionText.isEmpty() ? "" : " - " + descriptionText
-                );
+                writeParameter(writer, paramName, schema);
             }
         }
 
         writer.println("\nReturns:\n");
         writeReturn(writer, operation);
         writer.print("\n\n\n");
+    }
+
+    private void writeParameter(PrintWriter writer, String paramName, Schema<?> schema) {
+        String descriptionText = findDescription(schema);
+        String suffix = descriptionText.isEmpty() ? "" : " - " + descriptionText;
+        Schema<?> resolved = resolveSchemaReference(schema);
+
+        if (hasProperties(resolved)) {
+            String label = legacyDocType(schema);
+            writer.printf("* [.%s]#%s#  %s%s%n%n", label.isEmpty() ? "struct" : label,
+                    label.isEmpty() ? "struct" : label, paramName, suffix);
+            printStructProperties(writer, resolved);
+            writer.println();
+            return;
+        }
+
+        writer.printf("* %s  %s%s%n%n", parameterType(schema), paramName, suffix);
+    }
+
+    private boolean hasProperties(Schema<?> schema) {
+        return schema != null && schema.getProperties() != null && !schema.getProperties().isEmpty();
+    }
+
+    private String parameterType(Schema<?> schema) {
+        String legacyType = legacyDocType(schema);
+        if (!legacyType.isEmpty()) {
+            return "[." + legacyType + "]#" + legacyType + "#";
+        }
+        if ("array".equals(schema.getType())) {
+            return "[.array]#string array#";
+        }
+        return "[." + displayType(schema) + "]#" + displayType(schema) + "#";
+    }
+
+    private String legacyDocType(Schema<?> schema) {
+        if (schema.getExtensions() == null) {
+            return "";
+        }
+        Object value = schema.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_TYPE_EXTENSION);
+        return value == null ? "" : value.toString();
     }
 
     private boolean isSecurityRequired(Operation operation) {
@@ -300,7 +327,7 @@ public class OpenApiToAsciidocParser {
 
         writer.println("* [.array]#array# :");
         writer.printf("    * [.struct]#struct#  %s%n", itemRefName);
-        printArrayStructProperties(writer, resolved);
+        printStructProperties(writer, resolved);
         writer.println();
     }
 
@@ -316,7 +343,7 @@ public class OpenApiToAsciidocParser {
         writer.println();
     }
 
-    private void printArrayStructProperties(PrintWriter writer, Schema<?> resolved) {
+    private void printStructProperties(PrintWriter writer, Schema<?> resolved) {
         if (resolved == null || resolved.getProperties() == null) {
             return;
         }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -204,11 +204,31 @@ public class OpenApiToDocBookParser {
             if (schema == null) {
                 continue;
             }
-            String type = formatType(schema);
             String desc = findDescription(schema);
-            params.add(new ParamDoc(type, name, desc));
+            Schema<?> resolved = resolveSchemaReference(schema);
+            if (hasProperties(resolved)) {
+                String legacyType = getLegacyDocType(schema);
+                params.add(new ParamDoc(legacyType.isEmpty() ? "struct" : legacyType, name, desc));
+                resolved.getProperties().forEach((propName, propSchema) ->
+                        params.add(new ParamDoc(formatType(propSchema), "\"" + propName + "\"",
+                                findDescription(propSchema))));
+                continue;
+            }
+            params.add(new ParamDoc(formatType(schema), name, desc));
         }
         return params;
+    }
+
+    private boolean hasProperties(Schema<?> schema) {
+        return schema != null && schema.getProperties() != null && !schema.getProperties().isEmpty();
+    }
+
+    private String getLegacyDocType(Schema<?> schema) {
+        if (schema.getExtensions() == null) {
+            return "";
+        }
+        Object value = schema.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_TYPE_EXTENSION);
+        return value == null ? "" : value.toString();
     }
 
     private Map<String, Schema<?>> getAllPossibleProperties(Operation op) {
@@ -586,6 +606,10 @@ public class OpenApiToDocBookParser {
     private String formatType(Schema<?> s) {
         if (s == null) {
             return "string";
+        }
+        String legacyType = getLegacyDocType(s);
+        if (!legacyType.isEmpty()) {
+            return legacyType;
         }
         String type = s.getType();
         if ("array".equals(type)) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -290,7 +290,7 @@ public class OpenApiToDocBookParser {
                         .toLowerCase().trim()
         );
 
-        return renderReturnSchema(schema, label, legacyDocResponse.type());
+        return renderReturnSchema(schema, label, legacyDocResponse.type(), legacyDocResponse.name());
     }
 
     private LegacyDocResponseData getLegacyDocResponse(ApiResponse response) {
@@ -308,10 +308,11 @@ public class OpenApiToDocBookParser {
     }
 
     private String renderReturnSchema(Schema<?> schema, String label) {
-        return renderReturnSchema(schema, label, "");
+        return renderReturnSchema(schema, label, "", "");
     }
 
-    private String renderReturnSchema(Schema<?> schema, String label, String typeOverride) {
+    private String renderReturnSchema(Schema<?> schema, String label, String typeOverride,
+                                      String legacyStructLabel) {
         if (schema == null) {
             return "<listitem><para></para></listitem>";
         }
@@ -320,11 +321,12 @@ public class OpenApiToDocBookParser {
             return renderReturnSchema(
                     resolveSchemaReference(resultSchema),
                     getResultLabel(resultSchema, label),
-                    typeOverride
+                    typeOverride,
+                    legacyStructLabel
             );
         }
         if ("array".equals(schema.getType()) && schema.getItems() != null) {
-            return renderArrayReturn(schema, label);
+            return renderArrayReturn(schema, label, legacyStructLabel);
         }
         if (isSimpleType(schema)) {
             return renderSimpleReturn(schema, label, typeOverride);
@@ -332,7 +334,7 @@ public class OpenApiToDocBookParser {
         if (schema.getAdditionalProperties() instanceof Schema<?> inner) {
             return renderAdditionalPropertiesReturn(inner, label);
         }
-        return renderStructList(schema, label);
+        return renderStructList(schema, label, legacyStructLabel);
     }
 
     private Schema<?> getResultSchema(Schema<?> schema) {
@@ -347,7 +349,7 @@ public class OpenApiToDocBookParser {
         return resultSchema.get$ref() != null ? extractRefName(resultSchema.get$ref()) : label;
     }
 
-    private String renderArrayReturn(Schema<?> schema, String label) {
+    private String renderArrayReturn(Schema<?> schema, String label, String legacyStructLabel) {
         Schema<?> item = schema.getItems();
         Schema<?> resolvedItem = resolveSchemaReference(item);
         if (resolvedItem != null && isSimpleType(resolvedItem) && label != null && !label.isBlank()) {
@@ -361,7 +363,7 @@ public class OpenApiToDocBookParser {
         sb.append("<listitem>\n");
         sb.append("  <para>array</para>\n");
         sb.append("  <itemizedlist spacing=\"compact\">\n");
-        sb.append(indentLines(renderReturnSchema(resolvedItem, itemLabel), 4));
+        sb.append(indentLines(renderReturnSchema(resolvedItem, itemLabel, "", legacyStructLabel), 4));
         sb.append("\n  </itemizedlist>\n");
         sb.append("</listitem>");
         return sb.toString();
@@ -402,16 +404,17 @@ public class OpenApiToDocBookParser {
         return "integer".equals(schema.getType()) ? "int" : schema.getType();
     }
 
-    private String renderStructList(Schema<?> schema, String label) {
+    private String renderStructList(Schema<?> schema, String label, String legacyStructLabel) {
+        String structLabel = legacyStructLabel.isBlank() ? label : legacyStructLabel;
         if (schema == null) {
-            return String.format("<listitem><para>struct %s</para></listitem>", escapeXml(label));
+            return String.format("<listitem><para>struct %s</para></listitem>", escapeXml(structLabel));
         }
         if (schema.getProperties() == null || schema.getProperties().isEmpty()) {
-            return String.format("<listitem><para>struct %s</para></listitem>", escapeXml(label));
+            return String.format("<listitem><para>struct %s</para></listitem>", escapeXml(structLabel));
         }
         StringBuilder sb = new StringBuilder();
         sb.append("<listitem>\n");
-        sb.append("  <para>struct ").append(escapeXml(label)).append("</para>\n");
+        sb.append("  <para>struct ").append(escapeXml(structLabel)).append("</para>\n");
         sb.append("  <itemizedlist spacing=\"compact\">\n");
         schema.getProperties().forEach((name, prop) -> {
             Schema<?> propSchema = prop;

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -13,6 +13,7 @@ package com.suse.manager.api.docs;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.beans.Introspector;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -199,7 +200,10 @@ public class UyuniSwaggerReader {
         if (name.startsWith("get")) {
             name = name.substring(3);
         }
-        return name.isEmpty() ? name : Character.toLowerCase(name.charAt(0)) + name.substring(1);
+        else if (name.startsWith("is")) {
+            name = name.substring(2);
+        }
+        return Introspector.decapitalize(name);
     }
 
     private void configureResponses(ApiEndpointDoc apiDoc, Operation operation) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -154,10 +154,52 @@ public class UyuniSwaggerReader {
         MediaType mediaType = new MediaType();
 
         resolveAndRegisterSchema(apiDoc.requestClass());
+        applyLegacyDocTypes(apiDoc.requestClass());
         mediaType.setSchema(buildSchemaRef(apiDoc.requestClass()));
         content.addMediaType(DEFAULT_MEDIA_TYPE, mediaType);
         requestBody.setContent(content);
         operation.setRequestBody(requestBody);
+    }
+
+    /**
+     * Carries the legacy documentation type of the request properties into the specification.
+     *
+     * Some legacy types have no OpenAPI counterpart, so swagger-core normalises them to the
+     * closest primitive. Annotating the request getter with {@link LegacyDocResponse#type()}
+     * keeps the original name available to the documentation parsers.
+     *
+     * @param requestClass the request class of the endpoint
+     */
+    private void applyLegacyDocTypes(Class<?> requestClass) {
+        if (this.components.getSchemas() == null) {
+            return;
+        }
+        Schema<?> requestSchema = this.components.getSchemas().get(schemaRefName(requestClass));
+        if (requestSchema == null || requestSchema.getProperties() == null) {
+            return;
+        }
+        for (Method getter : requestClass.getMethods()) {
+            LegacyDocResponse legacyDoc = getter.getAnnotation(LegacyDocResponse.class);
+            if (legacyDoc == null || legacyDoc.type().isBlank()) {
+                continue;
+            }
+            Schema<?> property = requestSchema.getProperties().get(resolvePropertyName(getter));
+            if (property != null) {
+                property.addExtension(DOC_RESPONSE_TYPE_EXTENSION, legacyDoc.type());
+            }
+        }
+    }
+
+    private String resolvePropertyName(Method getter) {
+        var schemaAnnotation = getter.getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
+        if (schemaAnnotation != null && !schemaAnnotation.name().isEmpty()) {
+            return schemaAnnotation.name();
+        }
+        String name = getter.getName();
+        if (name.startsWith("get")) {
+            name = name.substring(3);
+        }
+        return name.isEmpty() ? name : Character.toLowerCase(name.charAt(0)) + name.substring(1);
     }
 
     private void configureResponses(ApiEndpointDoc apiDoc, Operation operation) {
@@ -341,12 +383,15 @@ public class UyuniSwaggerReader {
     }
 
     private Schema<?> buildSchemaRef(Class<?> clazz) {
+        return new Schema<>().$ref("#/components/schemas/" + schemaRefName(clazz));
+    }
+
+    private String schemaRefName(Class<?> clazz) {
         var classAnnotation = findClassAnnotation(clazz, io.swagger.v3.oas.annotations.media.Schema.class);
-        String refName = Optional.ofNullable(classAnnotation)
+        return Optional.ofNullable(classAnnotation)
                 .map(io.swagger.v3.oas.annotations.media.Schema::name)
                 .filter(name -> !name.isEmpty())
                 .orElse(clazz.getSimpleName());
-        return new Schema<>().$ref("#/components/schemas/" + refName);
     }
 
     private <A extends Annotation> A findClassAnnotation(Class<?> cls, Class<A> annotationClass) {


### PR DESCRIPTION
Generalises the parameter side of the API documentation parsers so that struct parameters
and legacy-only parameter types can be documented. No handler is migrated here: this PR
touches three infrastructure files and nothing else. The handler migrations that use it are
in a follow-up PR.

Splits the parser changes out of #12293 so the handler migrations can go in on their own.

Renders a struct parameter with its properties, which also fixes a $ref parameter coming out as [.null]#null#. Reads @LegacyDocResponse(type = ...) from request getters rather than adding a second annotation for the request side, and lets @LegacyDocResponse(name = ...) set the label of a returned struct, which extractRefName() cannot produce when the label is not all lowercase (SSH data, CPU, OpenSCAP XCCDF Scan).

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No additional tests: the change is covered by the existing
  `ApiDocumentationCompatibilityTest`, which compares the generated AsciiDoc and DocBook
  against the legacy doclet for every registered namespace.

- [x] **DONE**

## Links

Tracks: GSoC 2026 OpenAPI migration

Supersedes the parser part of #12293

- [x] **DONE**

## Changelogs

- [x] No changelog needed
