### PR TITLE
Fix tooltips staying on the page after clicking the button (bsc#1268334)

### DIFF
--- a/web/html/src/components/buttons/index.tsx
+++ b/web/html/src/components/buttons/index.tsx
@@ -30,6 +30,9 @@ type BaseProps = {
   className?: string;
   /** Tooltip placement */
   tooltipPlacement?: "top" | "right" | "bottom" | "left";
+
+  /** Tooltip delay */
+  tooltipDelay?: boolean;
 };
 
 type BaseState = Record<string, any>;
@@ -178,6 +181,9 @@ export class Button extends _ButtonBase<ButtonProps> {
     const tooltipProps = this.props.title
       ? {
           "data-bs-toggle": "tooltip",
+          ...(this.props.tooltipDelay && {
+            "data-bs-delay": JSON.stringify({ show: 500 }),
+          }),
           "aria-label": this.props.title,
           "data-bs-placement": this.props.tooltipPlacement,
         }

--- a/web/html/src/components/dialog/ModalButton.tsx
+++ b/web/html/src/components/dialog/ModalButton.tsx
@@ -19,6 +19,7 @@ export function ModalButton(props: Props) {
       text={props.text}
       icon={props.icon}
       disabled={props.disabled}
+      tooltipDelay={props.tooltipDelay}
       handler={() => {
         props.onClick?.(props.item);
         if (props.target) {

--- a/web/html/src/components/tooltips.test.tsx
+++ b/web/html/src/components/tooltips.test.tsx
@@ -1,0 +1,105 @@
+// Importing "bootstrap" itself pulls in the jQuery plugin types, which clash with our own declarations
+import Tooltip from "bootstrap/js/dist/tooltip";
+
+import { initializeTooltips } from "components/tooltips";
+
+// Bootstrap is a global provided by the JSP pages, see web/html/src/global.d.ts
+(global as any).bootstrap = { Tooltip };
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Bootstrap listens to `mouseover`/`mouseout` internally, see the `customEvents` map in its EventHandler
+const hover = (el: Element) => {
+  el.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+  el.dispatchEvent(new MouseEvent("mouseenter"));
+};
+
+const visibleTooltips = () => document.querySelectorAll(".tooltip").length;
+
+const renderButton = () => {
+  document.body.innerHTML = `<button id="btn" data-bs-toggle="tooltip" title="Tip">Click me</button>`;
+  initializeTooltips();
+  return document.getElementById("btn")!;
+};
+
+afterEach(async () => {
+  document.body.innerHTML = "";
+  // Let the observer clean up the tooltips of the removed elements
+  await wait(10);
+});
+
+test("shows a tooltip on hover", async () => {
+  const button = renderButton();
+
+  hover(button);
+  await wait(20);
+
+  expect(visibleTooltips()).toBe(1);
+});
+
+test("hides the tooltip when the trigger is clicked", async () => {
+  const button = renderButton();
+
+  hover(button);
+  await wait(20);
+  button.click();
+  await wait(20);
+
+  expect(visibleTooltips()).toBe(0);
+});
+
+test("doesn't show a tooltip queued by the hover right before the click", async () => {
+  const button = renderButton();
+
+  // The browser can dispatch the click before the timeout queued by `mouseover` runs
+  hover(button);
+  button.click();
+  await wait(20);
+
+  expect(visibleTooltips()).toBe(0);
+});
+
+test("shows the tooltip again on the next hover after a click", async () => {
+  const button = renderButton();
+
+  hover(button);
+  await wait(20);
+  button.click();
+  await wait(20);
+
+  button.dispatchEvent(new MouseEvent("mouseout", { bubbles: true }));
+  await wait(20);
+  hover(button);
+  await wait(20);
+
+  expect(visibleTooltips()).toBe(1);
+});
+
+test("removes the tooltip when its trigger is removed from the page", async () => {
+  const button = renderButton();
+
+  hover(button);
+  await wait(20);
+  // The trigger is unmounted, e.g. by a re-render or an SPA navigation, so no `mouseout` ever follows
+  button.remove();
+  await wait(20);
+
+  expect(visibleTooltips()).toBe(0);
+});
+
+test("keeps a single tooltip instance per element across DOM changes", async () => {
+  const button = renderButton();
+  const instance = Tooltip.getInstance(button);
+
+  // Unrelated renders keep triggering the mutation observer
+  for (let i = 0; i < 3; i++) {
+    document.body.appendChild(document.createElement("div"));
+    await wait(5);
+  }
+
+  expect(Tooltip.getInstance(button)).toBe(instance);
+
+  hover(button);
+  await wait(20);
+  expect(visibleTooltips()).toBe(1);
+});

--- a/web/html/src/components/tooltips.tsx
+++ b/web/html/src/components/tooltips.tsx
@@ -1,23 +1,58 @@
+const TOOLTIP_SELECTOR = '[data-bs-toggle="tooltip"]';
+const INITIALIZED_ATTRIBUTE = "data-tooltip-initialized";
+
 let isListening = false;
+
+// Bootstrap adds the tooltip to `document.body`, so it can remain after its trigger is removed.
+// Dispose of it when React removes the trigger, such as after a click or SPA navigation.
+const disposeTooltipsIn = (node: Node) => {
+  if (!(node instanceof Element)) {
+    return;
+  }
+
+  const triggers = Array.from(node.querySelectorAll(TOOLTIP_SELECTOR));
+  if (node.matches(TOOLTIP_SELECTOR)) {
+    triggers.push(node);
+  }
+
+  triggers.forEach((el) => {
+    bootstrap.Tooltip.getInstance(el)?.dispose();
+    // `dispose()` restores the `title` attribute, so the element can be initialized again if it's reattached
+    el.removeAttribute(INITIALIZED_ATTRIBUTE);
+  });
+};
+
 export function initializeTooltips() {
   // Initialize tooltips on existing elements
 
   const initTooltips = () => {
-    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+    // Skip the elements we already know about, the observer below runs on every DOM change and a second instance
+    // would leave the first one behind, still listening and still rendering tooltips nothing can hide anymore
+    const tooltipTriggerList = document.querySelectorAll(`${TOOLTIP_SELECTOR}:not([${INITIALIZED_ATTRIBUTE}])`);
     tooltipTriggerList.forEach((el) => {
+      el.setAttribute(INITIALIZED_ATTRIBUTE, "true");
+
       const tooltip = new bootstrap.Tooltip(el, {
         trigger: "hover",
       });
 
-      el.addEventListener("click", () => tooltip.hide());
-      el.addEventListener("mouseleave", () => tooltip.hide());
+      el.addEventListener("click", () => {
+        tooltip.hide();
+        // Hover can queue the tooltip to appear after the click, so disable it to prevent that.
+        // The next hover enables it again.
+        tooltip.disable();
+      });
+      el.addEventListener("mouseenter", () => tooltip.enable());
     });
   };
 
   initTooltips();
   if (isListening) return;
 
-  new MutationObserver(() => initTooltips()).observe(document.body, {
+  new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => mutation.removedNodes.forEach(disposeTooltipsIn));
+    initTooltips();
+  }).observe(document.body, {
     childList: true,
     subtree: true,
   });

--- a/web/html/src/manager/content-management/list-filters/list-filters.tsx
+++ b/web/html/src/manager/content-management/list-filters/list-filters.tsx
@@ -233,6 +233,7 @@ const ListFilters = (props: Props) => {
                   className="btn-default btn-sm"
                   icon="fa-pencil"
                   title={t("Edit Filter")}
+                  tooltipDelay
                   onClick={() => setEditingFilter(row)}
                 />
               )}

--- a/web/spacewalk-web.changes.bisht-richa.fix-stuck-tooltips
+++ b/web/spacewalk-web.changes.bisht-richa.fix-stuck-tooltips
@@ -1,0 +1,2 @@
+- Fix tooltips staying on the page after clicking the button.
+  (bsc#1268334)


### PR DESCRIPTION
## What does this PR change?

**Clean up tooltips when their trigger element is removed.**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.



- [x] **DONE**

## Documentation
- No documentation needed: **Clean up tooltips when their trigger element is removed.**


- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Unit tests were added


- [x] **DONE**

## Links

Issue(s): [#30990](https://github.com/SUSE/spacewalk/issues/30990)
Port(s): [# **5.2**](https://github.com/uyuni-project/uyuni/pull/11830)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
