### PR TITLE
Reuse Check component in RBAC UI

### DIFF
--- a/web/html/src/manager/admin/access-control/access-group-permissions.test.tsx
+++ b/web/html/src/manager/admin/access-control/access-group-permissions.test.tsx
@@ -1,0 +1,171 @@
+import { Utils } from "utils/functions";
+import Network from "utils/network";
+import { click, render, screen, within } from "utils/test-utils";
+
+import type { AccessGroupState } from "./access-group";
+import AccessGroupPermissions, { type NamespaceItem } from "./access-group-permissions";
+import { type PermissionType, AccessMode } from "./access-mode";
+
+type Permission = AccessGroupState["permissions"][string];
+type NamespaceLeaf = Omit<NamespaceItem, "id"> & { id: number };
+const permissionTypes: PermissionType[] = ["view", "modify"];
+
+const buildNamespaceBranch = (overrides: Partial<NamespaceItem> = {}): NamespaceItem => ({
+  namespace: "test",
+  name: "test",
+  description: "",
+  isAPI: false,
+  accessMode: AccessMode.NONE,
+  children: [],
+  ...overrides,
+});
+
+const buildNamespaceLeaf = (overrides: Partial<NamespaceLeaf> = {}): NamespaceLeaf => ({
+  id: 1,
+  namespace: "test.namespace",
+  name: "namespace",
+  description: "Test permission",
+  isAPI: false,
+  accessMode: AccessMode.READ_WRITE,
+  children: [],
+  ...overrides,
+});
+
+const buildPermission = (overrides: Partial<Permission> = {}): Permission => ({
+  id: 1,
+  namespace: "test.namespace",
+  description: "Test permission",
+  accessMode: AccessMode.READ_WRITE,
+  view: false,
+  modify: false,
+  ...overrides,
+});
+
+const buildAccessGroupState = (overrides: Partial<AccessGroupState> = {}): AccessGroupState => ({
+  id: 1,
+  name: "Test group",
+  description: "",
+  orgId: 1,
+  orgName: "Test organization",
+  accessGroups: [],
+  permissions: {},
+  users: [],
+  errors: {},
+  permissionsModified: false,
+  ...overrides,
+});
+
+const detailsNamespace = buildNamespaceLeaf({
+  id: 1,
+  namespace: "systems.details",
+  name: "details",
+  description: "View system details",
+});
+
+const historyNamespace = buildNamespaceLeaf({
+  id: 2,
+  namespace: "systems.history",
+  name: "history",
+  description: "View system history",
+});
+
+const namespaces = [
+  buildNamespaceBranch({
+    namespace: "systems",
+    name: "systems",
+    children: [detailsNamespace, historyNamespace],
+  }),
+];
+
+const buildSelectedPermission = (namespace: NamespaceLeaf, type: PermissionType): Permission =>
+  buildPermission({
+    id: namespace.id,
+    namespace: namespace.namespace,
+    description: namespace.description,
+    accessMode: namespace.accessMode,
+    [type]: true,
+  });
+
+const renderPermissions = async (permissions: AccessGroupState["permissions"], onChange = jest.fn()) => {
+  jest.spyOn(Network, "get").mockReturnValue(Utils.cancelable(Promise.resolve({ namespaces })));
+  const state = buildAccessGroupState({ permissions });
+
+  render(<AccessGroupPermissions state={state} onChange={onChange} errors={state.errors} />);
+
+  const parentRow = (await screen.findByText("systems")).closest("tr");
+  expect(parentRow).not.toBeNull();
+
+  const [view, modify] = within(parentRow!).getAllByRole("checkbox") as HTMLInputElement[];
+  return { view, modify };
+};
+
+describe("AccessGroupPermissions", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("renders permission checkboxes using the unstyled CheckInput component", async () => {
+    const checkboxes = await renderPermissions({});
+
+    Object.values(checkboxes).forEach((checkbox) => {
+      expect(checkbox.className).not.toContain("form-check-input");
+    });
+  });
+
+  test.each<PermissionType>(permissionTypes)(
+    "renders the parent %s permission as indeterminate when only one child is selected",
+    async (type) => {
+      const checkboxes = await renderPermissions({
+        [detailsNamespace.namespace]: buildSelectedPermission(detailsNamespace, type),
+      });
+
+      expect(checkboxes[type].checked).toBe(false);
+      expect(checkboxes[type].indeterminate).toBe(true);
+    }
+  );
+
+  test.each<PermissionType>(permissionTypes)(
+    "renders the parent %s permission as checked when all children are selected",
+    async (type) => {
+      const checkboxes = await renderPermissions({
+        [detailsNamespace.namespace]: buildSelectedPermission(detailsNamespace, type),
+        [historyNamespace.namespace]: buildSelectedPermission(historyNamespace, type),
+      });
+
+      expect(checkboxes[type].checked).toBe(true);
+      expect(checkboxes[type].indeterminate).toBe(false);
+    }
+  );
+
+  test("selecting a parent permission applies the change to all children", async () => {
+    const onChange = jest.fn();
+    const checkboxes = await renderPermissions({}, onChange);
+
+    await click(checkboxes.view);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({
+      [detailsNamespace.namespace]: expect.objectContaining({ namespace: detailsNamespace.namespace, view: true }),
+      [historyNamespace.namespace]: expect.objectContaining({ namespace: historyNamespace.namespace, view: true }),
+    });
+  });
+
+  test("clearing a parent permission removes the permission from all children", async () => {
+    const onChange = jest.fn();
+    const checkboxes = await renderPermissions(
+      {
+        [detailsNamespace.namespace]: buildSelectedPermission(detailsNamespace, "view"),
+        [historyNamespace.namespace]: buildSelectedPermission(historyNamespace, "view"),
+      },
+      onChange
+    );
+
+    await click(checkboxes.view);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({
+      [detailsNamespace.namespace]: undefined,
+      [historyNamespace.namespace]: undefined,
+    });
+  });
+});

