### PR TITLE
Report which health check containers are missing on failure

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1859,7 +1859,7 @@ end
 When(/^I stop the health check tool on "([^"]*)"$/) do |host|
   node = get_target(host)
   node.run('mgr-health-check stop', check_errors: false, verbose: true)
-  node.run('podman rm -f health_check_loki health_check_promtail health_check_supportconfig_exporter health-check-grafana', check_errors: false)
+  node.run("podman rm -f #{HEALTH_CHECK_CONTAINERS.join(' ')}", check_errors: false)
   node.run('podman network rm -f health-check-network', check_errors: false)
 end
 
@@ -1947,7 +1947,20 @@ end
 
 Then(/^the health check tool (should be|should not be) running on "([^"]*)"$/) do |action, host|
   node = get_target(host)
-  node.run("test $(podman ps | grep health-check | wc -l) == #{action == 'should be' ? '4' : '0'}", check_errors: true, verbose: true)
+  expected = action == 'should be' ? HEALTH_CHECK_CONTAINERS : []
+  running, _code = node.run('podman ps --format "{{.Names}}"', check_errors: true, verbose: true)
+  running_containers = running.lines.map(&:strip).grep(/^health[-_]check/)
+  missing = expected - running_containers
+  unexpected = running_containers - expected
+  next if missing.empty? && unexpected.empty?
+
+  problems = []
+  problems << "not running: #{missing.join(', ')}" unless missing.empty?
+  problems << "unexpectedly running: #{unexpected.join(', ')}" unless unexpected.empty?
+  output, _code = node.run('podman ps -a --format "{{.Names}} {{.Status}}"', check_errors: true)
+  containers = output.lines.map(&:strip).grep(/^health[-_]check/)
+  statuses = containers.empty? ? 'no health check containers found' : containers.join("\n")
+  raise "Health check containers #{problems.join('; ')}\n#{statuses}"
 end
 
 Then(/^podman container "([^"]*)" should be (running|healthy) on "([^"]*)"$/) do |container, state, host|

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -1892,3 +1892,11 @@ UYUNI_MAIN_REPO_URL_BYPASS = {
   'ubuntu-2404-amd64-uyuni-client-devel' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/xUbuntu_24.04-debbuild/',
   'uyuni-proxy-devel-tumbleweed-x86_64' => 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/'
 }.freeze
+
+# Containers started by the health check tool, as named in its config.toml
+HEALTH_CHECK_CONTAINERS = %w[
+  health_check_loki
+  health_check_promtail
+  health_check_supportconfig_exporter
+  health-check-grafana
+].freeze


### PR DESCRIPTION
## What does this PR change?

Checks the health check tool by container name instead of by container count,
and reports which containers are missing when the check fails.

The check was a single `test $(podman ps | grep health-check | wc -l) == 4`, so a
mismatch produced nothing but an exit code, and a container running under an
unexpected name still satisfied the count. The four names now live in a
`HEALTH_CHECK_CONTAINERS` constant, shared with the step that stops the tool, and
the step compares the running names against it — reporting both the ones that are
missing and any unexpected leftover — followed by the health check containers from
`podman ps -a` with their status:

```
Health check containers not running: health_check_promtail, health_check_supportconfig_exporter
health_check_loki Up 2 seconds
health_check_promtail Exited (1) 1 second ago
health_check_supportconfig_exporter Exited (1) 1 second ago
health-check-grafana Up 1 second
```

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s):
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31632
Manager-5.1: https://github.com/SUSE/spacewalk/pull/31633

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
