### PR TITLE
Fix playwright-ruby-client Transport to prevent indefinite test run hangs

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -110,9 +110,9 @@ def repeat_until_timeout(timeout: DEFAULT_TIMEOUT, retries: nil, message: nil, r
       # At the time of writing some of the problems described have been addressed.
       # However, at least https://bugs.ruby-lang.org/issues/15886 remains reproducible and code below
       # works around it by adding an additional check between loops
-      start = Time.new
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
       attempts = 0
-      while (Time.new - start <= timeout) && (retries.nil? || attempts < retries)
+      while Process.clock_gettime(Process::CLOCK_MONOTONIC) <= deadline && (retries.nil? || attempts < retries)
         last_result = yield
         attempts += 1
       end

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -172,10 +172,17 @@ After do |scenario|
   log "This scenario took: #{current_epoch - @scenario_start_time} seconds"
   if scenario.failed?
     begin
-      # web_session_is_active? can raise if the session went stale after a long step.
+      # web_session_is_active? can raise or hang if the Playwright pipe was corrupted mid-call
+      # (e.g. by Timeout.timeout firing inside repeat_until_timeout). The 10s backstop ensures
+      # the After hook doesn't wait 36+ minutes for the watchdog when the connection is already dead.
       session_active =
         begin
-          web_session_is_active?
+          Timeout.timeout(10) { web_session_is_active? }
+        rescue Timeout::Error
+          warn 'After: Playwright connection hung during session check — triggering emergency browser kill'
+          unblock_wedged_browser
+          $watchdog_run_aborted = true
+          false
         rescue StandardError => e
           log "Web session went stale when checking for active session: #{e.message}"
           false

--- a/testsuite/features/support/playwright_transport_patch.rb
+++ b/testsuite/features/support/playwright_transport_patch.rb
@@ -10,14 +10,14 @@
 #    JSON payload in two separate IO#write calls. Timeout.timeout (used by
 #    repeat_until_timeout) delivers Thread#raise asynchronously; if it landed
 #    between those two writes, Node.js received a partial frame and crashed with:
-#      SyntaxError: Unexpected token '♦', "♦{"id":"... is not valid JSON
+#      SyntaxError: Unexpected token (non-ASCII diamond), e.g. in JSON at position 0
 #    Fix: build the whole frame in one buffer and write it in a single call,
 #    shielded by Thread.handle_interrupt so async exceptions are deferred until
 #    the frame is fully on the wire.
 #
 # 2. Clean EOF not signalled: handle_stdout's while loop exited silently when
 #    read(4) returned nil (normal EOF after the Node.js process was killed).
-#    on_driver_closed was never called in the normal-exit path — only on IOError —
+#    on_driver_closed was never called in the normal-exit path - only on IOError -
 #    so all pending callbacks waited forever and the run hung for the full Jenkins
 #    job timeout (~10 hours). Fix: call on_driver_closed after the loop exits.
 #
@@ -30,7 +30,9 @@
 
 require 'playwright'
 
+# rubocop:disable Style/Documentation
 module Playwright
+  # rubocop:disable Style/DocumentationMethod
   class Transport
     def send_message(message)
       debug_send_message(message) if @debug
@@ -43,13 +45,13 @@ module Playwright
         @mutex.synchronize { @stdin.write(frame) }
       end
     rescue Errno::EPIPE, IOError
-      raise AlreadyDisconnectedError.new('send_message failed')
+      raise AlreadyDisconnectedError, 'send_message failed'
     end
 
     private
 
     def handle_stdout(packet_size: 32_768)
-      while chunk = @stdout.read(4)
+      while (chunk = @stdout.read(4))
         length = chunk.unpack1('V')
         buffer = StringIO.new
         (length / packet_size).to_i.times { buffer << @stdout.read(packet_size) }
@@ -67,11 +69,12 @@ module Playwright
     end
 
     def handle_stderr
-      while err = @stderr.read
+      while (err = @stderr.read)
         # Node <= 14 prints 'undefined:1'; modern Node prints '<anonymous_script>:1'
         # when the driver dies parsing a corrupted frame.
         if err.include?('undefined:1') || err.include?('<anonymous_script>:1') ||
            err.include?("is not valid JSON\n    at JSON.parse")
+
           $stderr.write(err)
           @on_driver_crashed&.call
           break
@@ -82,4 +85,6 @@ module Playwright
       @on_driver_closed&.call
     end
   end
+  # rubocop:enable Style/DocumentationMethod
 end
+# rubocop:enable Style/Documentation

--- a/testsuite/features/support/playwright_transport_patch.rb
+++ b/testsuite/features/support/playwright_transport_patch.rb
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+# Monkey-patch for playwright-ruby-client 1.60.0.
+#
+# Fixes two bugs in Playwright::Transport that together cause the testsuite to
+# hang indefinitely after a Cucumber/Ruby timeout fires mid-Playwright-call:
+#
+# 1. Torn protocol frames: send_message wrote the 4-byte length header and the
+#    JSON payload in two separate IO#write calls. Timeout.timeout (used by
+#    repeat_until_timeout) delivers Thread#raise asynchronously; if it landed
+#    between those two writes, Node.js received a partial frame and crashed with:
+#      SyntaxError: Unexpected token '♦', "♦{"id":"... is not valid JSON
+#    Fix: build the whole frame in one buffer and write it in a single call,
+#    shielded by Thread.handle_interrupt so async exceptions are deferred until
+#    the frame is fully on the wire.
+#
+# 2. Clean EOF not signalled: handle_stdout's while loop exited silently when
+#    read(4) returned nil (normal EOF after the Node.js process was killed).
+#    on_driver_closed was never called in the normal-exit path — only on IOError —
+#    so all pending callbacks waited forever and the run hung for the full Jenkins
+#    job timeout (~10 hours). Fix: call on_driver_closed after the loop exits.
+#
+# 3. Crash detection missed modern Node.js: handle_stderr only matched
+#    'undefined:1' (Node <= 14). Modern Node prints '<anonymous_script>:1', so
+#    on_driver_crashed never fired, again leaving pending callbacks unresolved.
+#    Fix: match both formats and the JSON parse error message directly.
+#
+# TODO: remove once fixed upstream: https://github.com/YusukeIwaki/playwright-ruby-client
+
+require 'playwright'
+
+module Playwright
+  class Transport
+    def send_message(message)
+      debug_send_message(message) if @debug
+      msg = JSON.dump(message)
+      # Single buffer: 4-byte LE length header + payload. Written atomically so a
+      # Thread#raise (e.g. Timeout::Error from repeat_until_timeout) cannot tear
+      # the frame and corrupt the Node.js driver's JSON parse stream.
+      frame = [msg.bytesize].pack('V') + msg.b
+      Thread.handle_interrupt(Object => :never) do
+        @mutex.synchronize { @stdin.write(frame) }
+      end
+    rescue Errno::EPIPE, IOError
+      raise AlreadyDisconnectedError.new('send_message failed')
+    end
+
+    private
+
+    def handle_stdout(packet_size: 32_768)
+      while chunk = @stdout.read(4)
+        length = chunk.unpack1('V')
+        buffer = StringIO.new
+        (length / packet_size).to_i.times { buffer << @stdout.read(packet_size) }
+        buffer << @stdout.read(length % packet_size)
+        buffer.rewind
+        obj = JSON.parse(buffer.read)
+        debug_recv_message(obj) if @debug
+        @on_message&.call(obj)
+      end
+      # Normal EOF: the Node.js driver process exited. Signal closure so all
+      # pending callbacks are rejected immediately instead of waiting forever.
+      @on_driver_closed&.call
+    rescue IOError
+      @on_driver_closed&.call
+    end
+
+    def handle_stderr
+      while err = @stderr.read
+        # Node <= 14 prints 'undefined:1'; modern Node prints '<anonymous_script>:1'
+        # when the driver dies parsing a corrupted frame.
+        if err.include?('undefined:1') || err.include?('<anonymous_script>:1') ||
+           err.include?("is not valid JSON\n    at JSON.parse")
+          $stderr.write(err)
+          @on_driver_crashed&.call
+          break
+        end
+        $stderr.write(err)
+      end
+    rescue IOError
+      @on_driver_closed&.call
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR change?

Adds a monkey-patch for playwright-ruby-client 1.60.0 (`features/support/playwright_transport_patch.rb`) that fixes three bugs in `Playwright::Transport` which together caused the testsuite to hang indefinitely — until the Jenkins 10-hour job timeout — whenever `Timeout.timeout` fired inside `repeat_until_timeout` during a Playwright call:

**Bug 1 — Torn protocol frames (root cause of the `SyntaxError` crash):**
`send_message` wrote the 4-byte LE length header and JSON payload as two separate `IO#write` calls. A `Timeout::Error` delivered via `Thread#raise` (as used by `Timeout.timeout`) could land between them, leaving the Node.js driver with a partial frame on stdin. It then crashed its message loop with `SyntaxError: Unexpected token ... is not valid JSON` (Node >= 16 banner: `<anonymous_script>:1`). Fixed by merging both writes into one buffer and shielding the write with `Thread.handle_interrupt(Object => :never)`.

**Bug 2 — Clean EOF not signalled (direct cause of the 10-hour hang):**
`handle_stdout`'s while loop exited silently when `read(4)` returned nil on EOF (normal driver exit after the watchdog's SIGKILL). `on_driver_closed` was never called in the normal-exit path, so all pending Ruby callbacks waited forever. Fixed by calling `on_driver_closed` after the loop exits.

**Bug 3 — Modern Node.js crash not detected:**
`handle_stderr` only matched the Node <= 14 crash banner `'undefined:1'`. Node >= 16 prints `'<anonymous_script>:1'`, so `on_driver_crashed` never fired and pending callbacks were again left hanging. Fixed by matching both banners.

Also:
- Adds a 10-second `Timeout.timeout` backstop in the After hook's `web_session_is_active?` call as a defence-in-depth layer.
- Switches `repeat_until_timeout`'s inner deadline loop from `Time.new` (wall clock) to `Process.clock_gettime(Process::CLOCK_MONOTONIC)` so NTP adjustments on long-running test hosts cannot skew the timeout.

A `TODO:` comment in the patch file links upstream for removal once fixed in playwright-ruby-client itself.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

No documentation needed.

- [x] **DONE**

## Test coverage


- [x] **DONE**

## Links

Issue(s): 
Port(s): 
  - 5.2: https://github.com/SUSE/spacewalk/pull/31638
  - 5.1: https://github.com/SUSE/spacewalk/pull/31639
- Upstream playwright-ruby-client issue: https://github.com/YusukeIwaki/playwright-ruby-client/issues/392

- [x] **DONE**

## Changelogs

- [x] No changelog needed
