### PR TITLE
Add mgradm support ptf deployment test

### DIFF
--- a/testsuite/features/core/srv_uyuni_tools.feature
+++ b/testsuite/features/core/srv_uyuni_tools.feature
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@susemanager
+@containerized_server
+Feature: Check mgradm support ptf podman command availability
+  From the server host
+  All uyuni tool commands must be accessible
+  So they can be used reliably with valid parameters
+
+  Scenario: Check that 'mgradm support ptf podman' is available
+    Given the "mgradm" command is available on the host
+    Then the argument "support ptf podman" is valid in mgradm

--- a/testsuite/features/secondary/srv_support_ptf.feature
+++ b/testsuite/features/secondary/srv_support_ptf.feature
@@ -1,0 +1,21 @@
+# Copyright (c) 2025 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@skip_if_github_validation
+Feature: Test Program Temporary Fixes (PTF) deployment
+  Applying and rolling back Program Temporary Fixes should work reliably
+  Without leaving the system in an inactive state
+
+  @susemanager
+  Scenario: Successfully apply a Program Temporary Fix
+    When I apply a Program Temporary Fix to the containerized server
+    And I wait for "30" seconds
+    Then I expect "uyuni-server" container to be healthy within 300 seconds
+    And I expect "uyuni-server" container to run the PTF image
+
+  @susemanager
+  Scenario: Re-deploy the original server container
+    When I redeploy the original server container
+    And I wait for "30" seconds
+    Then I expect "uyuni-server" container to be healthy within 300 seconds
+    And I expect "uyuni-server" container to not run the PTF image

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1112,6 +1112,72 @@ When(/I generate a supportconfig for the server$/) do
   node.run('mv /root/scc_*.tar.gz /root/server-supportconfig.tar.gz', runs_in_container: false)
 end
 
+Given(/^the "([^"]*)" command is available on the host$/) do |command|
+  node = get_target('server')
+  _result, return_code = node.run("command -v #{command}", runs_in_container: false, check_errors: false)
+  raise ScriptError, "#{command} command not found" unless return_code.zero?
+end
+
+Then(/^the argument "([^"]*)" is valid in mgradm$/) do |arg|
+  node = get_target('server')
+  cmd = "mgradm #{arg} --help"
+
+  output, return_code = node.run(cmd, runs_in_container: false, check_errors: false)
+  raise ScriptError, "#{cmd} argument is unknown or not found" unless return_code.zero?
+  raise ScriptError, "#{cmd} one of parameters supplied is invalid" if output.include?('for more information')
+end
+
+When(/^I apply a Program Temporary Fix to the containerized server$/) do
+  ptf_id = ENV['SCC_PTF_ID']
+  ptf_username = ENV['SCC_PTF_USER']
+  ptf_password = ENV['SCC_PTF_PASSWORD']
+  raise ScriptError, 'SCC_PTF_ID environment variable not set' if ptf_id.nil? || ptf_id.empty?
+  raise ScriptError, 'SCC_PTF_USER environment variable not set' if ptf_username.nil? || ptf_username.empty?
+  raise ScriptError, 'SCC_PTF_PASSWORD environment variable not set' if ptf_password.nil? || ptf_password.empty?
+
+  node = get_target('server')
+  # mgradm builds its own authentication file to pull the PTF image and never reads the one
+  # 'podman login' writes, so the DUMMY Sanity Check Account credentials are passed to it directly.
+  cmd = "mgradm support ptf podman --ptf #{ptf_id} --user a127499 --scc-user '#{ptf_username}' --scc-password '#{ptf_password}'"
+  # The command carries the password, so it is kept out of the error and only the output is reported.
+  output, return_code = node.run(cmd, timeout: 180, runs_in_container: false, check_errors: false)
+  raise ScriptError, "Failed to apply the Program Temporary Fix #{ptf_id}:\n#{output}" unless return_code.zero?
+end
+
+Then(/^I expect "([^"]*)" container to be healthy within (\d+) seconds$/) do |container, timeout|
+  node = get_target('server')
+  healthcheck_cmd = "podman inspect #{container} --format '{{.State.Health.Status}}'"
+
+  repeat_until_timeout(timeout: timeout.to_i, message: "Timeout after #{timeout} seconds: container '#{container}' is not healthy") do
+    output, _code = node.run(healthcheck_cmd, runs_in_container: false, check_errors: false)
+    status = output.strip
+    break if status == "healthy"
+    sleep 5
+  end
+end
+
+Then(/^I expect "([^"]*)" container to( not)? run the PTF image$/) do |container, negated|
+  ptf_id = ENV['SCC_PTF_ID']
+  raise ScriptError, 'SCC_PTF_ID environment variable not set' if ptf_id.nil? || ptf_id.empty?
+
+  node = get_target('server')
+  output, _code = node.run("podman inspect #{container} --format '{{.ImageName}}'", runs_in_container: false)
+  image = output.strip
+  ptf_tag_suffix = "-ptf-#{ptf_id}"
+
+  if negated
+    raise ScriptError, "Container '#{container}' still runs the PTF image #{image}" if image.end_with?(ptf_tag_suffix)
+  else
+    raise ScriptError, "Container '#{container}' runs #{image}, expected an image tagged #{ptf_tag_suffix}" unless image.end_with?(ptf_tag_suffix)
+  end
+end
+
+When(/^I redeploy the original server container$/) do
+  node = get_target('server')
+  original_container_repository, _code = node.run("venv-salt-call --local grains.get container_repository | cut -d':' -f2 | xargs", runs_in_container: false)
+  node.run("mgradm upgrade podman --registry #{original_container_repository}", timeout: 180, runs_in_container: false)
+end
+
 When(/I obtain and extract the supportconfig from the server$/) do
   supportconfig_path = '/root/server-supportconfig.tar.gz'
   test_runner_file = '/root/server-supportconfig.tar.gz'

