### PR TITLE
Fix html export when test is failing

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -47,6 +47,22 @@ namespace :cucumber do
       # Cucumber is now configured to use the consistent path/timestamp
       t.cucumber_opts = cucumber_opts + features unless features.nil?
     end
+    # Cucumber::Rake::Task's own action raises as soon as any scenario fails (fail_on_error
+    # defaults to true), which would skip the html-export `enhance` action below entirely —
+    # Rake::Task#execute runs a task's actions in sequence with no rescue between them, so
+    # _html_path.txt never gets written on a failing run. Swap in a wrapped action that stashes
+    # the failure and re-raises it after the export below runs, mirroring the `cucumber_error`
+    # capture/cleanup/re-raise shape the `parallel` namespace already uses further down.
+    cucumber_task = Rake::Task[task_name]
+    run_action = cucumber_task.actions.pop
+    cucumber_error = nil
+    cucumber_task.enhance do |t, args|
+      begin
+        run_action.call(t, args)
+      rescue RuntimeError => e
+        cucumber_error = e
+      end
+    end
     if filename == :reference_reposync
       # The SLES 15 SP7 product-sync scenario in this run set waits on ~19 channels sequentially;
       # individual channel syncs have been observed taking up to 1110s, so the default 2400s
@@ -67,6 +83,7 @@ namespace :cucumber do
     # This block executes when the task runs and uses the exact same `html_results` path.
     # This file is used to expose the cucumber html report in Jenkins
     Rake::Task[task_name].enhance do
+      sh "echo '#{html_results}' > #{path_export_file}", verbose: false
       if File.exist?(html_results)
         html_content = File.read(html_results)
         sort_call = 'i.sort(((e,t)=>(e.uri||"").localeCompare(t.uri||"")))'
@@ -77,8 +94,7 @@ namespace :cucumber do
           raise "Could not find sort patch target in #{html_results} — report ordering will be broken. Update sort_call if the formatter was upgraded."
         end
       end
-
-      sh "echo '#{html_results}' > #{path_export_file}", verbose: false
+      raise cucumber_error if cucumber_error
     end
   end
 end


### PR DESCRIPTION
## What does this PR change?

`rake cucumber:*` raises as soon as a scenario fails (`fail_on_error` defaults to true in `Cucumber::Rake::Task`), which skipped the `enhance` block right after it that writes the HTML report export path file. On a failing run, `_html_path.txt` was never written, so Jenkins couldn't publish the HTML report for the run that most needed it.

Wraps the task's own action so a failure is stashed instead of raised immediately, lets the html-export `enhance` block run as before, then re-raises the stashed failure afterwards — so the build still fails, but the HTML report is exported first.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): 
Port(s): 
  - 5.2: https://github.com/SUSE/spacewalk/pull/31582
  - 5.1: https://github.com/SUSE/spacewalk/pull/31583

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test`

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!