### PR TITLE
Pick the psutil package matching the container python

### DIFF
--- a/testsuite/features/profiles/Docker/add_packages.sh
+++ b/testsuite/features/profiles/Docker/add_packages.sh
@@ -16,7 +16,12 @@ zypper rr sles15sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3 python3-psutil
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # kill avahi
 /usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/Docker/authprofile/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/Docker/serverhost/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/cloud_aws/Docker/add_packages.sh
+++ b/testsuite/features/profiles/cloud_aws/Docker/add_packages.sh
@@ -16,7 +16,12 @@ zypper rr sles15sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3 python3-psutil
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # kill avahi
 /usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/cloud_aws/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/cloud_aws/Docker/authprofile/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/cloud_aws/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/cloud_aws/Docker/serverhost/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/internal_nue/Docker/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/add_packages.sh
@@ -16,7 +16,12 @@ zypper rr sles15sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3 python3-psutil
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # kill avahi
 /usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/internal_nue/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/authprofile/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/internal_nue/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/serverhost/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/internal_slc/Docker/add_packages.sh
+++ b/testsuite/features/profiles/internal_slc/Docker/add_packages.sh
@@ -16,7 +16,12 @@ zypper rr sles15sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3 python3-psutil
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # kill avahi
 /usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/internal_slc/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/internal_slc/Docker/authprofile/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/internal_slc/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/internal_slc/Docker/serverhost/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo and remove helper repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/temporary/docker_profiles/Docker/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/Docker/add_packages.sh
@@ -16,7 +16,12 @@ zypper rr sles15sp7
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3 python3-psutil
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # kill avahi
 /usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/temporary/docker_profiles/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/Docker/authprofile/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/temporary/docker_profiles/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/Docker/serverhost/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/add_packages.sh
@@ -16,7 +16,12 @@ zypper rr sles15sp7
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3 python3-psutil
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # kill avahi
 /usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/authprofile/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/cloud_aws/Docker/serverhost/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/add_packages.sh
@@ -16,7 +16,12 @@ zypper rr sles15sp7
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3 python3-psutil
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # kill avahi
 /usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/authprofile/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_nue/Docker/serverhost/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/add_packages.sh
@@ -16,7 +16,12 @@ zypper rr sles15sp7
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3 python3-psutil
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # kill avahi
 /usr/sbin/avahi-daemon -k

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/authprofile/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/authprofile/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :

--- a/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/serverhost/add_packages.sh
+++ b/testsuite/features/profiles/temporary/docker_profiles/internal_slc1/Docker/serverhost/add_packages.sh
@@ -10,8 +10,13 @@ zypper --non-interactive in avahi
 cp /root/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 /usr/sbin/avahi-daemon -D
 
-# install python3 and python3-psutil in the container
-zypper --non-interactive in tar gzip python3 python3-psutil
+# install the packages salt-thin needs inside the container
+zypper --non-interactive in tar gzip python3
+# psutil is called python3-psutil on SLE 15, but python313-psutil on Leap 16 and SLE 16
+python_abi=$(python3 -c 'import sys; print("%d%d" % sys.version_info[:2])')
+psutil_package="python${python_abi}-psutil"
+zypper --non-interactive search --match-exact "${psutil_package}" | grep -q "${psutil_package}" || psutil_package="python3-psutil"
+zypper --non-interactive in "${psutil_package}"
 
 # re-enable normal repo
 zypper mr --enable Fake-RPM-SUSE-Channel || :


### PR DESCRIPTION
## What does this PR change?

Makes the container image build profiles install the psutil package that matches the container's python, instead of the hardcoded `python3-psutil`.

`add_packages.sh` asked zypper for `python3-psutil` by exact name. On Leap 16 and SLE 16 no package has that name — the capability comes from `python313-psutil` — but as soon as SLE 15 SP7 channels are present in the container a package really named `python3-psutil` appears, and zypper prefers the exact name over the capability. That one requires `python(abi) = 3.6`, which a Leap 16 container cannot satisfy, so under `--non-interactive` the solver prompt is answered with cancel and `set -e` aborts the build. The profiles now install `python3` first, derive the ABI from the interpreter, and install `python313-psutil` on Leap 16 and SLE 16, falling back to `python3-psutil` on SLE 15.

It fixes four scenarios that fail with `image build failed. (SystemCallError)`:

| Feature | Scenario |
|---|---|
| Build container images and CVE audit them | Build the suse_real_key image with and without activation key |
| Build container images and CVE audit them | Build an image via the GUI |
| Build container images and CVE audit them | Login as Docker image administrator and build an image |
| Build image with authenticated registry | Build an image in the authenticated image store |

Before, on the Leap 16 base image:

```
Problem: 1: the to be installed python3-psutil-5.9.1-150300.3.6.1.x86_64 requires 'python(abi) = 3.6', but this requirement cannot be provided
 Solution 1: do not install python3-psutil-5.9.1-150300.3.6.1.x86_64
 Solution 2: do not install python3-3.13.14-160000.1.1.x86_64
Choose from above solutions by number or cancel [1/2/3/c/d/?] (c): c
```

After, same base image:

```
(1/1) Installing: python313-psutil-7.0.0-160000.2.2.x86_64 [..done]
```

The SLE 15 profiles are unaffected and still install `python3-psutil-5.9.1-150300.3.6.1`.

**All four scenarios pass now.** Both features were re-run on a 5.1 environment with `GITPROFILES` pointed at this branch, so MLM cloned the fixed profiles itself:

```
38 scenarios (2 failed, 36 passed)
166 steps (2 failed, 164 passed)
```

The 2 remaining failures are `Check the list of packages is not empty`, a separate image inspection bug unrelated to this change.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Closes SUSE/spacewalk#31665
Closes SUSE/spacewalk#31666
Closes SUSE/spacewalk#31667
Closes SUSE/spacewalk#31664

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

