### PR TITLE
QE: add Leap 16.0 aarch64 product migrations to SLE 16.0

### DIFF
--- a/testsuite/features/build_validation/migration/migration_opensuse16arm_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_opensuse16arm_minion.feature
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@opensuse160arm_minion
+Feature: Migrate an OpenSUSE Leap 16.0 aarch64 Salt minion to SLE 16.0
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Prerequisite: update OS zypper to the latest version
+    When I upgrade "zypper" on "opensuse160arm_minion" using the API
+
+  Scenario: Migrate this minion to SLE 16.0
+    Given I am on the Systems overview page of this "opensuse160arm_minion"
+    When I follow "Software" in the content area
+    And I follow "Product Migration" in the content area
+    And I wait until I see "Target Products:" text, refreshing the page
+    And I wait until I see "SUSE Linux Enterprise Server 16.0 aarch64" text
+    And I click on "Select Channels"
+    And I check "allowVendorChange"
+    And I click on "Schedule Migration"
+    Then I should see a "Product Migration - Confirm" text
+    When I click on "Confirm"
+    Then I should see a "This system is scheduled to be migrated to" text
+
+  Scenario: Check the migration is successful for this minion
+    Given I am on the Systems overview page of this "opensuse160arm_minion"
+    When I follow "Events"
+    And I follow "History"
+    And I wait at most 600 seconds until event "Product Migration" is completed
+    And I wait until event "Package List Refresh" is completed
+    And I follow "Details" in the content area
+    Then I wait until I see "SUSE Linux Enterprise Server 16.0" text, refreshing the page
+    And vendor change should be enabled for product migration on "opensuse160arm_minion"
+
+  Scenario: Detect latest Salt changes on the SLES minion
+    When I query latest Salt changes on "opensuse160arm_minion"
+
+  Scenario: Check events history for failures on SLES minion
+    Given I am on the Systems overview page of this "opensuse160arm_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/build_validation/migration/migration_opensuse16arm_sshminion.feature
+++ b/testsuite/features/build_validation/migration/migration_opensuse16arm_sshminion.feature
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@opensuse160arm_sshminion
+Feature: Migrate an OpenSUSE Leap 16.0 aarch64 Salt SSH minion to SLE 16.0
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Prerequisite: update OS zypper to the latest version
+    When I upgrade "zypper" on "opensuse160arm_sshminion" using the API
+
+  Scenario: Migrate this SSH minion to SLE 16.0
+    Given I am on the Systems overview page of this "opensuse160arm_sshminion"
+    When I follow "Software" in the content area
+    And I follow "Product Migration" in the content area
+    And I wait until I see "Target Products:" text, refreshing the page
+    And I wait until I see "SUSE Linux Enterprise Server 16.0 aarch64" text
+    And I click on "Select Channels"
+    And I check "allowVendorChange"
+    And I click on "Schedule Migration"
+    Then I should see a "Product Migration - Confirm" text
+    When I click on "Confirm"
+    Then I should see a "This system is scheduled to be migrated to" text
+
+  Scenario: Check the migration is successful for this SSH minion
+    Given I am on the Systems overview page of this "opensuse160arm_sshminion"
+    When I follow "Events"
+    And I follow "History"
+    And I wait until event "Apply states" is completed
+    And I wait at most 600 seconds until event "Product Migration" is completed
+    And I wait until event "Package List Refresh" is completed
+    And I follow "Details" in the content area
+    Then I should see a "SUSE Linux Enterprise Server 16.0" text
+    And vendor change should be enabled for product migration on "opensuse160arm_sshminion"
+
+
+  Scenario: Check events history for failures on SSH minion
+    Given I am on the Systems overview page of this "opensuse160arm_sshminion"
+    Then I check for failed events on history event page

--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -461,6 +461,24 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "openSUSE Leap 16.0 aarch64" product has been added
     And I wait until all synchronized channels for "leap16.0-aarch64" have finished
 
+# needed to test Leap 16.0 ARM to SLE 16.0 ARM migrations in BV
+@susemanager
+@opensuse160arm_minion
+  Scenario: Add SUSE Linux Enterprise Server 16.0 for ARM
+    Given I am authorized for the "Admin" section
+    When I follow the left menu "Admin > Setup Wizard > Products"
+    And I wait until I do not see "currently running" text
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 16.0" as the filtered product description
+    And I wait until I see "SUSE Linux Enterprise Server 16.0 aarch64" text
+    And I open the sub-list of the product "SUSE Linux Enterprise Server 16.0 aarch64"
+    When I select "SUSE Linux Enterprise Server 16.0 aarch64" as a product
+    Then I should see the "SUSE Linux Enterprise Server 16.0 aarch64" selected
+    When I click the Add Product button
+    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
+    And I wait until I see "SUSE Linux Enterprise Server 16.0 aarch64" product has been added
+    And I wait until all synchronized channels for "sles16-aarch64" have finished
+
 @uyuni
 @opensuse160arm_minion
   Scenario: Add openSUSE 16.0 for ARM Uyuni Client tools

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -993,6 +993,11 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sle-product-sles-16.0-x86_64
         multi-linux-managertools-sle-16-x86_64
       ],
+    'sles16-aarch64' =>
+      %w[
+        sle-product-sles-16.0-aarch64
+        multi-linux-managertools-sle-16-aarch64
+      ],
     'slesforsap15-sp5' =>
       %w[
         managertools-sle15-pool-x86_64-sap-sp5
@@ -1669,6 +1674,7 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'managertools-ubuntu2404-updates-amd64' => 60,
   'managertools-ubuntu2604-updates-amd64' => 60,
   'multi-linux-managertools-sle-16-aarch64-opensuse-16.0' => 60,
+  'multi-linux-managertools-sle-16-aarch64' => 60,
   'multi-linux-managertools-sle-16-x86_64' => 60,
   'opensuse-backports-15.6-updates-aarch64' => 300,
   'opensuse_leap15_6-aarch64' => 10_020,
@@ -1814,6 +1820,7 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-product-sles15-sp6-ltss-updates-x86_64' => 660,
   'sle-product-sles15-sp7-pool-x86_64' => 60,
   'sle-product-sles15-sp7-updates-x86_64' => 60,
+  'sle-product-sles-16.0-aarch64' => 1920,
   'sle-product-sles-16.0-x86_64' => 1920,
   'sles12-sp5-installer-updates-x86_64' => 60,
   'sles12-sp5-pool-x86_64' => 120,


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/30382
Adds E2E testing feature files for migrating Leap 16.0 to SLES 16.0.

As in BV we have the Leap 16 minion on ARM and the SLES 16.0 on x86, we`ll need to ad-hoc sync the SLES 16.0 aarch64 product for this.

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/31301
Ports:

- [x] 5.1https://github.com/SUSE/spacewalk/pull/31766
- [x] 5.2https://github.com/SUSE/spacewalk/pull/31767

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
