### PR TITLE
Use the distro podman on GitHub runners and dump diagnostics on a hang

### DIFF
--- a/.github/workflows/acceptance_tests_base.yml
+++ b/.github/workflows/acceptance_tests_base.yml
@@ -86,6 +86,26 @@ jobs:
         timeout-minutes: 10
         run: sudo apt install podman
 
+      # The step above installs podman 4.9.3 in /usr/bin, but since runner image
+      # 20260810.271 the image itself also ships podman 5.8.4 in /usr/local/bin,
+      # which wins on root's PATH. That is the image where the jobs began to
+      # wedge in "podman exec", so keep using the version that has been running
+      # these tests all along. The two use different storage backends, so start
+      # from an empty store.
+      - name: Use the distro podman, not the one shipped with the runner image
+        if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
+        run: |
+          if [ -e /usr/local/bin/podman ]; then
+            sudo mv -v /usr/local/bin/podman /usr/local/bin/podman-runner-image
+            sudo rm -rf /var/lib/containers
+          fi
+          # The rest of the image is still built around podman 5: its conmon has
+          # no journald support, so keep the log driver 5.8.4 was using here.
+          sudo mkdir -p /etc/containers/containers.conf.d
+          printf '[containers]\nlog_driver = "k8s-file"\n\n[engine]\nconmon_path = ["/usr/bin/conmon"]\n' \
+            | sudo tee /etc/containers/containers.conf.d/99-distro-podman.conf
+          sudo -i podman version | head -2
+
       - name: Install Python dependencies
         if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
         run: pip install pyyaml
@@ -153,6 +173,14 @@ jobs:
       - name: Create temporary directories
         if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/01_setup_tmp_dirs.sh
+
+      # Before the first podman call, so an early wedge is still on record.
+      - name: Container runtime info
+        if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
+        # Purely informational, and it calls podman: never let it fail the job.
+        continue-on-error: true
+        timeout-minutes: 5
+        run: ./testsuite/podman_runner/00_container_runtime_info.sh
 
       - name: Create Podman network
         if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
@@ -293,12 +321,24 @@ jobs:
           # For more details: https://github.com/actions/upload-artifact?tab=readme-ov-file#altering-compressions-level-speed-v-size
           compression-level: 6
 
