### PR TITLE
Make the Ubuntu USN database url configurable via java.ubuntu_errata_db_download_url

### DIFF
--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -295,3 +295,6 @@ java.disable_supportdata_upload = false
 #url to download advisory-map.csv, the map of errata patch id, announcement id and advisory URL
 java.errata_advisory_map_csv_download_url = https://ftp.suse.com/pub/projects/security/advisory-map.csv
 
+# url to download the Ubuntu USN database from, the source of the Ubuntu errata information.
+java.ubuntu_errata_db_download_url = https://usn.ubuntu.com/usn-db/database.json
+

--- a/java/core/src/main/java/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -24,6 +24,9 @@ import com.suse.utils.CertificateUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -1369,9 +1372,22 @@ public class ConfigDefaults {
      * Return the url to download the Ubuntu USN database, the source of the Ubuntu errata information
      *
      * @return the url to download the Ubuntu USN database from
+     * @throws IOException in case the configured url is not a http(s) url
      */
-    public String getUbuntuErrataDbDownloadUrl() {
-        return Config.get().getString(UBUNTU_ERRATA_DB_DOWNLOAD_URL, "https://usn.ubuntu.com/usn-db/database.json");
+    public String getUbuntuErrataDbDownloadUrl() throws IOException {
+        String jsonDBUrl = Config.get().getString(UBUNTU_ERRATA_DB_DOWNLOAD_URL,
+                "https://usn.ubuntu.com/usn-db/database.json");
+        String scheme;
+        try {
+            scheme = new URI(jsonDBUrl).getScheme();
+        }
+        catch (URISyntaxException e) {
+            throw new IOException(UBUNTU_ERRATA_DB_DOWNLOAD_URL + " must be a http(s) url: " + jsonDBUrl, e);
+        }
+        if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+            throw new IOException(UBUNTU_ERRATA_DB_DOWNLOAD_URL + " must be a http(s) url: " + jsonDBUrl);
+        }
+        return jsonDBUrl;
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -433,12 +433,6 @@ public class ConfigDefaults {
     private static final String UBUNTU_ERRATA_DB_DOWNLOAD_URL = "java.ubuntu_errata_db_download_url";
 
     /**
-     * Default url to download the Ubuntu USN database from
-     */
-    private static final String DEFAULT_UBUNTU_ERRATA_DB_DOWNLOAD_URL =
-            "https://usn.ubuntu.com/usn-db/database.json";
-
-    /**
      * OpenID Connect authorization parameters
      */
     public static final String OIDC_ENABLED = "web.oidc.enabled";
@@ -1377,7 +1371,7 @@ public class ConfigDefaults {
      * @return the url to download the Ubuntu USN database from
      */
     public String getUbuntuErrataDbDownloadUrl() {
-        return Config.get().getString(UBUNTU_ERRATA_DB_DOWNLOAD_URL, DEFAULT_UBUNTU_ERRATA_DB_DOWNLOAD_URL);
+        return Config.get().getString(UBUNTU_ERRATA_DB_DOWNLOAD_URL, "https://usn.ubuntu.com/usn-db/database.json");
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -428,6 +428,17 @@ public class ConfigDefaults {
     private static final String ERRATA_ADVISORY_MAP_CSV_DOWNLOAD_URL = "java.errata_advisory_map_csv_download_url";
 
     /**
+     * url to download the Ubuntu USN database, the source of the Ubuntu errata information
+     */
+    private static final String UBUNTU_ERRATA_DB_DOWNLOAD_URL = "java.ubuntu_errata_db_download_url";
+
+    /**
+     * Default url to download the Ubuntu USN database from
+     */
+    private static final String DEFAULT_UBUNTU_ERRATA_DB_DOWNLOAD_URL =
+            "https://usn.ubuntu.com/usn-db/database.json";
+
+    /**
      * OpenID Connect authorization parameters
      */
     public static final String OIDC_ENABLED = "web.oidc.enabled";
@@ -1358,6 +1369,15 @@ public class ConfigDefaults {
     public String getErrataAdvisoryMapCsvDownloadUrl() {
         return Config.get().getString(ERRATA_ADVISORY_MAP_CSV_DOWNLOAD_URL,
                 "https://ftp.suse.com/pub/projects/security/advisory-map.csv");
+    }
+
+    /**
+     * Return the url to download the Ubuntu USN database, the source of the Ubuntu errata information
+     *
+     * @return the url to download the Ubuntu USN database from
+     */
+    public String getUbuntuErrataDbDownloadUrl() {
+        return Config.get().getString(UBUNTU_ERRATA_DB_DOWNLOAD_URL, DEFAULT_UBUNTU_ERRATA_DB_DOWNLOAD_URL);
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
@@ -59,7 +59,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.Type;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -231,30 +230,8 @@ public class UbuntuErrataManager {
         });
     }
 
-    /**
-     * Returns the url of the Ubuntu USN database as configured by the operator, using the default when
-     * java.ubuntu_errata_db_download_url is not set.
-     *
-     * @return the url of the Ubuntu USN database
-     * @throws IOException in case the configured url is not a http(s) url
-     */
-    static String getUbuntuErrataDbUrl() throws IOException {
-        String jsonDBUrl = ConfigDefaults.get().getUbuntuErrataDbDownloadUrl();
-        String scheme = null;
-        try {
-            scheme = new URI(jsonDBUrl).getScheme();
-        }
-        catch (URISyntaxException e) {
-            LOG.error("Unable to create ubuntu errata database url: {} {}.", jsonDBUrl, e.getMessage());
-        }
-        if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
-            throw new IOException("java.ubuntu_errata_db_download_url must be a http(s) url: " + jsonDBUrl);
-        }
-        return jsonDBUrl;
-    }
-
     private static Map<String, UbuntuErrataInfo> getUbuntuErrataInfo() throws IOException {
-        String jsonDBUrl = getUbuntuErrataDbUrl();
+        String jsonDBUrl = ConfigDefaults.get().getUbuntuErrataDbDownloadUrl();
         if (isFromDir()) {
             URI uri = MgrSyncUtils.urlToFSPath(jsonDBUrl, "");
             try (

--- a/java/core/src/main/java/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.manager.content.ubuntu;
 
 import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.util.TimeUtils;
 import com.redhat.rhn.common.util.http.HttpClientAdapter;
 import com.redhat.rhn.domain.channel.Channel;
@@ -58,6 +59,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -229,8 +231,30 @@ public class UbuntuErrataManager {
         });
     }
 
+    /**
+     * Returns the url of the Ubuntu USN database as configured by the operator, using the default when
+     * java.ubuntu_errata_db_download_url is not set.
+     *
+     * @return the url of the Ubuntu USN database
+     * @throws IOException in case the configured url is not a http(s) url
+     */
+    static String getUbuntuErrataDbUrl() throws IOException {
+        String jsonDBUrl = ConfigDefaults.get().getUbuntuErrataDbDownloadUrl();
+        String scheme = null;
+        try {
+            scheme = new URI(jsonDBUrl).getScheme();
+        }
+        catch (URISyntaxException e) {
+            LOG.error("Unable to create ubuntu errata database url: {} {}.", jsonDBUrl, e.getMessage());
+        }
+        if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+            throw new IOException("java.ubuntu_errata_db_download_url must be a http(s) url: " + jsonDBUrl);
+        }
+        return jsonDBUrl;
+    }
+
     private static Map<String, UbuntuErrataInfo> getUbuntuErrataInfo() throws IOException {
-        String jsonDBUrl = "https://usn.ubuntu.com/usn-db/database.json";
+        String jsonDBUrl = getUbuntuErrataDbUrl();
         if (isFromDir()) {
             URI uri = MgrSyncUtils.urlToFSPath(jsonDBUrl, "");
             try (

--- a/java/core/src/test/java/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManagerTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -36,34 +37,34 @@ public class UbuntuErrataManagerTest {
     @Test
     public void testDefaultErrataDbUrl() throws IOException {
         Config.get().remove(CONFIG_KEY);
-        assertEquals(DEFAULT_URL, UbuntuErrataManager.getUbuntuErrataDbUrl());
+        assertEquals(DEFAULT_URL, ConfigDefaults.get().getUbuntuErrataDbDownloadUrl());
     }
 
     @Test
     public void testConfiguredErrataDbUrl() throws IOException {
         String mirrorUrl = "http://mirror.example.com/usn-db/database.json";
         Config.get().setString(CONFIG_KEY, mirrorUrl);
-        assertEquals(mirrorUrl, UbuntuErrataManager.getUbuntuErrataDbUrl());
+        assertEquals(mirrorUrl, ConfigDefaults.get().getUbuntuErrataDbDownloadUrl());
     }
 
     @Test
     public void testEmptyErrataDbUrlFallsBackToDefault() throws IOException {
         Config.get().setString(CONFIG_KEY, "");
-        assertEquals(DEFAULT_URL, UbuntuErrataManager.getUbuntuErrataDbUrl());
+        assertEquals(DEFAULT_URL, ConfigDefaults.get().getUbuntuErrataDbDownloadUrl());
     }
 
     @Test
     public void testNonHttpErrataDbUrlIsRejected() {
         Config.get().setString(CONFIG_KEY, "file:///srv/mirror/database.json");
-        assertThrows(IOException.class, UbuntuErrataManager::getUbuntuErrataDbUrl);
+        assertThrows(IOException.class, () -> ConfigDefaults.get().getUbuntuErrataDbDownloadUrl());
 
         Config.get().setString(CONFIG_KEY, "/srv/mirror/database.json");
-        assertThrows(IOException.class, UbuntuErrataManager::getUbuntuErrataDbUrl);
+        assertThrows(IOException.class, () -> ConfigDefaults.get().getUbuntuErrataDbDownloadUrl());
     }
 
     @Test
     public void testMalformedErrataDbUrlIsRejected() {
         Config.get().setString(CONFIG_KEY, "ht tp://mirror.example.com");
-        assertThrows(IOException.class, UbuntuErrataManager::getUbuntuErrataDbUrl);
+        assertThrows(IOException.class, () -> ConfigDefaults.get().getUbuntuErrataDbDownloadUrl());
     }
 }

--- a/java/core/src/test/java/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManagerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.manager.content.ubuntu;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.redhat.rhn.common.conf.Config;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/**
+ * Test class for the Ubuntu USN database url configuration.
+ */
+public class UbuntuErrataManagerTest {
+
+    private static final String CONFIG_KEY = "java.ubuntu_errata_db_download_url";
+    private static final String DEFAULT_URL = "https://usn.ubuntu.com/usn-db/database.json";
+
+    @AfterEach
+    public void tearDown() {
+        Config.clear();
+    }
+
+    @Test
+    public void testDefaultErrataDbUrl() throws IOException {
+        Config.get().remove(CONFIG_KEY);
+        assertEquals(DEFAULT_URL, UbuntuErrataManager.getUbuntuErrataDbUrl());
+    }
+
+    @Test
+    public void testConfiguredErrataDbUrl() throws IOException {
+        String mirrorUrl = "http://mirror.example.com/usn-db/database.json";
+        Config.get().setString(CONFIG_KEY, mirrorUrl);
+        assertEquals(mirrorUrl, UbuntuErrataManager.getUbuntuErrataDbUrl());
+    }
+
+    @Test
+    public void testEmptyErrataDbUrlFallsBackToDefault() throws IOException {
+        Config.get().setString(CONFIG_KEY, "");
+        assertEquals(DEFAULT_URL, UbuntuErrataManager.getUbuntuErrataDbUrl());
+    }
+
+    @Test
+    public void testNonHttpErrataDbUrlIsRejected() {
+        Config.get().setString(CONFIG_KEY, "file:///srv/mirror/database.json");
+        assertThrows(IOException.class, UbuntuErrataManager::getUbuntuErrataDbUrl);
+
+        Config.get().setString(CONFIG_KEY, "/srv/mirror/database.json");
+        assertThrows(IOException.class, UbuntuErrataManager::getUbuntuErrataDbUrl);
+    }
+
+    @Test
+    public void testMalformedErrataDbUrlIsRejected() {
+        Config.get().setString(CONFIG_KEY, "ht tp://mirror.example.com");
+        assertThrows(IOException.class, UbuntuErrataManager::getUbuntuErrataDbUrl);
+    }
+}


### PR DESCRIPTION
## What does this PR change?

The url of Canonical's USN database was hardcoded in `UbuntuErrataManager`, so there was no supported way to point Uyuni at a mirror.

Some workarounds were mentioned in #6534, none of them satisfying.

This adds `java.ubuntu_errata_db_download_url`, defaulting to the current url. Installations that don't set it behave exactly as before.
This accepts only http(s) urls.

It follows the existing `java.errata_advisory_map_csv_download_url`.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: the new option is documented in the shipped `rhn_java.conf`, the same way as the existing `java.errata_advisory_map_csv_download_url`

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): #6534

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!