### PR TITLE
feat(openapi): migrate the kickstart.profile.software handler to OpenAPI contract

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/software/SoftwareHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/software/SoftwareHandler.java
@@ -40,7 +40,7 @@ import java.util.Set;
  * @apidoc.doc Provides methods to access and modify the software list
  * associated with a kickstart profile.
  */
-public class SoftwareHandler extends BaseHandler {
+public class SoftwareHandler extends BaseHandler implements SoftwareHandlerApi {
 
     /**
      * Get a list of a kickstart profile's software packages.
@@ -175,8 +175,8 @@ public class SoftwareHandler extends BaseHandler {
      * @apidoc.param #param_desc("string", "ksLabel", "the label of the kickstart profile")
      * @apidoc.param
      *          #struct_desc("params", "kickstart packages info")
-     *              #prop_desc("string", "noBase", "install @Base package group")
-     *              #prop_desc("string", "ignoreMissing", "ignore missing packages")
+     *              #prop_desc("boolean", "noBase", "install @Base package group")
+     *              #prop_desc("boolean", "ignoreMissing", "ignore missing packages")
      *          #struct_end()
      * @apidoc.returntype #return_int_success()
      */
@@ -201,8 +201,8 @@ public class SoftwareHandler extends BaseHandler {
      * @apidoc.param #param_desc("string", "ksLabel", "the label of the kickstart profile")
      * @apidoc.returntype
      *          #struct_begin("kickstart packages info")
-     *              #prop_desc("string", "noBase", "install @Base package group")
-     *              #prop_desc("string", "ignoreMissing", "ignore missing packages")
+     *              #prop_desc("boolean", "noBase", "install @Base package group")
+     *              #prop_desc("boolean", "ignoreMissing", "ignore missing packages")
      *          #struct_end()
      */
     @ReadOnly

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/software/SoftwareHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/software/SoftwareHandlerApi.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.kickstart.profile.software;
+
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import spark.route.HttpMethod;
+
+/**
+ * API contract for {@link SoftwareHandler}.
+ */
+@Tag(name = "kickstart.profile.software", description = "Provides methods to access and modify the software list " +
+        "associated with a kickstart profile.")
+public interface SoftwareHandlerApi {
+
+    /**
+     * Get a list of a kickstart profile's software packages.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the label of the kickstart profile
+     * @return the list of the kickstart profile's software packages
+     */
+    @ApiEndpointDoc(
+        summary = "Get a list of a kickstart profile's software packages.",
+        method = HttpMethod.get,
+        responseClass = SoftwareListResponse.class,
+        responseDescription = "the list of the kickstart profile's software packages"
+    )
+    List<String> getSoftwareList(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "ksLabel", in = ParameterIn.QUERY, required = true,
+            description = "the label of the kickstart profile") String ksLabel);
+
+    /**
+     * Set the list of software packages for a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the label of the kickstart profile
+     * @param packageList the list of package names to be set on the profile
+     * @param ignoreMissing whether missing packages should be ignored
+     * @param noBase whether the @Base package group should not be installed
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set the list of software packages for a kickstart profile.",
+        requestClass = SetSoftwareListRequest.class,
+        isIntegerResponse = true
+    )
+    int setSoftwareList(User loggedInUser, String ksLabel, List<String> packageList, Boolean ignoreMissing,
+                        Boolean noBase);
+
+    /**
+     * Append the list of software packages to a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the label of the kickstart profile
+     * @param packageList the list of package names to be added to the profile
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Append the list of software packages to a kickstart profile. Duplicate packages will be ignored.",
+        requestClass = AppendToSoftwareListRequest.class,
+        isIntegerResponse = true
+    )
+    int appendToSoftwareList(User loggedInUser, String ksLabel, List<String> packageList);
+
+    /**
+     * Set the software details of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the label of the kickstart profile
+     * @param params the software parameters
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Sets kickstart profile software details.",
+        requestClass = SetSoftwareDetailsRequest.class,
+        isIntegerResponse = true
+    )
+    int setSoftwareDetails(User loggedInUser, String ksLabel, Map<String, Object> params);
+
+    /**
+     * Get the software details of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the label of the kickstart profile
+     * @return the software details of the kickstart profile
+     */
+    @ApiEndpointDoc(
+        summary = "Gets kickstart profile software details.",
+        method = HttpMethod.get,
+        responseClass = SoftwareDetailsResponse.class
+    )
+    Map<String, Boolean> getSoftwareDetails(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "ksLabel", in = ParameterIn.QUERY, required = true,
+            description = "the label of the kickstart profile") String ksLabel);
+
+    @Schema(name = "SetKickstartSoftwareListRequest")
+    @JsonPropertyOrder({"ksLabel", "packageList", "ignoreMissing", "noBase"})
+    interface SetSoftwareListRequest {
+
+        /**
+         * @return the label of the kickstart profile
+         */
+        @Schema(description = "the label of the kickstart profile", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getKsLabel();
+
+        /**
+         * @return the list of package names to be set on the profile
+         */
+        @Schema(description = "the list of package names to be set on the profile",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        List<String> getPackageList();
+
+        /**
+         * @return whether missing packages should be ignored
+         */
+        @Schema(description = "ignore missing packages if true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Boolean getIgnoreMissing();
+
+        /**
+         * @return whether the @Base package group should not be installed
+         */
+        @Schema(description = "don't install @Base package group if true",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Boolean getNoBase();
+    }
+
+    @Schema(name = "AppendToKickstartSoftwareListRequest")
+    @JsonPropertyOrder({"ksLabel", "packageList"})
+    interface AppendToSoftwareListRequest {
+
+        /**
+         * @return the label of the kickstart profile
+         */
+        @Schema(description = "the label of the kickstart profile", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getKsLabel();
+
+        /**
+         * @return the list of package names to be added to the profile
+         */
+        @Schema(description = "the list of package names to be added to the profile",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        List<String> getPackageList();
+    }
+
+    @Schema(name = "SetKickstartSoftwareDetailsRequest")
+    @JsonPropertyOrder({"ksLabel", "params"})
+    interface SetSoftwareDetailsRequest {
+
+        /**
+         * @return the label of the kickstart profile
+         */
+        @Schema(description = "the label of the kickstart profile", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getKsLabel();
+
+        /**
+         * @return the software parameters
+         */
+        @Schema(description = "kickstart packages info", requiredMode = Schema.RequiredMode.REQUIRED)
+        KickstartPackagesInfoDoc getParams();
+    }
+
+    @Schema(name = "KickstartPackagesInfo")
+    @JsonPropertyOrder({"noBase", "ignoreMissing"})
+    interface KickstartPackagesInfoDoc {
+
+        /**
+         * @return whether the @Base package group should be installed
+         */
+        @Schema(description = "install @Base package group", requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getNoBase();
+
+        /**
+         * @return whether missing packages should be ignored
+         */
+        @Schema(description = "ignore missing packages", requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getIgnoreMissing();
+    }
+
+    @Schema(name = "ApiResponseKickstartSoftwareList")
+    interface SoftwareListResponse extends ApiResponseWrapper<List<String>> { }
+
+    @Schema(name = "ApiResponseKickstartPackagesInfo")
+    interface SoftwareDetailsResponse extends ApiResponseWrapper<KickstartPackagesInfoDoc> { }
+}

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.frontend.xmlrpc.channel.access.ChannelAccessHandler;
 import com.redhat.rhn.frontend.xmlrpc.distchannel.DistChannelHandler;
 import com.redhat.rhn.frontend.xmlrpc.image.profile.ImageProfileHandler;
 import com.redhat.rhn.frontend.xmlrpc.image.store.ImageStoreHandler;
+import com.redhat.rhn.frontend.xmlrpc.kickstart.profile.software.SoftwareHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.snippet.SnippetHandler;
 import com.redhat.rhn.frontend.xmlrpc.packages.search.PackagesSearchHandler;
 import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
@@ -120,6 +121,7 @@ public final class OpenApiConfig {
         handlers.put("distchannel", DistChannelHandler.class);
         handlers.put("image.profile", ImageProfileHandler.class);
         handlers.put("image.store", ImageStoreHandler.class);
+        handlers.put("kickstart.profile.software", SoftwareHandler.class);
         handlers.put("kickstart.snippet", SnippetHandler.class);
         handlers.put("packages.search", PackagesSearchHandler.class);
         handlers.put("preferences.locale", PreferencesLocaleHandler.class);

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/KickstartProfileSoftwareHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/KickstartProfileSoftwareHandlerContractTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.kickstart.profile.software.SoftwareHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class KickstartProfileSoftwareHandlerContractTest extends BaseOpenApiTest {
+
+    @Override
+    protected String getApiNamespace() {
+        return "kickstart.profile.software";
+    }
+
+    @Override
+    protected Class<SoftwareHandler> getHandlerClass() {
+        return SoftwareHandler.class;
+    }
+
+    private SoftwareHandler handler() {
+        return (SoftwareHandler) handlerMock;
+    }
+
+    @Test
+    public void testGetSoftwareList() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getSoftwareList(with(mockUser), with("test-profile"));
+            will(returnValue(List.of("vim", "emacs")));
+        }});
+
+        validateApiContract("/kickstart.profile.software/getSoftwareList", "GET")
+                .withParams(Map.of("ksLabel", new String[]{"test-profile"}))
+                .onHandlerMethod("getSoftwareList", User.class, String.class);
+    }
+
+    @Test
+    public void testSetSoftwareList() throws Exception {
+        var packageList = List.of("vim", "emacs");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setSoftwareList(with(mockUser), with("test-profile"), with(packageList),
+                    with(Boolean.TRUE), with(Boolean.FALSE));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.software/setSoftwareList", "POST")
+                .withBody(Map.of(
+                        "ksLabel", "test-profile",
+                        "packageList", packageList,
+                        "ignoreMissing", true,
+                        "noBase", false))
+                .onHandlerMethod("setSoftwareList", User.class, String.class, List.class,
+                        Boolean.class, Boolean.class);
+    }
+
+    /**
+     * ignoreMissing and noBase are optional, so a request omitting them must dispatch to the
+     * shorter overload.
+     */
+    @Test
+    public void testSetSoftwareListWithoutFlags() throws Exception {
+        var packageList = List.of("vim", "emacs");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setSoftwareList(with(mockUser), with("test-profile"), with(packageList));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.software/setSoftwareList", "POST")
+                .withBody(Map.of("ksLabel", "test-profile", "packageList", packageList))
+                .onHandlerMethod("setSoftwareList", User.class, String.class, List.class);
+    }
+
+    @Test
+    public void testAppendToSoftwareList() throws Exception {
+        var packageList = List.of("vim");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).appendToSoftwareList(with(mockUser), with("test-profile"), with(packageList));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.software/appendToSoftwareList", "POST")
+                .withBody(Map.of("ksLabel", "test-profile", "packageList", packageList))
+                .onHandlerMethod("appendToSoftwareList", User.class, String.class, List.class);
+    }
+
+    @Test
+    public void testSetSoftwareDetails() throws Exception {
+        var params = Map.<String, Object>of("noBase", Boolean.TRUE, "ignoreMissing", Boolean.FALSE);
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setSoftwareDetails(with(mockUser), with("test-profile"), with(params));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.software/setSoftwareDetails", "POST")
+                .withBody(Map.of("ksLabel", "test-profile", "params", params))
+                .onHandlerMethod("setSoftwareDetails", User.class, String.class, Map.class);
+    }
+
+    @Test
+    public void testGetSoftwareDetails() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getSoftwareDetails(with(mockUser), with("test-profile"));
+            will(returnValue(Map.of("noBase", Boolean.TRUE, "ignoreMissing", Boolean.FALSE)));
+        }});
+
+        validateApiContract("/kickstart.profile.software/getSoftwareDetails", "GET")
+                .withParams(Map.of("ksLabel", new String[]{"test-profile"}))
+                .onHandlerMethod("getSoftwareDetails", User.class, String.class);
+    }
+}


### PR DESCRIPTION
## What does this PR change?

Migrates the `kickstart.profile.software` namespace from the `@apidoc` Javadoc doclet to an
OpenAPI contract interface, following the same pattern as the handlers migrated so far.


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

This only changes how the API documentation is produced. The two differences described above are
listed there as well.

- [x] **DONE**

## Test coverage
- Unit tests were added

`KickstartProfileSoftwareHandlerContractTest` covers all 6 methods plus the additive
`setSoftwareList` overload.

- [x] **DONE**

## Links

Issue(s): #
Port(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
