### PR TITLE
QE: add SLES 15 SP7 to 16.0 product migrations

### DIFF
--- a/testsuite/features/build_validation/migration/migration_sles15sp7_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_sles15sp7_minion.feature
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@sles15sp7_minion 
+@sles160_minion
+Feature: Migrate a SLES 15 SP7 Salt minion to 16.0
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Prerequisite: update OS zypper to the latest version
+    When I upgrade "zypper" on "sles15sp7_minion" using the API
+
+  Scenario: Migrate this minion to SLE 16.0
+    Given I am on the Systems overview page of this "sles15sp7_minion"
+    When I follow "Software" in the content area
+    And I follow "Product Migration" in the content area
+    And I wait until I see "Target Products:" text, refreshing the page
+    And I wait until I see "SUSE Linux Enterprise Server 16.0 x86_64" text
+    And I click on "Select Channels"
+    When I select the channel "Custom Channel for sles160_minion"
+    And I check "allowVendorChange"
+    And I click on "Schedule Migration"
+    Then I should see a "Product Migration - Confirm" text
+    When I click on "Confirm"
+    Then I should see a "This system is scheduled to be migrated to" text
+
+  Scenario: Check the migration is successful for this minion
+    Given I am on the Systems overview page of this "sles15sp7_minion"
+    When I follow "Events"
+    And I follow "History"
+    And I wait at most 600 seconds until event "Product Migration" is completed
+    And I wait until event "Package List Refresh" is completed
+    And I follow "Details" in the content area
+    Then I wait until I see "SUSE Linux Enterprise Server 16.0" text, refreshing the page
+    And vendor change should be enabled for product migration on "sles15sp7_minion"
+
+  Scenario: Detect latest Salt changes on the SLES minion
+    When I query latest Salt changes on "sles15sp7_minion"
+
+  Scenario: Check events history for failures on SLES minion
+    Given I am on the Systems overview page of this "sles15sp7_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/build_validation/migration/migration_sles15sp7_sshminion.feature
+++ b/testsuite/features/build_validation/migration/migration_sles15sp7_sshminion.feature
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@sles15sp7_sshminion 
+@sles160_sshminion
+Feature: Migrate a SLES 15 SP7 Salt SSH minion to 16.0
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Prerequisite: update OS zypper to the latest version
+    When I upgrade "zypper" on "sles15sp7_sshminion" using the API
+
+  Scenario: Migrate this SSH minion to SLE 16.0
+    Given I am on the Systems overview page of this "sles15sp7_sshminion"
+    When I follow "Software" in the content area
+    And I follow "Product Migration" in the content area
+    And I wait until I see "Target Products:" text, refreshing the page
+    And I wait until I see "SUSE Linux Enterprise Server 16.0 x86_64" text
+    And I click on "Select Channels"
+    When I select the channel "Custom Channel for sles160_minion"
+    And I check "allowVendorChange"
+    And I click on "Schedule Migration"
+    Then I should see a "Product Migration - Confirm" text
+    When I click on "Confirm"
+    Then I should see a "This system is scheduled to be migrated to" text
+
+  Scenario: Check the migration is successful for this SSH minion
+    Given I am on the Systems overview page of this "sles15sp7_sshminion"
+    When I follow "Events"
+    And I follow "History"
+    And I wait until event "Apply states" is completed
+    And I wait at most 600 seconds until event "Product Migration" is completed
+    And I wait until event "Package List Refresh" is completed
+    And I follow "Details" in the content area
+    Then I should see a "SUSE Linux Enterprise Server 16.0" text
+    And vendor change should be enabled for product migration on "sles15sp7_sshminion"
+
+  Scenario: Check events history for failures on SSH minion
+    Given I am on the Systems overview page of this "sles15sp7_sshminion"
+    Then I check for failed events on history event page


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/31301
Adds E2E testing feature files for migrating SLES 15 SP7 to SLES 16.0.

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/31301
Ports:

 - [x] 5.1https://github.com/SUSE/spacewalk/pull/31757
 - [x] 5.2 https://github.com/SUSE/spacewalk/pull/31762

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
