### PR TITLE
feat(openapi): migrate the image.profile handler to OpenAPI contract

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/profile/ImageProfileHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/profile/ImageProfileHandler.java
@@ -50,7 +50,7 @@ import java.util.stream.Collectors;
  * @apidoc.namespace image.profile
  * @apidoc.doc Provides methods to access and modify image profiles.
  */
-public class ImageProfileHandler extends BaseHandler {
+public class ImageProfileHandler extends BaseHandler implements ImageProfileHandlerApi {
 
     /**
      * List available Image Profile Types

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/profile/ImageProfileHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/profile/ImageProfileHandlerApi.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.image.profile;
+
+import com.redhat.rhn.domain.image.ImageProfile;
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+import com.suse.manager.api.docs.LegacyDocResponse;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import spark.route.HttpMethod;
+
+/**
+ * API contract for {@link ImageProfileHandler}.
+ */
+@Tag(name = "image.profile", description = "Provides methods to access and modify image profiles.")
+public interface ImageProfileHandlerApi {
+
+    /**
+     * List available image profile types.
+     *
+     * @param loggedInUser the current user
+     * @return the list of image profile types
+     */
+    @ApiEndpointDoc(
+        summary = "List available image store types",
+        method = HttpMethod.get,
+        responseClass = ImageProfileTypeListResponse.class,
+        responseDescription = "the list of image profile types"
+    )
+    List<String> listImageProfileTypes(User loggedInUser);
+
+    /**
+     * List available image profiles.
+     *
+     * @param loggedInUser the current user
+     * @return the list of image profiles
+     */
+    @ApiEndpointDoc(
+        summary = "List available image profiles",
+        method = HttpMethod.get,
+        responseClass = ImageProfileListResponse.class
+    )
+    List<ImageProfile> listImageProfiles(User loggedInUser);
+
+    /**
+     * Get details of an image profile.
+     *
+     * @param loggedInUser the current user
+     * @param label the image profile label
+     * @return the image profile details
+     */
+    @ApiEndpointDoc(
+        summary = "Get details of an image profile",
+        method = HttpMethod.get,
+        responseClass = ImageProfileResponse.class
+    )
+    ImageProfile getDetails(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "label", in = ParameterIn.QUERY, required = true) String label);
+
+    /**
+     * Create a new image profile.
+     *
+     * @param loggedInUser the current user
+     * @param label the label
+     * @param type the profile type label
+     * @param storeLabel the image store label
+     * @param path the path or git uri to the source
+     * @param activationKey the activation key which defines the channels
+     * @param kiwiOptions command line options passed to Kiwi
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Create a new image profile",
+        requestClass = CreateRequest.class,
+        isIntegerResponse = true
+    )
+    int create(User loggedInUser, String label, String type, String storeLabel, String path,
+               String activationKey, String kiwiOptions);
+
+    /**
+     * Delete an image profile.
+     *
+     * @param loggedInUser the current user
+     * @param label the image profile label
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Delete an image profile",
+        requestClass = LabelRequest.class,
+        isIntegerResponse = true
+    )
+    int delete(User loggedInUser, String label);
+
+    /**
+     * Set details of an image profile.
+     *
+     * @param loggedInUser the current user
+     * @param label the image profile label
+     * @param details a map containing the new details
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set details of an image profile",
+        requestClass = SetDetailsRequest.class,
+        isIntegerResponse = true
+    )
+    int setDetails(User loggedInUser, String label, Map details);
+
+    /**
+     * Get the custom data values defined for the image profile.
+     *
+     * @param loggedInUser the current user
+     * @param label the image profile label
+     * @return the map of custom labels to custom values
+     */
+    @ApiEndpointDoc(
+        summary = "Get the custom data values defined for the image profile",
+        method = HttpMethod.get,
+        responseClass = CustomValuesResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "the map of custom labels to custom values")
+    )
+    Map<String, String> getCustomValues(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "label", in = ParameterIn.QUERY, required = true) String label);
+
+    /**
+     * Set custom values for the specified image profile.
+     *
+     * @param loggedInUser the current user
+     * @param label the image profile label
+     * @param values the map of custom labels to custom values
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set custom values for the specified image profile",
+        requestClass = SetCustomValuesRequest.class,
+        isIntegerResponse = true
+    )
+    int setCustomValues(User loggedInUser, String label, Map<String, String> values);
+
+    /**
+     * Delete the custom values defined for the specified image profile.
+     *
+     * @param loggedInUser the current user
+     * @param label the image profile label
+     * @param keys the custom data keys
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Delete the custom values defined for the specified image profile. " +
+                  "(Note: Attempt to delete values of non-existing keys throws exception. Attempt to " +
+                  "delete value of existing key which has assigned no values doesn't throw exception.)",
+        requestClass = DeleteCustomValuesRequest.class,
+        isIntegerResponse = true
+    )
+    int deleteCustomValues(User loggedInUser, String label, List<String> keys);
+
+    @Schema(name = "CreateImageProfileRequest")
+    @JsonPropertyOrder({"label", "type", "storeLabel", "path", "activationKey", "kiwiOptions"})
+    interface CreateRequest {
+
+        /**
+         * @return the label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the profile type label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getType();
+
+        /**
+         * @return the image store label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getStoreLabel();
+
+        /**
+         * @return the path or git uri to the source
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getPath();
+
+        /**
+         * @return the activation key which defines the channels
+         */
+        @Schema(description = "optional", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getActivationKey();
+
+        /**
+         * @return the command line options passed to Kiwi
+         */
+        @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getKiwiOptions();
+    }
+
+    @Schema(name = "ImageProfileLabelRequest")
+    interface LabelRequest {
+
+        /**
+         * @return the image profile label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+    }
+
+    @Schema(name = "SetImageProfileDetailsRequest")
+    @JsonPropertyOrder({"label", "details"})
+    interface SetDetailsRequest {
+
+        /**
+         * @return the image profile label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the new details
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        DetailsDoc getDetails();
+    }
+
+    @Schema(name = "ImageProfileDetails")
+    @JsonPropertyOrder({"storeLabel", "path", "activationKey"})
+    interface DetailsDoc {
+
+        /**
+         * @return the image store label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getStoreLabel();
+
+        /**
+         * @return the path
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getPath();
+
+        /**
+         * @return the activation key
+         */
+        @Schema(description = "set empty string to unset", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getActivationKey();
+    }
+
+    @Schema(name = "SetImageProfileCustomValuesRequest")
+    @JsonPropertyOrder({"label", "values"})
+    interface SetCustomValuesRequest {
+
+        /**
+         * @return the image profile label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the map of custom labels to custom values
+         */
+        @Schema(description = "the map of custom labels to custom values",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        CustomValuesDoc getValues();
+    }
+
+    @Schema(name = "DeleteImageProfileCustomValuesRequest")
+    @JsonPropertyOrder({"label", "keys"})
+    interface DeleteCustomValuesRequest {
+
+        /**
+         * @return the image profile label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the custom data keys
+         */
+        @Schema(description = "the custom data keys", requiredMode = Schema.RequiredMode.REQUIRED)
+        List<String> getKeys();
+    }
+
+    @Schema(name = "ImageProfileCustomValues")
+    @JsonPropertyOrder({"customInfoLabel", "value"})
+    interface CustomValuesDoc {
+
+        /**
+         * @return the custom info label
+         */
+        @Schema(name = "custom info label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getCustomInfoLabel();
+
+        /**
+         * @return the value
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getValue();
+    }
+
+    @Schema(name = "ImageProfileInformation")
+    @JsonPropertyOrder({"label", "imageType", "imageStore", "activationKey", "path"})
+    interface ImageProfileDoc {
+
+        /**
+         * @return the label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the image type
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getImageType();
+
+        /**
+         * @return the image store
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getImageStore();
+
+        /**
+         * @return the activation key
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getActivationKey();
+
+        /**
+         * @return the path
+         */
+        @Schema(description = "in case type support path", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getPath();
+    }
+
+    @Schema(name = "ApiResponseImageProfileTypeList")
+    interface ImageProfileTypeListResponse extends ApiResponseWrapper<List<String>> { }
+
+    @Schema(name = "ApiResponseImageProfileList")
+    interface ImageProfileListResponse extends ApiResponseWrapper<List<ImageProfileDoc>> { }
+
+    @Schema(name = "ApiResponseImageProfile")
+    interface ImageProfileResponse extends ApiResponseWrapper<ImageProfileDoc> { }
+
+    @Schema(name = "ApiResponseImageProfileCustomValues")
+    interface CustomValuesResponse extends ApiResponseWrapper<CustomValuesDoc> { }
+}

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/profile/ImageProfileHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/profile/ImageProfileHandlerApi.java
@@ -37,6 +37,10 @@ public interface ImageProfileHandlerApi {
     /**
      * List available image profile types.
      *
+     * The summary below intentionally mirrors the legacy doclet text ("image store types"),
+     * which is inaccurate but has to be reproduced verbatim to keep the generated
+     * documentation identical.
+     *
      * @param loggedInUser the current user
      * @return the list of image profile types
      */

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/store/ImageStoreHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/store/ImageStoreHandler.java
@@ -38,7 +38,7 @@ import java.util.Set;
  * @apidoc.namespace image.store
  * @apidoc.doc Provides methods to access and modify image stores.
  */
-public class ImageStoreHandler extends BaseHandler {
+public class ImageStoreHandler extends BaseHandler implements ImageStoreHandlerApi {
 
     /**
      * Create a new Image Store

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/store/ImageStoreHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/store/ImageStoreHandlerApi.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.image.store;
+
+import com.redhat.rhn.domain.image.ImageStore;
+import com.redhat.rhn.domain.image.ImageStoreType;
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import spark.route.HttpMethod;
+
+/**
+ * API contract for {@link ImageStoreHandler}.
+ */
+@Tag(name = "image.store", description = "Provides methods to access and modify image stores.")
+public interface ImageStoreHandlerApi {
+
+    /**
+     * Create a new image store.
+     *
+     * @param loggedInUser the current user
+     * @param label the label
+     * @param uri the uri
+     * @param storeType the store type
+     * @param credentials optional credentials
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Create a new image store",
+        requestClass = CreateRequest.class,
+        isIntegerResponse = true
+    )
+    int create(User loggedInUser, String label, String uri, String storeType, Map<String, String> credentials);
+
+    /**
+     * List available image store types.
+     *
+     * @param loggedInUser the current user
+     * @return the list of available image store types
+     */
+    @ApiEndpointDoc(
+        summary = "List available image store types",
+        method = HttpMethod.get,
+        responseClass = ImageStoreTypeListResponse.class
+    )
+    List<ImageStoreType> listImageStoreTypes(User loggedInUser);
+
+    /**
+     * List available image stores.
+     *
+     * @param loggedInUser the current user
+     * @return the list of configured image stores
+     */
+    @ApiEndpointDoc(
+        summary = "List available image stores",
+        method = HttpMethod.get,
+        responseClass = ImageStoreListResponse.class
+    )
+    List<ImageStore> listImageStores(User loggedInUser);
+
+    /**
+     * Get details of an image store.
+     *
+     * @param loggedInUser the current user
+     * @param label the image store label
+     * @return the image store details
+     */
+    @ApiEndpointDoc(
+        summary = "Get details of an image store",
+        method = HttpMethod.get,
+        responseClass = ImageStoreResponse.class
+    )
+    ImageStore getDetails(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(
+            name = "label",
+            in = ParameterIn.QUERY,
+            required = true
+        ) String label);
+
+    /**
+     * Delete an image store.
+     *
+     * @param loggedInUser the current user
+     * @param label the image store label
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Delete an image store",
+        requestClass = LabelRequest.class,
+        isIntegerResponse = true
+    )
+    int delete(User loggedInUser, String label);
+
+    /**
+     * Set details of an image store.
+     *
+     * @param loggedInUser the current user
+     * @param label the label
+     * @param details a map containing the new details
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set details of an image store",
+        requestClass = SetDetailsRequest.class,
+        isIntegerResponse = true
+    )
+    int setDetails(User loggedInUser, String label, Map details);
+
+    @Schema(name = "CreateImageStoreRequest")
+    @JsonPropertyOrder({"label", "uri", "storeType", "credentials"})
+    interface CreateRequest {
+
+        /**
+         * @return the label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the uri
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUri();
+
+        /**
+         * @return the store type
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getStoreType();
+
+        /**
+         * @return the optional credentials
+         */
+        @Schema(description = "optional", requiredMode = Schema.RequiredMode.REQUIRED)
+        CredentialsDoc getCredentials();
+    }
+
+    @Schema(name = "ImageStoreCredentials")
+    @JsonPropertyOrder({"username", "password"})
+    interface CredentialsDoc {
+
+        /**
+         * @return the username
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUsername();
+
+        /**
+         * @return the password
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getPassword();
+    }
+
+    @Schema(name = "ImageStoreLabelRequest")
+    interface LabelRequest {
+
+        /**
+         * @return the image store label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+    }
+
+    @Schema(name = "SetImageStoreDetailsRequest")
+    @JsonPropertyOrder({"label", "details"})
+    interface SetDetailsRequest {
+
+        /**
+         * @return the label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the new details
+         */
+        @Schema(description = "image store details", requiredMode = Schema.RequiredMode.REQUIRED)
+        DetailsDoc getDetails();
+    }
+
+    @Schema(name = "ImageStoreDetails")
+    @JsonPropertyOrder({"uri", "username", "password"})
+    interface DetailsDoc {
+
+        /**
+         * @return the uri
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUri();
+
+        /**
+         * @return the username
+         */
+        @Schema(description = "pass empty string to unset credentials",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUsername();
+
+        /**
+         * @return the password
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getPassword();
+    }
+
+    @Schema(name = "ImageStoreTypeInformation")
+    @JsonPropertyOrder({"id", "label", "name"})
+    interface ImageStoreTypeDoc {
+
+        /**
+         * @return the id
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the name
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+    }
+
+    @Schema(name = "ImageStoreInformation")
+    @JsonPropertyOrder({"label", "uri", "storetype", "hasCredentials", "username"})
+    interface ImageStoreDoc {
+
+        /**
+         * @return the label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the uri
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUri();
+
+        /**
+         * @return the store type
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getStoretype();
+
+        /**
+         * @return whether the store has credentials
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getHasCredentials();
+
+        /**
+         * @return the username
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUsername();
+    }
+
+    @Schema(name = "ApiResponseImageStoreTypeList")
+    interface ImageStoreTypeListResponse extends ApiResponseWrapper<List<ImageStoreTypeDoc>> { }
+
+    @Schema(name = "ApiResponseImageStoreList")
+    interface ImageStoreListResponse extends ApiResponseWrapper<List<ImageStoreDoc>> { }
+
+    @Schema(name = "ApiResponseImageStore")
+    interface ImageStoreResponse extends ApiResponseWrapper<ImageStoreDoc> { }
+}

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.frontend.xmlrpc.admin.ssh.AdminSshHandler;
 import com.redhat.rhn.frontend.xmlrpc.api.ApiHandler;
 import com.redhat.rhn.frontend.xmlrpc.channel.access.ChannelAccessHandler;
 import com.redhat.rhn.frontend.xmlrpc.distchannel.DistChannelHandler;
+import com.redhat.rhn.frontend.xmlrpc.image.profile.ImageProfileHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.snippet.SnippetHandler;
 import com.redhat.rhn.frontend.xmlrpc.packages.search.PackagesSearchHandler;
 import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
@@ -116,6 +117,7 @@ public final class OpenApiConfig {
         handlers.put("api", ApiHandler.class);
         handlers.put("channel.access", ChannelAccessHandler.class);
         handlers.put("distchannel", DistChannelHandler.class);
+        handlers.put("image.profile", ImageProfileHandler.class);
         handlers.put("kickstart.snippet", SnippetHandler.class);
         handlers.put("packages.search", PackagesSearchHandler.class);
         handlers.put("preferences.locale", PreferencesLocaleHandler.class);

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.frontend.xmlrpc.api.ApiHandler;
 import com.redhat.rhn.frontend.xmlrpc.channel.access.ChannelAccessHandler;
 import com.redhat.rhn.frontend.xmlrpc.distchannel.DistChannelHandler;
 import com.redhat.rhn.frontend.xmlrpc.image.profile.ImageProfileHandler;
+import com.redhat.rhn.frontend.xmlrpc.image.store.ImageStoreHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.snippet.SnippetHandler;
 import com.redhat.rhn.frontend.xmlrpc.packages.search.PackagesSearchHandler;
 import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
@@ -118,6 +119,7 @@ public final class OpenApiConfig {
         handlers.put("channel.access", ChannelAccessHandler.class);
         handlers.put("distchannel", DistChannelHandler.class);
         handlers.put("image.profile", ImageProfileHandler.class);
+        handlers.put("image.store", ImageStoreHandler.class);
         handlers.put("kickstart.snippet", SnippetHandler.class);
         handlers.put("packages.search", PackagesSearchHandler.class);
         handlers.put("preferences.locale", PreferencesLocaleHandler.class);

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ImageProfileHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ImageProfileHandlerContractTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.image.DockerfileProfile;
+import com.redhat.rhn.domain.image.ImageProfile;
+import com.redhat.rhn.domain.image.ImageStore;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.image.profile.ImageProfileHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class ImageProfileHandlerContractTest extends BaseOpenApiTest {
+
+    @Override
+    protected String getApiNamespace() {
+        return "image.profile";
+    }
+
+    @Override
+    protected Class<ImageProfileHandler> getHandlerClass() {
+        return ImageProfileHandler.class;
+    }
+
+    private ImageProfileHandler handler() {
+        return (ImageProfileHandler) handlerMock;
+    }
+
+    /**
+     * Builds a profile serialized by the registered ImageProfileSerializer. A Dockerfile
+     * profile is used because it is the variant carrying the documented "path" property.
+     *
+     * @return the image profile
+     */
+    private ImageProfile imageProfile() {
+        var store = new ImageStore();
+        store.setLabel("test-store");
+
+        var profile = new DockerfileProfile();
+        profile.setLabel("test-profile");
+        profile.setTargetStore(store);
+        profile.setPath("git://example.com/dockerfile#master:/");
+        return profile;
+    }
+
+    @Test
+    public void testListImageProfileTypes() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listImageProfileTypes(with(mockUser));
+            will(returnValue(List.of("dockerfile", "kiwi")));
+        }});
+
+        validateApiContract("/image.profile/listImageProfileTypes", "GET")
+                .onHandlerMethod("listImageProfileTypes", User.class);
+    }
+
+    @Test
+    public void testListImageProfiles() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listImageProfiles(with(mockUser));
+            will(returnValue(List.of(imageProfile())));
+        }});
+
+        validateApiContract("/image.profile/listImageProfiles", "GET")
+                .onHandlerMethod("listImageProfiles", User.class);
+    }
+
+    @Test
+    public void testGetDetails() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getDetails(with(mockUser), with("test-profile"));
+            will(returnValue(imageProfile()));
+        }});
+
+        validateApiContract("/image.profile/getDetails", "GET")
+                .withParams(Map.of("label", new String[]{"test-profile"}))
+                .onHandlerMethod("getDetails", User.class, String.class);
+    }
+
+    @Test
+    public void testCreate() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).create(with(mockUser), with("test-profile"), with("dockerfile"),
+                    with("test-store"), with("git://example.com/dockerfile#master:/"),
+                    with("activation-key"), with("--set-repo=value"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/image.profile/create", "POST")
+                .withBody(Map.of(
+                        "label", "test-profile",
+                        "type", "dockerfile",
+                        "storeLabel", "test-store",
+                        "path", "git://example.com/dockerfile#master:/",
+                        "activationKey", "activation-key",
+                        "kiwiOptions", "--set-repo=value"))
+                .onHandlerMethod("create", User.class, String.class, String.class, String.class, String.class,
+                        String.class, String.class);
+    }
+
+    /**
+     * kiwiOptions is optional, so a request omitting it must dispatch to the shorter overload.
+     */
+    @Test
+    public void testCreateWithoutKiwiOptions() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).create(with(mockUser), with("test-profile"), with("dockerfile"),
+                    with("test-store"), with("git://example.com/dockerfile#master:/"),
+                    with("activation-key"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/image.profile/create", "POST")
+                .withBody(Map.of(
+                        "label", "test-profile",
+                        "type", "dockerfile",
+                        "storeLabel", "test-store",
+                        "path", "git://example.com/dockerfile#master:/",
+                        "activationKey", "activation-key"))
+                .onHandlerMethod("create", User.class, String.class, String.class, String.class, String.class,
+                        String.class);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).delete(with(mockUser), with("test-profile"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/image.profile/delete", "POST")
+                .withBody(Map.of("label", "test-profile"))
+                .onHandlerMethod("delete", User.class, String.class);
+    }
+
+    @Test
+    public void testSetDetails() throws Exception {
+        var details = Map.<String, Object>of(
+                "storeLabel", "test-store",
+                "path", "git://example.com/dockerfile#master:/",
+                "activationKey", "activation-key");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setDetails(with(mockUser), with("test-profile"), with(details));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/image.profile/setDetails", "POST")
+                .withBody(Map.of("label", "test-profile", "details", details))
+                .onHandlerMethod("setDetails", User.class, String.class, Map.class);
+    }
+
+    @Test
+    public void testGetCustomValues() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getCustomValues(with(mockUser), with("test-profile"));
+            will(returnValue(Map.of("custom info label", "test-key", "value", "test-value")));
+        }});
+
+        validateApiContract("/image.profile/getCustomValues", "GET")
+                .withParams(Map.of("label", new String[]{"test-profile"}))
+                .onHandlerMethod("getCustomValues", User.class, String.class);
+    }
+
+    @Test
+    public void testSetCustomValues() throws Exception {
+        var values = Map.of("custom info label", "test-key", "value", "test-value");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setCustomValues(with(mockUser), with("test-profile"), with(values));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/image.profile/setCustomValues", "POST")
+                .withBody(Map.of("label", "test-profile", "values", values))
+                .onHandlerMethod("setCustomValues", User.class, String.class, Map.class);
+    }
+
+    @Test
+    public void testDeleteCustomValues() throws Exception {
+        var keys = List.of("test-key");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).deleteCustomValues(with(mockUser), with("test-profile"), with(keys));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/image.profile/deleteCustomValues", "POST")
+                .withBody(Map.of("label", "test-profile", "keys", keys))
+                .onHandlerMethod("deleteCustomValues", User.class, String.class, List.class);
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ImageStoreHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ImageStoreHandlerContractTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.image.ImageStore;
+import com.redhat.rhn.domain.image.ImageStoreType;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.image.store.ImageStoreHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class ImageStoreHandlerContractTest extends BaseOpenApiTest {
+
+    @Override
+    protected String getApiNamespace() {
+        return "image.store";
+    }
+
+    @Override
+    protected Class<ImageStoreHandler> getHandlerClass() {
+        return ImageStoreHandler.class;
+    }
+
+    private ImageStoreHandler handler() {
+        return (ImageStoreHandler) handlerMock;
+    }
+
+    /**
+     * Builds a store serialized by the registered ImageStoreSerializer. Credentials are left
+     * null so that "hasCredentials" is false and "username" is the empty string, which keeps
+     * the fixture from reaching the credentials tables.
+     *
+     * @return the image store
+     */
+    private ImageStore imageStore() {
+        var store = new ImageStore();
+        store.setLabel("test-store");
+        store.setUri("registry.example.com");
+        store.setStoreType(imageStoreType());
+        return store;
+    }
+
+    private ImageStoreType imageStoreType() {
+        var type = new ImageStoreType();
+        type.setId(1L);
+        type.setLabel("registry");
+        type.setName("Registry");
+        return type;
+    }
+
+    @Test
+    public void testListImageStoreTypes() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listImageStoreTypes(with(mockUser));
+            will(returnValue(List.of(imageStoreType())));
+        }});
+
+        validateApiContract("/image.store/listImageStoreTypes", "GET")
+                .onHandlerMethod("listImageStoreTypes", User.class);
+    }
+
+    @Test
+    public void testListImageStores() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listImageStores(with(mockUser));
+            will(returnValue(List.of(imageStore())));
+        }});
+
+        validateApiContract("/image.store/listImageStores", "GET")
+                .onHandlerMethod("listImageStores", User.class);
+    }
+
+    @Test
+    public void testGetDetails() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getDetails(with(mockUser), with("test-store"));
+            will(returnValue(imageStore()));
+        }});
+
+        validateApiContract("/image.store/getDetails", "GET")
+                .withParams(Map.of("label", new String[]{"test-store"}))
+                .onHandlerMethod("getDetails", User.class, String.class);
+    }
+
+    @Test
+    public void testCreate() throws Exception {
+        var credentials = Map.of("username", "test-user", "password", "test-password");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).create(with(mockUser), with("test-store"),
+                    with("registry.example.com"), with("registry"), with(credentials));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/image.store/create", "POST")
+                .withBody(Map.of(
+                        "label", "test-store",
+                        "uri", "registry.example.com",
+                        "storeType", "registry",
+                        "credentials", credentials))
+                .onHandlerMethod("create", User.class, String.class, String.class, String.class, Map.class);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).delete(with(mockUser), with("test-store"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/image.store/delete", "POST")
+                .withBody(Map.of("label", "test-store"))
+                .onHandlerMethod("delete", User.class, String.class);
+    }
+
+    @Test
+    public void testSetDetails() throws Exception {
+        var details = Map.<String, Object>of(
+                "uri", "registry.example.com",
+                "username", "test-user",
+                "password", "test-password");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setDetails(with(mockUser), with("test-store"), with(details));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/image.store/setDetails", "POST")
+                .withBody(Map.of("label", "test-store", "details", details))
+                .onHandlerMethod("setDetails", User.class, String.class, Map.class);
+    }
+}


### PR DESCRIPTION
## What does this PR change?

Migrates the `image.profile` namespace from the `@apidoc` Javadoc doclet to an OpenAPI contract
interface, following the same pattern as the handlers migrated so far.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

The generated API documentation is unchanged; this only changes how it is produced.

- [x] **DONE**

## Test coverage
- Unit tests were added

`ImageProfileHandlerContractTest` covers all 9 methods plus the additive `create` overload
(with and without `kiwiOptions`), 10 tests.

- [x] **DONE**

## Links

Issue(s): #
Port(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
