### PR TITLE
Uyuni: Fix correct assignment of peripheral entitlement (bsc#1269086)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/entitlement/PeripheralServerEntitlement.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/entitlement/PeripheralServerEntitlement.java
@@ -19,6 +19,9 @@ import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 
+import java.util.Objects;
+import java.util.function.Predicate;
+
 /**
  * PeripheralServer entitlement
  */
@@ -52,15 +55,20 @@ public class PeripheralServerEntitlement extends Entitlement {
 
     @Override
     public boolean isAllowedOnServer(Server server) {
+        Predicate<Server> differentForeignType = s -> server.isForeign() != s.isForeign();
+
+        //the last two filters (foreign type and hostname) were added to tackle bug (bsc#1269086)
         if (server.getFqdns().stream()
                 .flatMap(fqdn -> ServerFactory.listByFqdn(fqdn.getName()).stream())
                 .filter(s -> !s.equals(server))
+                .filter(differentForeignType)
+                .filter(s -> Objects.equals(s.getHostname(), server.getHostname()))
                 .anyMatch(s -> s.hasEntitlement(EntitlementManager.PERIPHERAL_SERVER))) {
             // Peripheral Server with given fqdn already exists
             return false;
         }
         return super.isAllowedOnServer(server) &&
                 ((server.getBaseEntitlement() instanceof SaltEntitlement) ||
-                 (server.getBaseEntitlement() instanceof ForeignEntitlement));
+                        (server.getBaseEntitlement() instanceof ForeignEntitlement));
     }
 }

--- a/java/core/src/main/resources/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9313,6 +9313,12 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="system_entitlements.addon.removed.success" xml:space="preserve">
         <source>Removed &lt;strong&gt;{1}&lt;/strong&gt; from &lt;strong&gt;{0}&lt;/strong&gt; system(s).</source>
       </trans-unit>
+      <trans-unit id="system.entitle.added.peripheral_server" xml:space="preserve">
+        <source>&lt;strong&gt;Peripheral server&lt;/strong&gt; type has been applied.</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/details/Overview.do</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="system.entitle.added.container_build_host" xml:space="preserve">
         <source>&lt;strong&gt;Container Build Host&lt;/strong&gt; type has been applied.&lt;br/&gt;&lt;strong&gt;Note:&lt;/strong&gt; This action will &lt;em&gt;not&lt;/em&gt; result in state application. To apply the state, either use the &lt;a href="/rhn/manager/systems/details/highstate?sid={0}"&gt;states page&lt;/a&gt; or run &lt;code class="text-info"&gt;state.highstate&lt;/code&gt; from the command line.</source>
         <context-group name="ctx">

