### PR TITLE
feat(openapi): honour responseDescription for integer responses

### DIFF
--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -210,7 +210,8 @@ public class UyuniSwaggerReader {
         ApiResponses apiResponses = new ApiResponses();
 
         if (apiDoc.isIntegerResponse()) {
-            apiResponses.addApiResponse(HTTP_200, addLegacyDocResponse(apiDoc, createIntegerResponse()));
+            apiResponses.addApiResponse(HTTP_200,
+                    addLegacyDocResponse(apiDoc, createIntegerResponse(apiDoc.responseDescription())));
             operation.setResponses(apiResponses);
             return;
         }
@@ -350,7 +351,7 @@ public class UyuniSwaggerReader {
         }
     }
 
-    private ApiResponse createIntegerResponse() {
+    private ApiResponse createIntegerResponse(String description) {
         if (this.components.getSchemas() == null || !this.components.getSchemas().containsKey("IntegerResponse")) {
             Schema<?> integerResponseSchema = new Schema<>()
                     .type("object")
@@ -366,7 +367,7 @@ public class UyuniSwaggerReader {
         }
 
         ApiResponse response = new ApiResponse();
-        response.setDescription("1 on success, exception thrown otherwise.");
+        response.setDescription(description.isEmpty() ? "1 on success, exception thrown otherwise." : description);
 
         Content content = new Content();
         MediaType mediaType = new MediaType();


### PR DESCRIPTION
## What does this PR change?

`@ApiEndpointDoc.responseDescription` is currently ignored when `isIntegerResponse = true`: the
response description is hardcoded to *"1 on success, exception thrown otherwise."*. That is right
for `#return_int_success()`, but the legacy doclet also has named integer returns with their own
text, written as `#param_desc("int", "id", "the ID of the newly created recurring action")`, and
those cannot be reproduced today.

This makes `createIntegerResponse` take the description and fall back to the existing default
when it is empty, so the annotation is honoured for integer responses the same way it already is
for every other response kind. No new annotation and no new lookup — `responseDescription` is
already declared on `@ApiEndpointDoc` and already defaults to the empty string.

Architecture only; no handlers are migrated here.

**Zero regression, measured.** I generated the AsciiDoc for every registered namespace plus
`openapi.json` before and after the change and compared them as files: all 12 already migrated
namespaces are byte identical. The only differences appear on a namespace that carries a named
integer return, which is the case being fixed.

17 namespaces contain this shape, so it is a prerequisite for migrating any of them.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

The generated documentation for every already migrated namespace is unchanged.

- [x] **DONE**

## Test coverage
- No tests: already covered

`ApiDocumentationCompatibilityTest` passes in both formats. The behaviour is additionally covered
by the before/after file comparison described above.

- [x] **DONE**

## Links

Issue(s): #
Port(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
