### PR TITLE
Post the PR greeting with gh instead of a blocked action

### DIFF
--- a/.github/workflows/acceptance_tests_feedback_comment.yml
+++ b/.github/workflows/acceptance_tests_feedback_comment.yml
@@ -34,33 +34,51 @@ jobs:
           pr_number="$(cat pr-number)"
           echo "number=${pr_number}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions-cool/maintain-one-comment@4b2dbf086015f892dcb5e8c1106f5fccd6c1476b # v3.2.0
-        with:
-          number: ${{ steps.pr.outputs.number }}
-          body: |
-            :wave: Hello! Thanks for contributing to our project.
-            Acceptance tests will take some time (approx. 1h), please be patient :coffee:
+      - name: Post or update the greeting comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          # Invisible when rendered, and it is how we find our own comment on a
+          # later run.
+          MARKER: <!-- uyuni-acceptance-tests-greeting -->
+        run: |
+          body=$(cat <<EOF
+          ${MARKER}
+          :wave: Hello! Thanks for contributing to our project.
+          Acceptance tests will take some time (approx. 1h), please be patient :coffee:
 
-            You can see the progress at the end of this page and at https://github.com/uyuni-project/uyuni/pull/${{ steps.pr.outputs.number }}/checks
-            Once tests finish, if they fail, you can check :eyes: the cucumber report. See the link at the output of the action.
-            You can also check the artifacts section, which contains the logs at https://github.com/uyuni-project/uyuni/pull/${{ steps.pr.outputs.number }}/checks.
-            
-            If you are unsure the failing tests are related to your code, you can check the "reference jobs". These are jobs that run on a scheduled time with code from master. If they fail for the same reason as your build, it means the tests or the infrastructure are broken. If they do not fail, but yours do, it means it is related to your code.
-            
-            Reference tests:
-            
-              * https://github.com/uyuni-project/uyuni/actions/workflows/acceptance_tests_secondary_parallel.yml?query=event%3Aschedule
-            
-              * https://github.com/uyuni-project/uyuni/actions/workflows/acceptance_tests_secondary.yml?query=event%3Aschedule
+          You can see the progress at the end of this page and at https://github.com/uyuni-project/uyuni/pull/${PR_NUMBER}/checks
+          Once tests finish, if they fail, you can check :eyes: the cucumber report. See the link at the output of the action.
+          You can also check the artifacts section, which contains the logs at https://github.com/uyuni-project/uyuni/pull/${PR_NUMBER}/checks.
 
-            KNOWN ISSUES
+          If you are unsure the failing tests are related to your code, you can check the "reference jobs". These are jobs that run on a scheduled time with code from master. If they fail for the same reason as your build, it means the tests or the infrastructure are broken. If they do not fail, but yours do, it means it is related to your code.
 
-            Sometimes the build can fail when pulling new jar files from download.opensuse.org . This is a known limitation. Given this happens rarely, when it does, all you need to do is rerun the test. Sorry for the inconvenience.
+          Reference tests:
+
+            * https://github.com/uyuni-project/uyuni/actions/workflows/acceptance_tests_secondary_parallel.yml?query=event%3Aschedule
+
+            * https://github.com/uyuni-project/uyuni/actions/workflows/acceptance_tests_secondary.yml?query=event%3Aschedule
+
+          KNOWN ISSUES
+
+          Sometimes the build can fail when pulling new jar files from download.opensuse.org . This is a known limitation. Given this happens rarely, when it does, all you need to do is rerun the test. Sorry for the inconvenience.
 
 
-            For more tips on troubleshooting, see the [troubleshooting guide](https://github.com/uyuni-project/uyuni/wiki/Running-Acceptance-Tests-at-PR#troubleshooting).
+          For more tips on troubleshooting, see the [troubleshooting guide](https://github.com/uyuni-project/uyuni/wiki/Running-Acceptance-Tests-at-PR#troubleshooting).
 
-            Happy hacking!
-            
-          body-include: ":warning: You should not merge if acceptance tests fail to pass. :warning:" 
+          Happy hacking!
+          EOF
+          )
+
+          # jq reads MARKER straight out of the step environment.
+          existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq '[.[] | select(.body | contains(env.MARKER)) | .id] | first // empty')
+
+          if [ -n "${existing}" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" \
+              -f body="${body}" --silent
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -f body="${body}" --silent
+          fi
 


### PR DESCRIPTION
## What does this PR change?

Replaces the blocked `actions-cool/maintain-one-comment` action with a `gh api` call, so the PR greeting comment is posted again.

GitHub blocked the `actions-cool` organisation for a terms of service violation on 2026-05-19, and since that day every run of this workflow fails at "Prepare all required actions" with `Repository access blocked`, before any step executes. The job already has `pull-requests: write`, so `gh` posts and updates the comment with no third party action. The comment text is unchanged. Finding the previous comment uses a hidden marker that is part of the body; the old `body-include` matched on a line the body never contained, so the action could never recognise its own comment and greeted the contributor again on every push.

The failure this removes:

```
##[error]Repository access blocked
```

## End-User Impact & Release Notes

- [x] **DONE**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): none — the workflow only exists on uyuni master.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
