### PR TITLE
feat(openapi): resolve legacy struct property types instead of collapsing them to string

### DIFF
--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -349,13 +349,7 @@ public class OpenApiToAsciidocParser {
         if (resolved == null || resolved.getProperties() == null) {
             return;
         }
-        resolved.getProperties().forEach((name, prop) -> {
-            Schema<?> propertySchema = prop;
-            String propDesc = propertySchema.getDescription() != null ?
-                    " - " + propertySchema.getDescription() : "";
-            String propertyType = structPropertyType(propertySchema);
-            writer.printf("** [.%s]#%s#  \"%s\"%s%n", propertyType, propertyType, name, propDesc);
-        });
+        resolved.getProperties().forEach((name, prop) -> writeStructProperty(writer, "", name, prop));
     }
 
     private void writeSimpleReturn(PrintWriter writer, Schema<?> schema,
@@ -402,16 +396,46 @@ public class OpenApiToAsciidocParser {
         return "integer".equals(schema.getType()) ? "int" : schema.getType();
     }
 
+    /**
+     * Resolves the legacy type name of a struct property, mirroring the doclet macros:
+     * {@code #type($t)} renders {@code [.$t]#$t#} and {@code #atype($t)} renders
+     * {@code [.array]#$t array#}, with {@code $date} bound to {@code dateTime.iso8601}.
+     */
     private String structPropertyType(Schema<?> schema) {
         String type = schema.getType();
         if ("integer".equals(type)) {
             return "int";
         }
-        if ("string".equals(type) || "boolean".equals(type) || "number".equals(type)) {
+        if ("string".equals(type)) {
+            return "date-time".equals(schema.getFormat()) ? UyuniSwaggerReader.LEGACY_DATE_TYPE : type;
+        }
+        if ("boolean".equals(type) || "number".equals(type)) {
             return type;
         }
-        // arrays, objects and $ref types keep the legacy "string" fallback
+        if ("array".equals(type)) {
+            // #prop_array renders the element type ("string array"); #prop_array_begin, which
+            // is what a non-scalar element compiles to, renders a bare "array".
+            Schema<?> items = resolveSchemaReference(schema.getItems());
+            return items != null && isSimpleType(items) ? structPropertyType(items) + " array" : "array";
+        }
+        if ("object".equals(type) || schema.get$ref() != null || schema.getProperties() != null) {
+            return "struct";
+        }
         return "string";
+    }
+
+    /**
+     * The AsciiDoc marker differs from the rendered type only for arrays, where the doclet
+     * emits {@code [.array]} but shows the element type.
+     */
+    private String structPropertyMarker(Schema<?> schema) {
+        return "array".equals(schema.getType()) ? "array" : structPropertyType(schema);
+    }
+
+    private void writeStructProperty(PrintWriter writer, String prefix, String name, Schema<?> schema) {
+        String description = schema.getDescription() != null ? " - " + schema.getDescription() : "";
+        writer.printf("%s** [.%s]#%s#  \"%s\"%s%n", prefix, structPropertyMarker(schema),
+                structPropertyType(schema), name, description);
     }
 
     private ApiResponse getSuccessResponse(ApiResponses responses) {
@@ -451,16 +475,8 @@ public class OpenApiToAsciidocParser {
         }
 
         if (schema.getProperties() != null) {
-            schema.getProperties().forEach((name, property) -> {
-                Schema<?> propertySchema = (Schema<?>) property;
-                String propertyDescription = "";
-                if (propertySchema.getDescription() != null) {
-                    propertyDescription = " - " + propertySchema.getDescription();
-                }
-                String propertyType = structPropertyType(propertySchema);
-                writer.printf("%s** [.%s]#%s#  \"%s\"%s%n", prefix, propertyType, propertyType, name,
-                        propertyDescription);
-            });
+            schema.getProperties().forEach((name, property) ->
+                    writeStructProperty(writer, prefix, name, property));
         }
 
         if (schema.getAdditionalProperties() instanceof Schema<?> inner) {
@@ -470,16 +486,8 @@ public class OpenApiToAsciidocParser {
                 resolvedInner = nested.get$ref() != null ? resolveSchema(nested.get$ref()) : nested;
             }
             if (resolvedInner.getProperties() != null) {
-                resolvedInner.getProperties().forEach((name, property) -> {
-                    Schema<?> propertySchema = (Schema<?>) property;
-                    String propertyDescription = "";
-                    if (propertySchema.getDescription() != null) {
-                        propertyDescription = " - " + propertySchema.getDescription();
-                    }
-                    String propertyType = structPropertyType(propertySchema);
-                    writer.printf("%s** [.%s]#%s#  \"%s\"%s%n", prefix, propertyType, propertyType, name,
-                            propertyDescription);
-                });
+                resolvedInner.getProperties().forEach((name, property) ->
+                        writeStructProperty(writer, prefix, name, property));
             }
             else if (isSimpleType(resolvedInner)) {
                 String description = "";

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -629,10 +629,20 @@ public class OpenApiToDocBookParser {
             return "array";
         }
         if (s.get$ref() != null) {
-            return extractRefName(s.get$ref());
+            // A referenced schema that carries properties is a struct in legacy terms; only a
+            // reference without properties keeps its name as the type.
+            Schema<?> resolved = resolveSchema(s.get$ref());
+            return resolved != null && resolved.getProperties() != null ?
+                    "struct" : extractRefName(s.get$ref());
         }
         if ("integer".equals(type)) {
             return "int";
+        }
+        if ("string".equals(type) && "date-time".equals(s.getFormat())) {
+            return UyuniSwaggerReader.LEGACY_DATE_TYPE;
+        }
+        if ("object".equals(type) || s.getProperties() != null) {
+            return "struct";
         }
         return type != null ? type : "string";
     }

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -57,6 +57,8 @@ public class UyuniSwaggerReader {
     public static final String DOC_RESPONSE_NAME_EXTENSION = "x-uyuni-doc-response-name";
     public static final String DEFAULT_MEDIA_TYPE = "application/json";
     public static final String HTTP_200 = "200";
+    /** Legacy name for a date, bound as {@code $date} in the doclet's macros for both formats. */
+    public static final String LEGACY_DATE_TYPE = "dateTime.iso8601";
 
     private final OpenAPI openAPI;
     private final Components components;


### PR DESCRIPTION
## What

`structPropertyType()` collapsed every non-scalar struct property to `string`, so a legacy
`#prop_array`, a nested `#struct`, a `map` or a `$date` all rendered as `[.string]#string#`.
This resolves them instead, and de-duplicates the three copy-pasted property-writing loops into a
single `writeStructProperty()`.


