### PR TITLE
Fix the Redfish mockup server on Python 3.12 and later

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -637,16 +637,21 @@ When(/^the controller starts mocking a Redfish host$/) do
   file_extract(get_target('server'), crt_path.strip, '/root/controller.crt')
 
   data_dir = "#{File.dirname(__FILE__)}/../upload_files/Redfish-Mockup-Server/data/public-catfish"
+  log_file = '/tmp/redfish_mockup_server.log'
   cmd = "/usr/bin/python3 #{File.dirname(__FILE__)}/../upload_files/Redfish-Mockup-Server/redfishMockupServer.py " \
         "-H #{hostname} -p 8443 " \
         "-S -D #{data_dir} " \
         '--ssl --cert /root/controller.crt --key /root/controller.key ' \
-        '< /dev/null > /dev/null 2>&1 &'
+        "< /dev/null > #{log_file} 2>&1 &"
   `#{cmd}`
-  repeat_until_timeout(timeout: 30, message: 'Redfish mock server did not start on port 8443') do
-    result = `curl -sk --connect-timeout 2 --max-time 3 https://#{hostname}:8443/redfish/v1 2>/dev/null`
-    break unless result.empty?
-    sleep 1
+  begin
+    repeat_until_timeout(timeout: 30, message: 'Redfish mock server did not start on port 8443') do
+      result = `curl -sk --connect-timeout 2 --max-time 3 https://#{hostname}:8443/redfish/v1 2>/dev/null`
+      break unless result.empty?
+      sleep 1
+    end
+  rescue Timeout::Error
+    raise ScriptError, "Redfish mock server did not start on port 8443:\n#{`tail -n 20 #{log_file} 2>&1`}"
   end
 end
 

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/redfishMockupServer.py
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/redfishMockupServer.py
@@ -913,9 +913,9 @@ def main():
 
     if sslMode:
         logger.info("Using SSL with certfile: {}".format(sslCert))
-        myServer.socket = ssl.wrap_socket(
-            myServer.socket, certfile=sslCert, keyfile=sslKey, server_side=True
-        )
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ssl_context.load_cert_chain(certfile=sslCert, keyfile=sslKey)
+        myServer.socket = ssl_context.wrap_socket(myServer.socket, server_side=True)
 
     # save the test flag, and real path to the mockup dir for the handler to use
     myServer.mockDir = mockDir


### PR DESCRIPTION
## What does this PR change?

Starts the Redfish mockup server with an `SSLContext` instead of `ssl.wrap_socket()`, and keeps its output in a log file that the step reports on failure.

`ssl.wrap_socket()` was removed in Python 3.12, so on a controller running Python 3.13 the mockup server aborted as soon as `--ssl` was used and nothing ever listened on port 8443. The step discarded the server output, so the only symptom was the 30 second timeout below, followed by every Redfish power operation failing. The server output now goes to `/tmp/redfish_mockup_server.log` and its tail is raised with the error.

```
execution expired (Timeout::Error)
./features/support/commonlib.rb:105:in 'Object#repeat_until_timeout'
./features/step_definitions/command_steps.rb:646:in `/^the controller starts mocking a Redfish host$/'
```

With the fix, the whole feature passes on a Python 3.13 controller:

```
11 scenarios (11 passed)
73 steps (73 passed)
```

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30532
Port(s):
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31643
Manager-5.1: https://github.com/SUSE/spacewalk/pull/31644
Manager-4.3: https://github.com/SUSE/spacewalk/pull/31652

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