--- a/testsuite/run_sets/sanity_check.yml
+++ b/testsuite/run_sets/sanity_check.yml
@@ -7,5 +7,6 @@
 ## Sanity Check BEGIN ###
 
 - features/core/allcli_sanity.feature
+- features/core/srv_uyuni_tools.feature
 
 ## Sanity Check END ###

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -71,5 +71,6 @@
 - features/secondary/srv_cobbler_distro.feature
 - features/secondary/srv_cobbler_buildiso.feature
 - features/secondary/srv_cobbler_profile.feature
+- features/secondary/srv_support_ptf.feature
 
 ## Secondary features END ##


### PR DESCRIPTION
## What does this PR change?

Adds Cucumber coverage for `mgradm support ptf`: a secondary feature that applies a Program Temporary Fix to the containerized server and redeploys the original container, and a core sanity check that the `mgradm support ptf podman` command is available with valid arguments.

The `support ptf` command is compiled into the SUSE Multi-Linux Manager build of uyuni-tools via a build tag and is absent from the community Uyuni build. Both features are therefore tagged `@susemanager` so they run on MLM (including Head) and are skipped on community Uyuni. Implements the CI/BV coverage requested in #24541.

Each scenario also checks which image the server container actually runs, so that neither a PTF that was never applied nor a rollback that never happened can pass on the health check alone. The tag `mgradm` computes ends in `-ptf-<id>`, which is what the step compares against. The credentials of the sanity check account are passed to `mgradm support ptf podman` as `--scc-user`/`--scc-password`: mgradm writes its own authentication file for the pull and never reads the one `podman login` leaves on the host.

The feature needs `SCC_PTF_ID`, `SCC_PTF_USER` and `SCC_PTF_PASSWORD` in the environment, and a PTF built for the version of MLM under test.

```
Container 'uyuni-server' runs registry.suse.com/suse/multi-linux-manager/5.1/x86_64/server:5.1.4, expected an image tagged -ptf-32054
```

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): #24541
Port(s):
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31739

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

