### PR TITLE
Add supervisor driver to detect crash session

### DIFF
--- a/.github/workflows/playwright-driver-supervisor-test.yml
+++ b/.github/workflows/playwright-driver-supervisor-test.yml
@@ -1,0 +1,27 @@
+name: Playwright Driver Supervisor Test
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/playwright-driver-supervisor-test.yml'
+      - 'testsuite/features/support/playwright_driver_supervisor.rb'
+      - 'testsuite/features/support/env.rb'
+      - 'testsuite/test/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+      - uses: ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71 #v1.268.0
+        with:
+          ruby-version: '3.3'
+
+      - name: Run supervisor test
+        run: |
+          cd testsuite
+          ruby test/playwright_driver_supervisor_test.rb

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,10 @@ schema/reportdb/postgres/views/common/
 
 # Charts
 .debug
+
+# Claude Code session files
+.claude/
+.mcp.json
+
+# Graphify output
+graphify-out/

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -111,7 +111,10 @@ def capybara_register_driver
       app,
       browser_type: :chromium,
       headless: !$debug_mode,
-      playwright_cli_executable_path: ENV.fetch('PLAYWRIGHT_CLI_EXECUTABLE_PATH', '/usr/local/bin/playwright'),
+      # Routed through playwright_driver_supervisor.rb (BUG-031 fix), which resolves the real
+      # driver itself from the same PLAYWRIGHT_CLI_EXECUTABLE_PATH env var and enforces each
+      # call's own declared metadata.timeout - see that file for why.
+      playwright_cli_executable_path: File.expand_path('playwright_driver_supervisor.rb', __dir__),
       args: %w[
         --disable-dev-shm-usage
         --ignore-certificate-errors

--- a/testsuite/features/support/playwright_driver_supervisor.rb
+++ b/testsuite/features/support/playwright_driver_supervisor.rb
@@ -1,0 +1,185 @@
+#!/usr/bin/env ruby
+# Copyright (c) 2010-2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+# External protocol-aware supervisor for the Playwright driver process (BUG-031).
+#
+# Sits between capybara-playwright-driver's Transport and the real `playwright` Node driver,
+# relaying the wire protocol ([4-byte LE length][UTF-8 JSON]) unmodified in both directions.
+# For every outbound message that declares its own `metadata.timeout`, tracks a deadline; if
+# that deadline elapses with no matching response, synthesizes a timeout-error frame for that
+# call's id and SIGKILLs the driver's whole process group.
+#
+# This exists because a wedged blocking native pipe read starves env.rb's Layer-3 Ruby
+# watchdog thread of the GVL, so that thread is scheduled to fire but never actually runs (see
+# BUG-031: zero WATCHDOG log lines on a build that hung 10.4h). Running as a separate OS
+# process is immune to that starvation.
+#
+# Messages with no metadata.timeout are forwarded with no deadline tracked - left entirely to
+# the existing Layer-3 SCENARIO_HARD_LIMIT watchdog in env.rb.
+#
+# Disable/pass-through: set PLAYWRIGHT_SUPERVISOR_DISABLED to skip all of this and exec the
+# real driver directly, byte-for-byte, with zero added behavior. Sole rollback mechanism.
+
+require 'json'
+require 'open3'
+
+DRIVER_PATH = ENV.fetch('PLAYWRIGHT_CLI_EXECUTABLE_PATH', '/usr/local/bin/playwright')
+POLL_INTERVAL = 0.05 # seconds between deadline sweeps
+
+exec(DRIVER_PATH, *ARGV) if ENV['PLAYWRIGHT_SUPERVISOR_DISABLED']
+
+# Reads one [4-byte LE length][JSON payload] frame; returns [raw_bytes, payload] or nil at EOF.
+def read_frame(io)
+  length_prefix = io.read(4)
+  return unless length_prefix && length_prefix.bytesize == 4
+
+  length = length_prefix.unpack1('V')
+  payload = io.read(length)
+  return unless payload && payload.bytesize == length
+
+  [length_prefix + payload, payload]
+end
+
+# Encodes a message hash as one [4-byte LE length][JSON payload] wire frame.
+def build_frame(message)
+  payload = JSON.generate(message)
+  [payload.bytesize].pack('V') + payload
+end
+
+# Builds the synthetic error frame sent upstream in place of a response that never arrived.
+def timeout_error_frame(id, entry)
+  build_frame(
+    'id' => id,
+    'error' => {
+      'error' => {
+        'name' => 'TimeoutError',
+        'message' => "Supervisor: #{entry[:method]}(#{entry[:guid]}) exceeded its declared timeout of #{entry[:timeout_ms]}ms"
+      }
+    }
+  )
+end
+
+# SIGKILLs pid's whole process group (pid == pgid, since the driver was spawned with pgroup: true).
+def kill_process_group(pid)
+  Process.kill('KILL', -pid)
+rescue Errno::ESRCH, Errno::EPERM
+  nil # already gone or permission denied (race condition)
+end
+
+$stdin.binmode
+$stdout.binmode
+
+# pgroup: true (matching capybara-playwright-driver's own spawn of the real driver) makes the
+# child's pid double as its process group id, so `Process.kill('KILL', -pid)` below reaches the
+# whole Chromium/Node subtree, not just the immediate child.
+driver_stdin, driver_stdout, driver_stderr, wait_thr = Open3.popen3(DRIVER_PATH, *ARGV, pgroup: true)
+driver_stdin.binmode
+driver_stdout.binmode
+
+# Drain and forward stderr unconditionally: an unread pipe fills once the driver logs enough
+# (Node warnings, a crash trace) and blocks the driver's write, wedging it exactly like the bug
+# this supervisor exists to catch. Forwarding (rather than just discarding) also keeps
+# capybara-playwright-driver's own "undefined:1" crash-signature detection working, since
+# Transport now watches our stderr instead of the real driver's.
+Thread.new do
+  IO.copy_stream(driver_stderr, $stderr)
+rescue IOError
+  nil
+end
+
+pending = {}
+pending_mutex = Mutex.new
+stdout_mutex = Mutex.new
+
+# Ruby -> driver: parse each outbound message just enough to note its deadline (if it declares
+# one), then forward the exact original bytes downstream unmodified.
+stdin_pump =
+  Thread.new do
+    loop do
+      frame = read_frame($stdin)
+      break unless frame
+
+      frame_bytes, payload = frame
+      begin
+        message = JSON.parse(payload)
+        timeout_ms = message.dig('metadata', 'timeout')
+        id = message['id']
+        if timeout_ms && id
+          pending_mutex.synchronize do
+            pending[id] = {
+              deadline: Process.clock_gettime(Process::CLOCK_MONOTONIC) + (timeout_ms / 1000.0),
+              method: message['method'],
+              guid: message['guid'],
+              timeout_ms: timeout_ms
+            }
+          end
+        end
+      rescue JSON::ParserError
+        nil # forward unmodified regardless; nothing to track
+      end
+
+      driver_stdin.write(frame_bytes)
+      driver_stdin.flush
+    end
+  rescue IOError, Errno::EPIPE
+    nil
+  ensure
+    driver_stdin.close unless driver_stdin.closed?
+  end
+
+# driver -> Ruby: clear the deadline for any id that got a real response, then forward the
+# exact original bytes upstream unmodified.
+stdout_pump =
+  Thread.new do
+    loop do
+      frame = read_frame(driver_stdout)
+      break unless frame
+
+      frame_bytes, payload = frame
+      begin
+        id = JSON.parse(payload)['id']
+        pending_mutex.synchronize { pending.delete(id) } if id
+      rescue JSON::ParserError
+        nil
+      end
+
+      stdout_mutex.synchronize do
+        $stdout.write(frame_bytes)
+        $stdout.flush
+      end
+    end
+  rescue IOError, Errno::EPIPE
+    nil
+  end
+
+# Deadline sweep: runs on the main thread so it can exit(1) directly once it intervenes.
+loop do
+  break unless stdin_pump.alive? && stdout_pump.alive?
+
+  expired =
+    pending_mutex.synchronize do
+      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      ids = pending.keys.select { |id| pending[id][:deadline] <= now }
+      ids.map { |id| [id, pending.delete(id)] }
+    end
+
+  unless expired.empty?
+    expired.each do |id, entry|
+      warn "PLAYWRIGHT_SUPERVISOR: #{entry[:method]}(#{entry[:guid]}) exceeded its declared timeout of " \
+           "#{entry[:timeout_ms]}ms - killing driver process group #{wait_thr.pid}"
+      stdout_mutex.synchronize do
+        $stdout.write(timeout_error_frame(id, entry))
+        $stdout.flush
+      end
+    end
+    kill_process_group(wait_thr.pid)
+    exit(1)
+  end
+
+  sleep POLL_INTERVAL
+end
+
+stdin_pump.join
+stdout_pump.join
+exit(wait_thr.value.exitstatus || 1)

--- a/testsuite/test/fixtures/fake_driver.rb
+++ b/testsuite/test/fixtures/fake_driver.rb
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+# Copyright (c) 2010-2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+# Fake Playwright driver for supervisor testing. Speaks the identical wire protocol
+# ([4-byte LE length][JSON payload]) as the real driver, but implements just enough
+# behavior to test the supervisor's timeout and kill logic.
+
+require 'json'
+
+def read_frame(io)
+  length_prefix = io.read(4)
+  return unless length_prefix && length_prefix.bytesize == 4
+
+  length = length_prefix.unpack1('V')
+  payload = io.read(length)
+  return unless payload && payload.bytesize == length
+
+  JSON.parse(payload)
+end
+
+def write_frame(io, message)
+  payload = JSON.generate(message)
+  io.write([payload.bytesize].pack('V') + payload)
+  io.flush
+end
+
+$stdin.binmode
+$stdout.binmode
+
+# Write our PID to the file so tests can check if we're still alive
+if ENV['FAKE_DRIVER_PID_FILE']
+  File.write(ENV['FAKE_DRIVER_PID_FILE'], $$.to_s)
+end
+
+# Process incoming messages and respond (or hang, if requested)
+loop do
+  message = read_frame($stdin)
+  break unless message
+
+  params = message['params'] || {}
+  id = message['id']
+
+  # Drain requested stderr bytes (used to test backpressure handling)
+  if params['stderrBytes']&.positive?
+    $stderr.write('X' * params['stderrBytes'])
+    $stderr.flush
+  end
+
+  # If hang is requested, just stop responding (supervisor should kill us)
+  next if params['hang']
+
+  # Otherwise echo back a response
+  response = {
+    'id' => id,
+    'echoGuid' => message['guid']
+  }
+
+  # Simulate a delay if requested
+  if params['delayMs']&.positive?
+    sleep(params['delayMs'] / 1000.0)
+  end
+
+  write_frame($stdout, response)
+end

--- a/testsuite/test/playwright_driver_supervisor_test.rb
+++ b/testsuite/test/playwright_driver_supervisor_test.rb
@@ -1,0 +1,160 @@
+# Copyright (c) 2010-2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+# Standalone process-boundary test for the BUG-031 fix (see
+# features/support/playwright_driver_supervisor.rb). No real Playwright/Node/Chromium needed:
+# a small fixture "fake driver" (test/fixtures/fake_driver.rb) speaks the identical wire
+# framing, and this test plays the role of the "Ruby side" that capybara-playwright-driver's
+# Transport would normally be.
+#
+# Run: ruby test/playwright_driver_supervisor_test.rb
+
+require 'io/wait'
+require 'json'
+require 'minitest/autorun'
+require 'open3'
+require 'tempfile'
+
+SUPERVISOR = File.expand_path('../features/support/playwright_driver_supervisor.rb', __dir__)
+FIXTURE_DRIVER = File.expand_path('fixtures/fake_driver.rb', __dir__)
+
+class PlaywrightDriverSupervisorTest < Minitest::Test
+  def setup
+    @pid_file = Tempfile.new('fake_driver_pid')
+    @stdin, @stdout, @wait_thr = spawn_supervisor
+  end
+
+  def teardown
+    @stdin.close if @stdin && !@stdin.closed?
+    Process.kill('KILL', -@wait_thr.pid) if @wait_thr
+  rescue Errno::ESRCH, IOError
+    nil
+  ensure
+    @wait_thr&.join
+    @pid_file&.unlink
+  end
+
+  def test_call_completing_before_its_deadline_passes_through_unmodified
+    write_frame(@stdin, id: 1, guid: 'page@1', method: 'click', params: { delayMs: 10 }, metadata: { timeout: 2000 })
+
+    response = read_frame(@stdout)
+
+    assert_equal 1, response['id']
+    assert_equal 'page@1', response['echoGuid']
+    refute response.key?('error')
+    assert driver_alive?, 'a call that completes in time must not trigger a kill'
+  end
+
+  def test_call_exceeding_its_declared_timeout_gets_a_synthetic_error_and_kills_the_driver
+    write_frame(@stdin, id: 2, guid: 'page@2', method: 'waitForSelector', params: { hang: true }, metadata: { timeout: 300 })
+
+    response = read_frame(@stdout, timeout: 3)
+
+    refute_nil response, 'expected a synthetic timeout frame'
+    assert_equal 2, response['id']
+    assert_equal 'TimeoutError', response.dig('error', 'error', 'name')
+
+    sleep 0.2 # give the SIGKILL a moment to land
+    refute driver_alive?, 'expected the fixture driver process group to be terminated'
+  end
+
+  def test_call_with_no_declared_timeout_is_left_to_layer_3
+    write_frame(@stdin, id: 3, guid: 'page@3', method: 'waitForSelector', params: { hang: true })
+
+    response = read_frame(@stdout, timeout: 1)
+
+    assert_nil response, 'supervisor must not intervene on calls with no metadata.timeout'
+    assert driver_alive?, 'supervisor must stay passive - only Layer 3 handles this case'
+  end
+
+  def test_concurrent_calls_only_the_timed_out_one_gets_a_synthetic_frame
+    write_frame(@stdin, id: 4, guid: 'page@4', method: 'click', params: { delayMs: 50 }, metadata: { timeout: 2000 })
+    write_frame(@stdin, id: 5, guid: 'page@5', method: 'waitForSelector', params: { hang: true }, metadata: { timeout: 300 })
+
+    responses = [read_frame(@stdout, timeout: 3), read_frame(@stdout, timeout: 3)].compact
+
+    normal = responses.find { |r| r['id'] == 4 }
+    timed_out = responses.find { |r| r['id'] == 5 }
+    refute_nil normal, 'the call that completed in time must still get its real response'
+    refute normal.key?('error')
+    refute_nil timed_out, 'the hung call must get its synthetic timeout frame'
+    assert_equal 'TimeoutError', timed_out.dig('error', 'error', 'name')
+  end
+
+  def test_a_noisy_driver_does_not_block_on_undrained_stderr
+    write_frame(@stdin, id: 8, guid: 'page@8', method: 'click', params: { stderrBytes: 500_000 }, metadata: { timeout: 2000 })
+
+    response = read_frame(@stdout, timeout: 3)
+
+    refute_nil response, 'the driver must not wedge writing to stderr just because nothing reads it'
+    assert_equal 8, response['id']
+    refute response.key?('error')
+  end
+
+  def test_disable_env_var_execs_the_real_driver_with_byte_for_byte_passthrough
+    @stdin.close
+    begin
+      Process.kill('KILL', -@wait_thr.pid)
+    rescue Errno::ESRCH
+      nil
+    end
+    @wait_thr.join
+
+    @stdin, @stdout, @wait_thr = spawn_supervisor('PLAYWRIGHT_SUPERVISOR_DISABLED' => '1')
+
+    write_frame(@stdin, id: 6, guid: 'page@6', method: 'waitForSelector', params: { hang: true }, metadata: { timeout: 300 })
+    sleep 0.5 # past what would have been the declared deadline under the enabled supervisor
+    write_frame(@stdin, id: 7, guid: 'page@7', method: 'click', params: { delayMs: 10 })
+
+    response = read_frame(@stdout, timeout: 3)
+
+    assert_equal 7, response['id'], 'id 6 never responds (hang) - passthrough means no intervention, so id 7 arrives untouched'
+  end
+
+  private
+
+  def spawn_supervisor(extra_env = {})
+    env = { 'PLAYWRIGHT_CLI_EXECUTABLE_PATH' => FIXTURE_DRIVER, 'FAKE_DRIVER_PID_FILE' => @pid_file.path }.merge(extra_env)
+    stdin, stdout, stderr, wait_thr = Open3.popen3(env, SUPERVISOR, 'run-driver', pgroup: true)
+    stdin.binmode
+    stdout.binmode
+    # Drain the supervisor's own stderr, same as capybara-playwright-driver's Transport does in
+    # production - otherwise an unread pipe here would recreate test/fixtures/fake_driver.rb's
+    # stderrBytes scenario one level up, in the test harness itself.
+    Thread.new { IO.copy_stream(stderr, File::NULL) }
+    [stdin, stdout, wait_thr]
+  end
+
+  def write_frame(io, message)
+    payload = JSON.generate(message)
+    io.write([payload.bytesize].pack('V') + payload)
+    io.flush
+  end
+
+  def read_frame(io, timeout: 5)
+    return unless io.wait_readable(timeout)
+
+    length_prefix = io.read(4)
+    return unless length_prefix && length_prefix.bytesize == 4
+
+    JSON.parse(io.read(length_prefix.unpack1('V')))
+  end
+
+  def driver_alive?
+    deadline = Time.now + 2
+    pid = nil
+    loop do
+      content = File.read(@pid_file.path)
+      pid = content.to_i
+      break if pid.positive? || Time.now > deadline
+    end
+    return false if pid.nil? || pid.zero?
+
+    # A SIGKILLed process lingers as a zombie until its (already-exited) parent would reap it,
+    # and kill(pid, 0) still succeeds against a zombie - so check /proc state, not just existence.
+    state = File.read("/proc/#{pid}/stat").rpartition(')').last.strip.split.first
+    state != 'Z'
+  rescue Errno::ENOENT
+    false
+  end
+end


### PR DESCRIPTION
## What does this PR change?

Adds an external protocol-aware supervisor process for the Playwright driver . The supervisor sits between the capybara-playwright-driver transport and the real Playwright Node driver, relaying wire protocol messages while enforcing timeouts declared in message metadata. When a timeout elapses with no response, it synthesizes a timeout error and SIGKILLs the driver process group to recover the session.

This addresses a root cause of hanging test sessions: when the driver's blocking native pipe read wedges, it starves the Ruby watchdog thread of the GVL, preventing timeouts from firing. Running the supervisor as a separate OS process bypasses GVL starvation entirely. The supervisor can be disabled via `PLAYWRIGHT_SUPERVISOR_DISABLED` environment variable for rollback if needed.

Testing: https://jenkins.mgr.suse.de/job/manager-5.2-dev-acceptance-tests/167/

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- [x] No documentation needed: internal infrastructure change, no user-facing behavior changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- [x] No tests: already covered by existing test suite runs (supervisor is infrastructure, not tested as a unit)

- [x] **DONE**

## Links

Fixes: BUG-031 (hanging playwright sessions)

Port(s):
 - 5.2: https://github.com/SUSE/spacewalk/pull/31613
 - 5.1: https://github.com/SUSE/spacewalk/pull/31614

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

