### PR TITLE
Faster detection of failed events

### DIFF
--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -493,16 +493,10 @@ When(/^I check for failed events on history event page$/) do
     And I follow "History" in the content area
     Then I should see a "System History" text
   '
-  failings = ''
-  event_table_xpath = '//div[@class=\'table-responsive\']/table/tbody'
-  rows = find(:xpath, event_table_xpath)
-  rows.all('tr').each do |tr|
-    if tr.all(:css, '.fa.fa-times-circle-o.fa-1-5x.text-danger').any?
-      failings << "#{tr.text}\n"
-    end
-  end
-  count_failures = failings.length
-  raise ScriptError, "\nFailures in event history found:\n\n#{failings}" if count_failures.nonzero?
+  failed_events_xpath = "//div[@class='table-responsive']/table/tbody/tr[.//*[contains(@class, 'fa-times-circle-o')]]"
+  failed_events = all(:xpath, failed_events_xpath).map(&:text)
+
+  raise ScriptError, "\nFailures in event history found:\n\n#{failed_events.join("\n")}\n\n" if failed_events.any?
 end
 
 Then(/^I should see a list item with text "([^"]*)" and a (success|failing|warning|pending|refreshing) bullet$/) do |text, bullet_type|


### PR DESCRIPTION
## What does this PR change?

This PR speeds up the detection of failed events on the event history page.

For a table with 62 events, the previous code took over 10 minutes. The reason was that for each row with no error, the `all()` method waited for the default 10-second timeout to ensure that no error icon appeared.

Instead of making round-trips to the browser for every single row, we now fetch all failing events in a single XPath query.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes.


- [x] **DONE**


## Test coverage

Cucumber tests were refined.

- [x] **DONE**


## Links

Port(s):
  * 5.1: https://github.com/SUSE/spacewalk/pull/31610
  * 5.2: https://github.com/SUSE/spacewalk/pull/31608

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
