### PR TITLE
Fix salt deletion on SSH minions (bsc#1274023)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
@@ -1,7 +1,9 @@
 include:
   - cleanup_minion.common_cleanup
+{% if salt['pillar.get']('contact_method') not in ['ssh-push', 'ssh-push-tunnel'] %}
 {% if grains.get('transactional', False) %}
   - cleanup_minion.transactional
 {% else %}
   - cleanup_minion.standard
+{% endif %}
 {% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mczernek.fix-1274023
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mczernek.fix-1274023
@@ -1,0 +1,1 @@
+- Fix salt deletion on SSH minions (bsc#1274023)


### PR DESCRIPTION
## What does this PR change?

During the https://github.com/uyuni-project/uyuni/commit/80ba9b2463d29204190ff1123cc5dfc546eba1d7 refactor, we didn't take into accounts minions managed via pure SSH.

For SSH minion, the cleanup is done in `cleanup_ssh_minion` (https://github.com/uyuni-project/uyuni/blob/master/susemanager-utils/susemanager-sls/salt/cleanup_ssh_minion/init.sls), so we can skip the minion-specific cleanup.

The cleanup of repositories is in `cleanup_minion.common` file.

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31576
Port(s): https://github.com/SUSE/spacewalk/pull/31603 https://github.com/SUSE/spacewalk/pull/31604

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
