### PR TITLE
Fix incorrect minion list usage in VirtualInstanceRefreshAction (bsc#1254316)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/action/VirtualInstanceRefreshAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/VirtualInstanceRefreshAction.java
@@ -63,13 +63,13 @@ public class VirtualInstanceRefreshAction extends Action {
         if (!sshPushMinions.isEmpty()) {
             ret.put(State.apply(List.of(
                             ApplyStatesEventMessage.VIRTUAL_PROFILE_UPDATE),
-                    Optional.empty()), minionSummaries);
+                    Optional.empty()), sshPushMinions);
         }
         if (!regularMinions.isEmpty()) {
             ret.put(State.apply(Arrays.asList(
                             ApplyStatesEventMessage.SYNC_ALL,
                             ApplyStatesEventMessage.VIRTUAL_PROFILE_UPDATE),
-                    Optional.empty()), minionSummaries);
+                    Optional.empty()), regularMinions);
         }
 
         return ret;

--- a/java/spacewalk-java.changes.welder.bsc1254316
+++ b/java/spacewalk-java.changes.welder.bsc1254316
@@ -1,0 +1,2 @@
+- Fix virtual instance refresh for mixed SSH and regular
+  minions (bsc#1254316)


### PR DESCRIPTION
## What does this PR change?

It is a port of https://github.com/SUSE/spacewalk/pull/29397

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29127
Port(s): https://github.com/SUSE/spacewalk/pull/29397 https://github.com/SUSE/spacewalk/pull/31740

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
