### PR TITLE
Wait for the action chain event per phase, not on one budget

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -524,6 +524,19 @@ Note that the text area variant handles the new lines characters while the other
   When I wait until event "Package Install/Upgrade scheduled by admin" is completed
 ```
 
+Both of the above give the event `DEFAULT_TIMEOUT` seconds to leave the pending
+list and `DEFAULT_TIMEOUT` seconds again to reach Completed, so the total wait can
+be twice that.
+When that phase can take longer than the execution itself — an action chain that
+reboots the system, or anything on a Salt SSH minion, where the chain resumes
+only on the next `ssh-service-default` push — wait for each phase on its own
+budget instead, from the system's page:
+
+```gherkin
+  When I wait at most 900 seconds until the event "Remote Command on" is picked up
+  And I wait at most 300 seconds until the event "Remote Command on" is completed in the history
+```
+
 ### Salt
 
 * Control Salt service

--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -183,6 +183,9 @@ Feature: Action chains on Salt minions
     And I click on "Save and Schedule"
     Then I should see a "Action Chain salt_minion_action_chain has been scheduled for execution." text
     When I wait for "virgo-dummy" to be installed on "sle_minion"
+    Given I am on the Systems overview page of this "sle_minion"
+    And I wait at most 600 seconds until the event "Remote Command on" is picked up
+    And I wait at most 300 seconds until the event "Remote Command on" is completed in the history
     And I wait at most 300 seconds until file "/tmp/action_chain_one_system_done" exists on "sle_minion"
 
   # previous, completed, action chain will no longer be available

--- a/testsuite/features/secondary/minssh_action_chain.feature
+++ b/testsuite/features/secondary/minssh_action_chain.feature
@@ -174,6 +174,9 @@ Feature: Salt SSH action chain
 
   Scenario: Verify that the action chain was executed successfully
     When I wait for "virgo-dummy" to be installed on "sshminion"
+    Given I am on the Systems overview page of this "sshminion"
+    And I wait at most 900 seconds until the event "Remote Command on" is picked up
+    And I wait at most 300 seconds until the event "Remote Command on" is completed in the history
     And I wait at most 300 seconds until file "/tmp/action_chain_one_system_done" exists on "sshminion"
 
   # previous, completed, action chain will no longer be available

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -151,27 +151,31 @@ When(/^I wait until event "([^"]*)" is completed$/) do |event|
   step %(I wait at most #{DEFAULT_TIMEOUT} seconds until event "#{event}" is completed)
 end
 
-When(/^I wait (\d+) seconds until the event is picked up and (\d+) seconds until the event "([^"]*)" is completed$/) do |pickup_timeout, complete_timeout, event|
-  # The code below is not perfect because there might be other events with the
-  # same name in the events history - however, that's the best we have so far.
+When(/^I wait at most (\d+) seconds until the event "([^"]*)" is picked up$/) do |timeout, event|
   steps %(
     When I follow "Events"
     And I wait until I see "Pending Events" text
     And I follow "Pending"
     And I wait until I see "Pending Events" text
-    And I wait at most #{pickup_timeout} seconds until I do not see "#{event}" text, refreshing the page
-    And I follow "History"
+    And I wait at most #{timeout} seconds until I do not see "#{event}" text, refreshing the page
+  )
+end
+
+When(/^I wait at most (\d+) seconds until the event "([^"]*)" is completed in the history$/) do |timeout, event|
+  steps %(
+    When I follow "History"
     And I wait until I see "System History" text
     And I wait until I see "#{event}" text, refreshing the page
     And I follow first "#{event}"
     And I wait until I see "This action will be executed after" text
     And I wait until I see "#{event}" text
-    And I wait at most #{complete_timeout} seconds until the event is completed, refreshing the page
+    And I wait at most #{timeout} seconds until the event is completed, refreshing the page
   )
 end
 
 When(/^I wait at most (\d+) seconds until event "([^"]*)" is completed$/) do |final_timeout, event|
-  step %(I wait 180 seconds until the event is picked up and #{final_timeout} seconds until the event "#{event}" is completed)
+  step %(I wait at most #{DEFAULT_TIMEOUT} seconds until the event "#{event}" is picked up)
+  step %(I wait at most #{final_timeout} seconds until the event "#{event}" is completed in the history)
 end
 
 When(/^I wait until I see the event "([^"]*)" completed during last minute, refreshing the page$/) do |event|

--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -251,9 +251,12 @@ When(/^I wait at most (\d+) seconds until onboarding is completed for "([^"]*)"$
     And I wait until I see the name of "#{host}", refreshing the page
     And I follow this "#{host}" link
     And I wait until I see "System Status" text
-    And I wait 180 seconds until the event is picked up and #{seconds} seconds until the event "Apply states" is completed
-    And I wait 180 seconds until the event is picked up and #{seconds} seconds until the event "Hardware List Refresh" is completed
-    And I wait 180 seconds until the event is picked up and #{seconds} seconds until the event "Package List Refresh" is completed
+    And I wait at most #{seconds} seconds until the event "Apply states" is picked up
+    And I wait at most #{seconds} seconds until the event "Apply states" is completed in the history
+    And I wait at most #{seconds} seconds until the event "Hardware List Refresh" is picked up
+    And I wait at most #{seconds} seconds until the event "Hardware List Refresh" is completed in the history
+    And I wait at most #{seconds} seconds until the event "Package List Refresh" is picked up
+    And I wait at most #{seconds} seconds until the event "Package List Refresh" is completed in the history
   )
 end
 


### PR DESCRIPTION
## What does this PR change?

Waits for the last action of the action chain per phase, instead of giving one fixed budget to everything that happens after the chain is scheduled.

The verify scenario used a single 300 second wait on the file the chain's remote command creates. That one budget had to cover the reboot in step 6, the boot, the wait for the next `ssh-service-default` push, and the remote command itself. On a Salt SSH minion the first phase alone takes around 340 seconds, so the file check expired before the chain had finished. It now waits on the server's own record of that action: one budget for it to leave the pending list, another for it to reach Completed in the history. The file check that follows is a formality, and a chain that genuinely fails raises `Event failed` instead of an opaque file timeout.

`I wait N seconds until the event is picked up and M seconds until the event "X" is completed` is split into the two steps this needs. No feature file called it, and it hardcoded the pickup budget at 180 seconds in its only wrapper, which is too short for a reboot. `I wait at most N seconds until event "X" is completed` keeps its name and calls the pair, using `DEFAULT_TIMEOUT` for the pickup.

`min_action_chain.feature` gets the same treatment: its chain also reboots at step 6, and only passes today because a regular minion reconnects to the event bus itself rather than waiting for a push.

Per-step timings from the scenario, showing where the time actually goes:

```
   69.5s  [passed]  I wait for "virgo-dummy" to be installed on "sshminion"
    1.0s  [passed]  I am on the Systems overview page of this "sshminion"
  342.1s  [passed]  I wait at most 900 seconds until the event "Remote Command on" is picked up
    0.8s  [passed]  I wait at most 300 seconds until the event "Remote Command on" is completed in the history
    0.4s  [passed]  I wait at most 300 seconds until file "/tmp/action_chain_one_system_done" exists on "sshminion"
```

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s):
Closes SUSE/spacewalk#31670
Closes SUSE/spacewalk#31804

Ports:
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31680
Manager-5.1: https://github.com/SUSE/spacewalk/pull/31681

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

