### PR TITLE
Mainframe foreign systems showing wrong os version (bsc#1260342)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/core/src/main/java/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -471,14 +471,25 @@ public class HardwareMapper {
         return sysvalues;
     }
 
-    //package-protected
-    String computeOsStringForS390Arch(Map<String, String> sysvalues) {
-        String osString = sysvalues.entrySet().stream()
+    protected String getOsStringForS390Arch(Map<String, String> sysvalues) {
+        return sysvalues.entrySet().stream()
                 .filter(e -> e.getKey().toLowerCase().contains("control program"))
                 .map(Map.Entry::getValue)
                 .findFirst().orElse("z/VM");
+    }
+
+    //package-protected
+    String computeOsStringForS390Arch(Map<String, String> sysvalues) {
+        String osString = getOsStringForS390Arch(sysvalues);
         int index = osString.indexOf(" ");
         return index > 0 ? osString.substring(0, index) : osString;
+    }
+
+    //package-protected
+    String computeOsVersionStringForS390Arch(Map<String, String> sysvalues) {
+        String osString = getOsStringForS390Arch(sysvalues);
+        int index = osString.indexOf(" ");
+        return index > 0 ? osString.substring(index).replace(" ", "") : "N/A";
     }
 
     //package-protected
@@ -519,6 +530,7 @@ public class HardwareMapper {
 
             String identifier = String.format("Z-%s", sysvalues.get("Sequence Code"));
             String os = computeOsStringForS390Arch(sysvalues);
+            String osVersion = computeOsVersionStringForS390Arch(sysvalues);
             String type = sysvalues.get("Type");
 
             String name = String.format("IBM Mainframe %s %s %s",
@@ -554,7 +566,7 @@ public class HardwareMapper {
                         String.format("Initial Registration Parameters:\n" +
                                 "OS: %s\n" +
                                 "Release: %s\n" +
-                                "CPU Arch: %s", os, type, cpuarch));
+                                "CPU Arch: %s", os, osVersion, cpuarch));
 
                 zhost.setDigitalServerId(identifier);
                 zhost.setOrg(OrgFactory.getSatelliteOrg()); // OLDTODO clarify this

--- a/java/core/src/test/java/com/suse/manager/reactor/hardware/HardwareMapperTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/hardware/HardwareMapperTest.java
@@ -220,6 +220,13 @@ public class HardwareMapperTest extends BaseTestCaseWithUser {
         assertEquals(expectedOsString, os);
     }
 
+    private void assertComputeOsVersionString(String expectedOsVersionString, HardwareMapper hwMapper,
+                                              String readValuesOutput) {
+        Map<String, String> sysValues = hwMapper.getSysValuesMap(readValuesOutput);
+        String osVersion = hwMapper.computeOsVersionStringForS390Arch(sysValues);
+        assertEquals(expectedOsVersionString, osVersion);
+    }
+
     private void assertHostS390ServerFamily(String expectedS390ServerFamily, HardwareMapper hwMapper,
                                             String readValuesOutput, String digitalServerId) {
         hwMapper.mapSysinfo(readValuesOutput);
@@ -235,13 +242,13 @@ public class HardwareMapperTest extends BaseTestCaseWithUser {
 
     private static Stream<Arguments> allServersInfo() {
         return Stream.of(
-                Arguments.of("z/VM", "z12", "IBM Mainframe z12 2827 0000000000061A23",
+                Arguments.of("z/VM", "6.3.0", "z12", "IBM Mainframe z12 2827 0000000000061A23",
                         SERVER_1_DIGITAL_SERVER_ID, SERVER_1_STATE_CHANGES_RET_READ_VALUES),
-                Arguments.of("z/VM", "z15", "IBM Mainframe z15 8561 00000000000612A3",
+                Arguments.of("z/VM", "7.4.0", "z15", "IBM Mainframe z15 8561 00000000000612A3",
                         SERVER_2_DIGITAL_SERVER_ID, SERVER_2_STATE_CHANGES_RET_PROC_SYSINFO),
-                Arguments.of("KVM/Linux", "z16", "IBM Mainframe z16 3932 00000000000987F6",
+                Arguments.of("KVM/Linux", "N/A", "z16", "IBM Mainframe z16 3932 00000000000987F6",
                         SERVER_3_DIGITAL_SERVER_ID, SERVER_3_STATE_CHANGES_RET_READ_VALUES),
-                Arguments.of("KVM/Linux", "z16", "IBM Mainframe z16 3932 00000000000987F6",
+                Arguments.of("KVM/Linux", "N/A", "z16", "IBM Mainframe z16 3932 00000000000987F6",
                         SERVER_3_DIGITAL_SERVER_ID, SERVER_3_STATE_CHANGES_RET_PROC_SYSINFO)
         );
     }
@@ -249,8 +256,8 @@ public class HardwareMapperTest extends BaseTestCaseWithUser {
     @ParameterizedTest
     @MethodSource("allServersInfo")
     @DisplayName("mapSysinfo correctly showing OS value on s390 hypervisors")
-    public void mapSysinfoShowingCorrectValues(String expectedOs, String expectedFamily, String expectedName,
-                                               String digitalServerId, String readValuesOutput) {
+    public void mapSysinfoShowingCorrectValues(String expectedOs, String expectedOsVersion, String expectedFamily,
+                                               String expectedName, String digitalServerId, String readValuesOutput) {
         HardwareMapper hwMapper = createTestS390HwMapper();
         assertNull(ServerFactory.lookupForeignSystemByDigitalServerId(digitalServerId));
 
@@ -258,6 +265,7 @@ public class HardwareMapperTest extends BaseTestCaseWithUser {
 
         assertNotNull(ServerFactory.lookupForeignSystemByDigitalServerId(digitalServerId));
         assertComputeOsString(expectedOs, hwMapper, readValuesOutput);
+        assertComputeOsVersionString(expectedOsVersion, hwMapper, readValuesOutput);
         assertHostOsString(expectedOs, digitalServerId);
 
         assertComputeS390ServerFamily(expectedFamily, hwMapper, readValuesOutput);

--- a/java/spacewalk-java.changes.carlo.uyuni-1260342-ibm-foreign-showing-wrong-os-version
+++ b/java/spacewalk-java.changes.carlo.uyuni-1260342-ibm-foreign-showing-wrong-os-version
@@ -1,0 +1,1 @@
+- Mainframe systems showing wrong os version (bsc#1260342)


### PR DESCRIPTION
## What does this PR change?

When onboarding a minion that is a VM running on a foreign system, the foreign system itself shows the wrong detail about the OS version

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
Before:
<img width="640" height="32" alt="image" src="https://github.com/user-attachments/assets/561cfad4-81a7-4a8a-992b-d80a459d743a" />

Examples of description strings:

- Initial Registration Parameters: OS: z/VM Release: **2827** CPU Arch: s390x
- Initial Registration Parameters: OS: z/VM Release: **8561** CPU Arch: s390x
- Initial Registration Parameters: OS: KVM/Linux Release: **3932** CPU Arch: s390x

After:

Examples of description strings:
- Initial Registration Parameters: OS: z/VM Release: **6.3.0** CPU Arch: s390x
- Initial Registration Parameters: OS: z/VM Release: **7.4.0** CPU Arch: s390x
- Initial Registration Parameters: OS: KVM/Linux Release: **N/A** CPU Arch: s390x

- [x] **DONE**

## Documentation
- No documentation needed: OS version needs no translation
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links
Issue(s): #  https://github.com/SUSE/spacewalk/issues/30572
Port(s): 
5.2: https://github.com/SUSE/spacewalk/pull/31606
5.1: https://github.com/SUSE/spacewalk/pull/31609
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

