### PR TITLE
SonarCloud error reduction fix step 23, references to null should never be dereferenced/accessed

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/common/db/datasource/ModeFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/db/datasource/ModeFactory.java
@@ -117,7 +117,8 @@ public class ModeFactory implements ManifestFactoryBuilder {
             return new WriteMode(session, pm);
         default:
             // should never reach here
-            return null;
+            throw new ModeNotFoundException(
+                    "Could not find mode type " + pm.getType() + " in mode " + mode + " in " + name);
         }
     }
 

--- a/java/core/src/main/java/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/channel/Channel.java
@@ -271,6 +271,9 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      * @return true if this Channel is a mgr server channel.
      */
     public boolean isMgrServer() {
+        if (null == getChannelFamily()) {
+            return false;
+        }
         return getChannelFamily().getLabel().startsWith(
                 ChannelFamilyFactory.SATELLITE_CHANNEL_FAMILY_LABEL);
     }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/dto/SystemCompareDto.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/dto/SystemCompareDto.java
@@ -329,12 +329,13 @@ public class SystemCompareDto {
         for (Server system : servers) {
             List keys = new LinkedList<>();
 
-            if (system.getBaseChannel() != null && !system.getBaseChannel().isCustom()) {
+            if ((system.getBaseChannel() != null) && (!system.getBaseChannel().isCustom()) &&
+                    (system.getBaseChannel().getChannelFamily() != null)) {
                 keys.add(system.getBaseChannel().getChannelFamily().getName());
             }
 
             for (Channel channel : system.getChildChannels()) {
-                if (!channel.isCustom()) {
+                if ((!channel.isCustom() && (channel.getChannelFamily() != null))) {
                     keys.add(channel.getChannelFamily().getName());
                 }
             }

--- a/java/core/src/main/java/com/redhat/rhn/manager/kickstart/KickstartEditCommand.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/kickstart/KickstartEditCommand.java
@@ -310,7 +310,9 @@ public class KickstartEditCommand extends BaseKickstartCommand {
         Collection<Channel> channels = getAvailableChannels();
         Set<ChannelFamily> retval = new HashSet<>();
         for (Channel c : channels) {
-            retval.add(c.getChannelFamily());
+            if (c.getChannelFamily() != null) {
+                retval.add(c.getChannelFamily());
+            }
         }
         logger.debug("getAvailableChannelFamilies() - end - return value={}", retval);
         return retval;

--- a/java/core/src/main/java/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/system/SystemManager.java
@@ -2054,8 +2054,10 @@ public class SystemManager extends BaseManager {
             Set<Channel> channels = server.getChannels();
             for (Channel c : channels) {
                 ChannelFamily cf = c.getChannelFamily();
-                if (cf.getLabel().equals(ChannelFamilyFactory.PROXY_CHANNEL_FAMILY_LABEL) ||
-                        cf.getLabel().equals(ChannelFamilyFactory.PROXY_ARM_CHANNEL_FAMILY_LABEL)) {
+                if ((cf != null) &&
+                        (cf.getLabel().equals(ChannelFamilyFactory.PROXY_CHANNEL_FAMILY_LABEL) ||
+                         cf.getLabel().equals(ChannelFamilyFactory.PROXY_ARM_CHANNEL_FAMILY_LABEL))
+                ) {
                     SystemManager.unsubscribeServerFromChannel(server, c);
                 }
             }


### PR DESCRIPTION
## What does this PR change?

SonarCloud error reduction fix step 23: references to null should never be dereferenced/accessed

SonarCloud fix: javabugs:S2259: A NULL object should not be accessed

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s): 5.2: https://github.com/SUSE/spacewalk/pull/31689
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