+      # Runs before the log collection below, because that one goes through
+      # podman too and hangs as well when the runtime is wedged.
+      - name: Dump container runtime diagnostics
+        if: ${{ failure() && !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
+        timeout-minutes: 10
+        run: ./testsuite/podman_runner/26_dump_hang_diagnostics.sh
+
+      # Both collect through podman, so when the runtime is the thing that is
+      # wedged they hang too. They have been seen running for hours on master,
+      # holding a runner for logs that will never arrive.
       - name: Get server logs
         if: ${{ failure() && !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true'}}
+        timeout-minutes: 15
         run: ./testsuite/podman_runner/24_get_server_logs.sh ${{ inputs.server_id }}
 
       - name: Get client logs
         if: ${{ failure() && !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
+        timeout-minutes: 15
         run: ./testsuite/podman_runner/25_get_client_logs.sh ${{ inputs.server_id }}
 
       - name: Upload server log artifacts

--- a/testsuite/podman_runner/00_container_runtime_info.sh
+++ b/testsuite/podman_runner/00_container_runtime_info.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Print what the container runtime looks like before any container is started.
+# A hang in a later "podman exec" cannot be explained without knowing which
+# storage driver and mount program podman picked on this runner, so record it
+# up front, in every job, whether or not the job goes on to fail.
+# Nothing here may fail the job.
+
+echo "===== runner ====="
+uname -a
+echo "ImageOS=${ImageOS} ImageVersion=${ImageVersion}"
+echo
+
+# Through "sudo -i", like the test scripts, and with the resolved path: root's
+# login PATH is exactly what decides which podman the tests get, and reporting
+# a different one here would hide the very discrepancy this file exists for.
+echo "===== versions ====="
+for binary in podman conmon crun runc; do
+    echo "--- ${binary}: $(sudo -i command -v "${binary}" 2>/dev/null || echo 'not on root PATH') ---"
+    sudo -i "${binary}" --version 2>/dev/null | head -2
+done
+echo
+
+echo "===== fuse-overlayfs shipped by the image ====="
+for path in /usr/local/bin/fuse-overlayfs /usr/bin/fuse-overlayfs; do
+    if [ -e "${path}" ]; then
+        echo "${path}: $("${path}" --version 2>&1 | head -1)"
+    fi
+done
+echo
+
+echo "===== storage configuration ====="
+for conf in /etc/containers/storage.conf /root/.config/containers/storage.conf; do
+    if sudo test -e "${conf}"; then
+        echo "--- ${conf} ---"
+        sudo grep -vE '^\s*(#|$)' "${conf}"
+    fi
+done
+echo
+
+echo "===== podman storage ====="
+sudo -i podman info --format 'driver={{ .Store.GraphDriverName }} options={{ .Store.GraphOptions }} root={{ .Store.GraphRoot }}'
+echo
+
+exit 0

--- a/testsuite/podman_runner/26_dump_hang_diagnostics.sh
+++ b/testsuite/podman_runner/26_dump_hang_diagnostics.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Dump the state of the container runtime after a step failed or timed out.
+# The failures this is meant to explain are podman calls that never return, so
+# every command here has a timeout and nothing is allowed to fail the job.
+# Host state comes first: a wedged podman can sit in the kernel where even
+# "timeout" cannot reach it, and that state is exactly what explains the hang.
+
+run() {
+    echo "===== $* ====="
+    timeout -k 5 30 "$@" 2>&1 | head -100
+    echo
+}
+
+# Command lines are what tells one "podman exec" from another, but they also
+# carry the flaky test token and the registry password, so redact them first.
+redact() {
+    sed -E -e 's/(TOKEN|PASSWD|PASSWORD|SECRET|CREDENTIALS)=[^[:space:]]*/\1=<redacted>/g' \
+           -e 's/(login[[:space:]].*)-p[[:space:]]+[^[:space:]]+/\1-p <redacted>/g'
+}
+
+echo "########## container runtime diagnostics ##########"
+
+run uname -a
+
+echo "===== overlay and fuse mounts ====="
+grep -E 'overlay|fuse' /proc/self/mounts | head -40
+echo
+
+echo "===== processes in uninterruptible sleep ====="
+ps -eo pid,stat,wchan:32,etimes,args | awk 'NR == 1 || $2 ~ /D/' | redact | head -40
+echo
+
+# Whatever their state: the wedge seen so far is a podman blocked on a futex,
+# which is an ordinary interruptible sleep and never shows up in the list above.
+echo "===== kernel stacks of the runtime processes ====="
+for pid in $(pgrep -f 'podman|conmon|crun|runc|fuse-overlayfs' | head -40); do
+    [ -r "/proc/${pid}/status" ] || continue
+    state=$(awk '/^State:/ { print $2 }' "/proc/${pid}/status" 2>/dev/null)
+    cmdline=$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null | redact | cut -c1-200)
+    echo "--- pid ${pid} state=${state} wchan=$(cat "/proc/${pid}/wchan" 2>/dev/null) :: ${cmdline} ---"
+    sudo cat "/proc/${pid}/stack" 2>/dev/null | head -20
+done
+echo
+
+echo "===== blocked tasks ====="
+echo w | sudo tee /proc/sysrq-trigger > /dev/null 2>&1
+sudo dmesg -T 2>&1 | tail -100
+echo
+
+# Podman last, and through "sudo -i" like the test scripts, so this reports the
+# same binary they run. Any of these can be the call that is already wedged.
+run sudo -i podman version
+run sudo -i podman ps -a
+run sudo -i podman info
+
+echo "===== container logs ====="
+for container in controller server; do
+    echo "--- ${container} ---"
+    timeout -k 5 30 sudo -i podman logs --tail 50 "${container}" 2>&1 | head -60
+done
+echo
+
+exit 0


### PR DESCRIPTION
## What does this PR change?

Makes the acceptance test jobs use the podman the workflow installs instead of the one the runner image ships, logs how podman is set up in every job, and dumps podman and kernel state when a step fails.

The jobs have been wedging in `podman exec` since 11 August. It is the runner, not the test suite: in run 31541429355, at the same commit and the same minute, the jobs on the `ubuntu-24.04` image `20260720.247.2` finished "Start controller, registry and build host" in about 100 seconds while the jobs on `20260810.271.1` sat there for hours. That image bumped **Podman 4.9.3 to 5.8.4**. `sudo apt install podman` still puts 4.9.3 in `/usr/bin`, but the image now also ships 5.8.4 in `/usr/local/bin`, and since the scripts call `sudo -i podman`, root's PATH picks the newer one. So the tests silently changed podman major version.

A hung job caught with the diagnostics below shows podman 5.8.4 blocked in `futex_wait` on the second `podman exec` into the controller, with no process in uninterruptible sleep and the container itself healthy. It is a lock in podman, not the kernel and not container storage.

Moving `/usr/local/bin/podman` aside puts the jobs back on the version that has been running these tests all along. The diagnostics are the part worth keeping either way, and they replace the tmate sessions: instead of an SSH shell nobody has the key for, every job prints its runtime up front and a failing job prints the state of the wedge.

Runtime info, printed by every job:

```
===== podman storage =====
driver=overlay options=map[overlay.mountopt:nodev,fsync=0] root=/var/lib/containers/storage
```

Failure dump, printed before the log collection steps that go through podman and hang too:

```
--- pid 3507 (podman) state=S wchan=0 ---
[<0>] futex_do_wait+0x3a/0x70
[<0>] __futex_wait+0x99/0x100
[<0>] futex_wait+0x72/0x120
```

## End-User Impact & Release Notes

- [x] **DONE**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): none

- [x] **DONE**

## Changelogs

- [x] No changelog needed
