### PR TITLE
Drop the SLE 15 SP7 helper repo from the container image profiles

### DIFF
--- a/testsuite/features/profiles/temporary/docker_profiles/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/temporary/docker_profiles/Docker/authprofile/Dockerfile
@@ -14,7 +14,6 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles15sp7.repo /etc/zypp/repos.d/sles15sp7.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/temporary/docker_profiles/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/Docker/authprofile/add_packages.sh
@@ -13,9 +13,8 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 # install python3 and python3-psutil in the container
 zypper --non-interactive in tar gzip python3 python3-psutil
 
-# re-enable normal repo and remove helper repo
+# re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :
-zypper rr sles15sp7
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/temporary/docker_profiles/Docker/authprofile/sles15sp7.repo
+++ b/testsuite/features/profiles/temporary/docker_profiles/Docker/authprofile/sles15sp7.repo
@@ -1,6 +1,0 @@
-[sles15sp7]
-name=sles15sp7
-enabled=1
-autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP7/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/temporary/docker_profiles/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/temporary/docker_profiles/Docker/serverhost/Dockerfile
@@ -14,7 +14,6 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles15sp7.repo /etc/zypp/repos.d/sles15sp7.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/temporary/docker_profiles/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/Docker/serverhost/add_packages.sh
@@ -13,9 +13,8 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 # install python3 and python3-psutil in the container
 zypper --non-interactive in tar gzip python3 python3-psutil
 
-# re-enable normal repo and remove helper repo
+# re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :
-zypper rr sles15sp7
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/temporary/docker_profiles/Docker/serverhost/sles15sp7.repo
+++ b/testsuite/features/profiles/temporary/docker_profiles/Docker/serverhost/sles15sp7.repo
@@ -1,6 +1,0 @@
-[sles15sp7]
-name=sles15sp7
-enabled=1
-autorefresh=0
-baseurl=http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP7/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/authprofile/Dockerfile
@@ -14,7 +14,6 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles15sp7.repo /etc/zypp/repos.d/sles15sp7.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/authprofile/add_packages.sh
@@ -13,9 +13,8 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 # install python3 and python3-psutil in the container
 zypper --non-interactive in tar gzip python3 python3-psutil
 
-# re-enable normal repo and remove helper repo
+# re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :
-zypper rr sles15sp7
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/authprofile/sles15sp7.repo
+++ b/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/authprofile/sles15sp7.repo
@@ -1,6 +1,0 @@
-[sles15sp7]
-name=sles15sp7
-enabled=1
-autorefresh=0
-baseurl=http://ip-172-16-1-175.eu-central-1.compute.internal/SUSE/Products/SLE-Module-Basesystem/15-SP7/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/serverhost/Dockerfile
@@ -14,7 +14,6 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles15sp7.repo /etc/zypp/repos.d/sles15sp7.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/serverhost/add_packages.sh
@@ -13,9 +13,8 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 # install python3 and python3-psutil in the container
 zypper --non-interactive in tar gzip python3 python3-psutil
 
-# re-enable normal repo and remove helper repo
+# re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :
-zypper rr sles15sp7
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/serverhost/sles15sp7.repo
+++ b/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/serverhost/sles15sp7.repo
@@ -1,6 +1,0 @@
-[sles15sp7]
-name=sles15sp7
-enabled=1
-autorefresh=0
-baseurl=http://ip-172-16-1-175.eu-central-1.compute.internal/SUSE/Products/SLE-Module-Basesystem/15-SP7/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/authprofile/Dockerfile
@@ -14,7 +14,6 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles15sp7.repo /etc/zypp/repos.d/sles15sp7.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/authprofile/add_packages.sh
@@ -13,9 +13,8 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 # install python3 and python3-psutil in the container
 zypper --non-interactive in tar gzip python3 python3-psutil
 
-# re-enable normal repo and remove helper repo
+# re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :
-zypper rr sles15sp7
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/authprofile/sles15sp7.repo
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/authprofile/sles15sp7.repo
@@ -1,6 +1,0 @@
-[sles15sp7]
-name=sles15sp7
-enabled=1
-autorefresh=0
-baseurl=http://minima-mirror-ci-bv.mgr.suse.de/SUSE/Products/SLE-Module-Basesystem/15-SP7/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/serverhost/Dockerfile
@@ -14,7 +14,6 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles15sp7.repo /etc/zypp/repos.d/sles15sp7.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/serverhost/add_packages.sh
@@ -13,9 +13,8 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 # install python3 and python3-psutil in the container
 zypper --non-interactive in tar gzip python3 python3-psutil
 
-# re-enable normal repo and remove helper repo
+# re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :
-zypper rr sles15sp7
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/serverhost/sles15sp7.repo
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/serverhost/sles15sp7.repo
@@ -1,6 +1,0 @@
-[sles15sp7]
-name=sles15sp7
-enabled=1
-autorefresh=0
-baseurl=http://minima-mirror-ci-bv.mgr.suse.de/SUSE/Products/SLE-Module-Basesystem/15-SP7/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/authprofile/Dockerfile
@@ -14,7 +14,6 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles15sp7.repo /etc/zypp/repos.d/sles15sp7.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/authprofile/add_packages.sh
@@ -13,9 +13,8 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 # install python3 and python3-psutil in the container
 zypper --non-interactive in tar gzip python3 python3-psutil
 