--- a/web/html/src/manager/admin/access-control/access-group-permissions.tsx
+++ b/web/html/src/manager/admin/access-control/access-group-permissions.tsx
@@ -2,10 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import debounce from "lodash/debounce";
 
-import { AccessGroupState } from "manager/admin/access-control/access-group";
+import type { AccessGroupState } from "manager/admin/access-control/access-group";
 
 import { Button } from "components/buttons";
-import { DEPRECATED_Check, Form } from "components/input";
+import { CheckInput, DEPRECATED_Check, Form } from "components/input";
 import { Column } from "components/table/Column";
 import { SearchField } from "components/table/SearchField";
 import { Table } from "components/table/Table";
@@ -13,6 +13,7 @@ import { MessagesContainer, showErrorToastr } from "components/toastr";
 
 import Network from "utils/network";
 
+import { type AccessModeValue, type PermissionType, AccessMode, AccessModeByPermissionType } from "./access-mode";
 import styles from "./AccessGroup.module.scss";
 
 type Props = {
@@ -21,18 +22,18 @@ type Props = {
   errors: any;
 };
 
-type NamespaceItem = {
+export type NamespaceItem = {
+  id?: number;
   namespace: string;
   name: string;
-  description?: string;
+  description: string;
   isAPI: boolean;
-  children?: NamespaceItem[];
-  accessMode?: string[];
+  children: NamespaceItem[];
+  accessMode: AccessModeValue;
 };
 
 const AccessGroupPermissions = (props: Props) => {
   const [namespaces, setNamespaces] = useState<NamespaceItem[]>([]);
-  const checkboxRefs = useRef({});
   const [apiNamespace, setApiNamespace] = useState(false);
   const [webNamespace, setWebNamespace] = useState(false);
   const [showOnlySelected, setShowOnlySelected] = useState(false);
@@ -42,8 +43,8 @@ const AccessGroupPermissions = (props: Props) => {
   const [expandCollapseAll, setExpandCollapseAll] = useState(false);
   const agAppliedRef = useRef(false);
 
-  const isItemDisabled = useCallback((item, type) => {
-    const requiredAccessMode = type === "view" ? "R" : "W";
+  const isItemDisabled = useCallback((item, type: PermissionType) => {
+    const requiredAccessMode = AccessModeByPermissionType[type];
 
     if (!item.children || item.children.length === 0) {
       return !item.accessMode.includes(requiredAccessMode);
@@ -139,8 +140,8 @@ const AccessGroupPermissions = (props: Props) => {
           response["toCopy"].forEach((item) => {
             changes[item.namespace] = {
               ...item,
-              view: item.accessMode.includes("R"),
-              modify: item.accessMode.includes("W"),
+              view: item.accessMode.includes(AccessMode.READ),
+              modify: item.accessMode.includes(AccessMode.WRITE),
             };
           });
 
@@ -171,22 +172,6 @@ const AccessGroupPermissions = (props: Props) => {
     debouncedGetNamespaces(searchValue);
   }, [searchValue, debouncedGetNamespaces]);
 
-  useEffect(() => {
-    namespaces.forEach((item) => {
-      const updateRefsRecursively = (node) => {
-        const state = getCheckState(node, "modify");
-        const ref = checkboxRefs.current[node.namespace];
-        if (ref) {
-          ref.indeterminate = state === "partially";
-        }
-        if (node.children) {
-          node.children.forEach(updateRefsRecursively);
-        }
-      };
-      updateRefsRecursively(item);
-    });
-  }, [namespaces, props.state.permissions, getCheckState]);
-
   const setNamespacesCheck = (model) => {
     setApiNamespace(!!model.apiNamespace);
     setWebNamespace(!!model.webNamespace);
@@ -207,7 +192,7 @@ const AccessGroupPermissions = (props: Props) => {
   });
 
   const namespacesFilter = (
-    <div className="d-flex">
+    <div key="namespace-filter" className="d-flex">
       <div className="ms-4">
         <Form model={{ apiNamespace, webNamespace, showOnlySelected }} onChange={setNamespacesCheck}>
           <div className="d-flex">
@@ -311,6 +296,20 @@ const AccessGroupPermissions = (props: Props) => {
     }
   }, [searchValue, isLoading]);
 
+  const renderPermissionCheck = (item: NamespaceItem, type: PermissionType) => {
+    const state = getCheckState(item, type);
+
+    return (
+      <CheckInput
+        name={type}
+        checked={state === "checked"}
+        indeterminate={state === "partially"}
+        disabled={isItemDisabled(item, type)}
+        onChange={() => handleChange(item, type)}
+      />
+    );
+  };
+
   return (
     <div>
       <MessagesContainer />
@@ -377,49 +376,11 @@ const AccessGroupPermissions = (props: Props) => {
           }}
           width="50%"
         />
-        <Column
-          columnKey="view"
-          header={t("View")}
-          cell={(item) => {
-            const state = getCheckState(item, "view");
-            return (
-              <input
-                key={item.namespace}
-                name="view"
-                type="checkbox"
-                checked={state === "checked"}
-                ref={(el) => {
-                  if (el) el.indeterminate = state === "partially";
-                }}
-                disabled={isItemDisabled(item, "view")}
-                onChange={() => handleChange(item, "view")}
-              />
-            );
-          }}
-          width="10%"
-        />
+        <Column columnKey="view" header={t("View")} cell={(item) => renderPermissionCheck(item, "view")} width="10%" />
         <Column
           columnKey="modify"
           header={t("Modify")}
-          cell={(item) => {
-            const state = getCheckState(item, "modify");
-            return (
-              <input
-                key={item.namespace}
-                name="modify"
-                type="checkbox"
-                checked={state === "checked"}
-                ref={(el) => {
-                  if (el) {
-                    checkboxRefs.current[item.namespace] = el;
-                    el.indeterminate = state === "partially";
-                  }
-                }}
-                disabled={isItemDisabled(item, "modify")}
-                onChange={() => handleChange(item, "modify")}
-              />
-            );
-          }}
+          cell={(item) => renderPermissionCheck(item, "modify")}
           width="10%"
         />
       </Table>

--- a/web/html/src/manager/admin/access-control/access-group-review.tsx
+++ b/web/html/src/manager/admin/access-control/access-group-review.tsx
@@ -7,6 +7,8 @@ import { Table } from "components/table/Table";
 import { Utils } from "utils/functions";
 import Network from "utils/network";
 
+import { type PermissionType, AccessModeByPermissionType } from "./access-mode";
+
 type Props = {
   state: any;
   onChange?: () => void;
@@ -18,8 +20,8 @@ const AccessGroupReview = (props: Props) => {
   const [expandCollapseAll, setExpandCollapseAll] = useState(true);
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
 
-  const isItemDisabled = useCallback((item, type) => {
-    const requiredAccessMode = type === "view" ? "R" : "W";
+  const isItemDisabled = useCallback((item, type: PermissionType) => {
+    const requiredAccessMode = AccessModeByPermissionType[type];
 
     if (!item.children || item.children.length === 0) {
       return !item.accessMode.includes(requiredAccessMode);

--- a/web/html/src/manager/admin/access-control/access-group.tsx
+++ b/web/html/src/manager/admin/access-control/access-group.tsx
@@ -13,12 +13,13 @@ import AccessGroupDetails, { AccessGroupDetailsHandle } from "./access-group-det
 import AccessGroupPermissions from "./access-group-permissions";
 import AccessGroupReview from "./access-group-review";
 import AccessGroupUsers from "./access-group-user";
+import type { AccessModeValue } from "./access-mode";
 
 type Permission = {
   id: number;
   namespace: string;
   description: string;
-  accessMode: string;
+  accessMode: AccessModeValue;
   view: boolean;
   modify: boolean;
 };

--- a/web/html/src/manager/admin/access-control/access-mode.ts
+++ b/web/html/src/manager/admin/access-control/access-mode.ts
@@ -1,0 +1,15 @@
+export const AccessMode = {
+  NONE: "",
+  READ: "R",
+  WRITE: "W",
+  READ_WRITE: "RW",
+} as const;
+
+export type AccessModeValue = (typeof AccessMode)[keyof typeof AccessMode];
+
+export const AccessModeByPermissionType = {
+  view: AccessMode.READ,
+  modify: AccessMode.WRITE,
+} as const;
+
+export type PermissionType = keyof typeof AccessModeByPermissionType;

--- a/web/spacewalk-web.changes.emaksy.rbac-check
+++ b/web/spacewalk-web.changes.emaksy.rbac-check
@@ -1,0 +1,2 @@
+- Refactor checkboxes in the RBAC UI
+- Reuse common Check component


### PR DESCRIPTION
## What does this PR change?

This PR replaces the custom RBAC permission checkboxes with the reusable `Check` component.

It preserves the existing checked and indeterminate states while removing the separate checkbox ref and `useEffect` logic.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [X ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31511
Port(s): # **add downstream PR(s), if any**

- [ X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [X ] Re-run test "changelog_test"
- [ X] Re-run test "backend_unittests_pgsql"
- [ X] Re-run test "java_pgsql_tests"
- [ X] Re-run test "schema_migration_test_pgsql"
- [ X] Re-run test "susemanager_unittests"
- [ X] Re-run test "frontend_checks"
- [ X] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
