### PR TITLE
Display an error status icon when image inspection fails (bsc#1255090)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/controllers/ImageBuildController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/ImageBuildController.java
@@ -844,6 +844,9 @@ public class ImageBuildController {
                                                                       ActionFactory.STATUS_FAILED.getId())
                                  );
 
+        imageOverview.getInspectServerAction()
+                .ifPresent(ia -> json.addProperty("inspectStatusId", ia.getStatus().getId()));
+
         return json;
     }
 

--- a/java/spacewalk-java.changes.bisht-richa.image-inspect-failed-status
+++ b/java/spacewalk-java.changes.bisht-richa.image-inspect-failed-status
@@ -1,0 +1,2 @@
+- Fix image status icon to reflect failed image inspections.
+  (bsc#1255090)

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -436,7 +436,7 @@ type ImageViewListState = {
   showObsolete: boolean;
 };
 
-class ImageViewList extends Component<ImageViewListProps, ImageViewListState> {
+export class ImageViewList extends Component<ImageViewListProps, ImageViewListState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -484,17 +484,39 @@ class ImageViewList extends Component<ImageViewListProps, ImageViewListState> {
     let icon;
 
     if (!row.patches || row.installedPackages === 0) {
-      icon = <i className="fa fa-question-circle fa-1-5x" title={t("No information")} />;
+      icon = <i className="fa fa-question-circle fa-1-5x" data-bs-toggle="tooltip" title={t("No information")} />;
     } else if (row.patches.critical > 0) {
-      icon = <i className="fa fa-exclamation-circle fa-1-5x text-danger" title={t("Critical updates available")} />;
+      icon = (
+        <i
+          className="fa fa-exclamation-circle fa-1-5x text-danger"
+          data-bs-toggle="tooltip"
+          title={t("Critical updates available")}
+        />
+      );
     } else if (row.patches.noncritical > 0) {
       icon = (
-        <i className="fa fa-exclamation-triangle fa-1-5x text-warning" title={t("Non-critical updates available")} />
+        <i
+          className="fa fa-exclamation-triangle fa-1-5x text-warning"
+          data-bs-toggle="tooltip"
+          title={t("Non-critical updates available")}
+        />
       );
     } else if (row.packages > 0) {
-      icon = <i className="fa fa-exclamation-triangle fa-1-5x text-warning" title={t("Package updates available")} />;
+      icon = (
+        <i
+          className="fa fa-exclamation-triangle fa-1-5x text-warning"
+          data-bs-toggle="tooltip"
+          title={t("Package updates available")}
+        />
+      );
     } else {
-      icon = <i className="fa fa-check-circle fa-1-5x text-success" title={t("Image is up to date")} />;
+      icon = (
+        <i
+          className="fa fa-check-circle fa-1-5x text-success"
+          data-bs-toggle="tooltip"
+          title={t("Image is up to date")}
+        />
+      );
     }
 
     return icon;
@@ -502,18 +524,28 @@ class ImageViewList extends Component<ImageViewListProps, ImageViewListState> {
 
   renderStatusIcon(row) {
     let icon;
-    if (row.external) {
-      icon = <i className="fa fa-minus-circle fa-1-5x text-muted" title={t("Built externally")} />;
+    // A failed inspect leaves the image unusable just like a failed build, so it takes
+    // precedence over the build status here.
+    if (row.inspectStatusId === 3) {
+      icon = (
+        <i className="fa fa-times-circle-o fa-1-5x text-danger" data-bs-toggle="tooltip" title={t("Inspect failed")} />
+      );
+    } else if (row.external) {
+      icon = (
+        <i className="fa fa-minus-circle fa-1-5x text-muted" data-bs-toggle="tooltip" title={t("Built externally")} />
+      );
     } else if (row.statusId === 0) {
-      icon = <i className="fa fa-clock-o fa-1-5x" title={t("Queued")} />;
+      icon = <i className="fa fa-clock-o fa-1-5x" data-bs-toggle="tooltip" title={t("Queued")} />;
     } else if (row.statusId === 1) {
-      icon = <i className="fa fa-exchange fa-1-5x text-info" title={t("Building")} />;
+      icon = <i className="fa fa-exchange fa-1-5x text-info" data-bs-toggle="tooltip" title={t("Building")} />;
     } else if (row.statusId === 2) {
-      icon = <i className="fa fa-check-circle fa-1-5x text-success" title={t("Built")} />;
+      icon = <i className="fa fa-check-circle fa-1-5x text-success" data-bs-toggle="tooltip" title={t("Built")} />;
     } else if (row.statusId === 3) {
-      icon = <i className="fa fa-times-circle-o fa-1-5x text-danger" title={t("Failed")} />;
+      icon = (
+        <i className="fa fa-times-circle-o fa-1-5x text-danger" data-bs-toggle="tooltip" title={t("Build failed")} />
+      );
     } else {
-      icon = <i className="fa fa-question-circle fa-1-5x" title={t("Unknown")} />;
+      icon = <i className="fa fa-question-circle fa-1-5x" data-bs-toggle="tooltip" title={t("Unknown")} />;
     }
 
     return icon;
@@ -521,7 +553,13 @@ class ImageViewList extends Component<ImageViewListProps, ImageViewListState> {
 
   renderRuntimeIcon = (row) => {
     if (!this.props.gotRuntimeInfo) {
-      return <i className="fa fa-circle-o-notch fa-spin fa-1-5x" title={t("Waiting for update ...")} />;
+      return (
+        <i
+          className="fa fa-circle-o-notch fa-spin fa-1-5x"
+          data-bs-toggle="tooltip"
+          title={t("Waiting for update ...")}
+        />
+      );
     }
 
     let icon = <span>-</span>;
@@ -529,13 +567,20 @@ class ImageViewList extends Component<ImageViewListProps, ImageViewListState> {
       icon = (
         <i
           className="fa fa-check-circle fa-1-5x text-success"
+          data-bs-toggle="tooltip"
           title={t("All instances are consistent with {productName}", { productName })}
         />
       );
     } else if (row.runtimeStatus === 2) {
-      icon = <i className="fa fa-question-circle fa-1-5x" title={t("No information")} />;
+      icon = <i className="fa fa-question-circle fa-1-5x" data-bs-toggle="tooltip" title={t("No information")} />;
     } else if (row.runtimeStatus === 3) {
-      icon = <i className="fa fa-exclamation-triangle fa-1-5x text-warning" title={t("Outdated instances found")} />;
+      icon = (
+        <i
+          className="fa fa-exclamation-triangle fa-1-5x text-warning"
+          data-bs-toggle="tooltip"
+          title={t("Outdated instances found")}
+        />
+      );
     }
 
     return icon;
@@ -570,7 +615,13 @@ class ImageViewList extends Component<ImageViewListProps, ImageViewListState> {
 
   renderInstances = (row) => {
     if (!this.props.gotRuntimeInfo) {
-      return <i className="fa fa-circle-o-notch fa-spin fa-1-5x" title={t("Waiting for update ...")} />;
+      return (
+        <i
+          className="fa fa-circle-o-notch fa-spin fa-1-5x"
+          data-bs-toggle="tooltip"
+          title={t("Waiting for update ...")}
+        />
+      );
     }
 
     let totalCount = 0;
@@ -676,7 +727,7 @@ class ImageViewList extends Component<ImageViewListProps, ImageViewListState> {
             comparator={Utils.sortByNumber}
             cell={(row) => (row.patches ? row.packages : "-")}
           />
-          <Column columnKey="status" header={t("Build")} cell={(row) => this.renderStatusIcon(row)} />
+          <Column columnKey="status" header={t("Status")} cell={(row) => this.renderStatusIcon(row)} />
           {runtimeColumns}
           <Column
             columnKey="modified"

--- a/web/spacewalk-web.changes.bisht-richa.image-inspect-failed-status
+++ b/web/spacewalk-web.changes.bisht-richa.image-inspect-failed-status
@@ -1,0 +1,2 @@
+- Fix image status icon to reflect failed image inspections.
+  (bsc#1255090)


### PR DESCRIPTION
## What does this PR change?

- Improve image status display by handling failed inspections.
- Added tooltips to distinguish between "Build failed" and "Inspect failed" on hover.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
<img width="955" height="338" alt="Screenshot 2026-08-12 at 17 05 36" src="https://github.com/user-attachments/assets/c75301df-0b40-4c59-85da-a158e2e64c72" />
<img width="959" height="346" alt="Screenshot 2026-08-12 at 17 05 51" src="https://github.com/user-attachments/assets/b77ec524-61a3-4b6a-9e50-1400f8852187" />



- [x] **DONE**

## Documentation
- No documentation needed: **Improve image status display by handling failed inspections.**


- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): [#](https://github.com/SUSE/spacewalk/issues/29250)
Port(s): [# **5.1**](https://github.com/SUSE/spacewalk/pull/31659) [# **5.2**](https://github.com/SUSE/spacewalk/pull/31662)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
