### PR TITLE
Restore the stopper keyword in check_text?

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -135,17 +135,26 @@ end
 #
 # @param text1 [String] The first text to check for visibility.
 # @param text2 [String, nil] The second text to check for visibility (optional).
+# @param stopper [String, nil] Text that aborts the wait and makes the check fail if it shows up first (optional).
 # @param timeout [Integer] The maximum time to wait for the text to become visible (default: Capybara.default_max_wait_time).
 # @return [Boolean] Returns true if the text is visible, false otherwise.
-def check_text?(text1, text2: nil, timeout: Capybara.default_max_wait_time)
+def check_text?(text1, text2: nil, stopper: nil, timeout: Capybara.default_max_wait_time)
   # Rely on Capybara's (Playwright-backed) native auto-waiting instead of a hand-rolled
   # polling loop: has_text? already polls the page until the text appears or `wait` elapses.
   # When two candidates are given, OR them into a single Regexp so the whole `timeout` budget
   # is shared across both instead of being spent sequentially on each one (the old loop waited
   # 1s on text1 before ever looking at text2). Capybara.default_normalize_ws collapses
   # whitespace for us. Regexp.union escapes both strings, so regex metacharacters stay literal.
-  pattern = text2.nil? ? text1 : Regexp.union(text1, text2)
-  has_text?(pattern, wait: timeout)
+  wanted = text2.nil? ? text1 : Regexp.union(text1, text2)
+  return has_text?(wanted, wait: timeout) if stopper.nil?
+
+  # A stopper is the opposite of text2: it must NOT appear. Race it against the wanted text in a
+  # single Regexp so the timeout stays a shared budget and we give up as soon as the stopper shows
+  # up, instead of burning the whole timeout waiting for a text that will never come.
+  return false unless has_text?(Regexp.union(wanted, stopper), wait: timeout)
+
+  # Both may be on the page by now; the wanted text wins, as in the pre-Playwright loop.
+  has_text?(wanted, wait: 0)
 rescue Capybara::ElementNotFound, NoMethodError
   # Page was mid-navigation / driver transiently unusable: treat as "not found".
   false


### PR DESCRIPTION
## What does this PR change?

The Playwright rewrite of `check_text?` dropped the `stopper:` keyword, but `navigation_steps.rb` still passes it. The step `I wait at most N seconds until I see "..." text but do not see "..." text` therefore raises `unknown keyword: :stopper (ArgumentError)` instead of running, so its only user, `minssh_tunnel.feature`, never checked for the cleanup error it was written to catch.

`stopper:` is restored with must-not-see semantics, which `text2:` does not provide — `text2:` is an OR-match. The stopper is raced against the wanted text in a single `Regexp`, so the timeout stays a shared budget and the check fails as soon as the stopper appears instead of waiting out the full 180 seconds.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s):
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31573
Manager-5.1: https://github.com/SUSE/spacewalk/pull/31574

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
