### PR TITLE
Fix spacecmd build on SLM 6

### DIFF
--- a/spacecmd/spacecmd.changes.mczernek.spacecmd-fix
+++ b/spacecmd/spacecmd.changes.mczernek.spacecmd-fix
@@ -1,0 +1,1 @@
+- Fix spacecmd build on SUSE Linux Micro 6

--- a/spacecmd/spacecmd.spec
+++ b/spacecmd/spacecmd.spec
@@ -76,6 +76,9 @@ BuildRequires:  python3
 Requires:       python3
 Requires:       python3-dateutil
 Requires:       python3-rpm
+%if 0%{?suse_version}
+BuildRequires:  fdupes
+%endif
 %if "%{_vendor}" == "debbuild"
 BuildRequires:  python3-dev
 %else
@@ -137,7 +140,9 @@ chmod 0644 %{buildroot}%{python_sitelib}/spacecmd/__init__.py
 
 %if 0%{?suse_version}
 %if 0%{?build_py3}
-%py3_compile -O %{buildroot}/%{python_sitelib}
+python3 -m compileall -q %{buildroot}/%{python_sitelib}
+python3 -O -m compileall -q %{buildroot}/%{python_sitelib}
+%fdupes %{buildroot}/%{python_sitelib}
 %else
 %py_compile -O %{buildroot}/%{python_sitelib}
 %endif


### PR DESCRIPTION
## What does this PR change?

Remove the `py3_compile` macro, which is missing on SLM 6 build targets.  

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Port(s):
- https://github.com/SUSE/spacewalk/pull/31798
- https://github.com/SUSE/spacewalk/pull/31799

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
