### PR TITLE
Use PTF 32023 in the Project Lotus tests

### DIFF
--- a/testsuite/features/secondary/min_project_lotus.feature
+++ b/testsuite/features/secondary/min_project_lotus.feature
@@ -72,7 +72,7 @@ Feature: Project Lotus
     When I follow "Software" in the content area
     And I follow "PTFs" in the content area
     And I follow "Install" in the content area
-    And I check "ptf-30961-3-0" in the list
+    And I check "ptf-32023-2-0" in the list
     And I click on "Install PTFs"
     And I click on "Confirm"
     Then I should see a "The action has been scheduled" text
@@ -83,7 +83,7 @@ Feature: Project Lotus
     When I follow "Software" in the content area
     And I follow "PTFs" in the content area
     And I follow "List / Remove" in the content area
-    And I check "ptf-30961-3-0" in the list
+    And I check "ptf-32023-2-0" in the list
     And I click on "Remove PTFs"
     And I click on "Confirm"
     Then I should see a "The action has been scheduled" text
@@ -94,9 +94,9 @@ Feature: Project Lotus
     When I follow "Software" in the content area
     And I follow "Packages" in the content area
     And I follow "Install" in the content area
-    And I enter "ptf-30961-3-0" as the filtered package name
+    And I enter "ptf-32023-2-0" as the filtered package name
     And I click on the filter button
-    And I check "ptf-30961-3-0" in the list
+    And I check "ptf-32023-2-0" in the list
     And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
@@ -107,9 +107,9 @@ Feature: Project Lotus
     When I follow "Software" in the content area
     And I follow "Packages" in the content area
     And I follow "List / Remove" in the content area
-    And I enter "ptf-30961-3-0" as the filtered package name
+    And I enter "ptf-32023-2-0" as the filtered package name
     And I click on the filter button
-    And I check "ptf-30961-3-0" in the list
+    And I check "ptf-32023-2-0" in the list
     And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "1 package removal has been scheduled for" text


### PR DESCRIPTION
## What does this PR change?

Switches the Project Lotus tests from `ptf-30961-3-0` to `ptf-32023-2-0`.

`ptf-30961-3-0` ships vim `9.1.1629-150500.20.38.1`, which is older than the vim now in the SLES 15 SP7 channels, so installing the PTF is a downgrade and the action fails. `ptf-32023-2-0` ships `which-2.21-2.20.32023.1`, an update over the `which-2.21-2.20` in the Basesystem module, and lives in the same repository the test already adds, so only the package name changes.

## Verification

Tested on the 5.1 CI env (`mlm-ci-51-server`), build [1434](https://ci.suse.de/view/Manager/view/Manager-5.1/job/manager-5.1-dev-acceptance-tests/1434/TestSuite_20Report/) of `manager-5.1-dev-acceptance-tests`. The minion carries `which-2.21-2.20`, so `which-2.21-2.20.32023.1` is an upgrade. The same file is on `Manager-5.1` as https://github.com/SUSE/spacewalk/pull/31736.

### Before

With `ptf-30961-3-0`, two scenarios fail in build 1434:

```
Scenario: Install PTF through Packages tab
  And I wait until event "Package Install/Upgrade scheduled" is completed
    unknown error - Event failed (SystemCallError)
    features/secondary/min_project_lotus.feature:106

Scenario: Remove PTF through Packages tab
  And I check "ptf-30961-3-0" in the list
    Unable to find xpath "//table/tbody/tr[.//td[contains(.,'ptf-30961-3-0')]]//input[@type='checkbox']" (Capybara::ElementNotFound)
    features/secondary/min_project_lotus.feature:115
```

The install fails, so the package is never in the list and the removal cannot find its checkbox. Reported as https://github.com/SUSE/spacewalk/issues/31669.

### After

With `ptf-32023-2-0`, all four PTF scenarios pass. Ran twice on the same env:

```
  Scenario: Install PTF through PTFs tab                                    # features/secondary/min_project_lotus.feature:70
    And I check "ptf-32023-2-0" in the list
    And I wait until event "Package Install/Upgrade scheduled" is completed
      This scenario took: 40 seconds

  Scenario: Remove PTF through PTFs tab                             # features/secondary/min_project_lotus.feature:81
    And I check "ptf-32023-2-0" in the list
    And I wait until event "Package Removal scheduled" is completed
      This scenario took: 40 seconds

  Scenario: Install PTF through Packages tab                                # features/secondary/min_project_lotus.feature:92
    And I check "ptf-32023-2-0" in the list
    Then I should see a "1 package install has been scheduled for" text
      This scenario took: 43 seconds

  Scenario: Remove PTF through Packages tab                             # features/secondary/min_project_lotus.feature:105
    And I check "ptf-32023-2-0" in the list
    Then I should see a "1 package removal has been scheduled for" text
      This scenario took: 41 seconds

12 scenarios (1 failed, 11 passed)
96 steps (1 failed, 1 skipped, 94 passed)
```

The one failure is `Pre-requisite: Sync PTF repository` on `Then I should see a "Repository sync is running" text`. It is an artefact of running the feature by hand twice in a row. The repository metadata is already cached, so the sync ends before the banner is checked. The next step, `I wait until the channel "sles15sp7-ptfs" has been synced`, passes, and that scenario passes in build 1434 where the sync is cold.

## End-User Impact & Release Notes

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s):
Closes SUSE/spacewalk#30496
Closes SUSE/spacewalk#30844
Closes SUSE/spacewalk#31669
Closes SUSE/spacewalk#23448

Related: SUSE/spacewalk#31806 - Pre-requisite: Add custom channel to minion. A failed Subscribe Software Channels action on head, not covered by this change.

Port(s):
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31735
Manager-5.1: https://github.com/SUSE/spacewalk/pull/31736

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!


