### PR TITLE
Fixed inconsistent SSM button behavior across System Details tabs (bsc#1268632)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryAction.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.action.systems.sdc;
 
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.dto.SystemEventDto;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnAction;
@@ -48,6 +49,8 @@ public class SystemHistoryAction extends RhnAction implements Listable<SystemEve
         RequestContext context = new RequestContext(request);
         Long sid = context.getRequiredParam("sid");
         Server server = context.lookupAndBindServer();
+        User user = context.getCurrentUser();
+        SdcHelper.ssmCheck(request, sid, user);
 
         ListHelper helper = new ListHelper(this, request);
         helper.execute();

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.domain.action.ActionFormatter;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerHistoryEvent;
+import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
@@ -60,6 +61,8 @@ public class SystemHistoryEventAction extends RhnAction {
 
         RequestContext requestContext = new RequestContext(request);
         Server server = requestContext.lookupAndBindServer();
+        User user = requestContext.getCurrentUser();
+        SdcHelper.ssmCheck(request, server.getId(), user);
         Long aid = requestContext.getRequiredParam("aid");
 
         request.setAttribute("aid", aid);

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/sdc/SystemPendingEventsAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/sdc/SystemPendingEventsAction.java
@@ -55,6 +55,7 @@ public class SystemPendingEventsAction extends RhnAction {
         Long sid = context.getRequiredParam("sid");
         Server server = context.lookupAndBindServer();
         User user = context.getCurrentUser();
+        SdcHelper.ssmCheck(request, sid, user);
 
         Map<String, Object> params = makeParamMap(request);
         params.put("sid", server.getId());

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/sdc/SystemPendingEventsCancelAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/sdc/SystemPendingEventsCancelAction.java
@@ -63,6 +63,7 @@ public class SystemPendingEventsCancelAction extends RhnAction {
         Long sid = context.getRequiredParam("sid");
         User user =  context.getCurrentUser();
         Server server = context.lookupAndBindServer();
+        SdcHelper.ssmCheck(request, sid, user);
 
         RhnSet set = RhnSetDecl.PENDING_ACTIONS_TO_DELETE.get(user);
         DataResult<SystemPendingEventDto> result = ActionManager

--- a/java/core/src/main/resources/com/suse/manager/webui/templates/minion/minion-header.jade
+++ b/java/core/src/main/resources/com/suse/manager/webui/templates/minion/minion-header.jade
@@ -1,5 +1,9 @@
 .spacewalk-toolbar-h1
   .spacewalk-toolbar
+    if server.isConvertibleToProxy()
+      a.btn.btn-default(href="/rhn/manager/systems/details/proxy-config?sid=#{server.id}")
+          i.fa.fa-arrow-up(title='Convert to Proxy')
+          | #{l.t("Convert to Proxy")}
     a.btn.btn-danger(href="/rhn/systems/details/DeleteConfirm.do?sid=#{server.id}")
         i.fa.fa-trash-o(title='Delete System')
         | #{l.t("Delete System")}

--- a/java/spacewalk-java.changes.bisht-richa.fix-SSM-btn-inconsistency
+++ b/java/spacewalk-java.changes.bisht-richa.fix-SSM-btn-inconsistency
@@ -1,0 +1,2 @@
+- Fixed inconsistent SSM and Convert to Proxy buttons state on the
+  System Details tabs. (bsc#1268632)


### PR DESCRIPTION
## What does this PR change?

**Fixed inconsistent SSM button behavior across System Details tabs.**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

<img width="3176" height="642" alt="image" src="https://github.com/user-attachments/assets/76a419db-6046-4680-86fc-26e1c71407d5" />

- [x] **DONE**

## Documentation
- No documentation needed: **Fixed inconsistent SSM button behavior across System Details tabs.**


- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): [#31038](https://github.com/SUSE/spacewalk/issues/31038)
Port(s): [# **5.1**](https://github.com/SUSE/spacewalk/pull/31569) [# **5.2**](https://github.com/SUSE/spacewalk/pull/31571)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
