### PR TITLE
Enhance and fix connection checker (bsc#1262157)

### DIFF
--- a/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes.oholecek.connchecker_fix
+++ b/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes.oholecek.connchecker_fix
@@ -1,0 +1,4 @@
+- Allow 100 connections difference between Apache and Tomcat
+- Fix reading connections from the correct source
+- Add reportdb connections to the database connection limit
+  (bsc#1262157)

--- a/susemanager-utils/supportutils-plugin-susemanager/susemanager-connection-check.pl
+++ b/susemanager-utils/supportutils-plugin-susemanager/susemanager-connection-check.pl
@@ -3,14 +3,27 @@ use strict;
 use XML::Simple;
 use IPC::Open3 ();
 use List::Util qw(min);
+use File::Temp qw(tempfile);
 
 my $apachemax = 0;
 
+# match double quoted non-empty string, or unquoted non-empty string
+# reject empty or without closing double quotes
+my $VALUE_REGEXP = '\s*(?|"(.*?[\S].*?)"|([^\s"].*?)\s*$)';
+
+# default tomcat acceptCount value
+# these connections are on top of tomcat's maxThreads which can wait in TCP queue without triggering error response.
+# we can use them for apache static content not going through tomcat without fear of overloading tomcat.
+my $acceptCount = 100;
+
 sub run_query {
-    my ($command) = @_;
+    my ($command, $is_reportdb) = @_;
     $ENV{'LANG'} = 'C';
+    my @sql_args = ('spacewalk-sql');
+    push(@sql_args, '--reportdb') if $is_reportdb;
+    push(@sql_args, '--select-mode', '-');
     my $pid = IPC::Open3::open3(my $wfh, my $rfh, '>&STDERR',
-                                'spacewalk-sql', '--select-mode', '-') or return;
+                                @sql_args) or return;
     print $wfh $command;
     print $wfh "\n";
     close $wfh;
@@ -39,19 +52,96 @@ sub run_query {
 }
 
 
-open(FILE, "< /etc/apache2/server-tuning.conf") and do
-{
-    my $section = 1;
-    while (<FILE>)
-    {
-        my $line = $_;
-        next if($line =~ /^\s*#/);
-        $section = 0 if ($line =~ /IfModule worker/);
-        $section = 1 if ($section == 0 && /\/IfModule/);
-        $apachemax = int($1) if($section && $line =~ /MaxRequestWorkers\s+(\d+)/);
+sub get_apache_max_request_workers {
+    my $server_flags = "-DSYSCONFIG";
+    my $mpm = "prefork"; # default MPM
+
+    # 1. Read APACHE_SERVER_FLAGS and APACHE_MPM
+    if (open(my $fh, '<', '/etc/sysconfig/apache2')) {
+        while (<$fh>) {
+            if (/^\s*APACHE_SERVER_FLAGS\s*=$VALUE_REGEXP/) {
+                my $flags = $1;
+                $flags =~ s/"//g;
+                foreach my $flag (split(/\s+/, $flags)) {
+                    next unless $flag;
+                    if ($flag =~ /^-D/) {
+                        $server_flags .= " $flag";
+                    } else {
+                        $server_flags .= " -D$flag";
+                    }
+                }
+            }
+            if (/^\s*APACHE_MPM\s*=$VALUE_REGEXP/) {
+                $mpm = $1;
+                $mpm =~ s/"//g;
+            }
+        }
+        close($fh);
     }
-    close FILE;
-};
+
+    # 2. Determine binary based on active MPM
+    my $apache_bin = "/usr/sbin/httpd";
+    if (-x "/usr/sbin/httpd-$mpm") {
+        $apache_bin = "/usr/sbin/httpd-$mpm";
+    }
+
+    # 3. Create temp file to load mod_info
+    my ($tfh, $tfilename) = tempfile();
+    my $mod_path = "/usr/lib64/apache2-$mpm/mod_info.so";
+    $mod_path = "/usr/lib64/apache2/mod_info.so" unless -e $mod_path;
+    print $tfh "LoadModule info_module $mod_path\n";
+    close $tfh;
+
+    # 4. Construct and execute the direct binary call
+    my $cmd = "$apache_bin $server_flags " .
+              "-C 'Include /etc/apache2/sysconfig.d/loadmodule.conf' " .
+              "-C 'Include /etc/apache2/sysconfig.d/global.conf' " .
+              "-f /etc/apache2/httpd.conf " .
+              "-c 'Include /etc/apache2/sysconfig.d/include.conf' " .
+              "-c 'Include $tfilename' " .
+              "-D DUMP_CONFIG 2>&1";
+
+    my $max_clients = 0;
+    if (open(my $out, '-|', $cmd)) {
+        while (<$out>) {
+            if (/^\s*(?:MaxRequestWorkers|MaxClients)\s+(\d+)/i) {
+                $max_clients = int($1);
+            }
+        }
+        close($out);
+    }
+
+    unlink $tfilename;
+
+    # Fallback to static parsing if dynamic extraction failed
+    if ($max_clients == 0) {
+        if (open(my $sfh, "<", "/etc/apache2/server-tuning.conf")) {
+            my $in_active_mpm_section = 0;
+            while (<$sfh>) {
+                my $line = $_;
+                next if ($line =~ /^\s*#/);
+
+                if ($line =~ /<IfModule\s+${mpm}\.c>/) {
+                    $in_active_mpm_section = 1;
+                }
+                elsif ($line =~ /<\/IfModule>/) {
+                    $in_active_mpm_section = 0;
+                }
+
+                if ($in_active_mpm_section && $line =~ /(?:MaxRequestWorkers|MaxClients)\s+(\d+)/) {
+                    $max_clients = int($1);
+                }
+            }
+            close($sfh);
+        }
+    }
+    if ($max_clients == 0) {
+        print STDERR "ERROR: Unable to determine Apache connection limits.\n";
+    }
+    return $max_clients;
+}
+
+$apachemax = get_apache_max_request_workers();
 
 my $ref = XMLin("/etc/tomcat/server.xml");
 my $tomcatmax = 0;
@@ -61,26 +151,43 @@ foreach my $con (@{$ref->{'Service'}->{'Connector'}})
     $tomcatmax = int($con->{'maxThreads'}) if ($con->{'port'} eq "8009" && exists $con->{'maxThreads'} && int($con->{'maxThreads'}) > $tomcatmax);
 }
 
-if( $apachemax > $tomcatmax ) {
-    print STDERR "ERROR: Apache allows more connection ($apachemax) as tomcat do ($tomcatmax). Please align the values\n";
+my $hardmax = $tomcatmax + $acceptCount;
+
+if( $apachemax < $tomcatmax ) {
+    print STDERR "\nERROR: Apache allows fewer connections ($apachemax) than Tomcat does ($tomcatmax). Please align the values.\n";
 }
-else
-{
+elsif( $apachemax > $hardmax ) {
+    # 100 is the default acceptCount value for tomcat. Meaning tomcat accepts up to acceptCount in a TCP queue, see $acceptCount.
+    print STDERR "\nERROR: Apache allows significantly more connections ($apachemax) than Tomcat ($tomcatmax). Please align the values.\n";
+}
+else {
     print "Apache connections: $apachemax\nTomcat connections: $tomcatmax\n";
 }
 
 my $javamax = 0;
+my $reporting_javamax = 0;
 my $dbbackend = "";
 my $saltsshthreads = 0;
+my $report_db_name = "";
+my $db_host = "";
+my $db_port = "5432";
+my $report_db_host = "";
+my $report_db_port = "5432";
 open(FILE, "< /etc/rhn/rhn.conf") and do
 {
     while (<FILE>)
     {
         my $line = $_;
-        next if($line =~ /^\s*#/);
+        next if($line =~ /^\s*#|^\s*$/);
         $javamax = $1 if ($line =~ /hibernate.c3p0.max_size\s*=\s*(\d+)/);
+        $reporting_javamax = $1 if ($line =~ /reporting.hibernate.c3p0.max_size\s*=\s*(\d+)/);
         $dbbackend = $1 if($line =~ /db_backend\s*=\s*(\w+)/);
         $saltsshthreads = $1 if ($line =~ /taskomatic\.sshminion_action_executor\.parallel_threads\s*=\s*(\d+)/);
+        $report_db_name = $1 if ($line =~ /report_db_name\s*=\s*(\w+)/);
+        $db_host = $1 if ($line =~ /db_host\s*=\s*(\S+)/);
+        $db_port = $1 if ($line =~ /db_port\s*=\s*(\d+)/);
+        $report_db_host = $1 if ($line =~ /report_db_host\s*=\s*(\S+)/);
+        $report_db_port = $1 if ($line =~ /report_db_port\s*=\s*(\d+)/);
     }
     close FILE;
 };
@@ -93,6 +200,19 @@ if ($javamax == 0)
             my $line = $_;
             next if($line =~ /^\s*#/);
             $javamax = $1 if ($line =~ /hibernate.c3p0.max_size\s*=\s*(\d+)/);
+        }
+        close FILE;
+    };
+}
+if ($reporting_javamax == 0)
+{
+    open(FILE, "< /usr/share/rhn/config-defaults/rhn_reporting_hibernate.conf") and do
+    {
+        while (<FILE>)
+        {
+            my $line = $_;
+            next if($line =~ /^\s*#/);
+            $reporting_javamax = $1 if ($line =~ /reporting.hibernate.c3p0.max_size\s*=\s*(\d+)/);
         }
         close FILE;
     };
@@ -150,25 +270,60 @@ my $saltmax = $worker_threads + $saltsshthreads + 2;
 # java web ui, taskomatic uses c3p0 pooling
 # search used a fixed number of connections (10)
 # + every apache process can eat a connection
-# + every salt mworker (pillar rendering) + mgr_events.py engine + uyuni roster module
-# + every reposync subproccess connects for insertions
+# + every salt worker (pillar rendering) + mgr_events.py engine + uyuni roster module
+# + every reposync subprocess connects for insertions
 # + buffer for local connections (including custom Salt code)
 my $mindb = (2*$javamax) + $apachemax + 10 + $saltmax + $reposyncmax + 30;
-my $dblimit = 0;
+my $min_report_db = (2 * $reporting_javamax) + 10;
 
-$dblimit = run_query(<<EOF);
+my $dblimit = run_query(<<EOF, 0);
     show max_connections;
 EOF
-if (! defined $dblimit)
-{
-    print "Unable to query the allowed DB connections.\n";
-    print "Minimal required DB connection: $mindb\n";
+
+my $norm_db_host = $db_host || "localhost";
+$norm_db_host = "localhost" if $norm_db_host eq "127.0.0.1";
+my $norm_report_db_host = $report_db_host || "localhost";
+$norm_report_db_host = "localhost" if $norm_report_db_host eq "127.0.0.1";
+
+my $shared_db = 0;
+if ($report_db_name ne "" && $norm_db_host eq $norm_report_db_host && $db_port eq $report_db_port) {
+    $shared_db = 1;
 }
-elsif ($dblimit < $mindb)
-{
-    print STDERR "ERROR: SUSE Manager requires more connection ($mindb) as the database provide ($dblimit). Please align the values\n";
-}
-else
-{
-    print "Minimal required DB connection: $mindb\nAvailable DB connections: $dblimit\n";
+
+if ($shared_db) {
+    my $combined_min = $mindb + $min_report_db;
+    if (! defined $dblimit) {
+        print "Unable to query the allowed DB connections.\n";
+        print "Minimal required DB connections: $mindb\n";
+        print "Minimal required Report DB connections: $min_report_db\n";
+    } elsif ($dblimit < $combined_min) {
+        print STDERR "ERROR: SUSE Multi-Linux Manager requires more connections ($combined_min) than the database provides ($dblimit). Please align the values\n";
+    } else {
+        print "Minimal required DB connections: $mindb\n";
+        print "Minimal required Report DB connections: $min_report_db\n";
+        print "Minimal required connections: $combined_min\nAvailable DB connections: $dblimit\n";
+    }
+} else {
+    if (! defined $dblimit) {
+        print "Unable to query the allowed DB connections.\n";
+        print "Minimal required DB connections: $mindb\n";
+    } elsif ($dblimit < $mindb) {
+        print STDERR "ERROR: SUSE Multi-Linux Manager requires more connections ($mindb) than the database provides ($dblimit). Please align the values\n";
+    } else {
+        print "Minimal required DB connections: $mindb\nAvailable DB connections: $dblimit\n";
+    }
+
+    if ($report_db_name ne "") {
+        my $report_dblimit = run_query(<<EOF, 1);
+            show max_connections;
+EOF
+        if (! defined $report_dblimit) {
+            print "Unable to query the allowed Report DB connections.\n";
+            print "Minimal required Report DB connections: $min_report_db\n";
+        } elsif ($report_dblimit < $min_report_db) {
+            print STDERR "ERROR: SUSE Multi-Linux Manager Report DB requires more connections ($min_report_db) than the database provides ($report_dblimit). Please align the values\n";
+        } else {
+            print "Minimal required Report DB connections: $min_report_db\nAvailable Report DB connections: $report_dblimit\n";
+        }
+    }
 }

--- a/susemanager-utils/supportutils-plugin-susemanager/susemanager-connection-check.pl
+++ b/susemanager-utils/supportutils-plugin-susemanager/susemanager-connection-check.pl
@@ -3,7 +3,6 @@ use strict;
 use XML::Simple;
 use IPC::Open3 ();
 use List::Util qw(min);
-use File::Temp qw(tempfile);
 
 my $apachemax = 0;
 
@@ -53,10 +52,10 @@ sub run_query {
 
 
 sub get_apache_max_request_workers {
-    my $server_flags = "-DSYSCONFIG";
+    my @server_flags = ("-DSYSCONFIG");
     my $mpm = "prefork"; # default MPM
 
-    # 1. Read APACHE_SERVER_FLAGS and APACHE_MPM
+    # Read APACHE_SERVER_FLAGS and APACHE_MPM
     if (open(my $fh, '<', '/etc/sysconfig/apache2')) {
         while (<$fh>) {
             if (/^\s*APACHE_SERVER_FLAGS\s*=$VALUE_REGEXP/) {
@@ -65,9 +64,9 @@ sub get_apache_max_request_workers {
                 foreach my $flag (split(/\s+/, $flags)) {
                     next unless $flag;
                     if ($flag =~ /^-D/) {
-                        $server_flags .= " $flag";
+                        push @server_flags, $flag;
                     } else {
-                        $server_flags .= " -D$flag";
+                        push @server_flags, "-D$flag";
                     }
                 }
             }
@@ -79,42 +78,38 @@ sub get_apache_max_request_workers {
         close($fh);
     }
 
-    # 2. Determine binary based on active MPM
+    # Determine binary based on active MPM
     my $apache_bin = "/usr/sbin/httpd";
     if (-x "/usr/sbin/httpd-$mpm") {
         $apache_bin = "/usr/sbin/httpd-$mpm";
     }
 
-    # 3. Create temp file to load mod_info
-    my ($tfh, $tfilename) = tempfile();
     my $mod_path = "/usr/lib64/apache2-$mpm/mod_info.so";
     $mod_path = "/usr/lib64/apache2/mod_info.so" unless -e $mod_path;
-    print $tfh "LoadModule info_module $mod_path\n";
-    close $tfh;
 
-    # 4. Construct and execute the direct binary call
-    my $cmd = "$apache_bin $server_flags " .
-              "-C 'Include /etc/apache2/sysconfig.d/loadmodule.conf' " .
-              "-C 'Include /etc/apache2/sysconfig.d/global.conf' " .
-              "-f /etc/apache2/httpd.conf " .
-              "-c 'Include /etc/apache2/sysconfig.d/include.conf' " .
-              "-c 'Include $tfilename' " .
-              "-D DUMP_CONFIG 2>&1";
+    # Construct and execute the direct binary call
+    my @cmd = ($apache_bin,
+        @server_flags,
+        '-C', 'Include /etc/apache2/sysconfig.d/loadmodule.conf',
+        '-C', 'Include /etc/apache2/sysconfig.d/global.conf',
+        '-f', '/etc/apache2/httpd.conf',
+        '-c', 'Include /etc/apache2/sysconfig.d/include.conf',
+        '-c', "LoadModule info_module $mod_path",
+        '-D', 'DUMP_CONFIG');
 
     my $max_clients = 0;
-    if (open(my $out, '-|', $cmd)) {
-        while (<$out>) {
-            if (/^\s*(?:MaxRequestWorkers|MaxClients)\s+(\d+)/i) {
-                $max_clients = int($1);
-            }
+    my $out;
+    my $pid = IPC::Open3::open3(undef, $out, '>', @cmd);
+    while (my $line = <$out>) {
+        if ($line =~ /^\s*(?:MaxRequestWorkers|MaxClients)\s+(\d+)/i) {
+            $max_clients = int($1);
         }
-        close($out);
     }
-
-    unlink $tfilename;
+    waitpid( $pid, 0);
 
     # Fallback to static parsing if dynamic extraction failed
     if ($max_clients == 0) {
+        print STDERR "WARN: Unable to check Apache variables, trying conf files directly\n";
         if (open(my $sfh, "<", "/etc/apache2/server-tuning.conf")) {
             my $in_active_mpm_section = 0;
             while (<$sfh>) {
@@ -154,11 +149,11 @@ foreach my $con (@{$ref->{'Service'}->{'Connector'}})
 my $hardmax = $tomcatmax + $acceptCount;
 
 if( $apachemax < $tomcatmax ) {
-    print STDERR "\nERROR: Apache allows fewer connections ($apachemax) than Tomcat does ($tomcatmax). Please align the values.\n";
+    print STDERR "ERROR: Apache allows fewer connections ($apachemax) than Tomcat does ($tomcatmax). Please align the values.\n";
 }
 elsif( $apachemax > $hardmax ) {
     # 100 is the default acceptCount value for tomcat. Meaning tomcat accepts up to acceptCount in a TCP queue, see $acceptCount.
-    print STDERR "\nERROR: Apache allows significantly more connections ($apachemax) than Tomcat ($tomcatmax). Please align the values.\n";
+    print STDERR "ERROR: Apache allows significantly more connections ($apachemax) than Tomcat ($tomcatmax). Please align the values.\n";
 }
 else {
     print "Apache connections: $apachemax\nTomcat connections: $tomcatmax\n";


### PR DESCRIPTION
## What does this PR change?

Parse info from http server for correct max connections, as a fallback it reads server-tuning but now the correct section.

Allow http server connections to be up to 100 more then tomcat. This is in line with acceptCount property of tomcat which is by default 100 and means that tomcat can queue 100 TCP connections on top of maxThreads. We also should have more connections in http server to serve content not going through tomcat.

Add reportdb connections to the overall database connection check.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: not covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30359
Port(s): https://github.com/SUSE/spacewalk/pull/31546 https://github.com/SUSE/spacewalk/pull/31553
- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
