### PR TITLE
feat(openapi): migrate the virtualhostmanager handler to OpenAPI contract

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/virtualhostmanager/VirtualHostManagerHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/virtualhostmanager/VirtualHostManagerHandler.java
@@ -36,7 +36,7 @@ import java.util.Map;
  * @apidoc.namespace virtualhostmanager
  * @apidoc.doc Provides the namespace for the Virtual Host Manager methods.
  */
-public class VirtualHostManagerHandler extends BaseHandler {
+public class VirtualHostManagerHandler extends BaseHandler implements VirtualHostManagerHandlerApi {
 
     /**
      * Lists Virtual Host Managers visible to a user

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/virtualhostmanager/VirtualHostManagerHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/virtualhostmanager/VirtualHostManagerHandlerApi.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.virtualhostmanager;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManager;
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+import com.suse.manager.api.docs.LegacyDocResponse;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import spark.route.HttpMethod;
+
+/**
+ * API contract for {@link VirtualHostManagerHandler}.
+ */
+@Tag(name = "virtualhostmanager", description = "Provides the namespace for the Virtual Host Manager methods.")
+public interface VirtualHostManagerHandlerApi {
+
+    /**
+     * Lists the Virtual Host Managers visible to the user.
+     *
+     * @param loggedInUser the current user
+     * @return the visible Virtual Host Managers
+     */
+    @ApiEndpointDoc(
+        summary = "Lists Virtual Host Managers visible to a user",
+        method = HttpMethod.get,
+        responseClass = VirtualHostManagerListResponse.class
+    )
+    List<VirtualHostManager> listVirtualHostManagers(User loggedInUser);
+
+    /**
+     * Creates a Virtual Host Manager.
+     *
+     * @param loggedInUser the current user
+     * @param label the Virtual Host Manager label
+     * @param moduleName the name of the Gatherer module
+     * @param parameters additional parameters
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Creates a Virtual Host Manager from given arguments",
+        requestClass = CreateVirtualHostManagerRequest.class,
+        isIntegerResponse = true
+    )
+    int create(User loggedInUser, String label, String moduleName, Map<String, String> parameters);
+
+    /**
+     * Deletes a Virtual Host Manager.
+     *
+     * @param loggedInUser the current user
+     * @param label the Virtual Host Manager label
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Deletes a Virtual Host Manager with a given label",
+        requestClass = VirtualHostManagerLabelRequest.class,
+        isIntegerResponse = true
+    )
+    int delete(User loggedInUser, String label);
+
+    /**
+     * Gets the details of a Virtual Host Manager.
+     *
+     * @param loggedInUser the current user
+     * @param label the Virtual Host Manager label
+     * @return the Virtual Host Manager
+     */
+    @ApiEndpointDoc(
+        summary = "Gets details of a Virtual Host Manager with a given label",
+        method = HttpMethod.get,
+        responseClass = VirtualHostManagerResponse.class
+    )
+    VirtualHostManager getDetail(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "label", description = "Virtual Host Manager label",
+            in = ParameterIn.QUERY, required = true) String label
+    );
+
+    /**
+     * Lists the available virtual-host-gatherer modules.
+     *
+     * @param loggedInUser the current user
+     * @return the available module names
+     */
+    @ApiEndpointDoc(
+        summary = "List all available modules from virtual-host-gatherer",
+        method = HttpMethod.get,
+        responseClass = ModuleNameListResponse.class,
+        responseDescription = "moduleName"
+    )
+    Collection<String> listAvailableVirtualHostGathererModules(User loggedInUser);
+
+    /**
+     * Gets the parameters of a virtual-host-gatherer module.
+     *
+     * @param loggedInUser the current user
+     * @param moduleName the name of the module
+     * @return the module parameters
+     */
+    @ApiEndpointDoc(
+        summary = "Get a list of parameters for a virtual-host-gatherer module.",
+        method = HttpMethod.get,
+        responseClass = ModuleParametersResponse.class,
+        responseDescription = "module parameters",
+        legacyDocResponse = @LegacyDocResponse(type = "map", name = "module_params")
+    )
+    Map<String, String> getModuleParameters(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "moduleName", description = "The name of the module",
+            in = ParameterIn.QUERY, required = true) String moduleName
+    );
+
+    @Schema(name = "CreateVirtualHostManagerRequest")
+    @JsonPropertyOrder({"label", "moduleName", "parameters"})
+    interface CreateVirtualHostManagerRequest {
+
+        /**
+         * @return the Virtual Host Manager label
+         */
+        @Schema(description = "Virtual Host Manager label", requiredMode = REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the name of the Gatherer module
+         */
+        @Schema(description = "the name of the Gatherer module", requiredMode = REQUIRED)
+        String getModuleName();
+
+        /**
+         * @return the additional parameters
+         */
+        @LegacyDocResponse(type = "parameters")
+        @Schema(description = "additional parameters (credentials, parameters for virtual-host-gatherer)",
+                requiredMode = REQUIRED)
+        Map<String, String> getParameters();
+    }
+
+    @Schema(name = "VirtualHostManagerLabelRequest")
+    interface VirtualHostManagerLabelRequest {
+
+        /**
+         * @return the Virtual Host Manager label
+         */
+        @Schema(description = "Virtual Host Manager label", requiredMode = REQUIRED)
+        String getLabel();
+    }
+
+    @Schema(name = "VirtualHostManager", description = "virtual host manager")
+    @JsonPropertyOrder({"label", "orgId", "gathererModule", "configs"})
+    interface VirtualHostManagerDoc {
+
+        /**
+         * @return the Virtual Host Manager label
+         */
+        @Schema(requiredMode = REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the organization identifier
+         */
+        @Schema(name = "org_id", requiredMode = REQUIRED)
+        Integer getOrgId();
+
+        /**
+         * @return the Gatherer module name
+         */
+        @Schema(name = "gatherer_module", requiredMode = REQUIRED)
+        String getGathererModule();
+
+        /**
+         * @return the Virtual Host Manager configuration
+         */
+        @Schema(requiredMode = REQUIRED)
+        Map<String, String> getConfigs();
+    }
+
+    @Schema(name = "ApiResponseVirtualHostManagerList")
+    interface VirtualHostManagerListResponse extends ApiResponseWrapper<List<VirtualHostManagerDoc>> { }
+
+    @Schema(name = "ApiResponseVirtualHostManager")
+    interface VirtualHostManagerResponse extends ApiResponseWrapper<VirtualHostManagerDoc> { }
+
+    @Schema(name = "ApiResponseModuleNameList")
+    interface ModuleNameListResponse extends ApiResponseWrapper<List<String>> { }
+
+    @Schema(name = "ApiResponseModuleParameters")
+    interface ModuleParametersResponse extends ApiResponseWrapper<Map<String, String>> { }
+}

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -35,6 +35,7 @@ import com.redhat.rhn.frontend.xmlrpc.subscriptionmatching.PinnedSubscriptionHan
 import com.redhat.rhn.frontend.xmlrpc.system.custominfo.CustomInfoHandler;
 import com.redhat.rhn.frontend.xmlrpc.system.search.SystemSearchHandler;
 import com.redhat.rhn.frontend.xmlrpc.user.external.UserExternalHandler;
+import com.redhat.rhn.frontend.xmlrpc.virtualhostmanager.VirtualHostManagerHandler;
 
 import com.suse.manager.api.docs.UyuniSwaggerReader;
 import com.suse.manager.xmlrpc.admin.AdminPaygHandler;
@@ -141,6 +142,7 @@ public final class OpenApiConfig {
         handlers.put("system.custominfo", CustomInfoHandler.class);
         handlers.put("system.search", SystemSearchHandler.class);
         handlers.put("user.external", UserExternalHandler.class);
+        handlers.put("virtualhostmanager", VirtualHostManagerHandler.class);
         return handlers;
     }
 }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -288,7 +288,10 @@ public class OpenApiToAsciidocParser {
             return;
         }
 
-        if (isSimpleType(schema)) {
+        // A declared legacy type describes the whole return value, so it also applies to schemas
+        // that are not simple: the doclet renders those as a single typed line, without expanding
+        // the schema.
+        if (isSimpleType(schema) || !legacyDocResponse.type().isBlank()) {
             writeSimpleReturn(writer, schema, responseLabel, legacyDocResponse.type(), operation);
             return;
         }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -405,6 +405,12 @@ public class OpenApiToAsciidocParser {
      * {@code [.array]#$t array#}, with {@code $date} bound to {@code dateTime.iso8601}.
      */
     private String structPropertyType(Schema<?> schema) {
+        // A declared legacy type has no OpenAPI counterpart to derive, so it wins over the
+        // resolved type, exactly as it already does for parameters and in the DocBook parser.
+        String legacyType = legacyDocType(schema);
+        if (!legacyType.isEmpty()) {
+            return legacyType;
+        }
         String type = schema.getType();
         if ("integer".equals(type)) {
             return "int";

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -48,6 +48,15 @@ public class OpenApiToAsciidocParser {
 
     private static final Logger LOGGER = LogManager.getLogger(OpenApiToAsciidocParser.class);
 
+    /** Bullet level the doclet uses for the properties of a struct. */
+    private static final int STRUCT_PROPERTY_LEVEL = 2;
+
+    /** Bullet level the doclet uses for the element struct of an array-valued struct property. */
+    private static final int ELEMENT_STRUCT_LEVEL = 1;
+
+    /** Bullet level the doclet uses for the element struct of an array-valued parameter. */
+    private static final int PARAMETER_ELEMENT_STRUCT_LEVEL = 2;
+
     private final OpenAPI openAPI;
 
     /**
@@ -219,7 +228,34 @@ public class OpenApiToAsciidocParser {
             return;
         }
 
-        writer.printf("* %s  %s%s%n%n", parameterType(schema), paramName, suffix);
+        writer.printf("* %s  %s%s%n", parameterType(schema), paramName, suffix);
+        writeParameterElement(writer, resolved == null ? schema : resolved);
+        writer.println();
+    }
+
+    /**
+     * Writes the element type of an array parameter.
+     *
+     * The doclet expands the body of {@code #array_begin} into a nested item, one level deeper
+     * than the equivalent expansion in a return value. Struct elements bring their properties
+     * with them; simple elements are a single item labelled by the legacy element name.
+     */
+    private void writeParameterElement(PrintWriter writer, Schema<?> schema) {
+        if (!"array".equals(schema.getType()) || schema.getItems() == null) {
+            return;
+        }
+        Schema<?> resolvedItems = resolveSchemaReference(schema.getItems());
+        if (resolvedItems != null && resolvedItems.getProperties() != null &&
+                !resolvedItems.getProperties().isEmpty()) {
+            printElementStruct(writer, schema, PARAMETER_ELEMENT_STRUCT_LEVEL);
+            return;
+        }
+        String label = legacyDocName(schema);
+        if (resolvedItems != null && isSimpleType(resolvedItems) && !label.isEmpty()) {
+            String itemType = displayType(resolvedItems);
+            writer.printf("%s [.%s]#%s#  %s%n", "*".repeat(PARAMETER_ELEMENT_STRUCT_LEVEL),
+                    itemType, itemType, label);
+        }
     }
 
     private boolean hasProperties(Schema<?> schema) {
@@ -349,12 +385,16 @@ public class OpenApiToAsciidocParser {
     }
 
     private void printStructProperties(PrintWriter writer, Schema<?> resolved) {
+        printStructProperties(writer, resolved, STRUCT_PROPERTY_LEVEL);
+    }
+
+    private void printStructProperties(PrintWriter writer, Schema<?> resolved, int level) {
         if (resolved == null || resolved.getProperties() == null) {
             return;
         }
         resolved.getProperties().forEach((name, prop) -> {
-            writeStructProperty(writer, "", name, prop);
-            printElementStruct(writer, prop);
+            writeStructProperty(writer, "", name, prop, level);
+            printElementStruct(writer, prop, ELEMENT_STRUCT_LEVEL);
         });
     }
 
@@ -365,7 +405,7 @@ public class OpenApiToAsciidocParser {
      * the element struct followed by its properties, in the same shape it uses for an array return
      * value. Without this the element struct is documented by the legacy doclet but dropped here.
      */
-    private void printElementStruct(PrintWriter writer, Schema<?> property) {
+    private void printElementStruct(PrintWriter writer, Schema<?> property, int level) {
         if (!"array".equals(property.getType())) {
             return;
         }
@@ -378,9 +418,22 @@ public class OpenApiToAsciidocParser {
                 resolvedItems.getProperties().isEmpty()) {
             return;
         }
-        writer.printf("    * [.struct]#struct#  %s%n",
-                items.get$ref() != null ? extractRefName(items.get$ref()) : "");
-        printStructProperties(writer, resolvedItems);
+        String label = legacyDocName(property);
+        if (label.isEmpty()) {
+            label = items.get$ref() != null ? extractRefName(items.get$ref()) : "";
+        }
+        // the response shape the doclet uses indents the element struct instead of nesting it
+        String marker = level == ELEMENT_STRUCT_LEVEL ? "    *" : "*".repeat(level);
+        writer.printf("%s [.struct]#struct#  %s%n", marker, label);
+        printStructProperties(writer, resolvedItems, level + 1);
+    }
+
+    private String legacyDocName(Schema<?> schema) {
+        if (schema.getExtensions() == null) {
+            return "";
+        }
+        Object value = schema.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_NAME_EXTENSION);
+        return value == null ? "" : value.toString();
     }
 
     private void writeSimpleReturn(PrintWriter writer, Schema<?> schema,
@@ -470,8 +523,12 @@ public class OpenApiToAsciidocParser {
     }
 
     private void writeStructProperty(PrintWriter writer, String prefix, String name, Schema<?> schema) {
+        writeStructProperty(writer, prefix, name, schema, STRUCT_PROPERTY_LEVEL);
+    }
+
+    private void writeStructProperty(PrintWriter writer, String prefix, String name, Schema<?> schema, int level) {
         String description = schema.getDescription() != null ? " - " + schema.getDescription() : "";
-        writer.printf("%s** [.%s]#%s#  \"%s\"%s%n", prefix, structPropertyMarker(schema),
+        writer.printf("%s%s [.%s]#%s#  \"%s\"%s%n", prefix, "*".repeat(level), structPropertyMarker(schema),
                 structPropertyType(schema), name, description);
     }
 

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -51,9 +51,6 @@ public class OpenApiToAsciidocParser {
     /** Bullet level the doclet uses for the properties of a struct. */
     private static final int STRUCT_PROPERTY_LEVEL = 2;
 
-    /** Bullet level the doclet uses for the element struct of an array-valued struct property. */
-    private static final int ELEMENT_STRUCT_LEVEL = 1;
-
     /** Bullet level the doclet uses for the element struct of an array-valued parameter. */
     private static final int PARAMETER_ELEMENT_STRUCT_LEVEL = 2;
 
@@ -238,21 +235,40 @@ public class OpenApiToAsciidocParser {
      * with them; simple elements are a single item labelled by the legacy element name.
      */
     private void writeParameterElement(PrintWriter writer, Schema<?> schema) {
-        if (!"array".equals(schema.getType()) || schema.getItems() == null) {
+        if (!nestsElement(schema)) {
             return;
         }
         Schema<?> resolvedItems = resolveSchemaReference(schema.getItems());
-        if (resolvedItems != null && resolvedItems.getProperties() != null &&
-                !resolvedItems.getProperties().isEmpty()) {
+        if (hasProperties(resolvedItems)) {
             printElementStruct(writer, schema, PARAMETER_ELEMENT_STRUCT_LEVEL);
             return;
         }
-        String label = legacyDocName(schema);
-        if (resolvedItems != null && isSimpleType(resolvedItems) && !label.isEmpty()) {
-            String itemType = displayType(resolvedItems);
-            writer.printf("%s [.%s]#%s#  %s%n", "*".repeat(PARAMETER_ELEMENT_STRUCT_LEVEL),
-                    itemType, itemType, label);
+        String itemType = displayType(resolvedItems);
+        writer.printf("%s [.%s]#%s#  %s%n", "*".repeat(PARAMETER_ELEMENT_STRUCT_LEVEL),
+                itemType, itemType, legacyDocName(schema));
+    }
+
+    /**
+     * Tells whether an array documents its element type as a nested item.
+     *
+     * The doclet compiles a struct element, and a scalar element that carries a legacy element
+     * name, into {@code #array_begin}, which renders a bare {@code array} and nests the element
+     * below it. A plain scalar array compiles to {@code #array_single}, which renders the element
+     * type inline as {@code "<type> array"} and nests nothing.
+     *
+     * @param schema the array schema
+     * @return true if the element is documented as a nested item
+     */
+    private boolean nestsElement(Schema<?> schema) {
+        if (!"array".equals(schema.getType()) || schema.getItems() == null) {
+            return false;
         }
+        Schema<?> resolvedItems = resolveSchemaReference(schema.getItems());
+        if (resolvedItems == null) {
+            return false;
+        }
+        return hasProperties(resolvedItems) ||
+                (isSimpleType(resolvedItems) && !legacyDocName(schema).isEmpty());
     }
 
     private boolean hasProperties(Schema<?> schema) {
@@ -265,7 +281,10 @@ public class OpenApiToAsciidocParser {
             return "[." + legacyType + "]#" + legacyType + "#";
         }
         if ("array".equals(schema.getType())) {
-            return "[.array]#string array#";
+            // An element rendered as a nested item leaves the parent a bare "array", exactly as
+            // #array_begin does; otherwise the element type is shown inline by #array_single.
+            String type = nestsElement(schema) ? "array" : structPropertyType(schema);
+            return "[.array]#" + type + "#";
         }
         return "[." + displayType(schema) + "]#" + displayType(schema) + "#";
     }
@@ -393,7 +412,7 @@ public class OpenApiToAsciidocParser {
             Schema<?> nested = resolveNestedStruct(prop);
             String label = nested != null && !legacyDocName(prop).isEmpty() ? legacyDocName(prop) : name;
             writeStructProperty(writer, "", label, prop, level);
-            printElementStruct(writer, prop, ELEMENT_STRUCT_LEVEL);
+            printElementStruct(writer, prop, level + 1);
             printStructProperties(writer, nested, level + 1);
         });
     }
@@ -402,8 +421,7 @@ public class OpenApiToAsciidocParser {
      * Resolves a property that documents a nested struct, or {@code null} for any other property.
      *
      * The doclet expands a struct valued property into its own properties one level below the
-     * property itself. Without this those properties are documented by the legacy doclet but
-     * dropped here. Array properties are handled by {@link #printElementStruct} instead.
+     * property itself. Array properties are handled by {@link #printElementStruct} instead.
      *
      * @param property the property schema
      * @return the resolved schema of the nested struct, or null if the property is not one
@@ -424,7 +442,7 @@ public class OpenApiToAsciidocParser {
      *
      * The doclet expands the {@code $Serializer} reference inside {@code #prop_array_begin} into
      * the element struct followed by its properties, in the same shape it uses for an array return
-     * value. Without this the element struct is documented by the legacy doclet but dropped here.
+     * value.
      */
     private void printElementStruct(PrintWriter writer, Schema<?> property, int level) {
         if (!"array".equals(property.getType())) {
@@ -443,9 +461,7 @@ public class OpenApiToAsciidocParser {
         if (label.isEmpty()) {
             label = items.get$ref() != null ? extractRefName(items.get$ref()) : "";
         }
-        // the response shape the doclet uses indents the element struct instead of nesting it
-        String marker = level == ELEMENT_STRUCT_LEVEL ? "    *" : "*".repeat(level);
-        writer.printf("%s [.struct]#struct#  %s%n", marker, label);
+        writer.printf("%s [.struct]#struct#  %s%n", "*".repeat(level), label);
         printStructProperties(writer, resolvedItems, level + 1);
     }
 
@@ -508,7 +524,7 @@ public class OpenApiToAsciidocParser {
      */
     private String structPropertyType(Schema<?> schema) {
         // A declared legacy type has no OpenAPI counterpart to derive, so it wins over the
-        // resolved type, exactly as it already does for parameters and in the DocBook parser.
+        // resolved type.
         String legacyType = legacyDocType(schema);
         if (!legacyType.isEmpty()) {
             return legacyType;

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -142,12 +142,9 @@ public class OpenApiToAsciidocParser {
 
         List<DocEntry> entries = operationsByTag.computeIfAbsent(tag, key -> new ArrayList<>());
 
-        if (!optional.isEmpty()) {
-            List<String> allParams = new ArrayList<>(required);
-            allParams.addAll(optional);
-            entries.add(DocEntry.create(method, operation, allParams, securityRequired));
+        for (List<String> params : UyuniSwaggerReader.expandOverloads(operation, required, optional)) {
+            entries.add(DocEntry.create(method, operation, params, securityRequired));
         }
-        entries.add(DocEntry.create(method, operation, required, securityRequired));
     }
 
     private String renderAdocFile(String tag, List<DocEntry> entries) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -393,9 +393,33 @@ public class OpenApiToAsciidocParser {
             return;
         }
         resolved.getProperties().forEach((name, prop) -> {
-            writeStructProperty(writer, "", name, prop, level);
+            Schema<?> nested = resolveNestedStruct(prop);
+            String label = nested != null && !legacyDocName(prop).isEmpty() ? legacyDocName(prop) : name;
+            writeStructProperty(writer, "", label, prop, level);
             printElementStruct(writer, prop, ELEMENT_STRUCT_LEVEL);
+            printStructProperties(writer, nested, level + 1);
         });
+    }
+
+    /**
+     * Resolves a property that documents a nested struct, or {@code null} for any other property.
+     *
+     * The doclet expands a struct valued property into its own properties one level below the
+     * property itself. Without this those properties are documented by the legacy doclet but
+     * dropped here. Array properties are handled by {@link #printElementStruct} instead.
+     *
+     * @param property the property schema
+     * @return the resolved schema of the nested struct, or null if the property is not one
+     */
+    private Schema<?> resolveNestedStruct(Schema<?> property) {
+        if ("array".equals(property.getType())) {
+            return null;
+        }
+        Schema<?> resolved = resolveSchemaReference(property);
+        if (resolved == null || resolved.getProperties() == null || resolved.getProperties().isEmpty()) {
+            return null;
+        }
+        return resolved;
     }
 
     /**
@@ -569,8 +593,7 @@ public class OpenApiToAsciidocParser {
         }
 
         if (schema.getProperties() != null) {
-            schema.getProperties().forEach((name, property) ->
-                    writeStructProperty(writer, prefix, name, property));
+            printStructProperties(writer, schema);
         }
 
         if (schema.getAdditionalProperties() instanceof Schema<?> inner) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -352,7 +352,35 @@ public class OpenApiToAsciidocParser {
         if (resolved == null || resolved.getProperties() == null) {
             return;
         }
-        resolved.getProperties().forEach((name, prop) -> writeStructProperty(writer, "", name, prop));
+        resolved.getProperties().forEach((name, prop) -> {
+            writeStructProperty(writer, "", name, prop);
+            printElementStruct(writer, prop);
+        });
+    }
+
+    /**
+     * Writes the element type of an array property that holds structs.
+     *
+     * The doclet expands the {@code $Serializer} reference inside {@code #prop_array_begin} into
+     * the element struct followed by its properties, in the same shape it uses for an array return
+     * value. Without this the element struct is documented by the legacy doclet but dropped here.
+     */
+    private void printElementStruct(PrintWriter writer, Schema<?> property) {
+        if (!"array".equals(property.getType())) {
+            return;
+        }
+        Schema<?> items = property.getItems();
+        if (items == null) {
+            return;
+        }
+        Schema<?> resolvedItems = resolveSchemaReference(items);
+        if (resolvedItems == null || resolvedItems.getProperties() == null ||
+                resolvedItems.getProperties().isEmpty()) {
+            return;
+        }
+        writer.printf("    * [.struct]#struct#  %s%n",
+                items.get$ref() != null ? extractRefName(items.get$ref()) : "");
+        printStructProperties(writer, resolvedItems);
     }
 
     private void writeSimpleReturn(PrintWriter writer, Schema<?> schema,

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -208,7 +208,7 @@ public class OpenApiToDocBookParser {
                 params.add(new ParamDoc(legacyType.isEmpty() ? "struct" : legacyType, name, desc));
                 resolved.getProperties().forEach((propName, propSchema) ->
                         params.add(new ParamDoc(formatType(propSchema), "\"" + propName + "\"",
-                                findDescription(propSchema))));
+                                findDescription(propSchema), renderParameterElement(propSchema))));
                 continue;
             }
             params.add(new ParamDoc(formatType(schema), name, desc, renderParameterElement(schema)));

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -328,7 +328,10 @@ public class OpenApiToDocBookParser {
         if ("array".equals(schema.getType()) && schema.getItems() != null) {
             return renderArrayReturn(schema, label, legacyStructLabel);
         }
-        if (isSimpleType(schema)) {
+        // A declared legacy type describes the whole return value, so it also applies to schemas
+        // that are not simple: the doclet renders those as a single typed line, without expanding
+        // the schema.
+        if (isSimpleType(schema) || !typeOverride.isBlank()) {
             return renderSimpleReturn(schema, label, typeOverride);
         }
         if (schema.getAdditionalProperties() instanceof Schema<?> inner) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -214,9 +214,38 @@ public class OpenApiToDocBookParser {
                                 findDescription(propSchema))));
                 continue;
             }
-            params.add(new ParamDoc(formatType(schema), name, desc));
+            params.add(new ParamDoc(formatType(schema), name, desc, renderParameterElement(schema)));
         }
         return params;
+    }
+
+    /**
+     * Renders the element type of an array parameter as markup to nest under it.
+     *
+     * The doclet expands the body of {@code #array_begin} into an {@code itemizedlist} inside the
+     * parameter's own list item. Struct elements bring their properties with them; simple elements
+     * are a single item labelled by the legacy element name. Returns an empty string otherwise.
+     */
+    private String renderParameterElement(Schema<?> schema) {
+        if (!"array".equals(schema.getType()) || schema.getItems() == null) {
+            return "";
+        }
+        Schema<?> items = schema.getItems();
+        Schema<?> resolvedItems = resolveSchemaReference(items);
+        if (resolvedItems == null) {
+            return "";
+        }
+        if (resolvedItems.getProperties() != null && !resolvedItems.getProperties().isEmpty()) {
+            String label = getLegacyDocName(schema);
+            return renderStructList(resolvedItems,
+                    items.get$ref() != null ? extractRefName(items.get$ref()) : "", label);
+        }
+        String label = getLegacyDocName(schema);
+        if (isSimpleType(resolvedItems) && !label.isEmpty()) {
+            return String.format("<listitem><para>%s</para></listitem>",
+                    escapeXml(formatSimpleType(resolvedItems) + " " + label));
+        }
+        return "";
     }
 
     private boolean hasProperties(Schema<?> schema) {
@@ -228,6 +257,14 @@ public class OpenApiToDocBookParser {
             return "";
         }
         Object value = schema.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_TYPE_EXTENSION);
+        return value == null ? "" : value.toString();
+    }
+
+    private String getLegacyDocName(Schema<?> schema) {
+        if (schema.getExtensions() == null) {
+            return "";
+        }
+        Object value = schema.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_NAME_EXTENSION);
         return value == null ? "" : value.toString();
     }
 
@@ -463,7 +500,8 @@ public class OpenApiToDocBookParser {
             return "";
         }
         return renderStructList(resolvedItems,
-                items.get$ref() != null ? extractRefName(items.get$ref()) : "", "");
+                items.get$ref() != null ? extractRefName(items.get$ref()) : "",
+                getLegacyDocName(property));
     }
 
     private String renderHandlerFile(HandlerDoc handler) {
@@ -509,8 +547,16 @@ public class OpenApiToDocBookParser {
                 String body = p.description.isEmpty() ?
                         String.format("%s %s", p.type, p.name) :
                         String.format("%s %s - %s", p.type, p.name, p.description);
-                w.printf("            <listitem><para>%s</para></listitem>%n",
-                        escapeXml(body));
+                if (p.nested.isEmpty()) {
+                    w.printf("            <listitem><para>%s</para></listitem>%n", escapeXml(body));
+                    continue;
+                }
+                w.printf("            <listitem>%n");
+                w.printf("              <para>%s</para>%n", escapeXml(body));
+                w.printf("              <itemizedlist spacing=\"compact\">%n");
+                w.printf("%s%n", indentLines(p.nested, 16));
+                w.printf("              </itemizedlist>%n");
+                w.printf("            </listitem>%n");
             }
         }
         w.printf("          </itemizedlist>%n");
@@ -759,10 +805,18 @@ public class OpenApiToDocBookParser {
         private final String name;
         private final String description;
 
+        /** Pre-rendered element markup nested under this parameter, empty when there is none. */
+        private final String nested;
+
         ParamDoc(String paramType, String paramName, String paramDescription) {
+            this(paramType, paramName, paramDescription, "");
+        }
+
+        ParamDoc(String paramType, String paramName, String paramDescription, String nestedMarkup) {
             this.type = paramType;
             this.name = paramName;
             this.description = paramDescription;
+            this.nested = nestedMarkup;
         }
     }
 }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -456,14 +456,53 @@ public class OpenApiToDocBookParser {
         sb.append("<listitem>\n");
         sb.append("  <para>struct ").append(escapeXml(structLabel)).append("</para>\n");
         sb.append("  <itemizedlist spacing=\"compact\">\n");
+        sb.append(renderPropertyItems(schema));
+        sb.append("  </itemizedlist>\n");
+        sb.append("</listitem>");
+        return sb.toString();
+    }
+
+    /**
+     * Resolves a property that documents a nested struct, or {@code null} for any other property.
+     *
+     * The doclet expands a struct valued property into its own properties one level below the
+     * property itself. Without this those properties are documented by the legacy doclet but
+     * dropped here. Array properties are handled by {@link #renderElementStruct} instead.
+     *
+     * @param property the property schema
+     * @return the resolved schema of the nested struct, or null if the property is not one
+     */
+    private Schema<?> resolveNestedStruct(Schema<?> property) {
+        if ("array".equals(property.getType())) {
+            return null;
+        }
+        Schema<?> resolved = resolveSchemaReference(property);
+        if (resolved == null || resolved.getProperties() == null || resolved.getProperties().isEmpty()) {
+            return null;
+        }
+        return resolved;
+    }
+
+    private String renderNestedStructProperties(Schema<?> nested) {
+        return renderPropertyItems(nested).stripTrailing();
+    }
+
+    private String renderPropertyItems(Schema<?> schema) {
+        StringBuilder sb = new StringBuilder();
         schema.getProperties().forEach((name, prop) -> {
             Schema<?> propSchema = prop;
             String desc = findDescription(propSchema);
-            String body = String.format("%s \"%s\"", formatType(propSchema), name);
+            Schema<?> nested = resolveNestedStruct(propSchema);
+            String label = nested != null && !getLegacyDocName(propSchema).isBlank() ?
+                    getLegacyDocName(propSchema) : name;
+            // the doclet labels a nested struct with #struct_begin, which does not quote the label
+            String body = nested != null ? String.format("%s %s", formatType(propSchema), label) :
+                    String.format("%s \"%s\"", formatType(propSchema), label);
             if (!desc.isBlank()) {
                 body += " - " + desc;
             }
-            String elementStruct = renderElementStruct(propSchema);
+            String elementStruct = nested != null ? renderNestedStructProperties(nested) :
+                    renderElementStruct(propSchema);
             if (elementStruct.isEmpty()) {
                 sb.append("    <listitem><para>")
                   .append(escapeXml(body))
@@ -477,8 +516,6 @@ public class OpenApiToDocBookParser {
             sb.append("      </itemizedlist>\n");
             sb.append("    </listitem>\n");
         });
-        sb.append("  </itemizedlist>\n");
-        sb.append("</listitem>");
         return sb.toString();
     }
 

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -426,13 +426,44 @@ public class OpenApiToDocBookParser {
             if (!desc.isBlank()) {
                 body += " - " + desc;
             }
-            sb.append("    <listitem><para>")
-              .append(escapeXml(body))
-              .append("</para></listitem>\n");
+            String elementStruct = renderElementStruct(propSchema);
+            if (elementStruct.isEmpty()) {
+                sb.append("    <listitem><para>")
+                  .append(escapeXml(body))
+                  .append("</para></listitem>\n");
+                return;
+            }
+            sb.append("    <listitem>\n");
+            sb.append("      <para>").append(escapeXml(body)).append("</para>\n");
+            sb.append("      <itemizedlist spacing=\"compact\">\n");
+            sb.append(indentLines(elementStruct, 8)).append("\n");
+            sb.append("      </itemizedlist>\n");
+            sb.append("    </listitem>\n");
         });
         sb.append("  </itemizedlist>\n");
         sb.append("</listitem>");
         return sb.toString();
+    }
+
+    /**
+     * Renders the element type of an array property that holds structs.
+     *
+     * The doclet expands the {@code $Serializer} reference inside {@code #prop_array_begin} into a
+     * nested list holding the element struct. Without this the element struct is documented by the
+     * legacy doclet but dropped here. Returns an empty string for any other property.
+     */
+    private String renderElementStruct(Schema<?> property) {
+        if (!"array".equals(property.getType()) || property.getItems() == null) {
+            return "";
+        }
+        Schema<?> items = property.getItems();
+        Schema<?> resolvedItems = resolveSchemaReference(items);
+        if (resolvedItems == null || resolvedItems.getProperties() == null ||
+                resolvedItems.getProperties().isEmpty()) {
+            return "";
+        }
+        return renderStructList(resolvedItems,
+                items.get$ref() != null ? extractRefName(items.get$ref()) : "", "");
     }
 
     private String renderHandlerFile(HandlerDoc handler) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -463,8 +463,7 @@ public class OpenApiToDocBookParser {
      * Resolves a property that documents a nested struct, or {@code null} for any other property.
      *
      * The doclet expands a struct valued property into its own properties one level below the
-     * property itself. Without this those properties are documented by the legacy doclet but
-     * dropped here. Array properties are handled by {@link #renderElementStruct} instead.
+     * property itself. Array properties are handled by {@link #renderElementStruct} instead.
      *
      * @param property the property schema
      * @return the resolved schema of the nested struct, or null if the property is not one
@@ -520,8 +519,7 @@ public class OpenApiToDocBookParser {
      * Renders the element type of an array property that holds structs.
      *
      * The doclet expands the {@code $Serializer} reference inside {@code #prop_array_begin} into a
-     * nested list holding the element struct. Without this the element struct is documented by the
-     * legacy doclet but dropped here. Returns an empty string for any other property.
+     * nested list holding the element struct. Returns an empty string for any other property.
      */
     private String renderElementStruct(Schema<?> property) {
         if (!"array".equals(property.getType()) || property.getItems() == null) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -149,12 +149,9 @@ public class OpenApiToDocBookParser {
         List<String> required = getFieldsByRequirement(op, true);
         List<String> optional = getFieldsByRequirement(op, false);
 
-        if (!optional.isEmpty()) {
-            List<String> allParams = new ArrayList<>(required);
-            allParams.addAll(optional);
-            handler.calls.add(buildCallDoc(httpMethod, op, allParams, securityRequired));
+        for (List<String> params : UyuniSwaggerReader.expandOverloads(op, required, optional)) {
+            handler.calls.add(buildCallDoc(httpMethod, op, params, securityRequired));
         }
-        handler.calls.add(buildCallDoc(httpMethod, op, required, securityRequired));
     }
 
     private CallDoc buildCallDoc(String httpMethod, Operation op,

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -215,12 +215,18 @@ public class UyuniSwaggerReader {
         }
         for (Method getter : documentedClass.getMethods()) {
             LegacyDocResponse legacyDoc = getter.getAnnotation(LegacyDocResponse.class);
-            if (legacyDoc == null || legacyDoc.type().isBlank()) {
+            if (legacyDoc == null || (legacyDoc.type().isBlank() && legacyDoc.name().isBlank())) {
                 continue;
             }
             Schema<?> property = schema.getProperties().get(resolvePropertyName(getter));
-            if (property != null) {
+            if (property == null) {
+                continue;
+            }
+            if (!legacyDoc.type().isBlank()) {
                 property.addExtension(DOC_RESPONSE_TYPE_EXTENSION, legacyDoc.type());
+            }
+            if (!legacyDoc.name().isBlank()) {
+                property.addExtension(DOC_RESPONSE_NAME_EXTENSION, legacyDoc.name());
             }
         }
     }
@@ -244,7 +250,8 @@ public class UyuniSwaggerReader {
         ApiResponses apiResponses = new ApiResponses();
 
         if (apiDoc.isIntegerResponse()) {
-            apiResponses.addApiResponse(HTTP_200, addLegacyDocResponse(apiDoc, createIntegerResponse()));
+            apiResponses.addApiResponse(HTTP_200,
+                    addLegacyDocResponse(apiDoc, createIntegerResponse(apiDoc.responseDescription())));
             operation.setResponses(apiResponses);
             return;
         }
@@ -386,7 +393,7 @@ public class UyuniSwaggerReader {
         }
     }
 
-    private ApiResponse createIntegerResponse() {
+    private ApiResponse createIntegerResponse(String description) {
         if (this.components.getSchemas() == null || !this.components.getSchemas().containsKey("IntegerResponse")) {
             Schema<?> integerResponseSchema = new Schema<>()
                     .type("object")
@@ -402,7 +409,7 @@ public class UyuniSwaggerReader {
         }
 
         ApiResponse response = new ApiResponse();
-        response.setDescription("1 on success, exception thrown otherwise.");
+        response.setDescription(description.isBlank() ? "1 on success, exception thrown otherwise." : description);
 
         Content content = new Content();
         MediaType mediaType = new MediaType();

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -16,11 +16,15 @@ import org.apache.logging.log4j.Logger;
 import java.beans.Introspector;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.IntStream;
 
 import io.swagger.v3.core.converter.ModelConverters;
@@ -165,28 +169,56 @@ public class UyuniSwaggerReader {
     }
 
     /**
-     * Carries the legacy documentation type of the request properties into the specification.
+     * Carries the legacy documentation type of the documented properties into the specification.
      *
      * Some legacy types have no OpenAPI counterpart, so swagger-core normalises them to the
-     * closest primitive. Annotating the request getter with {@link LegacyDocResponse#type()}
-     * keeps the original name available to the documentation parsers.
+     * closest primitive. Annotating the getter with {@link LegacyDocResponse#type()} keeps the
+     * original name available to the documentation parsers.
      *
-     * @param requestClass the request class of the endpoint
+     * A documented class describes its payload through the classes its getters return, so the
+     * whole reachable graph is visited: the annotation means the same thing on a request property,
+     * on a response property and on a property of a nested structure.
+     *
+     * @param documentedClass the request or response class of the endpoint
      */
-    private void applyLegacyDocTypes(Class<?> requestClass) {
+    private void applyLegacyDocTypes(Class<?> documentedClass) {
         if (this.components.getSchemas() == null) {
             return;
         }
-        Schema<?> requestSchema = this.components.getSchemas().get(schemaRefName(requestClass));
-        if (requestSchema == null || requestSchema.getProperties() == null) {
+        applyLegacyDocTypes(documentedClass, new HashSet<>());
+    }
+
+    private void applyLegacyDocTypes(Type type, Set<Class<?>> visited) {
+        if (type instanceof ParameterizedType parameterized) {
+            applyLegacyDocTypes(parameterized.getRawType(), visited);
+            Arrays.stream(parameterized.getActualTypeArguments())
+                    .forEach(argument -> applyLegacyDocTypes(argument, visited));
             return;
         }
-        for (Method getter : requestClass.getMethods()) {
+        if (!(type instanceof Class<?> documentedClass) || documentedClass.getPackageName().startsWith("java.") ||
+                !visited.add(documentedClass)) {
+            return;
+        }
+
+        stampLegacyDocTypes(documentedClass);
+
+        Arrays.stream(documentedClass.getGenericInterfaces())
+                .forEach(iface -> applyLegacyDocTypes(iface, visited));
+        Arrays.stream(documentedClass.getMethods())
+                .forEach(getter -> applyLegacyDocTypes(getter.getGenericReturnType(), visited));
+    }
+
+    private void stampLegacyDocTypes(Class<?> documentedClass) {
+        Schema<?> schema = this.components.getSchemas().get(schemaRefName(documentedClass));
+        if (schema == null || schema.getProperties() == null) {
+            return;
+        }
+        for (Method getter : documentedClass.getMethods()) {
             LegacyDocResponse legacyDoc = getter.getAnnotation(LegacyDocResponse.class);
             if (legacyDoc == null || legacyDoc.type().isBlank()) {
                 continue;
             }
-            Schema<?> property = requestSchema.getProperties().get(resolvePropertyName(getter));
+            Schema<?> property = schema.getProperties().get(resolvePropertyName(getter));
             if (property != null) {
                 property.addExtension(DOC_RESPONSE_TYPE_EXTENSION, legacyDoc.type());
             }
@@ -260,6 +292,7 @@ public class UyuniSwaggerReader {
         MediaType mediaType = new MediaType();
 
         resolveAndRegisterSchema(apiDoc.responseClass());
+        applyLegacyDocTypes(apiDoc.responseClass());
         mediaType.setSchema(buildSchemaRef(apiDoc.responseClass()));
         content.addMediaType(DEFAULT_MEDIA_TYPE, mediaType);
 
@@ -275,6 +308,7 @@ public class UyuniSwaggerReader {
 
         if (legacyDocResponse.responseClass() != Void.class) {
             resolveAndRegisterSchema(legacyDocResponse.responseClass());
+            applyLegacyDocTypes(legacyDocResponse.responseClass());
             response.addExtension(DOC_RESPONSE_SCHEMA_EXTENSION, buildSchemaRef(legacyDocResponse.responseClass()));
         }
         if (!legacyDocResponse.type().isBlank()) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -22,6 +22,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -38,6 +39,7 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.IntegerSchema;
@@ -426,7 +428,8 @@ public class UyuniSwaggerReader {
                     );
                     if (parameterAnnotation != null && !parameterAnnotation.hidden()) {
                         operation.addParametersItem(
-                                mapToOpenApiParameter(parameterAnnotation, reflectionParams[index].getType())
+                                mapToOpenApiParameter(parameterAnnotation,
+                                        reflectionParams[index].getParameterizedType())
                         );
                     }
                 });
@@ -434,22 +437,45 @@ public class UyuniSwaggerReader {
 
     private Parameter mapToOpenApiParameter(
             io.swagger.v3.oas.annotations.Parameter parameterAnnotation,
-            Class<?> type) {
+            Type type) {
         Parameter openApiParam = new Parameter()
                 .name(parameterAnnotation.name())
                 .required(parameterAnnotation.required())
                 .in(parameterAnnotation.in().toString().toLowerCase())
-                .schema(switch (type.getName()) {
-                    case "int", "java.lang.Integer" -> new IntegerSchema();
-                    case "boolean", "java.lang.Boolean" -> new BooleanSchema();
-                    default -> new StringSchema();
-                });
+                .schema(literalParameterSchema(type));
 
         if (!parameterAnnotation.description().isBlank()) {
             openApiParam.setDescription(parameterAnnotation.description());
         }
 
         return openApiParam;
+    }
+
+    /**
+     * Maps the declared type of a literal parameter to its schema.
+     *
+     * A collection parameter is documented as an array of its element type, the same way a
+     * collection property of a request body is, so that both spell the parameter out with its
+     * element type rather than collapsing it to a string.
+     *
+     * @param type the declared parameter type
+     * @return the schema describing the parameter
+     */
+    private Schema<?> literalParameterSchema(Type type) {
+        if (type instanceof ParameterizedType parameterized &&
+                parameterized.getRawType() instanceof Class<?> rawType &&
+                Collection.class.isAssignableFrom(rawType)) {
+            Type[] arguments = parameterized.getActualTypeArguments();
+            return new ArraySchema()
+                    .items(literalParameterSchema(arguments.length == 1 ? arguments[0] : Object.class));
+        }
+
+        String typeName = type instanceof Class<?> parameterClass ? parameterClass.getName() : "";
+        return switch (typeName) {
+            case "int", "java.lang.Integer" -> new IntegerSchema();
+            case "boolean", "java.lang.Boolean" -> new BooleanSchema();
+            default -> new StringSchema();
+        };
     }
 
     private void registerOperationOnPath(String namespace, Method method, HttpMethod httpMethod, Operation operation) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -10,6 +10,8 @@
  */
 package com.suse.manager.api.docs;
 
+import com.redhat.rhn.domain.user.User;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -22,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -59,6 +62,8 @@ public class UyuniSwaggerReader {
     public static final String DOC_RESPONSE_SCHEMA_EXTENSION = "x-uyuni-doc-response-schema";
     public static final String DOC_RESPONSE_TYPE_EXTENSION = "x-uyuni-doc-response-type";
     public static final String DOC_RESPONSE_NAME_EXTENSION = "x-uyuni-doc-response-name";
+    /** Parameter counts of the handler overloads an operation stands for, longest first. */
+    public static final String DOC_OVERLOAD_ARITIES_EXTENSION = "x-uyuni-doc-overload-arities";
     public static final String DEFAULT_MEDIA_TYPE = "application/json";
     public static final String HTTP_200 = "200";
     /** Legacy name for a date, bound as {@code $date} in the doclet's macros for both formats. */
@@ -104,18 +109,19 @@ public class UyuniSwaggerReader {
 
         Arrays.stream(cls.getMethods())
                 .sorted(Comparator.comparing(Method::getName))
-                .forEach(method -> processMethod(namespace, method, tagAnnotation));
+                .forEach(method -> processMethod(cls, namespace, method, tagAnnotation));
 
         return openAPI;
     }
 
-    private void processMethod(String namespace, Method method, Tag tagAnnotation) {
+    private void processMethod(Class<?> cls, String namespace, Method method, Tag tagAnnotation) {
         ApiEndpointDoc apiDoc = findMethodAnnotation(method, ApiEndpointDoc.class);
         if (apiDoc == null) {
             return;
         }
 
         Operation openApiOperation = createOperationWithBasicInfo(method, tagAnnotation, apiDoc);
+        applyOverloadArities(cls, method, openApiOperation);
         applySecurityIfNeeded(method, openApiOperation);
         configureRequestBodyIfPresent(apiDoc, openApiOperation);
         configureResponses(apiDoc, openApiOperation);
@@ -134,6 +140,82 @@ public class UyuniSwaggerReader {
         }
         operation.addTagsItem(tagAnnotation.name());
         return operation;
+    }
+
+    /**
+     * Records how many parameters each handler overload of an operation takes.
+     *
+     * A single operation with optional parameters stands for every overload of the handler method,
+     * and the legacy doclet documents one call per overload. Which parameter combinations exist is
+     * a property of the handler, not of the schema: overloads may add several parameters at once,
+     * so the combinations cannot be derived from the optional parameters alone. The counts exclude
+     * the logged in user, which is not a documented parameter.
+     *
+     * @param cls the handler class being read
+     * @param method the handler method backing the operation
+     * @param operation the operation being built
+     */
+    private void applyOverloadArities(Class<?> cls, Method method, Operation operation) {
+        List<Integer> arities = Arrays.stream(cls.getMethods())
+                .filter(candidate -> candidate.getName().equals(method.getName()))
+                .filter(candidate -> candidate.getParameterCount() > 0 &&
+                        User.class.equals(candidate.getParameterTypes()[0]))
+                .map(candidate -> candidate.getParameterCount() - 1)
+                .distinct()
+                .sorted(Comparator.reverseOrder())
+                .toList();
+
+        if (arities.size() > 1) {
+            operation.addExtension(DOC_OVERLOAD_ARITIES_EXTENSION, arities);
+        }
+    }
+
+    /**
+     * Lists the parameter combinations the legacy doclet documents for an operation.
+     *
+     * Each combination is the required parameters plus as many of the optional ones as the
+     * corresponding handler overload takes, so an overload that adds several parameters at once
+     * produces no intermediate documented call. Combinations are returned longest first, the order
+     * the doclet uses, and an operation backed by a single overload yields a single combination.
+     *
+     * @param operation the operation to expand
+     * @param required the parameters present in every overload
+     * @param optional the parameters added by the longer overloads, in declaration order
+     * @return the parameter names of each documented call
+     */
+    public static List<List<String>> expandOverloads(Operation operation, List<String> required,
+                                                     List<String> optional) {
+        List<List<String>> combinations = new ArrayList<>();
+        for (int count : optionalParameterCounts(operation, required.size(), optional.size())) {
+            List<String> params = new ArrayList<>(required);
+            params.addAll(optional.subList(0, count));
+            combinations.add(params);
+        }
+        return combinations;
+    }
+
+    /**
+     * Resolves how many optional parameters each documented call carries.
+     *
+     * @param operation the operation to expand
+     * @param requiredCount the number of required parameters
+     * @param optionalCount the number of optional parameters
+     * @return the optional parameter counts, descending
+     */
+    private static List<Integer> optionalParameterCounts(Operation operation, int requiredCount, int optionalCount) {
+        Object arities = operation.getExtensions() == null ?
+                null : operation.getExtensions().get(DOC_OVERLOAD_ARITIES_EXTENSION);
+
+        if (arities instanceof List<?> recorded && !recorded.isEmpty()) {
+            return recorded.stream()
+                    .filter(Number.class::isInstance)
+                    .map(arity -> ((Number) arity).intValue() - requiredCount)
+                    .filter(count -> count >= 0 && count <= optionalCount)
+                    .distinct()
+                    .sorted(Comparator.reverseOrder())
+                    .toList();
+        }
+        return List.of(optionalCount);
     }
 
     private void applySecurityIfNeeded(Method method, Operation operation) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -455,8 +455,7 @@ public class UyuniSwaggerReader {
      * Maps the declared type of a literal parameter to its schema.
      *
      * A collection parameter is documented as an array of its element type, the same way a
-     * collection property of a request body is, so that both spell the parameter out with its
-     * element type rather than collapsing it to a string.
+     * collection property of a request body is.
      *
      * @param type the declared parameter type
      * @return the schema describing the parameter

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
@@ -297,7 +297,42 @@ public class ApiDocumentationCompatibilityTest {
      * @return the items with the element struct and its contents rebased, when indented
      */
     private List<DocItem> alignArrayElementNesting(List<DocItem> items) {
-        return alignNestedElementStructs(alignLeadingArrayElement(items));
+        return alignSerializerStructs(alignNestedElementStructs(alignLeadingArrayElement(items)));
+    }
+
+    /**
+     * Aligns the nesting of a struct that the doclet expanded from a serializer reference.
+     *
+     * The doclet renders the bullet level from a template variable that it resets whenever it
+     * inlines a {@code $Serializer} reference, so a struct reached through such a reference is
+     * always emitted at the top level, however deeply it is nested in the documented value. A
+     * struct spelled out inline with {@code #struct_begin} on the very same position is emitted
+     * one level below its parent instead. Both spell the same shape, and the OpenAPI schema is a
+     * reference either way, so the depth cannot be reproduced from the specification. The flattened
+     * form is rebased below the property it follows before comparing; the type, name and order of
+     * every item, and the nesting below the struct itself, all stay part of the comparison.
+     *
+     * @param items the parsed items
+     * @return the items with every flattened serializer struct and its contents rebased
+     */
+    private List<DocItem> alignSerializerStructs(List<DocItem> items) {
+        List<DocItem> aligned = new ArrayList<>(items);
+        for (int i = 1; i < aligned.size(); i++) {
+            DocItem struct = aligned.get(i);
+            boolean nestedBefore = aligned.subList(0, i).stream().anyMatch(item -> item.level() > 1);
+            if (!"struct".equals(struct.type()) || struct.level() != 1 || !nestedBefore ||
+                    "array".equals(aligned.get(i - 1).type())) {
+                continue;
+            }
+
+            int shift = aligned.get(i - 1).level() - 1;
+            aligned.set(i, new DocItem(struct.level() + shift, struct.type(), struct.name()));
+            for (int j = i + 1; j < aligned.size() && aligned.get(j).level() > 1; j++) {
+                DocItem item = aligned.get(j);
+                aligned.set(j, new DocItem(item.level() + shift, item.type(), item.name()));
+            }
+        }
+        return aligned;
     }
 
     private List<DocItem> alignLeadingArrayElement(List<DocItem> items) {

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
@@ -269,17 +269,49 @@ public class ApiDocumentationCompatibilityTest {
 
         expected.entrySet().stream()
                 .filter(entry -> actual.containsKey(entry.getKey()))
-                .filter(entry -> !entry.getValue().returns().equals(actual.get(entry.getKey()).returns()))
+                .filter(entry -> !alignArrayElementNesting(entry.getValue().returns())
+                        .equals(alignArrayElementNesting(actual.get(entry.getKey()).returns())))
                 .forEach(entry -> differences.add(
                         "[%s] Return mismatch for %s: expected %s, actual %s".formatted(
                                 namespace,
                                 entry.getKey(),
-                                entry.getValue().returns(),
-                                actual.get(entry.getKey()).returns()
+                                alignArrayElementNesting(entry.getValue().returns()),
+                                alignArrayElementNesting(actual.get(entry.getKey()).returns())
                         )
                 ));
 
         return differences;
+    }
+
+    /**
+     * Aligns the nesting of the struct that describes the element type of an array return value.
+     *
+     * The legacy doclet documents it in two interchangeable ways depending on the namespace: as a
+     * sibling of the array marker, or indented one level below it. Both describe the same return
+     * value, so the depth difference is an artifact of how each namespace was documented rather
+     * than a difference in the documented shape. The indented form is rebased on the sibling form
+     * before comparing, which keeps the depth of every other item, and the nesting relative to the
+     * element struct, part of the comparison.
+     *
+     * @param items the parsed return value items
+     * @return the items with the element struct and its contents rebased, when indented
+     */
+    private List<DocItem> alignArrayElementNesting(List<DocItem> items) {
+        if (items.size() < 2) {
+            return items;
+        }
+        DocItem array = items.get(0);
+        DocItem elementStruct = items.get(1);
+        if (!"array".equals(array.type()) || !"struct".equals(elementStruct.type()) ||
+                elementStruct.level() != array.level() + 1) {
+            return items;
+        }
+
+        List<DocItem> aligned = new ArrayList<>(items.size());
+        aligned.add(array);
+        items.subList(1, items.size())
+                .forEach(item -> aligned.add(new DocItem(item.level() - 1, item.type(), item.name())));
+        return aligned;
     }
 
     private Map<MethodKey, ApiMethodDoc> parse(String content) {

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
@@ -59,10 +59,10 @@ public class ApiDocumentationCompatibilityTest {
             Pattern.compile("(?s)<title>(?:<function>)?(?:Method: )?([^<]+)(?:</function>)?</title>");
     private static final Pattern DOCBOOK_HTTP =
             Pattern.compile("(?s)HTTP\\s+(?:<function>|<literal>)([^<]+)(?:</function>|</literal>)");
-    private static final Pattern DOCBOOK_PARAMETERS =
-            Pattern.compile("(?s)<term>Parameters</term>.*?<itemizedlist[^>]*>(.*?)</itemizedlist>");
-    private static final Pattern DOCBOOK_RETURNS =
-            Pattern.compile("(?s)<term>Return Value</term>.*?<itemizedlist[^>]*>(.*?)</itemizedlist>");
+    private static final Pattern DOCBOOK_PARAMETERS = Pattern.compile("<term>Parameters</term>");
+    private static final Pattern DOCBOOK_RETURNS = Pattern.compile("<term>Return Value</term>");
+    private static final Pattern DOCBOOK_LIST_OPEN = Pattern.compile("<itemizedlist[^>]*>");
+    private static final Pattern DOCBOOK_LIST_TAG = Pattern.compile("<(/)?itemizedlist[^>]*>");
     private static final Pattern DOCBOOK_LIST_ITEM =
             Pattern.compile("(?s)<listitem>\\s*<para>(.*?)</para>");
     private static final Pattern METHOD_TITLE = Pattern.compile("^== Method:\\s+(.+?)\\s*$");
@@ -435,11 +435,43 @@ public class ApiDocumentationCompatibilityTest {
         }
 
         List<DocItem> items = new ArrayList<>();
-        Matcher itemMatcher = DOCBOOK_LIST_ITEM.matcher(sectionMatcher.group(1));
+        Matcher itemMatcher = DOCBOOK_LIST_ITEM.matcher(itemizedListBody(section, sectionMatcher.start()));
         while (itemMatcher.find()) {
             parseDocBookItem(itemMatcher.group(1)).ifPresent(items::add);
         }
         return items;
+    }
+
+    /**
+     * Extracts the contents of the first item list of a section, nested lists included.
+     *
+     * A struct property and an {@code #options()} block are both rendered as an item list inside
+     * an item of the enclosing list, so the list that opens a section closes only after the ones
+     * it contains. Matching up to the first closing tag would cut the section short at the first
+     * nested list and silently drop every item after it, so the closing tag is found by balancing.
+     *
+     * @param section the method section to read
+     * @param from the offset of the section header
+     * @return the body of the item list, or an empty string when the section has none
+     */
+    private String itemizedListBody(String section, int from) {
+        Matcher openMatcher = DOCBOOK_LIST_OPEN.matcher(section);
+        if (!openMatcher.find(from)) {
+            return "";
+        }
+
+        int bodyStart = openMatcher.end();
+        int depth = 1;
+        Matcher tagMatcher = DOCBOOK_LIST_TAG.matcher(section);
+        int cursor = bodyStart;
+        while (tagMatcher.find(cursor)) {
+            depth += tagMatcher.group(1) == null ? 1 : -1;
+            if (depth == 0) {
+                return section.substring(bodyStart, tagMatcher.start());
+            }
+            cursor = tagMatcher.end();
+        }
+        return section.substring(bodyStart);
     }
 
     private Optional<DocItem> parseDocBookItem(String item) {

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
@@ -287,11 +287,8 @@ public class ApiDocumentationCompatibilityTest {
      * Aligns the nesting of the struct that describes the element type of an array return value.
      *
      * The legacy doclet documents it in two interchangeable ways depending on the namespace: as a
-     * sibling of the array marker, or indented one level below it. Both describe the same return
-     * value, so the depth difference is an artifact of how each namespace was documented rather
-     * than a difference in the documented shape. The indented form is rebased on the sibling form
-     * before comparing, which keeps the depth of every other item, and the nesting relative to the
-     * element struct, part of the comparison.
+     * sibling of the array marker, or indented one level below it. The indented form is rebased on
+     * the sibling form before comparing.
      *
      * @param items the parsed return value items
      * @return the items with the element struct and its contents rebased, when indented
@@ -307,10 +304,8 @@ public class ApiDocumentationCompatibilityTest {
      * inlines a {@code $Serializer} reference, so a struct reached through such a reference is
      * always emitted at the top level, however deeply it is nested in the documented value. A
      * struct spelled out inline with {@code #struct_begin} on the very same position is emitted
-     * one level below its parent instead. Both spell the same shape, and the OpenAPI schema is a
-     * reference either way, so the depth cannot be reproduced from the specification. The flattened
-     * form is rebased below the property it follows before comparing; the type, name and order of
-     * every item, and the nesting below the struct itself, all stay part of the comparison.
+     * one level below its parent instead. The OpenAPI schema is a reference either way, so the
+     * flattened form is rebased below the property it follows before comparing.
      *
      * @param items the parsed items
      * @return the items with every flattened serializer struct and its contents rebased
@@ -356,13 +351,10 @@ public class ApiDocumentationCompatibilityTest {
     /**
      * Aligns the nesting of a struct that describes the element type of an array valued property.
      *
-     * This is the same artifact as above, one level in. The doclet indents the element struct below
-     * its property when the namespace spells the element out with {@code #struct_begin}, and emits
-     * it flat when the namespace refers to a {@code $Serializer} instead. Both spellings describe
-     * the same property, and the OpenAPI schema is a reference either way, so the depth cannot be
-     * reproduced from the specification. The indented form is rebased on the flat form before
-     * comparing; the type, name and order of every item, and the nesting relative to the element
-     * struct, all stay part of the comparison.
+     * The doclet indents the element struct below its property when the namespace spells the
+     * element out with {@code #struct_begin}, and emits it flat when the namespace refers to a
+     * {@code $Serializer} instead. The OpenAPI schema is a reference either way, so the indented
+     * form is rebased on the flat form before comparing.
      *
      * @param items the parsed return value items
      * @return the items with every nested element struct and its contents rebased, when indented

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
@@ -297,6 +297,10 @@ public class ApiDocumentationCompatibilityTest {
      * @return the items with the element struct and its contents rebased, when indented
      */
     private List<DocItem> alignArrayElementNesting(List<DocItem> items) {
+        return alignNestedElementStructs(alignLeadingArrayElement(items));
+    }
+
+    private List<DocItem> alignLeadingArrayElement(List<DocItem> items) {
         if (items.size() < 2) {
             return items;
         }
@@ -311,6 +315,39 @@ public class ApiDocumentationCompatibilityTest {
         aligned.add(array);
         items.subList(1, items.size())
                 .forEach(item -> aligned.add(new DocItem(item.level() - 1, item.type(), item.name())));
+        return aligned;
+    }
+
+    /**
+     * Aligns the nesting of a struct that describes the element type of an array valued property.
+     *
+     * This is the same artifact as above, one level in. The doclet indents the element struct below
+     * its property when the namespace spells the element out with {@code #struct_begin}, and emits
+     * it flat when the namespace refers to a {@code $Serializer} instead. Both spellings describe
+     * the same property, and the OpenAPI schema is a reference either way, so the depth cannot be
+     * reproduced from the specification. The indented form is rebased on the flat form before
+     * comparing; the type, name and order of every item, and the nesting relative to the element
+     * struct, all stay part of the comparison.
+     *
+     * @param items the parsed return value items
+     * @return the items with every nested element struct and its contents rebased, when indented
+     */
+    private List<DocItem> alignNestedElementStructs(List<DocItem> items) {
+        List<DocItem> aligned = new ArrayList<>(items);
+        for (int i = 0; i + 1 < aligned.size(); i++) {
+            DocItem array = aligned.get(i);
+            DocItem elementStruct = aligned.get(i + 1);
+            if (!"array".equals(array.type()) || !"struct".equals(elementStruct.type()) ||
+                    elementStruct.level() <= array.level()) {
+                continue;
+            }
+            int shift = elementStruct.level() - 1;
+            aligned.set(i + 1, new DocItem(1, elementStruct.type(), elementStruct.name()));
+            for (int j = i + 2; j < aligned.size() && aligned.get(j).level() > array.level(); j++) {
+                DocItem item = aligned.get(j);
+                aligned.set(j, new DocItem(item.level() - shift, item.type(), item.name()));
+            }
+        }
         return aligned;
     }
 

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/VirtualHostManagerHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/VirtualHostManagerHandlerContractTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManager;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.virtualhostmanager.VirtualHostManagerHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class VirtualHostManagerHandlerContractTest extends BaseOpenApiTest {
+
+    private static final String LABEL = "test-vhm";
+    private static final String MODULE_NAME = "VMware";
+
+    @Override
+    protected String getApiNamespace() {
+        return "virtualhostmanager";
+    }
+
+    @Override
+    protected Class<VirtualHostManagerHandler> getHandlerClass() {
+        return VirtualHostManagerHandler.class;
+    }
+
+    private VirtualHostManagerHandler handler() {
+        return (VirtualHostManagerHandler) handlerMock;
+    }
+
+    private VirtualHostManager virtualHostManager() {
+        Org org = new Org();
+        org.setId(1L);
+
+        VirtualHostManager vhm = new VirtualHostManager();
+        vhm.setLabel(LABEL);
+        vhm.setOrg(org);
+        vhm.setGathererModule(MODULE_NAME);
+        return vhm;
+    }
+
+    @Test
+    public void testListVirtualHostManagers() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listVirtualHostManagers(with(mockUser));
+            will(returnValue(List.of(virtualHostManager())));
+        }});
+
+        validateApiContract("/virtualhostmanager/listVirtualHostManagers", "GET")
+                .onHandlerMethod("listVirtualHostManagers", User.class);
+    }
+
+    @Test
+    public void testGetDetail() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getDetail(with(mockUser), with(LABEL));
+            will(returnValue(virtualHostManager()));
+        }});
+
+        validateApiContract("/virtualhostmanager/getDetail", "GET")
+                .withParams(Map.of("label", new String[]{LABEL}))
+                .onHandlerMethod("getDetail", User.class, String.class);
+    }
+
+    @Test
+    public void testListAvailableVirtualHostGathererModules() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listAvailableVirtualHostGathererModules(with(mockUser));
+            will(returnValue(List.of(MODULE_NAME, "Kubernetes")));
+        }});
+
+        validateApiContract("/virtualhostmanager/listAvailableVirtualHostGathererModules", "GET")
+                .onHandlerMethod("listAvailableVirtualHostGathererModules", User.class);
+    }
+
+    @Test
+    public void testGetModuleParameters() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getModuleParameters(with(mockUser), with(MODULE_NAME));
+            will(returnValue(Map.of("hostname", "", "username", "", "password", "")));
+        }});
+
+        validateApiContract("/virtualhostmanager/getModuleParameters", "GET")
+                .withParams(Map.of("moduleName", new String[]{MODULE_NAME}))
+                .onHandlerMethod("getModuleParameters", User.class, String.class);
+    }
+
+    @Test
+    public void testCreate() throws Exception {
+        Map<String, String> parameters = Map.of("hostname", "vcenter.example.com", "username", "admin");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).create(with(mockUser), with(LABEL), with(MODULE_NAME), with(parameters));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/virtualhostmanager/create", "POST")
+                .withBody(Map.of("label", LABEL, "moduleName", MODULE_NAME, "parameters", parameters))
+                .onHandlerMethod("create", User.class, String.class, String.class, Map.class);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).delete(with(mockUser), with(LABEL));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/virtualhostmanager/delete", "POST")
+                .withBody(Map.of("label", LABEL))
+                .onHandlerMethod("delete", User.class, String.class);
+    }
+}


### PR DESCRIPTION
## What

Migrates the `virtualhostmanager` namespace to the OpenAPI contract: 6 methods
(`listVirtualHostManagers`, `getDetail`, `create`, `delete`, `listAvailableVirtualHostGathererModules`,
`getModuleParameters`), each with a contract test.

