### PR TITLE
Retag the notifications feature and drop profiles for dead scopes

### DIFF
--- a/testsuite/config/cucumber.yml
+++ b/testsuite/config/cucumber.yml
@@ -15,7 +15,6 @@ deblike: --tags @scope_deblike
 formulas: --tags @scope_formulas
 hibernate: --tags @scope_hibernate
 hub: --tags @scope_hub
-kubernetes_integration: --tags @scope_kubernetes_integration
 maintenance_windows: --tags @scope_maintenance_windows
 monitoring: --tags @scope_monitoring
 notification_message: --tags @scope_notification_message
@@ -23,7 +22,6 @@ onboarding: --tags @scope_onboarding
 openscap: --tags @scope_openscap
 power_management: --tags @scope_power_management
 project_lotus: --tags @scope_project_lotus
-proxy: --tags @scope_proxy
 recurring_actions: --tags @scope_recurring_actions
 reportdb: --tags @scope_reportdb
 res: --tags @scope_res
@@ -33,12 +31,7 @@ rhlike: --tags @scope_rhlike
 salt_ssh: --tags @scope_salt_ssh
 salt: --tags @scope_salt
 software_channels_and_repositories: --tags @scope_software_channels_and_repositories
-spacecmd: --tags @scope_spacecmd
 spacewalk_utils: --tags @scope_spacewalk_utils
-sp_migration: --tags @scope_sp_migration
-subscription_matching: --tags @scope_subscription_matching
-sumatoolbox: --tags @scope_sumatoolbox
 tomcat: --tags @scope_tomcat
 virtual_host_manager: --tags @scope_virtual_host_manager
-virtualization: --tags @scope_virtualization
 visualization: --tags @scope_visualization

--- a/testsuite/features/secondary/srv_notifications.feature
+++ b/testsuite/features/secondary/srv_notifications.feature
@@ -1,7 +1,7 @@
-# Copyright (c) 2018-2024 SUSE LLC
+# Copyright (c) 2018-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@scope_visualization
+@scope_notification_message
 Feature: Test the notification/notification-messages feature
 
   Scenario: Log in as org admin user


### PR DESCRIPTION
## What does this PR change?

`testsuite/config/cucumber.yml` defines one cucumber profile per scope tag, in the form `salt: --tags @scope_salt`. Entries have only ever been added, never removed, so the file now offers profiles for tags that no feature carries.

Two of them stay. `features/secondary/srv_notifications.feature` tests the notification messages page but carries `@scope_visualization`, the scope the other fifteen general UI features share; it now carries `@scope_notification_message`, so that scope selects the feature it is named after. `hub` matches no feature either, but its profile is reserved for the hub coverage still to come.

The other seven profiles are removed:

| Profile | Status |
|---|---|
| `kubernetes_integration`, `spacecmd`, `subscription_matching`, `sumatoolbox` | never had a feature |
| `sp_migration` | feature removed 2021-04-29 |
| `virtualization` | removed 2024-09-17 |
| `proxy` | renamed to `@scope_containerized_proxy` 2025-07-21 |

Every remaining profile except `hub` matches a tag that exists in `testsuite/features`, and every tag in use still has a profile.

Nothing in CI sets `PROFILE` — the pipelines select scopes through `TAGS` — so these entries only ever served manual local runs. They matter anyway because they are the list the `functional_scopes` checkboxes in the Jenkins jobs were copied from: a dead profile there becomes a scope a user can tick for a run that then matches nothing, reports `0 scenarios` and still exits green. SUSE/susemanager-ci#2171 rebuilds those lists from the tags each branch actually has, `@scope_notification_message` and `@scope_hub` included, and should merge after this one.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No new tests: one existing feature moves from `@scope_visualization` to `@scope_notification_message`, so the same scenarios run under a different scope

- [x] **DONE**

## Links

Issue(s): none
Port(s):
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31562
Manager-5.1: https://github.com/SUSE/spacewalk/pull/31563

Related:
susemanager-ci: https://github.com/SUSE/susemanager-ci/pull/2171
Follow-up card: https://github.com/SUSE/spacewalk/issues/31564

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
