### PR TITLE
Generalize the OpenAPI documentation parsers

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/api/ApiHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/api/ApiHandlerApi.java
@@ -58,7 +58,8 @@ public interface ApiHandlerApi {
     @ApiEndpointDoc(
         summary = "Returns the server product name.",
         method = HttpMethod.get,
-        responseClass = StringResponse.class
+        responseClass = StringResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "product name")
     )
     String productName();
 
@@ -71,7 +72,8 @@ public interface ApiHandlerApi {
     @ApiEndpointDoc(
         summary = "Returns the version of the API.",
         method = HttpMethod.get,
-        responseClass = StringResponse.class
+        responseClass = StringResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "version")
     )
     String getVersion();
 

--- a/java/core/src/main/java/com/suse/manager/api/docs/LegacyDocResponse.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/LegacyDocResponse.java
@@ -33,4 +33,14 @@ public @interface LegacyDocResponse {
      * @return optional response body type to use when rendering legacy API documentation
      */
     Class<?> responseClass() default Void.class;
+
+    /**
+     * Tells that the legacy documentation renders the return value as a bare type.
+     *
+     * A return value carries no name of its own in the specification, so the parsers label it
+     * with the operation name. A namespace that documents the type alone opts out of that.
+     *
+     * @return whether the legacy documentation renders the return value without a label
+     */
+    boolean unnamed() default false;
 }

--- a/java/core/src/main/java/com/suse/manager/api/docs/LegacyDocResponse.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/LegacyDocResponse.java
@@ -35,12 +35,14 @@ public @interface LegacyDocResponse {
     Class<?> responseClass() default Void.class;
 
     /**
-     * Tells that the legacy documentation renders the return value as a bare type.
+     * Tells that the legacy documentation renders the return value as plain text.
      *
-     * A return value carries no name of its own in the specification, so the parsers label it
-     * with the operation name. A namespace that documents the type alone opts out of that.
+     * The doclet passes a return value documented without a macro through as it was written,
+     * carrying neither the type role a documented one carries nor a label of its own. A return
+     * value has no name in the specification, so the parsers otherwise label it with the
+     * operation name, which such a return value does not show.
      *
-     * @return whether the legacy documentation renders the return value without a label
+     * @return whether the legacy documentation renders the return value as plain text
      */
-    boolean unnamed() default false;
+    boolean plainText() default false;
 }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -141,14 +141,15 @@ public class OpenApiToAsciidocParser {
         }
         String tag = operation.getTags().get(0);
 
-        boolean securityRequired = isSecurityRequired(operation);
         List<String> required = getFieldsByRequirement(operation, true);
         List<String> optional = getFieldsByRequirement(operation, false);
 
         List<DocEntry> entries = operationsByTag.computeIfAbsent(tag, key -> new ArrayList<>());
 
         for (List<String> params : UyuniSwaggerReader.expandOverloads(operation, required, optional)) {
-            entries.add(DocEntry.create(method, operation, params, securityRequired));
+            Operation documentedByOverload = UyuniSwaggerReader.operationForCall(operation, params);
+            entries.add(DocEntry.create(method, operation, documentedByOverload, params,
+                    isSecurityRequired(documentedByOverload)));
         }
     }
 
