### PR TITLE
Accept str DISTTAG in RPM_Header.modularity_label()

### DIFF
--- a/python/test/unit/uyuni/test_rhn_rpm.py
+++ b/python/test/unit/uyuni/test_rhn_rpm.py
@@ -1,0 +1,77 @@
+#  pylint: disable=missing-module-docstring,invalid-name
+#
+# Copyright (c) 2026 SUSE LLC
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    import rpm
+except ImportError:
+    # The rpm bindings are a native module that is not always available where
+    # the unit tests run. Only the two tags read by modularity_label() are
+    # needed here, so stub the module with their real values.
+    rpm = MagicMock()
+    rpm.RPMTAG_MODULARITYLABEL = 5096
+    rpm.RPMTAG_DISTTAG = 1155
+    sys.modules["rpm"] = rpm
+
+# pylint: disable-next=wrong-import-position
+from uyuni.common.rhn_rpm import RPM_Header
+
+MODULE = "postgresql:16:8090020240206124302:rhel8"
+
+
+def _header(tags):
+    """Build an RPM_Header around a plain dict, skipping __init__ (which reads
+    the signatures out of a real rpm header)."""
+    hdr = RPM_Header.__new__(RPM_Header)
+    hdr.hdr = tags
+    return hdr
+
+
+@pytest.mark.parametrize(
+    "disttag, expected",
+    [
+        pytest.param(f"module({MODULE})", MODULE, id="str"),
+        pytest.param(f"module({MODULE})".encode(), MODULE.encode(), id="bytes"),
+    ],
+)
+def test_modularity_label_from_disttag(disttag, expected):
+    """DISTTAG is returned as bytes by the older rpm bindings and as str since
+    Python 3.13: both have to be recognized as a modularity label."""
+    assert _header({rpm.RPMTAG_DISTTAG: disttag}).modularity_label() == expected
+
+
+@pytest.mark.parametrize(
+    "disttag",
+    [pytest.param("el8", id="str"), pytest.param(b"el8", id="bytes")],
+)
+def test_modularity_label_ignores_plain_disttag(disttag):
+    """A DISTTAG that is not a module(...) wrap yields no modularity label."""
+    assert _header({rpm.RPMTAG_DISTTAG: disttag}).modularity_label() is None
+
+
+def test_modularity_label_prefers_modularitylabel_tag():
+    """MODULARITYLABEL wins over DISTTAG when both are present."""
+    hdr = _header(
+        {
+            rpm.RPMTAG_MODULARITYLABEL: "nodejs:20:20240101:abcdef01",
+            rpm.RPMTAG_DISTTAG: f"module({MODULE})",
+        }
+    )
+    assert hdr.modularity_label() == "nodejs:20:20240101:abcdef01"
+
+
+def test_modularity_label_absent():
+    """No modularity tag at all yields None."""
+    assert _header({}).modularity_label() is None

--- a/python/uyuni/common/rhn_rpm.py
+++ b/python/uyuni/common/rhn_rpm.py
@@ -133,11 +133,14 @@ class RPM_Header:
         mtag = None
         if rpm.RPMTAG_MODULARITYLABEL in self.hdr.keys():
             mtag = self.hdr[rpm.RPMTAG_MODULARITYLABEL]
-        elif rpm.RPMTAG_DISTTAG in self.hdr.keys() and self.hdr[
-            rpm.RPMTAG_DISTTAG
-        ].startswith(b"module("):
-            # Strip away 'module(...)' wrap
-            mtag = self.hdr[rpm.RPMTAG_DISTTAG][7:-1]
+        elif rpm.RPMTAG_DISTTAG in self.hdr.keys():
+            dtag = self.hdr[rpm.RPMTAG_DISTTAG]
+            # rpm returns str for this tag since Python 3.13, bytes before that
+            if isinstance(dtag, bytes):
+                dtag = dtag.decode("utf-8", "ignore")
+            if dtag.startswith("module("):
+                # Strip away 'module(...)' wrap
+                mtag = self.hdr[rpm.RPMTAG_DISTTAG][7:-1]
         return mtag
 
     def checksum_type(self):

--- a/python/uyuni/uyuni-common-libs.changes.ilcalimero.disttag-str
+++ b/python/uyuni/uyuni-common-libs.changes.ilcalimero.disttag-str
@@ -1,0 +1,3 @@
+- Fix reposync failure on modular packages by accepting both
+  str and bytes for the RPM DISTTAG tag (TypeError with the
+  Python 3.13 rpm bindings)


### PR DESCRIPTION
## What does this PR change?

`RPM_Header.modularity_label()` falls back to the RPM `DISTTAG` tag to detect
modular packages, comparing it against the bytes literal `b"module("`. The rpm
Python bindings shipped with Python 3.13 return that tag as `str`, so the
comparison raises:

```
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```

The exception is not caught and it kills `spacewalk-repo-sync`: the channel log
stops right after `Regenerating bootstrap repositories` without ever reaching
`Sync completed.`, and the patches of the channel are then reported as
`not found in database ... skipped`. Nothing in the log mentions RPM headers or
modularity, which makes the failure look like a network or database problem.

Only channels carrying packages tagged with `DISTTAG` are affected, in practice
the modular AppStream repositories of the EL8 clones. Seen on Uyuni 5.3.2
(server image, Python 3.13) syncing Oracle Linux 8 AppStream.

The fix normalizes the tag to `str` before the comparison, so that both the old
(bytes) and the new (str) bindings are handled. The returned value keeps the
type of the original tag, so the behaviour of the callers does not change.

## Codespace

<!-- lasciato come da template -->

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Unit tests were added

`python/test/unit/uyuni/test_rhn_rpm.py` covers `modularity_label()` with
`DISTTAG` as both `str` and `bytes`, with a non-modular `DISTTAG`, with
`MODULARITYLABEL` taking precedence over `DISTTAG`, and with no modularity tag
at all. The parametrized `str` case fails with the `TypeError` above on the
unpatched code.

- [x] **DONE**

## Links

Issue(s): #
Port(s): #

- [x] **DONE**

## Changelogs

- [ ] No changelog needed

`python/uyuni/uyuni-common-libs.changes.<user>.disttag-str` added.