### PR TITLE
Fix ssh minion detection

### DIFF
--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -351,7 +351,7 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
   raise StandardError, 'Error creating activation key via the API' if key.nil?
 
   $stdout.puts "Activation key #{key} created"
-  contact_method = client.include?('ssh_minion') ? 'ssh-push' : 'default'
+  contact_method = client.include?('sshminion') ? 'ssh-push' : 'default'
   success = $api_test.activationkey.details_set?(key, description, base_channel_label, 100, contact_method)
   raise 'Failed to set activation key details' unless success
 


### PR DESCRIPTION
## What does this PR change?

Fix a typo in the activation key creation step that caused SSH minions to be registered with the wrong contact method. The `client.include?('ssh_minion')` check never matched because the actual client identifier is `'sshminion'` (no underscore), so all SSH minions silently received `'default'` instead of `'ssh-push'` as their contact method.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): 
  - 5.2: https://github.com/SUSE/spacewalk/pull/31636
  - 5.1: https://github.com/SUSE/spacewalk/pull/31637

- [x] **DONE**

## Changelogs

- [x] No changelog needed