### PR TITLE
Report whole log records in the server log error check

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -545,9 +545,24 @@ Then(/^the log messages should not contain out of memory errors$/) do
 end
 
 Then(/^the server log should not contain "([^"]*)" errors$/) do |component|
-  cmd = "cat /var/log/rhn/rhn_web_ui.log | grep -i 'Exception' | grep -i '#{component}'"
-  output, code = get_target('server').run(cmd, check_errors: false)
-  raise ScriptError, "Error related to \"#{component}\" found!\n#{output}" if code.zero?
+  log_file = '/var/log/rhn/rhn_web_ui.log'
+  output, _code = get_target('server').run("cat #{log_file}")
+
+  records = []
+  output.each_line do |line|
+    if records.empty? || line.match?(/\A\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}/)
+      records << line
+    else
+      records.last << line
+    end
+  end
+
+  errors = records.select { |record| record.match?(/exception/i) && record.match?(/#{Regexp.escape(component)}/i) }
+  unless errors.empty?
+    details = errors.take(5)
+    details << "... and #{errors.size - details.size} more" if errors.size > details.size
+    raise ScriptError, "#{errors.size} error(s) related to \"#{component}\" found in #{log_file}!\n#{details.join("\n")}"
+  end
 end
 
 When(/^I restart the spacewalk service$/) do


### PR DESCRIPTION
## What does this PR change?

The `the server log should not contain "<component>" errors` step greps the log
line by line, so it only reports the lines that contain both `Exception` and the
component name. For `hibernate` those are the `org.hibernate.*` frames, which say
nothing about where the error came from, and the same error is reported once per
matching frame.

The step now groups each timestamped line with the untimestamped lines that follow
it, and reports the matching records whole, stack trace included. It also counts
the errors and caps the output at five records.

Before, the whole failure message for a real failure was:

```
Error related to "hibernate" found!
	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:163)
	at org.hibernate.internal.ExceptionConverterImpl.wrapStaleStateException(ExceptionConverterImpl.java:246)
```

After, the same failure reports the record that produced those frames:

```
1 error(s) related to "hibernate" found in /var/log/rhn/rhn_web_ui.log!
2026-08-11 20:26:47,123 [salt-event-thread-3] ERROR ... - Error committing transaction
org.hibernate.StaleObjectStateException: Unexpected row count (expected row count 1 but was 0) [update rhnServerInfo set checkin=?,checkin_counter=? where server_id=?] for entity [com.redhat.rhn.domain.server.ServerInfo with id '1000010002']
	at com.suse.manager.reactor.messaging.JobReturnEventMessageAction.execute(JobReturnEventMessageAction.java:206)
	...
```

Reading the whole log and filtering in Ruby matches what the neighbouring
`the tomcat logs should not contain errors` and
`the taskomatic logs should not contain errors` steps already do.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: the change is in the test suite itself

- [x] **DONE**

## Links

Issue(s): #
Port(s):
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31875
Manager-5.1: https://github.com/SUSE/spacewalk/pull/31876

- [x] **DONE**

## Changelogs

- [x] No changelog needed

