### PR TITLE
Detect an existing cgroup2 mount by filesystem type, not mountpoint

### DIFF
--- a/containers/server-image/root/docker-entrypoint-init.d/99-cgroupfs-mount.sh
+++ b/containers/server-image/root/docker-entrypoint-init.d/99-cgroupfs-mount.sh
@@ -8,10 +8,17 @@ if [ "${container:=unknown}" != "oci" ]; then
 fi
 
 # Prepare the cgroup mount for systemd.
-# Skip it when the runtime already provides one (e.g. Kubernetes with
-# private cgroup namespaces): mounting cgroup2 on top of an existing
-# mount fails with EBUSY, which would abort the whole container startup
-# even though systemd can use the existing mount just fine.
-if ! mountpoint -q /sys/fs/cgroup; then
+# Only mount when /sys/fs/cgroup is not already a cgroup2 filesystem.
+#
+# We must check the filesystem type, not just whether it is a mountpoint:
+#   * On Kubernetes the chart mounts an emptyDir at /sys/fs/cgroup to avoid
+#     touching (and potentially corrupting) the host's cgroupfs. That
+#     emptyDir IS a mountpoint, but it is not cgroup2, so systemd needs us
+#     to mount cgroup2 into it.
+#   * Some runtimes pre-mount cgroup2 there (e.g. private cgroup
+#     namespaces). Mounting again would fail with EBUSY and abort startup,
+#     so in that case we must skip.
+# A plain "mountpoint -q" check cannot tell these two apart.
+if [ "$(stat -f -c %T /sys/fs/cgroup 2>/dev/null)" != "cgroup2fs" ]; then
     mount -t cgroup2 none /sys/fs/cgroup
 fi

--- a/containers/server-image/server-image.changes.mbussolotto.cgroup
+++ b/containers/server-image/server-image.changes.mbussolotto.cgroup
@@ -1,0 +1,2 @@
+- Detect an existing cgroup2 mount by filesystem type,
+  not mountpoint.


### PR DESCRIPTION
## What does this PR change?
Currently I cannot install the helm chart on Tumbleweed (RKE2). This PR is for working fix.
Detect an existing cgroup2 mount by filesystem type, not mountpoint.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
