### PR TITLE
feat(openapi): migrate the recurring.playbook handler to OpenAPI contract

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringPlaybookHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringPlaybookHandler.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * @apidoc.doc Provides methods to handle recurring ansible playbook execution
  * for minions, system groups and organizations.
  */
-public class RecurringPlaybookHandler extends BaseHandler {
+public class RecurringPlaybookHandler extends BaseHandler implements RecurringPlaybookHandlerApi {
     private final RecurringActionHandler actionHandler = new RecurringActionHandler();
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringPlaybookHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringPlaybookHandlerApi.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.recurringaction;
+
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+import com.suse.manager.api.docs.LegacyDocResponse;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * API contract for {@link RecurringPlaybookHandler}.
+ */
+@Tag(name = "recurring.playbook", description = "Provides methods to handle recurring ansible playbook execution " +
+        "for minions, system groups and organizations.")
+public interface RecurringPlaybookHandlerApi {
+
+    /**
+     * Create a new recurring playbook action.
+     *
+     * @param loggedInUser the current user
+     * @param actionProps map containing action properties
+     * @return the ID of the newly created recurring action
+     */
+    @ApiEndpointDoc(
+        summary = "Create a new recurring Ansible playbook action.",
+        requestClass = CreateRequest.class,
+        responseClass = ActionIdResponse.class,
+        responseDescription = "the ID of the newly created recurring action",
+        legacyDocResponse = @LegacyDocResponse(type = "int", name = "id")
+    )
+    int create(User loggedInUser, Map<String, Object> actionProps);
+
+    /**
+     * Update a recurring Ansible playbook action.
+     *
+     * @param loggedInUser the current user
+     * @param actionProps map containing properties to update
+     * @return the ID of the updated recurring action
+     */
+    @ApiEndpointDoc(
+        summary = "Update a recurring Ansbile playbook action.",
+        requestClass = UpdateRequest.class,
+        responseClass = ActionIdResponse.class,
+        responseDescription = "the ID of the updated recurring action",
+        legacyDocResponse = @LegacyDocResponse(type = "int", name = "id")
+    )
+    int update(User loggedInUser, Map<String, Object> actionProps);
+
+    @Schema(name = "ApiResponseRecurringActionId")
+    interface ActionIdResponse extends ApiResponseWrapper<Integer> { }
+
+    @Schema(name = "CreateRecurringPlaybookRequest")
+    interface CreateRequest {
+
+        /**
+         * @return the action properties
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        CreateActionPropsDoc getActionProps();
+    }
+
+    @Schema(name = "UpdateRecurringPlaybookRequest")
+    interface UpdateRequest {
+
+        /**
+         * @return the action properties to update
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        UpdateActionPropsDoc getActionProps();
+    }
+
+    @Schema(name = "CreateRecurringPlaybookProps")
+    @JsonPropertyOrder({"entityId", "name", "cronExpr", "extraVars", "flushCache", "inventoryPath",
+        "playbookPath", "test"})
+    interface CreateActionPropsDoc {
+
+        /**
+         * @return the ID of the target entity
+         */
+        @Schema(name = "entity_id", description = "the ID of the target entity",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getEntityId();
+
+        /**
+         * @return the name of the recurring action
+         */
+        @Schema(description = "the name of the recurring action", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the execution frequency of the action as a cron expression
+         */
+        @Schema(name = "cron_expr", description = "the execution frequency of the action as a cron expression",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getCronExpr();
+
+        /**
+         * @return extra variables to override existing vars or create new ones
+         */
+        @Schema(name = "extra_vars",
+                description = "extra variables to override existing vars or create new ones (optional)",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getExtraVars();
+
+        /**
+         * @return whether the Ansible cache should be flushed
+         */
+        @Schema(name = "flush_cache", description = "whether the Ansible cache should be flushed (optional)",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Boolean getFlushCache();
+
+        /**
+         * @return the path to the configured Ansible inventory
+         */
+        @Schema(name = "inventory_path", description = "the path to the configured Ansible inventory",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getInventoryPath();
+
+        /**
+         * @return the path to the playbook to be executed
+         */
+        @Schema(name = "playbook_path", description = "the path to the playbook to be executed",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getPlaybookPath();
+
+        /**
+         * @return whether the action should be executed in test mode
+         */
+        @Schema(description = "whether the action should be executed in test mode (optional)",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Boolean getTest();
+    }
+
+    @Schema(name = "UpdateRecurringPlaybookProps")
+    @JsonPropertyOrder({"id", "name", "cronExpr", "extraVars", "flushCache", "inventoryPath",
+        "playbookPath", "test", "active"})
+    interface UpdateActionPropsDoc {
+
+        /**
+         * @return the ID of the action to update
+         */
+        @Schema(description = "the ID of the action to update", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the name of the action
+         */
+        @Schema(description = "the name of the action (optional)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getName();
+
+        /**
+         * @return the execution frequency of the action
+         */
+        @Schema(name = "cron_expr", description = "the execution frequency of the action (optional)",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getCronExpr();
+
+        /**
+         * @return extra variables to override existing vars or create new ones
+         */
+        @Schema(name = "extra_vars",
+                description = "extra variables to override existing vars or create new ones (optional)",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getExtraVars();
+
+        /**
+         * @return whether the Ansible cache should be flushed
+         */
+        @Schema(name = "flush_cache", description = "whether the Ansible cache should be flushed (optional)",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Boolean getFlushCache();
+
+        /**
+         * @return the path to the configured Ansible inventory
+         */
+        @Schema(name = "inventory_path", description = "the path to the configured Ansible inventory (optional",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getInventoryPath();
+
+        /**
+         * @return the path to the playbook to be executed
+         */
+        @Schema(name = "playbook_path", description = "the path to the playbook to be executed (optional)",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String getPlaybookPath();
+
+        /**
+         * @return whether the action should be executed in test mode
+         */
+        @Schema(description = "whether the action should be executed in test mode (optional)",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Boolean getTest();
+
+        /**
+         * @return whether the action should be active
+         */
+        @Schema(description = "whether the action should be active (optional)",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Boolean getActive();
+    }
+}

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringPlaybookHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringPlaybookHandlerApi.java
@@ -129,7 +129,7 @@ public interface RecurringPlaybookHandlerApi {
          * @return the path to the configured Ansible inventory
          */
         @Schema(name = "inventory_path", description = "the path to the configured Ansible inventory",
-                requiredMode = Schema.RequiredMode.REQUIRED)
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         String getInventoryPath();
 
         /**

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.frontend.xmlrpc.kickstart.profile.software.SoftwareHandler
 import com.redhat.rhn.frontend.xmlrpc.kickstart.snippet.SnippetHandler;
 import com.redhat.rhn.frontend.xmlrpc.packages.search.PackagesSearchHandler;
 import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
+import com.redhat.rhn.frontend.xmlrpc.recurringaction.RecurringPlaybookHandler;
 import com.redhat.rhn.frontend.xmlrpc.saltkey.SaltKeyHandler;
 import com.redhat.rhn.frontend.xmlrpc.subscriptionmatching.PinnedSubscriptionHandler;
 
@@ -125,6 +126,7 @@ public final class OpenApiConfig {
         handlers.put("kickstart.snippet", SnippetHandler.class);
         handlers.put("packages.search", PackagesSearchHandler.class);
         handlers.put("preferences.locale", PreferencesLocaleHandler.class);
+        handlers.put("recurring.playbook", RecurringPlaybookHandler.class);
         handlers.put("saltkey", SaltKeyHandler.class);
         handlers.put("subscriptionmatching.pinnedsubscription", PinnedSubscriptionHandler.class);
         return handlers;

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/RecurringPlaybookHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/RecurringPlaybookHandlerContractTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.recurringaction.RecurringPlaybookHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class RecurringPlaybookHandlerContractTest extends BaseOpenApiTest {
+
+    @Override
+    protected String getApiNamespace() {
+        return "recurring.playbook";
+    }
+
+    @Override
+    protected Class<RecurringPlaybookHandler> getHandlerClass() {
+        return RecurringPlaybookHandler.class;
+    }
+
+    private RecurringPlaybookHandler handler() {
+        return (RecurringPlaybookHandler) handlerMock;
+    }
+
+    /**
+     * The documented property names are snake_case, so the map the handler receives uses them
+     * rather than the JavaBeans names of the request interface.
+     *
+     * @return the action properties for a create call
+     */
+    private Map<String, Object> createProps() {
+        Map<String, Object> props = new LinkedHashMap<>();
+        props.put("entity_id", 1000010000);
+        props.put("name", "test-playbook-action");
+        props.put("cron_expr", "0 0 3 ? * *");
+        props.put("extra_vars", "key=value");
+        props.put("flush_cache", true);
+        props.put("inventory_path", "/etc/ansible/hosts");
+        props.put("playbook_path", "/etc/ansible/playbooks/test.yml");
+        props.put("test", false);
+        return props;
+    }
+
+    @Test
+    public void testCreate() throws Exception {
+        var props = createProps();
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).create(with(mockUser), with(props));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/recurring.playbook/create", "POST")
+                .withBody(Map.of("actionProps", props))
+                .onHandlerMethod("create", User.class, Map.class);
+    }
+
+    /**
+     * extra_vars, flush_cache and test are optional, so a request carrying only the required
+     * properties must still satisfy the documented schema.
+     */
+    @Test
+    public void testCreateWithRequiredPropsOnly() throws Exception {
+        Map<String, Object> props = new LinkedHashMap<>();
+        props.put("entity_id", 1000010000);
+        props.put("name", "test-playbook-action");
+        props.put("cron_expr", "0 0 3 ? * *");
+        props.put("inventory_path", "/etc/ansible/hosts");
+        props.put("playbook_path", "/etc/ansible/playbooks/test.yml");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).create(with(mockUser), with(props));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/recurring.playbook/create", "POST")
+                .withBody(Map.of("actionProps", props))
+                .onHandlerMethod("create", User.class, Map.class);
+    }
+
+    @Test
+    public void testUpdate() throws Exception {
+        Map<String, Object> props = new LinkedHashMap<>();
+        props.put("id", 10);
+        props.put("name", "renamed-playbook-action");
+        props.put("cron_expr", "0 0 4 ? * *");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).update(with(mockUser), with(props));
+            will(returnValue(10));
+        }});
+
+        validateApiContract("/recurring.playbook/update", "POST")
+                .withBody(Map.of("actionProps", props))
+                .onHandlerMethod("update", User.class, Map.class);
+    }
+}


### PR DESCRIPTION
Migrates the `recurring.playbook` namespace (`create`, `update`) to the OpenAPI contract.

