### PR TITLE
Fix uyuni docs products

### DIFF
--- a/java/doclets/src/main/java/com/redhat/rhn/internal/doclet/DocWriter.java
+++ b/java/doclets/src/main/java/com/redhat/rhn/internal/doclet/DocWriter.java
@@ -107,8 +107,17 @@ public abstract class DocWriter {
      * @throws IOException e
      */
     public String generateHandler(Handler handler, String templateDir) throws IOException {
+        if (handler.getDesc() != null) {
+            handler.setDesc(renderMacro(templateDir, handler.getDesc(),
+                    "handler:" + handler.getName()));
+        }
+
         for (ApiCall call : handler.getCalls()) {
             log(String.format("Generating handler call %s.%s", handler.getName(), call.getName()));
+            if (call.getDoc() != null) {
+                call.setDoc(renderMacro(templateDir, call.getDoc(),
+                        "doc:" + handler.getName() + "." + call.getName()));
+            }
             call.setReturnDoc(renderMacro(templateDir, call.getReturnDoc(),
                     call.getName()));
             List<String> params = new ArrayList<>();


### PR DESCRIPTION
## What does this PR change?

Renders documentation macros in XML-RPC handler and method descriptions. This resolves placeholders such as #product() to the configured product name instead of leaving them visible in generated API documentation. There are no runtime, API, or GUI behavior changes.

Fix for https://github.com/uyuni-project/uyuni-docs-api/pull/74, with this we don't need to use {productname} it will be automaticly transformed to the correct product name

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation

No docs update needed

- [x] **DONE**

## Test coverage

- No tests: Just a fix
- 
Manually tested: 
```
0:35 $ ant -f manager-build.xml -Dproduct.name=Uyuni apidoc-asciidoc
Buildfile: /home/emaksy/Work/uyuni/java/manager-build.xml
..............................................
..............................................
✘-1 ~/Work/uyuni/java [fix_uyuni_docs_java_handler|✔] 
10:35 $ rg -n 'Uyuni' \
>   build/reports/apidocs/asciidoc/admin.configuration.adoc \
>   build/reports/apidocs/asciidoc/admin.monitoring.adoc \
>   build/reports/apidocs/asciidoc/system.scap.adoc
build/reports/apidocs/asciidoc/system.scap.adoc
39:Delete OpenSCAP XCCDF Scan from the Uyuni database. Note that

build/reports/apidocs/asciidoc/admin.monitoring.adoc
13:Provides methods to manage the monitoring of the Uyuni server. 

build/reports/apidocs/asciidoc/admin.configuration.adoc
11:Provides methods to configure the Uyuni server. 
36:* [.map]#map#  content - the Uyuni configuration formula data

```

- [x] **DONE**

## Links

Issue(s):  https://github.com/uyuni-project/uyuni-docs-api/pull/74
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
