### PR TITLE
Uyuni: Fix duplicate UI entries in rhel10-like minion package upgrades (bsc#1262234)

### DIFF
--- a/java/core/src/main/resources/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -1166,7 +1166,18 @@ SELECT  COUNT(pn.id) AS COUNT
 
 <mode name="system_upgradable_package_list" class="com.redhat.rhn.frontend.dto.UpgradablePackageListItem">
   <query params="sid">
-SELECT  n.id AS id,
+  WITH highest_id_packages AS (
+      SELECT p.name_id, p.evr_id, p.package_arch_id, max(p.id) AS id
+        FROM rhnServerPackage sp
+              INNER JOIN rhnServer s ON sp.server_id = s.id
+              INNER JOIN rhnServerChannel sc on sc.server_id = s.id
+              INNER JOIN rhnChannelPackage cp on cp.channel_id = sc.channel_id
+              INNER JOIN rhnPackage p
+              ON sp.name_id = p.name_id AND sp.package_arch_id = p.package_arch_id AND p.id = cp.package_id
+        WHERE sp.server_id = :sid AND (p.org_id = s.org_id or p.org_id is null)
+      GROUP BY p.name_id, p.evr_id, p.package_arch_id
+  )
+  SELECT  n.id AS id,
         n.id AS name_id,
         lookup_evr(((latest.evr)).epoch, (latest.evr).version, (latest.evr).release, (latest.evr).type) AS evr_id,
         latest.package_arch_id AS arch_id,
@@ -1203,15 +1214,15 @@ SELECT  n.id AS id,
   join rhnPackageUpgradeArchCompat puac
     on puac.package_arch_id = sp.package_arch_id
    and puac.package_upgrade_arch_id = latest.package_arch_id
-  LEFT JOIN rhnPackage p ON p.name_id = latest.package_name_id
-     AND p.evr_id = latest.package_evr_id
-     AND p.package_arch_id = latest.package_arch_id
-       LEFT JOIN (
+  LEFT JOIN highest_id_packages hp ON hp.name_id = latest.package_name_id
+      AND hp.evr_id = latest.package_evr_id
+      AND hp.package_arch_id = latest.package_arch_id
+  LEFT JOIN (
          select a.name as name, a.stream as stream, ap.package_id as package_id
          from suseAppStreamPackage ap
          inner join suseAppStream a on a.id = ap.module_id
          inner join rhnServerChannel sc on sc.channel_id = a.channel_id and sc.server_id = :sid
-       ) appStream on appStream.package_id = p.id
+       ) appStream on appStream.package_id = hp.id
  where sp.server_id = :sid
  order by upper(n.name)
   </query>

--- a/java/spacewalk-java.changes.carlo.uyuni-1262234-duplicate-packages-rhel10
+++ b/java/spacewalk-java.changes.carlo.uyuni-1262234-duplicate-packages-rhel10
@@ -1,0 +1,2 @@
+- Fix duplicate UI entries in rhel10-like minion package
+  upgrades (bsc#1262234)


### PR DESCRIPTION

## What does this PR change?

I reproduced the problem on a 5.2 server, onboarding a Rocky10 and an Alma10 clients.
The `Software > Packages > Upgrade` UI page was showing duplicates of some packages, as described in the bug.

As an example, let's take a package that shows as duplicate:
(`package c-ares: id = 13756; arch_id x86_64: id= 120; latest package: evr_id = 11386`)
this query shows the issue:


```
SELECT id, evr_id, vendor FROM rhnPackage p WHERE p.name_id = 13756
  AND p.evr_id = 11386 AND p.package_arch_id = 120
> id      evr_id    vendor
> 24803   11386    "AlmaLinux"
> 33014   11386    "Rocky Enterprise Software Foundation"
```

the problem is that both Alma and Rocky have the same package with same name and `evr_id` but coming from the two different vendors.

I noticed that the `Software > Packages > List/remove` UI page does **NOT** show this problem: the involved query `system_package_list` has an initial `WITH` clause whose aim is to select packages involving  the `rhnServerChannel` and `rhnChannelPackage` tables.
Joining this initial `WITH` table instead of the raw `rhnPackage` further on in the query, allows to filter the packages belonging to the right vendor instead of having them all, and hence the duplicates.

To solve the issue, then, I did mimic the same approach in the fautly `system_upgradable_package_list` query, adding a similar `WITH` clause at the beginning of the query itself, in order to filter out the unwanted packages from `rhnPackage`, and then redirecting the appropriate `join` to this clause instead of the entire `rhnPackage` table.

There is no impact on query speed, as far I saw.

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: tested manually
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/30430
Port(s): 
5.2: https://github.com/SUSE/spacewalk/pull/31770
5.1: https://github.com/SUSE/spacewalk/pull/31774
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
