### PR TITLE
Mount cgroup2 unless /sys/fs/cgroup already holds one

### DIFF
--- a/containers/server-image/root/docker-entrypoint-init.d/99-cgroupfs-mount.sh
+++ b/containers/server-image/root/docker-entrypoint-init.d/99-cgroupfs-mount.sh
@@ -8,10 +8,13 @@ if [ "${container:=unknown}" != "oci" ]; then
 fi
 
 # Prepare the cgroup mount for systemd.
-# Skip it when the runtime already provides one (e.g. Kubernetes with
+# Skip it when cgroup2 is already mounted there (e.g. Kubernetes with
 # private cgroup namespaces): mounting cgroup2 on top of an existing
-# mount fails with EBUSY, which would abort the whole container startup
-# even though systemd can use the existing mount just fine.
-if ! mountpoint -q /sys/fs/cgroup; then
+# cgroup2 mount fails with EBUSY, which would abort the whole container
+# startup even though systemd can use the existing mount just fine.
+# Test the filesystem type rather than mountpoint-ness: the Helm chart
+# mounts an emptyDir at /sys/fs/cgroup, which is a mountpoint but not a
+# cgroup filesystem, and systemd cannot start without cgroup2 there.
+if [ "$(stat -f -c %T /sys/fs/cgroup)" != "cgroup2fs" ]; then
     mount -t cgroup2 none /sys/fs/cgroup
 fi

--- a/containers/server-image/server-image.changes.ktsamis.cgroupfs-mount-fstype
+++ b/containers/server-image/server-image.changes.ktsamis.cgroupfs-mount-fstype
@@ -1,0 +1,3 @@
+- Mount cgroup2 in the entrypoint whenever /sys/fs/cgroup is not
+  already a cgroup2 filesystem, so the server container starts on
+  Kubernetes where the Helm chart mounts an emptyDir there


### PR DESCRIPTION
## What does this PR change?

`99-cgroupfs-mount.sh` skips the cgroup2 mount whenever `/sys/fs/cgroup` is a mountpoint. On Kubernetes the server Helm chart mounts an **emptyDir** there (since b39fe9096d06, "Stop using the host's cgroupfs on Kubernetes server"), which is a mountpoint but an ordinary filesystem, so the mount is skipped, systemd finds no cgroup2, falls back to the v1 hierarchy and exits:

```
Failed to mount cgroup (type cgroup) on /sys/fs/cgroup/systemd (MS_NOSUID|MS_NODEV|MS_NOEXEC "none,name=systemd"): Operation not permitted
[!!!!!!] Failed to mount cgroup v1 hierarchy.
Exiting PID 1...
```

The pod crash-loops with exit code 255 and an empty container log, because systemd writes that to `/dev/console`.

Test the filesystem type instead of mountpoint-ness. An existing cgroup2 mount is still left alone, so the runtimes #12239 was written for do not hit EBUSY.

Verified on the RKE2 acceptance-tests environment with server image `2026.08`: with the current script the pod crash-loops as above; with the filesystem-type check systemd reaches `running in system mode` and the pod goes `1/1 Running`.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