@@ -193,14 +194,14 @@ public class OpenApiToAsciidocParser {
                     """,
                 tag,
                 entry.anchor(),
-                Boolean.TRUE.equals(operation.getDeprecated()) ?
+                Boolean.TRUE.equals(entry.documentedByOverload().getDeprecated()) ?
                         operation.getOperationId() + " (Deprecated)" : operation.getOperationId(),
                 entry.method(),
                 summary,
                 description
         );
 
-        if (isSecurityRequired(operation)) {
+        if (isSecurityRequired(entry.documentedByOverload())) {
             writer.println("* [.string]#string#  sessionKey\n");
         }
 
@@ -213,7 +214,7 @@ public class OpenApiToAsciidocParser {
         }
 
         writer.println("\nReturns:\n");
-        writeReturn(writer, operation);
+        writeReturn(writer, operation, entry.activeParams());
         writer.print("\n\n\n");
     }
 
@@ -314,8 +315,8 @@ public class OpenApiToAsciidocParser {
         return openAPI.getSecurity() != null && !openAPI.getSecurity().isEmpty();
     }
 
-    private void writeReturn(PrintWriter writer, Operation operation) {
-        var responses = operation.getResponses();
+    private void writeReturn(PrintWriter writer, Operation operation, List<String> activeParams) {
+        var responses = UyuniSwaggerReader.operationForCall(operation, activeParams).getResponses();
         if (responses == null) {
             return;
         }
@@ -819,9 +820,11 @@ public class OpenApiToAsciidocParser {
         return schema.getItems() != null ? findDescription(schema.getItems()) : "";
     }
 
-    private record DocEntry(String method, String anchor, Operation operation, List<String> activeParams) {
+    private record DocEntry(String method, String anchor, Operation operation,
+                           Operation documentedByOverload, List<String> activeParams) {
 
-        static DocEntry create(String method, Operation operation, List<String> params, boolean securityRequired) {
+        static DocEntry create(String method, Operation operation, Operation documentedByOverload,
+                               List<String> params, boolean securityRequired) {
             String suffix = String.join("-", params);
             String authPart = securityRequired ? "loggedInUser" : "";
 
@@ -839,7 +842,7 @@ public class OpenApiToAsciidocParser {
                 anchor += "-";
             }
 
-            return new DocEntry(method, anchor, operation, List.copyOf(params));
+            return new DocEntry(method, anchor, operation, documentedByOverload, List.copyOf(params));
         }
     }
 }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -343,7 +343,10 @@ public class OpenApiToAsciidocParser {
             schema = resolveSchemaReference(docSchema);
         }
 
-        if (docSchema == null && schema.getProperties() != null && schema.getProperties().containsKey("result")) {
+        // The payload of a response is carried beside the status of the call, which tells the
+        // wrapper apart from a documented struct that happens to hold a property called result.
+        if (docSchema == null && schema.getProperties() != null &&
+                schema.getProperties().containsKey("result") && schema.getProperties().containsKey("success")) {
             Schema<?> resultSchema = (Schema<?>) schema.getProperties().get("result");
             refName = extractRefName(resultSchema.get$ref());
             schema = resolveSchemaReference(resultSchema);

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -217,7 +217,7 @@ public class OpenApiToAsciidocParser {
         }
 
         writer.println("\nReturns:\n");
-        writeReturn(writer, operation, entry.activeParams());
+        writeReturn(writer, operation, entry.documentedByOverload());
         writer.print("\n\n\n");
     }
 
@@ -318,8 +318,15 @@ public class OpenApiToAsciidocParser {
         return openAPI.getSecurity() != null && !openAPI.getSecurity().isEmpty();
     }
 
-    private void writeReturn(PrintWriter writer, Operation operation, List<String> activeParams) {
-        var responses = UyuniSwaggerReader.operationForCall(operation, activeParams).getResponses();
+    /**
+     * Writes the return value of a documented call.
+     *
+     * @param writer the writer to write to
+     * @param operation the operation the call belongs to, which names it
+     * @param documentedByOverload the overload documenting the call, which describes what it answers
+     */
+    private void writeReturn(PrintWriter writer, Operation operation, Operation documentedByOverload) {
+        var responses = documentedByOverload.getResponses();
         if (responses == null) {
             return;
         }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -388,8 +388,8 @@ public class OpenApiToAsciidocParser {
                 type,
                 name,
                 Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_PLAIN_TEXT_EXTENSION)),
-                response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_VALUES_EXTENSION)
-                        instanceof Schema<?> values ? values : null
+                response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_VALUES_EXTENSION) instanceof
+                        Schema<?> values ? values : null
         );
     }
 

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -612,7 +612,14 @@ public class OpenApiToAsciidocParser {
     }
 
     private String displayType(Schema<?> schema) {
-        return "integer".equals(schema.getType()) ? "int" : schema.getType();
+        if ("integer".equals(schema.getType())) {
+            return "int";
+        }
+        // The doclet binds $date to its own type name, whichever value carries the date.
+        if ("string".equals(schema.getType()) && "date-time".equals(schema.getFormat())) {
+            return UyuniSwaggerReader.LEGACY_DATE_TYPE;
+        }
+        return schema.getType();
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -54,6 +54,9 @@ public class OpenApiToAsciidocParser {
     /** Bullet level the doclet uses for the element struct of an array-valued parameter. */
     private static final int PARAMETER_ELEMENT_STRUCT_LEVEL = 2;
 
+    /** Bullet level the doclet uses for the documented values of a parameter. */
+    private static final int PARAMETER_OPTION_LEVEL = 2;
+
     /** OpenAPI type name for an array-valued schema. */
     private static final String ARRAY_TYPE = "array";
 
@@ -226,6 +229,7 @@ public class OpenApiToAsciidocParser {
         }
 
         writer.printf("* %s  %s%s%n", parameterType(schema), paramName, suffix);
+        printOptions(writer, resolved == null ? schema : resolved, PARAMETER_OPTION_LEVEL);
         writeParameterElement(writer, resolved == null ? schema : resolved);
         writer.println();
     }
@@ -415,6 +419,7 @@ public class OpenApiToAsciidocParser {
             Schema<?> nested = resolveNestedStruct(prop);
             String label = nested != null && !legacyDocName(prop).isEmpty() ? legacyDocName(prop) : name;
             writeStructProperty(writer, "", label, prop, level);
+            printOptions(writer, prop, level + 1);
             printElementStruct(writer, prop, level + 1);
             printStructProperties(writer, nested, level + 1);
         });
@@ -466,6 +471,65 @@ public class OpenApiToAsciidocParser {
         }
         writer.printf("%s [.struct]#struct#  %s%n", "*".repeat(level), label);
         printStructProperties(writer, resolvedItems, level + 1);
+    }
+
+    /**
+     * Writes the documented values of a parameter or property, one bullet level below it.
+     *
+     * The doclet renders {@code #options()} as a plain bullet list carrying no type marker, and
+     * appends the description after a dash for the {@code #item_desc} form.
+     *
+     * @param writer the writer to write to
+     * @param schema the parameter or property schema
+     * @param level the bullet level of the values
+     */
+    private void printOptions(PrintWriter writer, Schema<?> schema, int level) {
+        Schema<?> documented = optionsSchema(schema);
+        if (documented == null || documented.getEnum() == null) {
+            return;
+        }
+        Map<String, String> descriptions = optionDescriptions(documented);
+        for (Object value : documented.getEnum()) {
+            String option = String.valueOf(value);
+            String description = descriptions.getOrDefault(option, "");
+            writer.printf("%s %s%s%n", "*".repeat(level), option,
+                    description.isEmpty() ? "" : " - " + description);
+        }
+    }
+
+    /**
+     * Resolves the schema that carries the documented values.
+     *
+     * An array documents the values of its element type; every other parameter or property
+     * documents its own.
+     *
+     * @param schema the parameter or property schema
+     * @return the schema holding the values, or null when there is none
+     */
+    private Schema<?> optionsSchema(Schema<?> schema) {
+        if (schema == null) {
+            return null;
+        }
+        return ARRAY_TYPE.equals(schema.getType()) && schema.getItems() != null ?
+                resolveSchemaReference(schema.getItems()) : schema;
+    }
+
+    /**
+     * Reads the descriptions the namespace documented for individual values.
+     *
+     * @param schema the schema holding the values
+     * @return the description of each value, empty when the values carry none
+     */
+    private Map<String, String> optionDescriptions(Schema<?> schema) {
+        Object descriptions = schema.getExtensions() == null ? null :
+                schema.getExtensions().get(UyuniSwaggerReader.DOC_OPTION_DESCRIPTIONS_EXTENSION);
+        if (!(descriptions instanceof Map<?, ?> documented)) {
+            return Map.of();
+        }
+        Map<String, String> byOption = new LinkedHashMap<>();
+        documented.forEach((option, description) ->
+                byOption.put(String.valueOf(option), String.valueOf(description)));
+        return byOption;
     }
 
     private String legacyDocName(Schema<?> schema) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -205,7 +205,10 @@ public class OpenApiToAsciidocParser {
             writer.println("* [.string]#string#  sessionKey\n");
         }
 
+        // A call takes the parameters of the overload documenting it, which describes the ones it
+        // shares with the others as its own signature declares them.
         Map<String, Schema> allProps = getAllPossibleProperties(operation);
+        allProps.putAll(getAllPossibleProperties(entry.documentedByOverload()));
         for (String paramName : entry.activeParams()) {
             Schema schema = allProps.get(paramName);
             if (schema != null) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -368,7 +368,7 @@ public class OpenApiToAsciidocParser {
         // that are not simple: the doclet renders those as a single typed line, without expanding
         // the schema.
         if (isSimpleType(schema) || !legacyDocResponse.type().isBlank()) {
-            writeSimpleReturn(writer, schema, responseLabel, legacyDocResponse.type(), operation,
+            writeSimpleReturn(writer, schema, responseLabel, legacyDocResponse.type(),
                     legacyDocResponse.plainText(), legacyDocResponse.values());
             return;
         }
@@ -595,12 +595,11 @@ public class OpenApiToAsciidocParser {
     }
 
     private void writeSimpleReturn(PrintWriter writer, Schema<?> schema, String responseLabel,
-                                   String legacyType, Operation operation, boolean plainText,
-                                   Schema<?> documentedValues) {
+                                   String legacyType, boolean plainText, Schema<?> documentedValues) {
         String displayType = legacyType.isBlank() ? displayType(schema) : legacyType;
         Schema<?> values = documentedValues == null ? schema : documentedValues;
         // The doclet passes a return value documented without a macro through as written, so it
-        // carries neither the type role nor a label synthesised from the operation.
+        // carries no type role.
         if (plainText) {
             writer.printf("* %s%s %n", displayType, responseLabel.isBlank() ? "" : " - " + responseLabel);
             printOptions(writer, values, RETURN_OPTION_LEVEL);
@@ -608,14 +607,9 @@ public class OpenApiToAsciidocParser {
             return;
         }
 
-        String label = Optional.of(responseLabel)
-                .filter(d -> !d.isBlank())
-                .orElseGet(() -> operation.getOperationId()
-                        .replace("get", "")
-                        .replaceAll("([a-z])([A-Z])", "$1 $2")
-                        .toLowerCase().trim());
-
-        writer.printf("* [.%s]#%s#  %s%n", displayType, displayType, label);
+        // The doclet renders the label the namespace documented and invents none, so a return
+        // value documented without one is a bare typed line.
+        writer.printf("* [.%s]#%s#  %s%n", displayType, displayType, responseLabel);
         printOptions(writer, values, RETURN_OPTION_LEVEL);
         writer.print(" ");
     }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -57,6 +57,8 @@ public class OpenApiToAsciidocParser {
     /** Bullet level the doclet uses for the documented values of a parameter. */
     private static final int PARAMETER_OPTION_LEVEL = 2;
 
+    private static final int RETURN_OPTION_LEVEL = 2;
+
     /** OpenAPI type name for an array-valued schema. */
     private static final String ARRAY_TYPE = "array";
 
@@ -191,7 +193,8 @@ public class OpenApiToAsciidocParser {
                     """,
                 tag,
                 entry.anchor(),
-                operation.getOperationId(),
+                Boolean.TRUE.equals(operation.getDeprecated()) ?
+                        operation.getOperationId() + " (Deprecated)" : operation.getOperationId(),
                 entry.method(),
                 summary,
                 description
@@ -330,7 +333,8 @@ public class OpenApiToAsciidocParser {
         LegacyDocResponseData legacyDocResponse = getLegacyDocResponse(successResponse);
         Schema<?> docSchema = legacyDocResponse.schema();
         String responseDescription = responseDescription(successResponse);
-        String responseLabel = legacyDocResponse.label(responseDescription).orElse(responseDescription);
+        String responseLabel = legacyDocResponse.unnamed() ? "" :
+                legacyDocResponse.label(responseDescription).orElse(responseDescription);
         if (docSchema != null) {
             refName = docSchema.get$ref() != null ? extractRefName(docSchema.get$ref()) : "";
             schema = resolveSchemaReference(docSchema);
@@ -351,7 +355,8 @@ public class OpenApiToAsciidocParser {
         // that are not simple: the doclet renders those as a single typed line, without expanding
         // the schema.
         if (isSimpleType(schema) || !legacyDocResponse.type().isBlank()) {
-            writeSimpleReturn(writer, schema, responseLabel, legacyDocResponse.type(), operation);
+            writeSimpleReturn(writer, schema, responseLabel, legacyDocResponse.type(), operation,
+                    legacyDocResponse.unnamed());
             return;
         }
 
@@ -368,7 +373,8 @@ public class OpenApiToAsciidocParser {
         return new LegacyDocResponseData(
                 schema instanceof Schema<?> docSchema ? docSchema : null,
                 type,
-                name
+                name,
+                Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_UNNAMED_EXTENSION))
         );
     }
 
@@ -417,10 +423,18 @@ public class OpenApiToAsciidocParser {
         }
         resolved.getProperties().forEach((name, prop) -> {
             Schema<?> nested = resolveNestedStruct(prop);
-            String label = nested != null && !legacyDocName(prop).isEmpty() ? legacyDocName(prop) : name;
+            // An array property spends its legacy name on the element struct, so only a scalar or
+            // struct property renames itself with it.
+            String label = ARRAY_TYPE.equals(prop.getType()) || legacyDocName(prop).isEmpty() ?
+                    name : legacyDocName(prop);
             writeStructProperty(writer, "", label, prop, level);
             printOptions(writer, prop, level + 1);
             printElementStruct(writer, prop, level + 1);
+            // A serializer referenced by a struct property brings its own struct label, which the
+            // doclet renders as a sibling of the property before the fields it introduces.
+            if (nested != null && !legacyDocName(nested).isEmpty()) {
+                writer.printf("%s [.struct]#struct#  %s%n", "*".repeat(level), legacyDocName(nested));
+            }
             printStructProperties(writer, nested, level + 1);
         });
     }
@@ -540,9 +554,18 @@ public class OpenApiToAsciidocParser {
         return value == null ? "" : value.toString();
     }
 
-    private void writeSimpleReturn(PrintWriter writer, Schema<?> schema,
-                                   String responseLabel, String legacyType, Operation operation) {
+    private void writeSimpleReturn(PrintWriter writer, Schema<?> schema, String responseLabel,
+                                   String legacyType, Operation operation, boolean unnamed) {
         String displayType = legacyType.isBlank() ? displayType(schema) : legacyType;
+        // The doclet renders a return value documented as a bare type as plain text, without the
+        // type role a named one carries.
+        if (unnamed) {
+            writer.printf("* %s %n", displayType);
+            printOptions(writer, schema, RETURN_OPTION_LEVEL);
+            writer.print(" ");
+            return;
+        }
+
         String label = Optional.of(responseLabel)
                 .filter(d -> !d.isBlank())
                 .orElseGet(() -> operation.getOperationId()
@@ -550,7 +573,9 @@ public class OpenApiToAsciidocParser {
                         .replaceAll("([a-z])([A-Z])", "$1 $2")
                         .toLowerCase().trim());
 
-        writer.printf("* [.%s]#%s#  %s%n ", displayType, displayType, label);
+        writer.printf("* [.%s]#%s#  %s%n", displayType, displayType, label);
+        printOptions(writer, schema, RETURN_OPTION_LEVEL);
+        writer.print(" ");
     }
 
     private Schema<?> resolveSchemaReference(Schema<?> schema) {
@@ -566,8 +591,8 @@ public class OpenApiToAsciidocParser {
                 .orElse("");
     }
 
-    private record LegacyDocResponseData(Schema<?> schema, String type, String name) {
-        private static final LegacyDocResponseData EMPTY = new LegacyDocResponseData(null, "", "");
+    private record LegacyDocResponseData(Schema<?> schema, String type, String name, boolean unnamed) {
+        private static final LegacyDocResponseData EMPTY = new LegacyDocResponseData(null, "", "", false);
 
         Optional<String> label(String description) {
             if (name.isBlank()) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -333,8 +333,7 @@ public class OpenApiToAsciidocParser {
         LegacyDocResponseData legacyDocResponse = getLegacyDocResponse(successResponse);
         Schema<?> docSchema = legacyDocResponse.schema();
         String responseDescription = responseDescription(successResponse);
-        String responseLabel = legacyDocResponse.unnamed() ? "" :
-                legacyDocResponse.label(responseDescription).orElse(responseDescription);
+        String responseLabel = legacyDocResponse.label(responseDescription).orElse(responseDescription);
         if (docSchema != null) {
             refName = docSchema.get$ref() != null ? extractRefName(docSchema.get$ref()) : "";
             schema = resolveSchemaReference(docSchema);
@@ -356,7 +355,7 @@ public class OpenApiToAsciidocParser {
         // the schema.
         if (isSimpleType(schema) || !legacyDocResponse.type().isBlank()) {
             writeSimpleReturn(writer, schema, responseLabel, legacyDocResponse.type(), operation,
-                    legacyDocResponse.unnamed());
+                    legacyDocResponse.plainText(), legacyDocResponse.values());
             return;
         }
 
@@ -374,7 +373,9 @@ public class OpenApiToAsciidocParser {
                 schema instanceof Schema<?> docSchema ? docSchema : null,
                 type,
                 name,
-                Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_UNNAMED_EXTENSION))
+                Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_PLAIN_TEXT_EXTENSION)),
+                response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_VALUES_EXTENSION)
+                        instanceof Schema<?> values ? values : null
         );
     }
 
@@ -555,13 +556,15 @@ public class OpenApiToAsciidocParser {
     }
 
     private void writeSimpleReturn(PrintWriter writer, Schema<?> schema, String responseLabel,
-                                   String legacyType, Operation operation, boolean unnamed) {
+                                   String legacyType, Operation operation, boolean plainText,
+                                   Schema<?> documentedValues) {
         String displayType = legacyType.isBlank() ? displayType(schema) : legacyType;
-        // The doclet renders a return value documented as a bare type as plain text, without the
-        // type role a named one carries.
-        if (unnamed) {
-            writer.printf("* %s %n", displayType);
-            printOptions(writer, schema, RETURN_OPTION_LEVEL);
+        Schema<?> values = documentedValues == null ? schema : documentedValues;
+        // The doclet passes a return value documented without a macro through as written, so it
+        // carries neither the type role nor a label synthesised from the operation.
+        if (plainText) {
+            writer.printf("* %s%s %n", displayType, responseLabel.isBlank() ? "" : " - " + responseLabel);
+            printOptions(writer, values, RETURN_OPTION_LEVEL);
             writer.print(" ");
             return;
         }
@@ -574,7 +577,7 @@ public class OpenApiToAsciidocParser {
                         .toLowerCase().trim());
 
         writer.printf("* [.%s]#%s#  %s%n", displayType, displayType, label);
-        printOptions(writer, schema, RETURN_OPTION_LEVEL);
+        printOptions(writer, values, RETURN_OPTION_LEVEL);
         writer.print(" ");
     }
 
@@ -591,8 +594,10 @@ public class OpenApiToAsciidocParser {
                 .orElse("");
     }
 
-    private record LegacyDocResponseData(Schema<?> schema, String type, String name, boolean unnamed) {
-        private static final LegacyDocResponseData EMPTY = new LegacyDocResponseData(null, "", "", false);
+    private record LegacyDocResponseData(Schema<?> schema, String type, String name, boolean plainText,
+                                         Schema<?> values) {
+        private static final LegacyDocResponseData EMPTY =
+                new LegacyDocResponseData(null, "", "", false, null);
 
         Optional<String> label(String description) {
             if (name.isBlank()) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -435,6 +435,7 @@ public class OpenApiToAsciidocParser {
             writeStructProperty(writer, "", label, prop, level);
             printOptions(writer, prop, level + 1);
             printElementStruct(writer, prop, level + 1);
+            printSimpleElement(writer, prop, level);
             // A serializer referenced by a struct property brings its own struct label, which the
             // doclet renders as a sibling of the property before the fields it introduces.
             if (nested != null && !legacyDocName(nested).isEmpty()) {
@@ -490,6 +491,30 @@ public class OpenApiToAsciidocParser {
         }
         writer.printf("%s [.struct]#struct#  %s%n", "*".repeat(level), label);
         printStructProperties(writer, resolvedItems, level + 1);
+    }
+
+    /**
+     * Writes the named element of an array property that holds a simple type.
+     *
+     * The doclet names such an element with {@code #array_single}, which it renders as an item of
+     * its own beside a property documented as a bare array. A property documenting the element
+     * type on itself, with {@code #prop_array}, names the element there and shows no such item,
+     * so only a property declaring the bare array type carries one.
+     *
+     * @param writer the writer to write to
+     * @param property the array property schema
+     * @param level the bullet level of the property
+     */
+    private void printSimpleElement(PrintWriter writer, Schema<?> property, int level) {
+        String label = legacyDocName(property);
+        if (!ARRAY_TYPE.equals(legacyDocType(property)) || label.isEmpty()) {
+            return;
+        }
+        Schema<?> items = resolveSchemaReference(property.getItems());
+        if (items == null || !isSimpleType(items)) {
+            return;
+        }
+        writer.printf("%s [.array]#%s array#  %s%n", "*".repeat(level), structPropertyType(items), label);
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -217,7 +217,7 @@ public class OpenApiToAsciidocParser {
         }
 
         writer.println("\nReturns:\n");
-        writeReturn(writer, operation, entry.documentedByOverload());
+        writeReturn(writer, entry.documentedByOverload());
         writer.print("\n\n\n");
     }
 
@@ -322,10 +322,9 @@ public class OpenApiToAsciidocParser {
      * Writes the return value of a documented call.
      *
      * @param writer the writer to write to
-     * @param operation the operation the call belongs to, which names it
      * @param documentedByOverload the overload documenting the call, which describes what it answers
      */
-    private void writeReturn(PrintWriter writer, Operation operation, Operation documentedByOverload) {
+    private void writeReturn(PrintWriter writer, Operation documentedByOverload) {
         var responses = documentedByOverload.getResponses();
         if (responses == null) {
             return;

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -317,7 +317,8 @@ public class OpenApiToDocBookParser {
             schema = resolveSchemaReference(docSchema);
         }
 
-        String label = legacyDocResponse.label(responseDescription).orElseGet(() ->
+        String label = legacyDocResponse.unnamed() ? "" :
+                legacyDocResponse.label(responseDescription).orElseGet(() ->
                 !responseDescription.isBlank() ?
                 responseDescription :
                 fallbackLabel
@@ -339,7 +340,8 @@ public class OpenApiToDocBookParser {
         return new LegacyDocResponseData(
                 schema instanceof Schema<?> docSchema ? docSchema : null,
                 type,
-                name
+                name,
+                Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_UNNAMED_EXTENSION))
         );
     }
 
@@ -411,7 +413,9 @@ public class OpenApiToDocBookParser {
     private String renderSimpleReturn(Schema<?> schema, String label, String typeOverride) {
         String type = typeOverride.isBlank() ? formatSimpleType(schema) : typeOverride;
         String text = (label == null || label.isBlank()) ? type : type + " - " + label;
-        return String.format("<listitem><para>%s</para></listitem>", escapeXml(text));
+        String item = String.format("<listitem><para>%s</para></listitem>", escapeXml(text));
+        String options = renderOptions(schema);
+        return options.isEmpty() ? item : item + "\n" + options;
     }
 
     private String extensionString(ApiResponse response, String extensionName) {
@@ -491,14 +495,19 @@ public class OpenApiToDocBookParser {
             Schema<?> propSchema = prop;
             String desc = findDescription(propSchema);
             Schema<?> nested = resolveNestedStruct(propSchema);
-            String label = nested != null && !getLegacyDocName(propSchema).isBlank() ?
-                    getLegacyDocName(propSchema) : name;
+            // An array property spends its legacy name on the element struct, so only a scalar or
+            // struct property renames itself with it.
+            String label = "array".equals(propSchema.getType()) || getLegacyDocName(propSchema).isBlank() ?
+                    name : getLegacyDocName(propSchema);
             // the doclet labels a nested struct with #struct_begin, which does not quote the label
             String body = nested != null ? String.format("%s %s", formatType(propSchema), label) :
                     String.format("%s \"%s\"", formatType(propSchema), label);
             if (!desc.isBlank()) {
                 body += " - " + desc;
             }
+            // A serializer referenced by a struct property brings its own struct label, which the
+            // doclet renders as a sibling of the property before the fields it introduces.
+            String structLabel = nested == null ? "" : getLegacyDocName(nested);
             String elementStruct = nested != null ? renderNestedStructProperties(nested) :
                     renderElementStruct(propSchema);
             String options = renderOptions(propSchema);
@@ -506,6 +515,19 @@ public class OpenApiToDocBookParser {
                 sb.append("    <listitem><para>")
                   .append(escapeXml(body))
                   .append("</para></listitem>\n");
+                appendOptions(sb, options);
+                return;
+            }
+            if (!structLabel.isBlank()) {
+                sb.append("    <listitem><para>")
+                  .append(escapeXml(body))
+                  .append("</para></listitem>\n");
+                sb.append("    <listitem>\n");
+                sb.append("      <para>").append(escapeXml(String.format("struct %s", structLabel))).append("</para>\n");
+                sb.append("      <itemizedlist spacing=\"compact\">\n");
+                sb.append(indentLines(elementStruct, 8)).append("\n");
+                sb.append("      </itemizedlist>\n");
+                sb.append("    </listitem>\n");
                 appendOptions(sb, options);
                 return;
             }
@@ -875,8 +897,8 @@ public class OpenApiToDocBookParser {
         return out.toString();
     }
 
-    private record LegacyDocResponseData(Schema<?> schema, String type, String name) {
-        private static final LegacyDocResponseData EMPTY = new LegacyDocResponseData(null, "", "");
+    private record LegacyDocResponseData(Schema<?> schema, String type, String name, boolean unnamed) {
+        private static final LegacyDocResponseData EMPTY = new LegacyDocResponseData(null, "", "", false);
 
         Optional<String> label(String description) {
             if (name.isBlank()) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -349,8 +349,8 @@ public class OpenApiToDocBookParser {
                 type,
                 name,
                 Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_PLAIN_TEXT_EXTENSION)),
-                response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_VALUES_EXTENSION)
-                        instanceof Schema<?> values ? values : null
+                response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_VALUES_EXTENSION) instanceof
+                        Schema<?> values ? values : null
         );
     }
 
@@ -543,7 +543,8 @@ public class OpenApiToDocBookParser {
                   .append(escapeXml(body))
                   .append("</para></listitem>\n");
                 sb.append("    <listitem>\n");
-                sb.append("      <para>").append(escapeXml(String.format("struct %s", structLabel))).append("</para>\n");
+                sb.append("      <para>").append(escapeXml(String.format("struct %s", structLabel)))
+                  .append("</para>\n");
                 sb.append("      <itemizedlist spacing=\"compact\">\n");
                 sb.append(indentLines(elementStruct, 8)).append("\n");
                 sb.append("      </itemizedlist>\n");

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -395,7 +395,10 @@ public class OpenApiToDocBookParser {
     }
 
     private Schema<?> getResultSchema(Schema<?> schema) {
-        if (schema.getProperties() == null || !schema.getProperties().containsKey("result")) {
+        // The payload of a response is carried beside the status of the call, which tells the
+        // wrapper apart from a documented struct that happens to hold a property called result.
+        if (schema.getProperties() == null || !schema.getProperties().containsKey("result") ||
+                !schema.getProperties().containsKey("success")) {
             return null;
         }
         Object resultProp = schema.getProperties().get("result");

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -150,19 +150,19 @@ public class OpenApiToDocBookParser {
         List<String> optional = getFieldsByRequirement(op, false);
 
         for (List<String> params : UyuniSwaggerReader.expandOverloads(op, required, optional)) {
-            handler.calls.add(buildCallDoc(httpMethod, op, params,
-                    isSecurityRequired(UyuniSwaggerReader.operationForCall(op, params))));
+            handler.calls.add(buildCallDoc(httpMethod, op, params));
         }
     }
 
-    private CallDoc buildCallDoc(String httpMethod, Operation op,
-                                 List<String> activeParams, boolean securityRequired) {
+    private CallDoc buildCallDoc(String httpMethod, Operation op, List<String> activeParams) {
+        Operation documentedByOverload = UyuniSwaggerReader.operationForCall(op, activeParams);
         String name = Optional.ofNullable(op.getOperationId())
                 .filter(s -> !s.isBlank())
                 .orElse("");
         String description = buildDescription(op);
-        List<ParamDoc> params = buildParams(op, activeParams, securityRequired);
-        String returnDoc = buildReturnDoc(op, name, activeParams);
+        List<ParamDoc> params = buildParams(op, documentedByOverload, activeParams,
+                isSecurityRequired(documentedByOverload));
+        String returnDoc = buildReturnDoc(documentedByOverload, name);
         return new CallDoc(name, httpMethod, description, params, returnDoc);
     }
 
@@ -187,8 +187,8 @@ public class OpenApiToDocBookParser {
         return fields;
     }
 
-    private List<ParamDoc> buildParams(Operation op, List<String> activeParams,
-                                       boolean securityRequired) {
+    private List<ParamDoc> buildParams(Operation op, Operation documentedByOverload,
+                                       List<String> activeParams, boolean securityRequired) {
         List<ParamDoc> params = new ArrayList<>();
 
         if (securityRequired) {
@@ -196,7 +196,10 @@ public class OpenApiToDocBookParser {
                     "Session token, must be obtained via auth.login."));
         }
 
+        // A call takes the parameters of the overload documenting it, which describes the ones it
+        // shares with the others as its own signature declares them.
         Map<String, Schema<?>> allProps = getAllPossibleProperties(op);
+        allProps.putAll(getAllPossibleProperties(documentedByOverload));
         for (String name : activeParams) {
             Schema<?> schema = allProps.get(name);
             if (schema == null) {
@@ -286,8 +289,8 @@ public class OpenApiToDocBookParser {
         return props;
     }
 
-    private String buildReturnDoc(Operation op, String fallbackLabel, List<String> activeParams) {
-        ApiResponses responses = UyuniSwaggerReader.operationForCall(op, activeParams).getResponses();
+    private String buildReturnDoc(Operation op, String fallbackLabel) {
+        ApiResponses responses = op.getResponses();
         if (responses == null) {
             return "<listitem><para></para></listitem>";
         }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -40,6 +40,7 @@ import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 
 /**
  * Converts the generated OpenAPI specification into DocBook XML files.
@@ -145,12 +146,12 @@ public class OpenApiToDocBookParser {
         HandlerDoc handler = handlers.computeIfAbsent(tag,
                 k -> new HandlerDoc(k, getTagDescription(k)));
 
-        boolean securityRequired = isSecurityRequired(op);
         List<String> required = getFieldsByRequirement(op, true);
         List<String> optional = getFieldsByRequirement(op, false);
 
         for (List<String> params : UyuniSwaggerReader.expandOverloads(op, required, optional)) {
-            handler.calls.add(buildCallDoc(httpMethod, op, params, securityRequired));
+            handler.calls.add(buildCallDoc(httpMethod, op, params,
+                    isSecurityRequired(UyuniSwaggerReader.operationForCall(op, params))));
         }
     }
 
@@ -161,7 +162,7 @@ public class OpenApiToDocBookParser {
                 .orElse("");
         String description = buildDescription(op);
         List<ParamDoc> params = buildParams(op, activeParams, securityRequired);
-        String returnDoc = buildReturnDoc(op, name);
+        String returnDoc = buildReturnDoc(op, name, activeParams);
         return new CallDoc(name, httpMethod, description, params, returnDoc);
     }
 
@@ -285,11 +286,12 @@ public class OpenApiToDocBookParser {
         return props;
     }
 
-    private String buildReturnDoc(Operation op, String fallbackLabel) {
-        if (op.getResponses() == null) {
+    private String buildReturnDoc(Operation op, String fallbackLabel, List<String> activeParams) {
+        ApiResponses responses = UyuniSwaggerReader.operationForCall(op, activeParams).getResponses();
+        if (responses == null) {
             return "<listitem><para></para></listitem>";
         }
-        ApiResponse resp = op.getResponses().entrySet().stream()
+        ApiResponse resp = responses.entrySet().stream()
                 .filter(e -> e.getKey().startsWith("2") || e.getKey().equals("default"))
                 .map(Map.Entry::getValue)
                 .findFirst()

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -531,6 +531,7 @@ public class OpenApiToDocBookParser {
                 sb.append("    <listitem><para>")
                   .append(escapeXml(body))
                   .append("</para></listitem>\n");
+                appendSimpleElement(sb, propSchema);
                 appendOptions(sb, options);
                 return;
             }
@@ -556,6 +557,31 @@ public class OpenApiToDocBookParser {
             appendOptions(sb, options);
         });
         return sb.toString();
+    }
+
+    /**
+     * Appends the named element of an array property that holds a simple type.
+     *
+     * The doclet names such an element with {@code #array_single}, which it renders as an item of
+     * its own beside a property documented as a bare array. A property documenting the element
+     * type on itself, with {@code #prop_array}, names the element there and shows no such item,
+     * so only a property declaring the bare array type carries one.
+     *
+     * @param sb the markup being built
+     * @param property the array property schema
+     */
+    private void appendSimpleElement(StringBuilder sb, Schema<?> property) {
+        String label = getLegacyDocName(property);
+        if (!"array".equals(getLegacyDocType(property)) || label.isBlank()) {
+            return;
+        }
+        Schema<?> items = resolveSchemaReference(property.getItems());
+        if (items == null || !isSimpleType(items)) {
+            return;
+        }
+        sb.append("    <listitem><para>")
+          .append(escapeXml(String.format("array(%s) %s", formatSimpleType(items), label)))
+          .append("</para></listitem>\n");
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -317,7 +317,8 @@ public class OpenApiToDocBookParser {
             schema = resolveSchemaReference(docSchema);
         }
 
-        String label = legacyDocResponse.unnamed() ? "" :
+        String label = legacyDocResponse.plainText() ?
+                legacyDocResponse.label(responseDescription).orElse(responseDescription) :
                 legacyDocResponse.label(responseDescription).orElseGet(() ->
                 !responseDescription.isBlank() ?
                 responseDescription :
@@ -327,7 +328,8 @@ public class OpenApiToDocBookParser {
                         .toLowerCase().trim()
         );
 
-        return renderReturnSchema(schema, label, legacyDocResponse.type(), legacyDocResponse.name());
+        return renderReturnSchema(schema, label, legacyDocResponse.type(), legacyDocResponse.name(),
+                legacyDocResponse.values());
     }
 
     private LegacyDocResponseData getLegacyDocResponse(ApiResponse response) {
@@ -341,16 +343,23 @@ public class OpenApiToDocBookParser {
                 schema instanceof Schema<?> docSchema ? docSchema : null,
                 type,
                 name,
-                Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_UNNAMED_EXTENSION))
+                Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_PLAIN_TEXT_EXTENSION)),
+                response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_VALUES_EXTENSION)
+                        instanceof Schema<?> values ? values : null
         );
     }
 
     private String renderReturnSchema(Schema<?> schema, String label) {
-        return renderReturnSchema(schema, label, "", "");
+        return renderReturnSchema(schema, label, "", "", null);
     }
 
     private String renderReturnSchema(Schema<?> schema, String label, String typeOverride,
                                       String legacyStructLabel) {
+        return renderReturnSchema(schema, label, typeOverride, legacyStructLabel, null);
+    }
+
+    private String renderReturnSchema(Schema<?> schema, String label, String typeOverride,
+                                      String legacyStructLabel, Schema<?> documentedValues) {
         if (schema == null) {
             return "<listitem><para></para></listitem>";
         }
@@ -360,7 +369,8 @@ public class OpenApiToDocBookParser {
                     resolveSchemaReference(resultSchema),
                     getResultLabel(resultSchema, label),
                     typeOverride,
-                    legacyStructLabel
+                    legacyStructLabel,
+                    documentedValues
             );
         }
         if ("array".equals(schema.getType()) && schema.getItems() != null) {
@@ -370,7 +380,8 @@ public class OpenApiToDocBookParser {
         // that are not simple: the doclet renders those as a single typed line, without expanding
         // the schema.
         if (isSimpleType(schema) || !typeOverride.isBlank()) {
-            return renderSimpleReturn(schema, label, typeOverride);
+            return renderSimpleReturn(documentedValues == null ? schema : documentedValues, label, typeOverride,
+                    schema);
         }
         if (schema.getAdditionalProperties() instanceof Schema<?> inner) {
             return renderAdditionalPropertiesReturn(inner, label);
@@ -410,11 +421,11 @@ public class OpenApiToDocBookParser {
         return sb.toString();
     }
 
-    private String renderSimpleReturn(Schema<?> schema, String label, String typeOverride) {
+    private String renderSimpleReturn(Schema<?> values, String label, String typeOverride, Schema<?> schema) {
         String type = typeOverride.isBlank() ? formatSimpleType(schema) : typeOverride;
         String text = (label == null || label.isBlank()) ? type : type + " - " + label;
         String item = String.format("<listitem><para>%s</para></listitem>", escapeXml(text));
-        String options = renderOptions(schema);
+        String options = renderOptions(values);
         return options.isEmpty() ? item : item + "\n" + options;
     }
 
@@ -897,8 +908,10 @@ public class OpenApiToDocBookParser {
         return out.toString();
     }
 
-    private record LegacyDocResponseData(Schema<?> schema, String type, String name, boolean unnamed) {
-        private static final LegacyDocResponseData EMPTY = new LegacyDocResponseData(null, "", "", false);
+    private record LegacyDocResponseData(Schema<?> schema, String type, String name, boolean plainText,
+                                         Schema<?> values) {
+        private static final LegacyDocResponseData EMPTY =
+                new LegacyDocResponseData(null, "", "", false, null);
 
         Optional<String> label(String description) {
             if (name.isBlank()) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -208,10 +208,12 @@ public class OpenApiToDocBookParser {
                 params.add(new ParamDoc(legacyType.isEmpty() ? "struct" : legacyType, name, desc));
                 resolved.getProperties().forEach((propName, propSchema) ->
                         params.add(new ParamDoc(formatType(propSchema), "\"" + propName + "\"",
-                                findDescription(propSchema), renderParameterElement(propSchema))));
+                                findDescription(propSchema), renderParameterElement(propSchema),
+                                renderOptions(propSchema))));
                 continue;
             }
-            params.add(new ParamDoc(formatType(schema), name, desc, renderParameterElement(schema)));
+            params.add(new ParamDoc(formatType(schema), name, desc, renderParameterElement(schema),
+                    renderOptions(schema)));
         }
         return params;
     }
@@ -499,10 +501,12 @@ public class OpenApiToDocBookParser {
             }
             String elementStruct = nested != null ? renderNestedStructProperties(nested) :
                     renderElementStruct(propSchema);
+            String options = renderOptions(propSchema);
             if (elementStruct.isEmpty()) {
                 sb.append("    <listitem><para>")
                   .append(escapeXml(body))
                   .append("</para></listitem>\n");
+                appendOptions(sb, options);
                 return;
             }
             sb.append("    <listitem>\n");
@@ -511,6 +515,7 @@ public class OpenApiToDocBookParser {
             sb.append(indentLines(elementStruct, 8)).append("\n");
             sb.append("      </itemizedlist>\n");
             sb.append("    </listitem>\n");
+            appendOptions(sb, options);
         });
         return sb.toString();
     }
@@ -534,6 +539,84 @@ public class OpenApiToDocBookParser {
         return renderStructList(resolvedItems,
                 items.get$ref() != null ? extractRefName(items.get$ref()) : "",
                 getLegacyDocName(property));
+    }
+
+    /**
+     * Renders the documented values of a parameter or property as a sibling item list.
+     *
+     * The doclet renders {@code #options()} as a separate {@code <listitem override="none">}
+     * following the item it documents, and appends the description after a dash for the
+     * {@code #item_desc} form.
+     *
+     * @param schema the parameter or property schema
+     * @return the markup for the values, or an empty string when there are none
+     */
+    private void writeOptions(PrintWriter w, String options) {
+        if (!options.isEmpty()) {
+            w.printf("%s%n", indentLines(options, 12));
+        }
+    }
+
+    private void appendOptions(StringBuilder sb, String options) {
+        if (!options.isEmpty()) {
+            sb.append(indentLines(options, 4)).append("\n");
+        }
+    }
+
+    private String renderOptions(Schema<?> schema) {
+        Schema<?> documented = optionsSchema(schema);
+        if (documented == null || documented.getEnum() == null) {
+            return "";
+        }
+        Map<String, String> descriptions = optionDescriptions(documented);
+        StringBuilder sb = new StringBuilder();
+        sb.append("<listitem override=\"none\">\n");
+        sb.append("  <itemizedlist spacing=\"compact\">\n");
+        for (Object value : documented.getEnum()) {
+            String option = String.valueOf(value);
+            String description = descriptions.getOrDefault(option, "");
+            sb.append("  <listitem><para>")
+              .append(escapeXml(description.isEmpty() ? option : option + " - " + description))
+              .append("</para></listitem>\n");
+        }
+        sb.append("  </itemizedlist>\n");
+        sb.append("</listitem>");
+        return sb.toString();
+    }
+
+    /**
+     * Resolves the schema that carries the documented values.
+     *
+     * An array documents the values of its element type; every other parameter or property
+     * documents its own.
+     *
+     * @param schema the parameter or property schema
+     * @return the schema holding the values, or null when there is none
+     */
+    private Schema<?> optionsSchema(Schema<?> schema) {
+        if (schema == null) {
+            return null;
+        }
+        return "array".equals(schema.getType()) && schema.getItems() != null ?
+                resolveSchemaReference(schema.getItems()) : schema;
+    }
+
+    /**
+     * Reads the descriptions the namespace documented for individual values.
+     *
+     * @param schema the schema holding the values
+     * @return the description of each value, empty when the values carry none
+     */
+    private Map<String, String> optionDescriptions(Schema<?> schema) {
+        Object descriptions = schema.getExtensions() == null ? null :
+                schema.getExtensions().get(UyuniSwaggerReader.DOC_OPTION_DESCRIPTIONS_EXTENSION);
+        if (!(descriptions instanceof Map<?, ?> documented)) {
+            return Map.of();
+        }
+        Map<String, String> byOption = new LinkedHashMap<>();
+        documented.forEach((option, description) ->
+                byOption.put(String.valueOf(option), String.valueOf(description)));
+        return byOption;
     }
 
     private String renderHandlerFile(HandlerDoc handler) {
@@ -581,6 +664,7 @@ public class OpenApiToDocBookParser {
                         String.format("%s %s - %s", p.type, p.name, p.description);
                 if (p.nested.isEmpty()) {
                     w.printf("            <listitem><para>%s</para></listitem>%n", escapeXml(body));
+                    writeOptions(w, p.options);
                     continue;
                 }
                 w.printf("            <listitem>%n");
@@ -589,6 +673,7 @@ public class OpenApiToDocBookParser {
                 w.printf("%s%n", indentLines(p.nested, 16));
                 w.printf("              </itemizedlist>%n");
                 w.printf("            </listitem>%n");
+                writeOptions(w, p.options);
             }
         }
         w.printf("          </itemizedlist>%n");
@@ -840,15 +925,20 @@ public class OpenApiToDocBookParser {
         /** Pre-rendered element markup nested under this parameter, empty when there is none. */
         private final String nested;
 
+        /** Pre-rendered value list following this parameter, empty when there is none. */
+        private final String options;
+
         ParamDoc(String paramType, String paramName, String paramDescription) {
-            this(paramType, paramName, paramDescription, "");
+            this(paramType, paramName, paramDescription, "", "");
         }
 
-        ParamDoc(String paramType, String paramName, String paramDescription, String nestedMarkup) {
+        ParamDoc(String paramType, String paramName, String paramDescription, String nestedMarkup,
+                 String optionsMarkup) {
             this.type = paramType;
             this.name = paramName;
             this.description = paramDescription;
             this.nested = nestedMarkup;
+            this.options = optionsMarkup;
         }
     }
 }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -162,7 +162,7 @@ public class OpenApiToDocBookParser {
         String description = buildDescription(op);
         List<ParamDoc> params = buildParams(op, documentedByOverload, activeParams,
                 isSecurityRequired(documentedByOverload));
-        String returnDoc = buildReturnDoc(documentedByOverload, name);
+        String returnDoc = buildReturnDoc(documentedByOverload);
         return new CallDoc(name, httpMethod, description, params, returnDoc);
     }
 
@@ -289,7 +289,7 @@ public class OpenApiToDocBookParser {
         return props;
     }
 
-    private String buildReturnDoc(Operation op, String fallbackLabel) {
+    private String buildReturnDoc(Operation op) {
         ApiResponses responses = op.getResponses();
         if (responses == null) {
             return "<listitem><para></para></listitem>";
@@ -322,16 +322,9 @@ public class OpenApiToDocBookParser {
             schema = resolveSchemaReference(docSchema);
         }
 
-        String label = legacyDocResponse.plainText() ?
-                legacyDocResponse.label(responseDescription).orElse(responseDescription) :
-                legacyDocResponse.label(responseDescription).orElseGet(() ->
-                !responseDescription.isBlank() ?
-                responseDescription :
-                fallbackLabel
-                        .replaceAll("^(get|list|is|set|create|delete|update)", "")
-                        .replaceAll("([a-z])([A-Z])", "$1 $2")
-                        .toLowerCase().trim()
-        );
+        // The doclet renders the label the namespace documented and invents none, so a return
+        // value documented without one carries no label.
+        String label = legacyDocResponse.label(responseDescription).orElse(responseDescription);
 
         return renderReturnSchema(schema, label, legacyDocResponse.type(), legacyDocResponse.name(),
                 legacyDocResponse.values());

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
@@ -75,6 +76,9 @@ public class UyuniSwaggerReader {
     public static final String DOC_OVERLOAD_ARITIES_EXTENSION = "x-uyuni-doc-overload-arities";
 
     public static final String DOC_OVERLOAD_SHAPES_EXTENSION = "x-uyuni-doc-overload-shapes";
+
+    /** Facts a documented call takes from its own overload rather than from the merged operation. */
+    public static final String DOC_OVERLOAD_CALLS_EXTENSION = "x-uyuni-doc-overload-calls";
 
     /** Extension holding the description the namespace documented for each allowed value. */
     public static final String DOC_OPTION_DESCRIPTIONS_EXTENSION = "x-uyuni-doc-option-descriptions";
@@ -662,7 +666,8 @@ public class UyuniSwaggerReader {
      */
     private Operation mergeAlternativeOverload(Operation documented, Operation alternative) {
         List<List<String>> calls = new ArrayList<>(documentedCalls(documented));
-        documentedCalls(alternative).stream().filter(call -> !calls.contains(call)).forEach(calls::add);
+        List<List<String>> alternativeCalls = documentedCalls(alternative);
+        alternativeCalls.stream().filter(call -> !calls.contains(call)).forEach(calls::add);
 
         if (alternative.getParameters() != null) {
             alternative.getParameters().stream()
@@ -685,8 +690,90 @@ public class UyuniSwaggerReader {
                     .toList());
         }
 
+        recordAlternativeCalls(documented, alternative, alternativeCalls);
         documented.addExtension(DOC_OVERLOAD_SHAPES_EXTENSION, calls);
         return documented;
+    }
+
+    /**
+     * Keeps what an overload documents differently from the ones read before it.
+     *
+     * The overloads sharing an endpoint are one operation, which is documented once, while the
+     * legacy doclet documents each overload on its own: overloads may answer with a different
+     * return value, authenticate differently, or be deprecated one at a time. The calls such an
+     * overload stands for are therefore recorded against what it documents, so that each call is
+     * described by the overload it comes from rather than by the first overload read.
+     *
+     * @param documented the operation built from the overloads read so far
+     * @param alternative the operation built from an overload taking different parameters
+     * @param alternativeCalls the calls the alternative overload stands for
+     */
+    private void recordAlternativeCalls(Operation documented, Operation alternative,
+                                        List<List<String>> alternativeCalls) {
+        if (!documentsDifferently(documented, alternative)) {
+            return;
+        }
+        Operation documentedByOverload = new Operation()
+                .responses(alternative.getResponses())
+                .security(alternative.getSecurity())
+                .deprecated(Boolean.TRUE.equals(alternative.getDeprecated()));
+
+        Map<String, Operation> calls = new LinkedHashMap<>(recordedCalls(documented));
+        alternativeCalls.forEach(call -> calls.putIfAbsent(callKey(call), documentedByOverload));
+        documented.addExtension(DOC_OVERLOAD_CALLS_EXTENSION, calls);
+    }
+
+    /**
+     * Tells whether an overload documents anything differently from the operation it folds into.
+     *
+     * @param documented the operation built from the overloads read so far
+     * @param alternative the operation built from an overload taking different parameters
+     * @return whether the alternative overload needs its calls recorded
+     */
+    private boolean documentsDifferently(Operation documented, Operation alternative) {
+        return !Objects.equals(documented.getResponses(), alternative.getResponses()) ||
+                !Objects.equals(documented.getSecurity(), alternative.getSecurity()) ||
+                Boolean.TRUE.equals(documented.getDeprecated()) !=
+                        Boolean.TRUE.equals(alternative.getDeprecated());
+    }
+
+    /**
+     * Reads what the overloads of an operation document for the calls they stand for.
+     *
+     * @param operation the operation to read
+     * @return what each recorded call documents, keyed by call
+     */
+    private static Map<String, Operation> recordedCalls(Operation operation) {
+        Object recorded = operation.getExtensions() == null ?
+                null : operation.getExtensions().get(DOC_OVERLOAD_CALLS_EXTENSION);
+        if (!(recorded instanceof Map<?, ?> byCall)) {
+            return Map.of();
+        }
+        Map<String, Operation> calls = new LinkedHashMap<>();
+        byCall.forEach((call, documented) -> {
+            if (documented instanceof Operation documentedByOverload) {
+                calls.put(String.valueOf(call), documentedByOverload);
+            }
+        });
+        return calls;
+    }
+
+    /**
+     * Reads what a documented call documents of its own.
+     *
+     * A call is described by the overload it comes from, which is the operation itself unless
+     * another overload documented that call differently.
+     *
+     * @param operation the operation the call belongs to
+     * @param call the parameters of the documented call
+     * @return the operation documenting the call
+     */
+    public static Operation operationForCall(Operation operation, List<String> call) {
+        return recordedCalls(operation).getOrDefault(callKey(call), operation);
+    }
+
+    private static String callKey(List<String> call) {
+        return String.join(",", call);
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -24,7 +24,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -69,6 +71,8 @@ public class UyuniSwaggerReader {
     public static final String DOC_RESPONSE_UNNAMED_EXTENSION = "x-uyuni-doc-response-unnamed";
     /** Parameter counts of the handler overloads an operation stands for, longest first. */
     public static final String DOC_OVERLOAD_ARITIES_EXTENSION = "x-uyuni-doc-overload-arities";
+
+    public static final String DOC_OVERLOAD_SHAPES_EXTENSION = "x-uyuni-doc-overload-shapes";
 
     /** Extension holding the description the namespace documented for each allowed value. */
     public static final String DOC_OPTION_DESCRIPTIONS_EXTENSION = "x-uyuni-doc-option-descriptions";
@@ -181,6 +185,46 @@ public class UyuniSwaggerReader {
         }
     }
 
+    private List<String> documentedParameters(Operation operation) {
+        List<String> names = new ArrayList<>();
+        if (operation.getParameters() != null) {
+            operation.getParameters().forEach(parameter -> names.add(parameter.getName()));
+        }
+        Schema<?> body = requestBodySchema(operation);
+        if (body != null && body.getProperties() != null) {
+            names.addAll(body.getProperties().keySet());
+        }
+        return names;
+    }
+
+    private boolean isRequired(Operation operation, String name) {
+        if (operation.getParameters() != null) {
+            for (var parameter : operation.getParameters()) {
+                if (name.equals(parameter.getName())) {
+                    return Boolean.TRUE.equals(parameter.getRequired());
+                }
+            }
+        }
+        Schema<?> body = requestBodySchema(operation);
+        return body != null && body.getRequired() != null && body.getRequired().contains(name);
+    }
+
+    private Schema<?> requestBodySchema(Operation operation) {
+        if (operation.getRequestBody() == null || operation.getRequestBody().getContent() == null) {
+            return null;
+        }
+        MediaType mediaType = operation.getRequestBody().getContent().get(DEFAULT_MEDIA_TYPE);
+        if (mediaType == null || mediaType.getSchema() == null) {
+            return null;
+        }
+        Schema<?> schema = mediaType.getSchema();
+        if (schema.get$ref() == null || this.components.getSchemas() == null) {
+            return schema;
+        }
+        return this.components.getSchemas()
+                .get(schema.get$ref().substring(schema.get$ref().lastIndexOf('/') + 1));
+    }
+
     /**
      * Lists the parameter combinations the legacy doclet documents for an operation.
      *
@@ -196,6 +240,11 @@ public class UyuniSwaggerReader {
      */
     public static List<List<String>> expandOverloads(Operation operation, List<String> required,
                                                      List<String> optional) {
+        List<List<String>> resolved = overloadShapes(operation);
+        if (resolved != null) {
+            return resolved;
+        }
+
         List<List<String>> combinations = new ArrayList<>();
         for (int count : optionalParameterCounts(operation, required.size(), optional.size())) {
             List<String> params = new ArrayList<>(required);
@@ -203,6 +252,27 @@ public class UyuniSwaggerReader {
             combinations.add(params);
         }
         return combinations;
+    }
+
+    /**
+     * Reads the parameters of each documented call, when counting them cannot describe them.
+     *
+     * @param operation the operation to expand
+     * @return the parameters of each documented call, or null when the counts describe them
+     */
+    private static List<List<String>> overloadShapes(Operation operation) {
+        Object shapes = operation.getExtensions() == null ?
+                null : operation.getExtensions().get(DOC_OVERLOAD_SHAPES_EXTENSION);
+        if (!(shapes instanceof List<?> recorded) || recorded.isEmpty()) {
+            return null;
+        }
+        List<List<String>> calls = new ArrayList<>();
+        for (Object shape : recorded) {
+            if (shape instanceof List<?> parameters) {
+                calls.add(parameters.stream().map(String::valueOf).toList());
+            }
+        }
+        return calls.isEmpty() ? null : calls;
     }
 
     /**
@@ -552,7 +622,109 @@ public class UyuniSwaggerReader {
     private void registerOperationOnPath(String namespace, Method method, HttpMethod httpMethod, Operation operation) {
         String path = buildPath(namespace, method.getName());
         PathItem pathItem = openAPI.getPaths().computeIfAbsent(path, key -> new PathItem());
-        setOperationOnPathItem(pathItem, httpMethod, operation);
+        Operation documented = getOperationOnPathItem(pathItem, httpMethod);
+        setOperationOnPathItem(pathItem, httpMethod,
+                documented == null ? operation : mergeAlternativeOverload(documented, operation));
+    }
+
+    /**
+     * Folds an overload taking different parameters into the operation already documented.
+     *
+     * Overloads of a handler method answer on one endpoint, so they are one operation, while the
+     * legacy doclet documents one call per overload. An overload that only takes further
+     * parameters is described by the optional ones it leaves out, but an overload taking a
+     * different parameter instead has to contribute that parameter, and the calls it stands for,
+     * to the operation the others share.
+     *
+     * @param documented the operation built from the overloads read so far
+     * @param alternative the operation built from an overload taking different parameters
+     * @return the operation standing for both
+     */
+    private Operation mergeAlternativeOverload(Operation documented, Operation alternative) {
+        List<List<String>> calls = new ArrayList<>(documentedCalls(documented));
+        documentedCalls(alternative).stream().filter(call -> !calls.contains(call)).forEach(calls::add);
+
+        if (alternative.getParameters() != null) {
+            alternative.getParameters().stream()
+                    .filter(parameter -> !documentedParameters(documented).contains(parameter.getName()))
+                    .forEach(parameter -> documented.addParametersItem(parameter));
+        }
+        mergeRequestBodies(documented, alternative);
+
+        // A parameter the operation does not take in every call is optional, whichever overload
+        // introduced it.
+        if (documented.getParameters() != null) {
+            documented.getParameters().stream()
+                    .filter(parameter -> !calls.stream().allMatch(call -> call.contains(parameter.getName())))
+                    .forEach(parameter -> parameter.setRequired(false));
+        }
+        Schema<?> body = requestBodySchema(documented);
+        if (body != null && body.getRequired() != null) {
+            body.setRequired(body.getRequired().stream()
+                    .filter(name -> calls.stream().allMatch(call -> call.contains(name)))
+                    .toList());
+        }
+
+        documented.addExtension(DOC_OVERLOAD_SHAPES_EXTENSION, calls);
+        return documented;
+    }
+
+    /**
+     * Merges the request body of an alternative overload into the documented one.
+     *
+     * Two overloads sending different bodies describe one payload holding the properties of both,
+     * so the merged body is spelled out rather than referring to either side's schema.
+     *
+     * @param documented the operation built from the overloads read so far
+     * @param alternative the operation built from an overload taking different parameters
+     */
+    private void mergeRequestBodies(Operation documented, Operation alternative) {
+        Schema<?> alternativeBody = requestBodySchema(alternative);
+        if (alternativeBody == null || alternativeBody.getProperties() == null) {
+            return;
+        }
+        if (documented.getRequestBody() == null) {
+            documented.setRequestBody(alternative.getRequestBody());
+            return;
+        }
+        Schema<?> documentedBody = requestBodySchema(documented);
+        if (documentedBody == null || documentedBody.getProperties() == null) {
+            return;
+        }
+
+        Schema<Object> merged = new Schema<>().type("object");
+        merged.setProperties(new LinkedHashMap<>(documentedBody.getProperties()));
+        merged.setRequired(documentedBody.getRequired() == null ?
+                new ArrayList<>() : new ArrayList<>(documentedBody.getRequired()));
+        alternativeBody.getProperties().forEach((name, property) -> {
+            if (!merged.getProperties().containsKey(name)) {
+                merged.addProperty(name, property);
+            }
+        });
+        documented.getRequestBody().getContent().get(DEFAULT_MEDIA_TYPE).setSchema(merged);
+    }
+
+    /**
+     * Lists the calls an operation stands for on its own.
+     *
+     * @param operation the operation to expand
+     * @return the parameters of each documented call
+     */
+    private List<List<String>> documentedCalls(Operation operation) {
+        List<String> documented = documentedParameters(operation);
+        return expandOverloads(operation,
+                documented.stream().filter(name -> isRequired(operation, name)).toList(),
+                documented.stream().filter(name -> !isRequired(operation, name)).toList());
+    }
+
+    private Operation getOperationOnPathItem(PathItem pathItem, HttpMethod httpMethod) {
+        return switch (httpMethod) {
+            case get -> pathItem.getGet();
+            case put -> pathItem.getPut();
+            case delete -> pathItem.getDelete();
+            case patch -> pathItem.getPatch();
+            default -> pathItem.getPost();
+        };
     }
 
     private String buildPath(String namespace, String methodName) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -68,7 +68,9 @@ public class UyuniSwaggerReader {
     public static final String DOC_RESPONSE_TYPE_EXTENSION = "x-uyuni-doc-response-type";
     public static final String DOC_RESPONSE_NAME_EXTENSION = "x-uyuni-doc-response-name";
 
-    public static final String DOC_RESPONSE_UNNAMED_EXTENSION = "x-uyuni-doc-response-unnamed";
+    public static final String DOC_RESPONSE_PLAIN_TEXT_EXTENSION = "x-uyuni-doc-response-plain-text";
+
+    public static final String DOC_RESPONSE_VALUES_EXTENSION = "x-uyuni-doc-response-values";
     /** Parameter counts of the handler overloads an operation stands for, longest first. */
     public static final String DOC_OVERLOAD_ARITIES_EXTENSION = "x-uyuni-doc-overload-arities";
 
@@ -463,12 +465,6 @@ public class UyuniSwaggerReader {
                     default -> new StringSchema();
                 };
 
-                var responseSchemaAnnotation =
-                        findMethodAnnotation(method, io.swagger.v3.oas.annotations.media.Schema.class);
-                if (responseSchemaAnnotation != null) {
-                    applyDocumentedValues(schema, responseSchemaAnnotation);
-                }
-
                 mediaType.setSchema(schema);
                 content.addMediaType(DEFAULT_MEDIA_TYPE, mediaType);
                 response.setContent(content);
@@ -483,7 +479,31 @@ public class UyuniSwaggerReader {
             apiResponses.addApiResponse(HTTP_200, addLegacyDocResponse(apiDoc, response));
         }
 
+        applyDocumentedReturnValues(method, apiResponses);
         operation.setResponses(apiResponses);
+    }
+
+    /**
+     * Carries the values a return value documents into the specification.
+     *
+     * A return value is documented on the operation, the only place an annotation can reach the
+     * result of a wrapped response, and the values it lists travel with the response rather than
+     * with the schema, which a wrapper shares with every other operation returning it.
+     *
+     * @param method the handler method backing the operation
+     * @param apiResponses the responses of the operation
+     */
+    private void applyDocumentedReturnValues(Method method, ApiResponses apiResponses) {
+        var annotation = findMethodAnnotation(method, io.swagger.v3.oas.annotations.media.Schema.class);
+        ApiResponse response = apiResponses.get(HTTP_200);
+        if (annotation == null || response == null) {
+            return;
+        }
+        Schema<?> values = new Schema<>();
+        applyDocumentedValues(values, annotation);
+        if (values.getEnum() != null && !values.getEnum().isEmpty()) {
+            response.addExtension(DOC_RESPONSE_VALUES_EXTENSION, values);
+        }
     }
 
     private void processApiResponseClass(ApiEndpointDoc apiDoc, ApiResponses apiResponses) {
@@ -521,8 +541,8 @@ public class UyuniSwaggerReader {
         if (!legacyDocResponse.name().isBlank()) {
             response.addExtension(DOC_RESPONSE_NAME_EXTENSION, legacyDocResponse.name());
         }
-        if (legacyDocResponse.unnamed()) {
-            response.addExtension(DOC_RESPONSE_UNNAMED_EXTENSION, Boolean.TRUE);
+        if (legacyDocResponse.plainText()) {
+            response.addExtension(DOC_RESPONSE_PLAIN_TEXT_EXTENSION, Boolean.TRUE);
         }
         return response;
     }
@@ -531,7 +551,7 @@ public class UyuniSwaggerReader {
         return legacyDocResponse.responseClass() == Void.class &&
                 legacyDocResponse.type().isBlank() &&
                 legacyDocResponse.name().isBlank() &&
-                !legacyDocResponse.unnamed();
+                !legacyDocResponse.plainText();
     }
 
     private void processLiteralParameters(Method method, Operation operation) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.stream.IntStream;
 
 import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.util.AnnotationsUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -441,17 +442,42 @@ public class UyuniSwaggerReader {
     private Parameter mapToOpenApiParameter(
             io.swagger.v3.oas.annotations.Parameter parameterAnnotation,
             Type type) {
+        Schema<?> schema = literalParameterSchema(type);
+        applyDocumentedValues(schema, parameterAnnotation.schema());
         Parameter openApiParam = new Parameter()
                 .name(parameterAnnotation.name())
                 .required(parameterAnnotation.required())
                 .in(parameterAnnotation.in().toString().toLowerCase())
-                .schema(literalParameterSchema(type));
+                .schema(schema);
 
         if (!parameterAnnotation.description().isBlank()) {
             openApiParam.setDescription(parameterAnnotation.description());
         }
 
         return openApiParam;
+    }
+
+    /**
+     * Carries the values a literal parameter documents onto its schema.
+     *
+     * The type of a literal parameter is derived from its declared Java type, so the documented
+     * values are the only part of the annotation left to read. An array parameter documents the
+     * values of its element type, the same way an array property does.
+     *
+     * @param schema the schema built from the declared type
+     * @param annotation the schema annotation of the parameter
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void applyDocumentedValues(Schema<?> schema, io.swagger.v3.oas.annotations.media.Schema annotation) {
+        AnnotationsUtils.getSchemaFromAnnotation(annotation, null)
+                .filter(documented -> documented.getEnum() != null && !documented.getEnum().isEmpty())
+                .ifPresent(documented -> {
+                    Schema target = schema.getItems() != null ? schema.getItems() : schema;
+                    target.setEnum(documented.getEnum());
+                    if (documented.getExtensions() != null) {
+                        target.setExtensions(documented.getExtensions());
+                    }
+                });
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -580,7 +580,7 @@ public class UyuniSwaggerReader {
     private Parameter mapToOpenApiParameter(
             io.swagger.v3.oas.annotations.Parameter parameterAnnotation,
             Type type) {
-        Schema<?> schema = literalParameterSchema(type);
+        Schema<?> schema = documentedParameterSchema(parameterAnnotation, type);
         applyDocumentedValues(schema, parameterAnnotation.schema());
         Parameter openApiParam = new Parameter()
                 .name(parameterAnnotation.name())
@@ -616,6 +616,28 @@ public class UyuniSwaggerReader {
                         target.setExtensions(documented.getExtensions());
                     }
                 });
+    }
+
+    /**
+     * Resolves the schema describing a literal parameter.
+     *
+     * A parameter documented as a struct cannot be described by its declared type, a map naming
+     * none of the properties the namespace documents, so the class standing for the struct is
+     * named on the parameter and its schema is built from that class, the way a request body is.
+     *
+     * @param parameterAnnotation the annotation documenting the parameter
+     * @param type the declared parameter type
+     * @return the schema describing the parameter
+     */
+    private Schema<?> documentedParameterSchema(io.swagger.v3.oas.annotations.Parameter parameterAnnotation,
+                                                Type type) {
+        Class<?> documentedClass = parameterAnnotation.schema().implementation();
+        if (documentedClass == Void.class) {
+            return literalParameterSchema(type);
+        }
+        resolveAndRegisterSchema(documentedClass);
+        applyLegacyDocTypes(documentedClass);
+        return buildSchemaRef(documentedClass);
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -46,6 +46,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.DateTimeSchema;
 import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
@@ -639,6 +640,9 @@ public class UyuniSwaggerReader {
         return switch (typeName) {
             case "int", "java.lang.Integer" -> new IntegerSchema();
             case "boolean", "java.lang.Boolean" -> new BooleanSchema();
+            // A date reaches the specification as a string carrying the date-time format, the
+            // shape the model converter gives a date property of a request body.
+            case "java.util.Date" -> new DateTimeSchema();
             default -> new StringSchema();
         };
     }

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -718,6 +718,8 @@ public class UyuniSwaggerReader {
             return;
         }
         Operation documentedByOverload = new Operation()
+                .parameters(alternative.getParameters())
+                .requestBody(alternative.getRequestBody())
                 .responses(alternative.getResponses())
                 .security(alternative.getSecurity())
                 .deprecated(Boolean.TRUE.equals(alternative.getDeprecated()));
@@ -738,7 +740,44 @@ public class UyuniSwaggerReader {
         return !Objects.equals(documented.getResponses(), alternative.getResponses()) ||
                 !Objects.equals(documented.getSecurity(), alternative.getSecurity()) ||
                 Boolean.TRUE.equals(documented.getDeprecated()) !=
-                        Boolean.TRUE.equals(alternative.getDeprecated());
+                        Boolean.TRUE.equals(alternative.getDeprecated()) ||
+                documentsParameterDifferently(documented, alternative);
+    }
+
+    /**
+     * Tells whether an overload describes a parameter both overloads take differently.
+     *
+     * Overloads taking a parameter of the same name in different types describe one property, so
+     * the operation can only hold one of the two, while the legacy doclet documents each overload
+     * with the type its own signature declares.
+     *
+     * @param documented the operation built from the overloads read so far
+     * @param alternative the operation built from an overload taking different parameters
+     * @return whether a parameter the two overloads share is described differently
+     */
+    private boolean documentsParameterDifferently(Operation documented, Operation alternative) {
+        Map<String, Schema<?>> described = describedParameters(documented);
+        return describedParameters(alternative).entrySet().stream()
+                .anyMatch(parameter -> described.containsKey(parameter.getKey()) &&
+                        !Objects.equals(described.get(parameter.getKey()), parameter.getValue()));
+    }
+
+    /**
+     * Reads the schema describing each parameter of an operation, wherever the parameter is sent.
+     *
+     * @param operation the operation to read
+     * @return the schema of each parameter, keyed by name
+     */
+    private Map<String, Schema<?>> describedParameters(Operation operation) {
+        Map<String, Schema<?>> described = new LinkedHashMap<>();
+        if (operation.getParameters() != null) {
+            operation.getParameters().forEach(parameter -> described.put(parameter.getName(), parameter.getSchema()));
+        }
+        Schema<?> body = requestBodySchema(operation);
+        if (body != null && body.getProperties() != null) {
+            body.getProperties().forEach((name, property) -> described.put(name, property));
+        }
+        return described;
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -66,6 +66,9 @@ public class UyuniSwaggerReader {
     public static final String DOC_RESPONSE_NAME_EXTENSION = "x-uyuni-doc-response-name";
     /** Parameter counts of the handler overloads an operation stands for, longest first. */
     public static final String DOC_OVERLOAD_ARITIES_EXTENSION = "x-uyuni-doc-overload-arities";
+
+    /** Extension holding the description the namespace documented for each allowed value. */
+    public static final String DOC_OPTION_DESCRIPTIONS_EXTENSION = "x-uyuni-doc-option-descriptions";
     public static final String DEFAULT_MEDIA_TYPE = "application/json";
     public static final String HTTP_200 = "200";
     /** Legacy name for a date, bound as {@code $date} in the doclet's macros for both formats. */

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -65,6 +65,8 @@ public class UyuniSwaggerReader {
     public static final String DOC_RESPONSE_SCHEMA_EXTENSION = "x-uyuni-doc-response-schema";
     public static final String DOC_RESPONSE_TYPE_EXTENSION = "x-uyuni-doc-response-type";
     public static final String DOC_RESPONSE_NAME_EXTENSION = "x-uyuni-doc-response-name";
+
+    public static final String DOC_RESPONSE_UNNAMED_EXTENSION = "x-uyuni-doc-response-unnamed";
     /** Parameter counts of the handler overloads an operation stands for, longest first. */
     public static final String DOC_OVERLOAD_ARITIES_EXTENSION = "x-uyuni-doc-overload-arities";
 
@@ -130,7 +132,7 @@ public class UyuniSwaggerReader {
         applyOverloadArities(cls, method, openApiOperation);
         applySecurityIfNeeded(method, openApiOperation);
         configureRequestBodyIfPresent(apiDoc, openApiOperation);
-        configureResponses(apiDoc, openApiOperation);
+        configureResponses(apiDoc, method, openApiOperation);
         processLiteralParameters(method, openApiOperation);
         registerOperationOnPath(namespace, method, apiDoc.method(), openApiOperation);
     }
@@ -138,6 +140,9 @@ public class UyuniSwaggerReader {
     private Operation createOperationWithBasicInfo(Method method, Tag tagAnnotation, ApiEndpointDoc apiDoc) {
         Operation operation = new Operation();
         operation.setOperationId(method.getName());
+        if (findMethodAnnotation(method, Deprecated.class) != null) {
+            operation.setDeprecated(true);
+        }
         if (!apiDoc.summary().isEmpty()) {
             operation.setSummary(apiDoc.summary());
         }
@@ -301,13 +306,18 @@ public class UyuniSwaggerReader {
         if (schema == null || schema.getProperties() == null) {
             return;
         }
+        LegacyDocResponse structDoc = documentedClass.getAnnotation(LegacyDocResponse.class);
+        if (structDoc != null && !structDoc.name().isBlank()) {
+            schema.addExtension(DOC_RESPONSE_NAME_EXTENSION, structDoc.name());
+        }
         for (Method getter : documentedClass.getMethods()) {
-            LegacyDocResponse legacyDoc = getter.getAnnotation(LegacyDocResponse.class);
-            if (legacyDoc == null || (legacyDoc.type().isBlank() && legacyDoc.name().isBlank())) {
-                continue;
-            }
             Schema<?> property = schema.getProperties().get(resolvePropertyName(getter));
             if (property == null) {
+                continue;
+            }
+            applyDocumentedValues(property, getter);
+            LegacyDocResponse legacyDoc = getter.getAnnotation(LegacyDocResponse.class);
+            if (legacyDoc == null || (legacyDoc.type().isBlank() && legacyDoc.name().isBlank())) {
                 continue;
             }
             if (!legacyDoc.type().isBlank()) {
@@ -316,6 +326,29 @@ public class UyuniSwaggerReader {
             if (!legacyDoc.name().isBlank()) {
                 property.addExtension(DOC_RESPONSE_NAME_EXTENSION, legacyDoc.name());
             }
+        }
+    }
+
+    /**
+     * Applies the values a property documents to its schema.
+     *
+     * The model converter builds a property schema knowing the declared Java type, and coerces
+     * every documented value to it: a value the type cannot hold is reshaped, or lost. Resolving
+     * the annotation without a type context, the way a documented parameter already does, keeps
+     * the values as the namespace spelled them.
+     *
+     * @param property the property schema built for the getter
+     * @param getter the getter documenting the property
+     */
+    private void applyDocumentedValues(Schema<?> property, Method getter) {
+        var arraySchema = getter.getAnnotation(io.swagger.v3.oas.annotations.media.ArraySchema.class);
+        if (arraySchema != null) {
+            applyDocumentedValues(property, arraySchema.schema());
+            return;
+        }
+        var schemaAnnotation = getter.getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
+        if (schemaAnnotation != null) {
+            applyDocumentedValues(property, schemaAnnotation);
         }
     }
 
@@ -334,7 +367,7 @@ public class UyuniSwaggerReader {
         return Introspector.decapitalize(name);
     }
 
-    private void configureResponses(ApiEndpointDoc apiDoc, Operation operation) {
+    private void configureResponses(ApiEndpointDoc apiDoc, Method method, Operation operation) {
         ApiResponses apiResponses = new ApiResponses();
 
         if (apiDoc.isIntegerResponse()) {
@@ -359,6 +392,12 @@ public class UyuniSwaggerReader {
                     case "Boolean" -> new BooleanSchema();
                     default -> new StringSchema();
                 };
+
+                var responseSchemaAnnotation =
+                        findMethodAnnotation(method, io.swagger.v3.oas.annotations.media.Schema.class);
+                if (responseSchemaAnnotation != null) {
+                    applyDocumentedValues(schema, responseSchemaAnnotation);
+                }
 
                 mediaType.setSchema(schema);
                 content.addMediaType(DEFAULT_MEDIA_TYPE, mediaType);
@@ -412,13 +451,17 @@ public class UyuniSwaggerReader {
         if (!legacyDocResponse.name().isBlank()) {
             response.addExtension(DOC_RESPONSE_NAME_EXTENSION, legacyDocResponse.name());
         }
+        if (legacyDocResponse.unnamed()) {
+            response.addExtension(DOC_RESPONSE_UNNAMED_EXTENSION, Boolean.TRUE);
+        }
         return response;
     }
 
     private boolean isEmptyLegacyDocResponse(LegacyDocResponse legacyDocResponse) {
         return legacyDocResponse.responseClass() == Void.class &&
                 legacyDocResponse.type().isBlank() &&
-                legacyDocResponse.name().isBlank();
+                legacyDocResponse.name().isBlank() &&
+                !legacyDocResponse.unnamed();
     }
 
     private void processLiteralParameters(Method method, Operation operation) {

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
@@ -515,12 +515,25 @@ public class ApiDocumentationCompatibilityTest {
                 .replace("&amp;", "&");
     }
 
+    /**
+     * Tells whether a line ends the text of the item before it.
+     *
+     * @param trimmed the trimmed line
+     * @return true when the line starts something else
+     */
+    private boolean isBoundary(String trimmed) {
+        return trimmed.startsWith("*") || trimmed.startsWith("==") || trimmed.startsWith("[#") ||
+                trimmed.startsWith("HTTP ") || trimmed.endsWith(":");
+    }
+
     private Optional<ApiMethodDoc> parseMethod(List<String> lines) {
         String method = "";
         String httpMethod = "";
         List<DocItem> parameters = new ArrayList<>();
         List<DocItem> returns = new ArrayList<>();
         Section section = Section.NONE;
+        String itemText = "";
+        boolean continues = false;
 
         for (String line : lines) {
             Matcher methodMatcher = METHOD_TITLE.matcher(line);
@@ -545,19 +558,31 @@ public class ApiDocumentationCompatibilityTest {
                 continue;
             }
 
+            List<DocItem> items = section == Section.PARAMETERS ? parameters : returns;
             Matcher itemMatcher = LIST_ITEM.matcher(line);
             if (itemMatcher.matches() && section != Section.NONE) {
-                DocItem item = new DocItem(
+                itemText = itemMatcher.group(3);
+                items.add(new DocItem(
                         itemMatcher.group(1).length(),
                         normalize(itemMatcher.group(2)),
-                        normalizeLabel(itemMatcher.group(3))
-                );
-                if (section == Section.PARAMETERS) {
-                    parameters.add(item);
-                }
-                else {
-                    returns.add(item);
-                }
+                        normalizeLabel(itemText)
+                ));
+                continues = true;
+                continue;
+            }
+            if (trimmed.isEmpty() || isBoundary(trimmed)) {
+                continues = false;
+                continue;
+            }
+
+            // The doclet keeps the line breaks of the documentation it copies, so an item whose
+            // text runs over several lines arrives as the item followed by the rest of its text.
+            // The DocBook renderer joins them, and so does this one, or the text would be read
+            // only as far as the break.
+            if (continues && section != Section.NONE && !items.isEmpty()) {
+                itemText = itemText + " " + trimmed;
+                DocItem previous = items.remove(items.size() - 1);
+                items.add(new DocItem(previous.level(), previous.type(), normalizeLabel(itemText)));
             }
         }
 

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
@@ -343,8 +343,14 @@ public class ApiDocumentationCompatibilityTest {
 
         List<DocItem> aligned = new ArrayList<>(items.size());
         aligned.add(array);
-        items.subList(1, items.size())
-                .forEach(item -> aligned.add(new DocItem(item.level() - 1, item.type(), item.name())));
+        boolean rebasing = true;
+        for (DocItem item : items.subList(1, items.size())) {
+            // The doclet resets its bullet level when it inlines a serializer reference, so the
+            // struct it expands there and everything below it are numbered from the top again,
+            // independently of the element struct this rebases.
+            rebasing = rebasing && !(aligned.size() > 1 && "struct".equals(item.type()) && item.level() == 1);
+            aligned.add(rebasing ? new DocItem(item.level() - 1, item.type(), item.name()) : item);
+        }
         return aligned;
     }
 

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
@@ -294,7 +294,33 @@ public class ApiDocumentationCompatibilityTest {
      * @return the items with the element struct and its contents rebased, when indented
      */
     private List<DocItem> alignArrayElementNesting(List<DocItem> items) {
-        return alignSerializerStructs(alignNestedElementStructs(alignLeadingArrayElement(items)));
+        return alignSerializerStructs(
+                alignNestedElementStructs(alignLeadingArrayElement(dropElementListMarkers(items))));
+    }
+
+    /**
+     * Drops the marker the doclet writes when a property opens the list of its elements.
+     *
+     * A namespace documents an array valued property either with {@code #prop_array_begin}, which
+     * expands straight into the element, or as a bare array followed by {@code #return_array_begin}
+     * , which writes an unnamed array marker before it. The schema describes the property the same
+     * way either way, so the marker is dropped before comparing.
+     *
+     * @param items the parsed return value items
+     * @return the items without the element list markers
+     */
+    private List<DocItem> dropElementListMarkers(List<DocItem> items) {
+        List<DocItem> kept = new ArrayList<>(items.size());
+        for (int i = 0; i < items.size(); i++) {
+            DocItem item = items.get(i);
+            DocItem property = i == 0 ? null : items.get(i - 1);
+            if (property != null && "array".equals(item.type()) && item.name().isEmpty() &&
+                    "array".equals(property.type()) && !property.name().isEmpty()) {
+                continue;
+            }
+            kept.add(item);
+        }
+        return kept;
     }
 
     /**


### PR DESCRIPTION
This is the architecture half of the remaining migration, with no handler migrated in it.

The parsers now describe each documented call from the overload it actually came from, render the legacy struct labels, allowed values, deprecation notes and date types that the doclet emits, and name array elements the way it names them. The api namespace picks up two return labels because the renderer no longer invents one when the javadoc does not give it.

The six namespaces already on OpenAPI render byte for byte as before.