--- a/java/core/src/test/java/com/redhat/rhn/domain/entitlement/PeripheralServerEntitlementTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/entitlement/PeripheralServerEntitlementTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.domain.server.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFQDN;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
@@ -31,7 +32,10 @@ import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.webui.services.TestSaltApi;
 import com.suse.manager.webui.services.iface.SaltApi;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 /**
  * Test for {@link com.redhat.rhn.domain.entitlement.PeripheralServerEntitlement}
@@ -50,6 +54,83 @@ public class PeripheralServerEntitlementTest extends BaseEntitlementTestCase {
     @Override
     protected String getLabel() {
         return EntitlementManager.PERIPHERAL_SERVER_ENTITLED;
+    }
+
+    private Server exTestForeignServer;
+    private Server exTestActualServer;
+    private Server exTestOtherMinion;
+    private List<Server> exTestServers;
+
+    private void prepareExclusionTest() throws Exception {
+        exTestForeignServer = setupServer(ServerTestUtils.createForeignSystem(user, "9999"),
+                "foreign", "peripheral.server.com");
+        exTestActualServer = setupServer(MinionServerFactoryTest.createTestMinionServer(user),
+                "server", "peripheral.server.com");
+        exTestOtherMinion = setupServer(MinionServerFactoryTest.createTestMinionServer(user),
+                "otherMinion", "otherMinion.com");
+        exTestServers = List.of(exTestForeignServer, exTestActualServer, exTestOtherMinion);
+    }
+
+    private Server setupServer(Server server, String name, String hostName) {
+        server.setName(name);
+        server.setHostname(hostName);
+        server.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
+
+        ServerFQDN primaryFqdn = new ServerFQDN(server, server.getName() + ".com");
+        primaryFqdn.setPrimary(true);
+        server.getFqdns().add(primaryFqdn);
+
+        server.addFqdn("common.dns.com");
+        return server;
+    }
+
+    private void resetEntitlements() {
+        exTestServers.forEach(m ->
+                systemEntitlementManager.removeServerEntitlement(m, EntitlementManager.PERIPHERAL_SERVER));
+    }
+
+    private void setPeripheralEntitlementTo(Server serverIn) {
+        systemEntitlementManager.addEntitlementToServer(serverIn, EntitlementManager.PERIPHERAL_SERVER);
+        exTestServers.forEach(TestUtils::saveAndFlush);
+    }
+
+    private boolean isAllowedToBePeripheral(Server serverIn) {
+        return EntitlementManager.PERIPHERAL_SERVER.isAllowedOnServer(serverIn);
+    }
+
+    private List<Server> buildFourMinions() {
+        Server minion1 = MinionServerFactoryTest.createTestMinionServer(user);
+        minion1.setName("minion1");
+        Server minion2 = MinionServerFactoryTest.createTestMinionServer(user);
+        minion2.setName("minion2");
+        Server minion3 = MinionServerFactoryTest.createTestMinionServer(user);
+        minion3.setName("minion3");
+        Server minion4 = MinionServerFactoryTest.createTestMinionServer(user);
+        minion4.setName("minion4");
+        List<Server> allMinions = List.of(minion1, minion2, minion3, minion4);
+
+        allMinions.forEach(m -> m.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux")));
+        allMinions.forEach(m -> {
+            ServerFQDN primaryFqdn = new ServerFQDN(m, m.getName() + ".com");
+            primaryFqdn.setPrimary(true);
+            m.getFqdns().add(primaryFqdn);
+        });
+
+        return allMinions;
+    }
+
+    private void printMinion(Server minion) {
+        String debugString = "%s (%s) (%s): foreign: %s peripheral entitled: %s peripheral isAllowedOnServer: %s"
+                .formatted(
+                        minion.getName(),
+                        minion.getHostname(),
+                        minion.getFqdns().stream()
+                                .map(fqdn -> "%s/%s".formatted(fqdn.getName(), fqdn.isPrimary())).toList(),
+                        minion.isForeign(),
+                        minion.hasEntitlement(EntitlementManager.PERIPHERAL_SERVER),
+                        EntitlementManager.PERIPHERAL_SERVER.isAllowedOnServer(minion)
+                );
+        System.out.println(debugString);
     }
 
     /**
@@ -75,4 +156,91 @@ public class PeripheralServerEntitlementTest extends BaseEntitlementTestCase {
         // the entitlement can't be enabled on 2 servers with the same fqdn
         assertFalse(EntitlementManager.PERIPHERAL_SERVER.isAllowedOnServer(minion));
     }
+
+    @Test
+    @DisplayName("non-foreign unrelated minions can all have peripheral server entitlement")
+    public void testNonForeignUnrelatedMinions() {
+        List<Server> fourMinions = buildFourMinions();
+        //check entitlement is allowed
+        fourMinions.forEach(m -> assertTrue(EntitlementManager.PERIPHERAL_SERVER.isAllowedOnServer(m)));
+
+        //set entitlement on all minions
+        fourMinions.forEach(m ->
+                systemEntitlementManager.addEntitlementToServer(m, EntitlementManager.PERIPHERAL_SERVER));
+        fourMinions.forEach(TestUtils::saveAndFlush);
+
+        //check entitlement is set and allowed on all minions
+        fourMinions.forEach(m -> assertTrue(m.hasEntitlement(EntitlementManager.PERIPHERAL_SERVER)));
+        fourMinions.forEach(m -> assertTrue(EntitlementManager.PERIPHERAL_SERVER.isAllowedOnServer(m)));
+        fourMinions.forEach(this::printMinion);
+    }
+
+    @Test
+    @DisplayName("non-foreign minions correlated with the same FQDN can all have peripheral server entitlement")
+    public void testNonForeignFqdnCorrelatedMinions() {
+        List<Server> fourMinions = buildFourMinions();
+        // correlate minions with the same FQDN
+        fourMinions.forEach(m -> m.addFqdn("common.dns.com"));
+        //check entitlement is allowed
+        fourMinions.forEach(m -> assertTrue(EntitlementManager.PERIPHERAL_SERVER.isAllowedOnServer(m)));
+
+        //set entitlement on one minion
+        systemEntitlementManager.addEntitlementToServer(fourMinions.get(0), EntitlementManager.PERIPHERAL_SERVER);
+        fourMinions.forEach(TestUtils::saveAndFlush);
+
+        //check entitlement is allowed on all minions
+        fourMinions.forEach(m -> assertTrue(EntitlementManager.PERIPHERAL_SERVER.isAllowedOnServer(m)));
+
+        //setting entitlement on all minions should be possible
+        fourMinions.forEach(m ->
+                systemEntitlementManager.addEntitlementToServer(m, EntitlementManager.PERIPHERAL_SERVER));
+        fourMinions.forEach(TestUtils::saveAndFlush);
+
+        //check entitlement is set and allowed on all minions
+        fourMinions.forEach(m -> assertTrue(m.hasEntitlement(EntitlementManager.PERIPHERAL_SERVER)));
+        fourMinions.forEach(m -> assertTrue(EntitlementManager.PERIPHERAL_SERVER.isAllowedOnServer(m)));
+        fourMinions.forEach(this::printMinion);
+    }
+
+
+    @Test
+    @DisplayName("foreign and actual servers are mutually exclusive")
+    public void exclusionTest() throws Exception {
+        prepareExclusionTest();
+        //check entitlement is allowed for all servers
+        exTestServers.forEach(m -> assertTrue(isAllowedToBePeripheral(m)));
+
+        //set foreign as peripheral
+        resetEntitlements();
+        setPeripheralEntitlementTo(exTestForeignServer);
+
+        // if foreign is peripheral, corresponding actual server should not be allowed to have peripheral entitlement
+        // always allowed on other non-corresponding minion
+        assertTrue(isAllowedToBePeripheral(exTestForeignServer));
+        assertFalse(isAllowedToBePeripheral(exTestActualServer));
+        assertTrue(isAllowedToBePeripheral(exTestOtherMinion));
+
+        //set actual server as peripheral
+        resetEntitlements();
+        setPeripheralEntitlementTo(exTestActualServer);
+
+        // if actual server is peripheral, corresponding foreign should not be allowed to have peripheral entitlement
+        // always allowed on other non-corresponding minion
+        assertFalse(isAllowedToBePeripheral(exTestForeignServer));
+        assertTrue(isAllowedToBePeripheral(exTestActualServer));
+        assertTrue(isAllowedToBePeripheral(exTestOtherMinion));
+
+        //set other minion as peripheral
+        resetEntitlements();
+        setPeripheralEntitlementTo(exTestOtherMinion);
+
+        // if other minion is peripheral, both foreign and corresponding actual server should be allowed
+        // to have peripheral entitlement
+        // always allowed on other non-corresponding minion
+        exTestServers.forEach(this::printMinion);
+        assertTrue(isAllowedToBePeripheral(exTestForeignServer));
+        assertTrue(isAllowedToBePeripheral(exTestActualServer));
+        assertTrue(isAllowedToBePeripheral(exTestOtherMinion));
+    }
+
 }

--- a/java/spacewalk-java.changes.carlo.uyuni-1269086-peripheral-entitlement
+++ b/java/spacewalk-java.changes.carlo.uyuni-1269086-peripheral-entitlement
@@ -1,0 +1,1 @@
+- Fix correct assignment of peripheral entitlement (bsc#1269086)


### PR DESCRIPTION
## What does this PR change?

The system entitlement "Peripheral server" is mutually exclusive when more servers share one of their FDQNs, so when one of the server has it, the UI checkbox does not show in the others, until revoked in the first one.
This behaviour was intended to avoid setting this entitlement both on a foreign system and its actual server counterpart, when a server is enrolled as a peripheral server and **THEN** onboarded as a minion (so that 2 items show up, one being the foreign server, the other the actual server, although they refer to the same  server)
This fix allows to recognise this pattern, leaving other cases unscathed, and fixes the user bug

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference, only added a missing string from translation
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/31058
Port(s): 
5.2: https://github.com/SUSE/spacewalk/pull/31765
5.1: https://github.com/SUSE/spacewalk/pull/31763
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