-# re-enable normal repo and remove helper repo
+# re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :
-zypper rr sles15sp7
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/authprofile/sles15sp7.repo
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/authprofile/sles15sp7.repo
@@ -1,6 +1,0 @@
-[sles15sp7]
-name=sles15sp7
-enabled=1
-autorefresh=0
-baseurl=http://minima-mirror-ci-bv.mgr.slc1.suse.org/SUSE/Products/SLE-Module-Basesystem/15-SP7/x86_64/product/
-type=rpm-md

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/serverhost/Dockerfile
@@ -14,7 +14,6 @@ RUN echo "$repo" > /etc/zypp/repos.d/susemanager:dockerbuild.repo
 
 ADD nsswitch.conf /etc/nsswitch.conf
 ADD avahi-daemon.conf /root/avahi-daemon.conf
-ADD sles15sp7.repo /etc/zypp/repos.d/sles15sp7.repo
 
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/serverhost/add_packages.sh
@@ -13,9 +13,8 @@ cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 # install python3 and python3-psutil in the container
 zypper --non-interactive in tar gzip python3 python3-psutil
 
-# re-enable normal repo and remove helper repo
+# re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :
-zypper rr sles15sp7
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/serverhost/sles15sp7.repo
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/serverhost/sles15sp7.repo
@@ -1,6 +1,0 @@
-[sles15sp7]
-name=sles15sp7
-enabled=1
-autorefresh=0
-baseurl=http://minima-mirror-ci-bv.mgr.slc1.suse.org/SUSE/Products/SLE-Module-Basesystem/15-SP7/x86_64/product/
-type=rpm-md


### PR DESCRIPTION
## What does this PR change?

The `uyuni-master-testsuite` base image is now built on openSUSE Leap 16.0 (`org.opencontainers.image.version 16.0.6.171`), where `python3` is 3.13. The `serverhost` and `authprofile` Docker profiles still inject a SLE 15 SP7 Basesystem repo just to get `python3-psutil`, and SP7 only ships the python 3.6 build of it:

```
Problem: 1: the to be installed python3-psutil-5.9.1-150300.3.6.1.x86_64
         requires 'python(abi) = 3.6', but this requirement cannot be provided
 not installable providers: python3-base-3.6.15-150300.10.84.1.x86_64[sles15sp7]
Choose from above solutions by number or cancel [1/2/3/c/d/?] (c): c
```

`zypper --non-interactive` falls through to the default `c` (cancel), `set -e` aborts `add_packages.sh`, and `docker.build` reports a bare `Build failed for <profile url>` with no reason — the real output only exists in `/var/log/image-build<id>.log` on the build host.

Leap 16 ships `python313-psutil 7.0.0`, which provides `python3-psutil`, so the helper repo is not needed at all. This drops `sles15sp7.repo`, its `ADD` line, and the matching `zypper rr sles15sp7` from the `serverhost` and `authprofile` profiles in all four scopes — `internal_nue`, `internal_slc1`, `cloud_aws` and the default (no-domain) `Docker/`.

Only those two profiles are touched. The `Docker/Dockerfile` at the top of each scope is still `FROM registry.mgr.suse.de/suse/sle15:15.7`, where the SP7 repo is legitimate, so it keeps it.

No ports needed: every environment sets `git_profiles_repo` to `testsuite/features/profiles/temporary` on this branch, regardless of product version, and all scopes pull the same `uyuni-master-testsuite` image. The `sles15sp4.repo` copies under `profiles/internal_nue` and `profiles/internal_slc` are left alone — only the 4.3 configs point at those, and they have no build host, so nothing builds from them.

### Verified on a live environment

`features/secondary/buildhost_docker_build_image.feature`, run twice back to back on the same env (Uyuni master, podman, SLES 16 server), only `GITPROFILES` changed between the two.

**Before** — profiles from this branch's parent:

```
Failing Scenarios:
cucumber features/secondary/buildhost_docker_build_image.feature:86  # Scenario: Build the suse_real_key image with and without activation key
cucumber features/secondary/buildhost_docker_build_image.feature:96  # Scenario: Check the list of packages is not empty
cucumber features/secondary/buildhost_docker_build_image.feature:153 # Scenario: Build an image via the GUI
cucumber features/secondary/buildhost_docker_build_image.feature:165 # Scenario: Login as Docker image administrator and build an image

30 scenarios (4 failed, 26 passed)
126 steps (4 failed, 6 skipped, 116 passed)
14m6.315s
```

with, in the salt event log:

```
          ID: mgr_buildimage
    Function: module.run
        Name: docker.build
      Result: false
     Comment: Module function docker.build threw an exception. Exception: Build failed for
              https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/serverhost
```

**After** — profiles from this branch:

```
Failing Scenarios:
cucumber features/secondary/buildhost_docker_build_image.feature:96 # Scenario: Check the list of packages is not empty

30 scenarios (1 failed, 29 passed)
126 steps (1 failed, 125 passed)
15m22.757s
```

The build host log for the same image now resolves psutil from Leap 16 and completes:

```
  libmpdec4 libpython3_13-1_0 python3 python3-base python313 python313-base python313-psutil
(5/7) Installing: python313-psutil-7.0.0-160000.2.2.x86_64 [..done]
...
Successfully built 03130644640a
Successfully tagged registry.mgr.suse.de/suse_real_key:latest
```

The one scenario still failing is a **different, unrelated bug** that the build failure was masking. Image inspection copies the build host's `venv-salt-minion` bundle into the container and runs it there; the bundle is linked against OpenSSL 1.1, which Leap 16 does not have:

```
  File "/var/tmp/venv-salt-minion/lib64/python3.11/ssl.py", line 100, in <module>
    import _ssl
ImportError: libssl.so.1.1: cannot open shared object file: No such file or directory
```

So `docker.sls_build` throws, the package profile is never collected, and the image reports `installedPackages: 0` even though it really has 152. That needs its own fix and is out of scope here.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): SUSE/spacewalk#31579, SUSE/spacewalk#30720
Port(s): none — every environment reads these profiles from uyuni master via `git_profiles_repo`, whatever the product version, so there is nothing to port them to.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
