### PR TITLE
Migrate the channel.software, packages, image, org and kickstart.profile.system handlers

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/api/ApiHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/api/ApiHandlerApi.java
@@ -58,7 +58,8 @@ public interface ApiHandlerApi {
     @ApiEndpointDoc(
         summary = "Returns the server product name.",
         method = HttpMethod.get,
-        responseClass = StringResponse.class
+        responseClass = StringResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "product name")
     )
     String productName();
 
@@ -71,7 +72,8 @@ public interface ApiHandlerApi {
     @ApiEndpointDoc(
         summary = "Returns the version of the API.",
         method = HttpMethod.get,
-        responseClass = StringResponse.class
+        responseClass = StringResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "version")
     )
     String getVersion();
 

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/appstreams/ChannelAppStreamHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/appstreams/ChannelAppStreamHandlerApi.java
@@ -139,7 +139,7 @@ public interface ChannelAppStreamHandlerApi {
     @Schema(name = "SoftwareChannel")
     @JsonPropertyOrder({"id", "name", "label", "archName", "archLabel", "summary", "description",
         "checksumLabel", "lastModified", "maintainerName", "maintainerEmail", "maintainerPhone",
-        "supportPolicy", "gpgKeyUrl", "gpgKeyId", "gpgKeyFp", "yumrepoLastSync", "endOfLife",
+        "supportPolicy", "gpgKeyUrl", "gpgKeyId", "gpgKeyFp", "gpgCheck", "yumrepoLastSync", "endOfLife",
         "parentChannelLabel", "cloneOriginal", "syncStatus", "contentSources"})
     interface ChannelDoc {
 
@@ -238,6 +238,12 @@ public interface ChannelAppStreamHandlerApi {
          */
         @Schema(name = "gpg_key_fp", requiredMode = Schema.RequiredMode.REQUIRED)
         String getGpgKeyFp();
+
+        /**
+         * @return whether the GPG check is enabled
+         */
+        @Schema(name = "gpg_check", requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getGpgCheck();
 
         /**
          * @return the last repository synchronisation date

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -113,7 +113,7 @@ import jakarta.persistence.NoResultException;
  * @apidoc.namespace channel.software
  * @apidoc.doc Provides methods to access and modify many aspects of a channel.
  */
-public class ChannelSoftwareHandler extends BaseHandler {
+public class ChannelSoftwareHandler extends BaseHandler implements ChannelSoftwareHandlerApi {
 
     private static Logger log = LogManager.getLogger(ChannelSoftwareHandler.class);
     private final TaskomaticApi taskomaticApi;

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandlerApi.java
@@ -1,0 +1,2998 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.channel.software;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelArch;
+import com.redhat.rhn.domain.channel.ContentSource;
+import com.redhat.rhn.domain.channel.ContentSourceFilter;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.dto.ErrataOverview;
+import com.redhat.rhn.frontend.dto.PackageDto;
+import com.redhat.rhn.frontend.xmlrpc.channel.appstreams.ChannelAppStreamHandlerApi;
+import com.redhat.rhn.frontend.xmlrpc.image.ImageInfoHandlerApi;
+import com.redhat.rhn.frontend.xmlrpc.packages.PackagesHandlerApi;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+import com.suse.manager.api.docs.LegacyDocResponse;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import spark.route.HttpMethod;
+
+/**
+ * API contract for {@link ChannelSoftwareHandler}.
+ */
+@Tag(name = "channel.software",
+    description = "Provides methods to access and modify many aspects of a channel.")
+public interface ChannelSoftwareHandlerApi {
+
+    /**
+     * Lists the errata that would be updated by a channel synchronisation.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to update
+     * @return the errata needing synchronisation
+     */
+    @ApiEndpointDoc(
+        summary = "If you have synced a new channel then patches will have been " +
+            "updated with the packages that are in the newly synced channel. A cloned erratum " +
+            "will not have been automatically updated however. If you cloned a channel that " +
+            "includes those cloned errata and should include the new packages, they will not be " +
+            "included when they should. This method lists the errata that will be updated if you " +
+            "run the syncErrata method.",
+        method = HttpMethod.get,
+        responseClass = ErrataOverviewListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "errata")
+    )
+    List<ErrataOverview> listErrataNeedingSync(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel to update") String channelLabel);
+
+    /**
+     * Updates the cloned errata of a channel with the packages recently added to it.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to update
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "If you have synced a new channel then patches will have been " +
+            "updated with the packages that are in the newly synced channel. A cloned erratum " +
+            "will not have been automatically updated however. If you cloned a channel that " +
+            "includes those cloned errata and should include the new packages, they will not be " +
+            "included when they should. This method updates all the errata in the given cloned " +
+            "channel with packages that have recently been added, and ensures that all the " +
+            "packages you expect are in the channel. It also updates cloned errata attributes " +
+            "like advisoryStatus.",
+        requestClass = SyncErrataRequest.class,
+        isIntegerResponse = true
+    )
+    Integer syncErrata(User loggedInUser, String channelLabel);
+
+    /**
+     * Lists the latest packages of a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to query
+     * @return the latest packages of the channel
+     */
+    @ApiEndpointDoc(
+        summary = "Lists the packages with the latest version (including release and epoch) for " +
+            "the given channel",
+        method = HttpMethod.get,
+        responseClass = LatestPackageListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "package")
+    )
+    Object[] listLatestPackages(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel to query") String channelLabel);
+
+    /**
+     * Lists all packages of a channel modified between two dates.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to query
+     * @param startDate the start date
+     * @param endDate the end date
+     * @return the packages of the channel
+     */
+    @ApiEndpointDoc(
+        summary = "Lists all packages in the channel, regardless of package version, between " +
+            "the given dates.",
+        method = HttpMethod.get,
+        responseClass = PackageDtoListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "package")
+    )
+    List<PackageDto> listAllPackages(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel to query") String channelLabel,
+        @Parameter(name = "startDate", in = ParameterIn.QUERY, required = true) Date startDate,
+        @Parameter(name = "endDate", in = ParameterIn.QUERY, required = true) Date endDate);
+
+    /**
+     * Lists all packages of a channel modified after a date.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to query
+     * @param startDate the start date
+     * @return the packages of the channel
+     */
+    @ApiEndpointDoc(
+        summary = "Lists all packages in the channel, regardless of version whose last modified " +
+            "date is greater than given date.",
+        method = HttpMethod.get,
+        responseClass = PackageDtoListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "package")
+    )
+    List<PackageDto> listAllPackages(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel to query") String channelLabel,
+        @Parameter(name = "startDate", in = ParameterIn.QUERY, required = true) Date startDate);
+
+    /**
+     * Lists all packages of a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to query
+     * @return the packages of the channel
+     */
+    @ApiEndpointDoc(
+        summary = "Lists all packages in the channel, regardless of the package version",
+        method = HttpMethod.get,
+        responseClass = PackageDtoListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "package")
+    )
+    List<PackageDto> listAllPackages(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel to query") String channelLabel);
+
+    /**
+     * Lists the software channel architectures.
+     *
+     * @param loggedInUser the current user
+     * @return the software channel architectures
+     */
+    @ApiEndpointDoc(
+        summary = "Lists the potential software channel architectures that can be created",
+        method = HttpMethod.get,
+        responseClass = ChannelArchListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel arch")
+    )
+    List<ChannelArch> listArches(@Parameter(hidden = true) User loggedInUser);
+
+    /**
+     * Deletes a custom software channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to delete
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Deletes a custom software channel",
+        requestClass = DeleteRequest.class,
+        isIntegerResponse = true
+    )
+    int delete(User loggedInUser, String channelLabel);
+
+    /**
+     * Returns whether a channel is globally subscribable.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to query
+     * @return 1 if subscribable, 0 otherwise
+     */
+    @ApiEndpointDoc(
+        summary = "Returns whether the channel is subscribable by any user in the organization",
+        method = HttpMethod.get,
+        isIntegerResponse = true,
+        responseDescription = "1 if true, 0 otherwise",
+        legacyDocResponse = @LegacyDocResponse(name = "subscribable")
+    )
+    int isGloballySubscribable(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel to query") String channelLabel);
+
+    /**
+     * Returns the details of a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to query
+     * @return the details of the channel
+     */
+    @ApiEndpointDoc(
+        summary = "Returns details of the given channel as a map",
+        method = HttpMethod.get,
+        responseClass = SoftwareChannelResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    Channel getDetails(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel to query") String channelLabel);
+
+    /**
+     * Returns the details of a channel.
+     *
+     * @param loggedInUser the current user
+     * @param id the id of the channel to query
+     * @return the details of the channel
+     */
+    @ApiEndpointDoc(
+        summary = "Returns details of the given channel as a map",
+        method = HttpMethod.get,
+        responseClass = SoftwareChannelResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    Channel getDetails(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "id", in = ParameterIn.QUERY, required = true,
+                description = "channel to query") Integer id);
+
+    /**
+     * Modifies the attributes of a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel label
+     * @param details the attributes to modify
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Allows to modify channel attributes",
+        requestClass = SetDetailsRequest.class,
+        isIntegerResponse = true
+    )
+    int setDetails(User loggedInUser, String channelLabel, Map<String, String> details);
+
+    /**
+     * Modifies the attributes of a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelId the channel id
+     * @param details the attributes to modify
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Allows to modify channel attributes",
+        requestClass = SetDetailsByIdRequest.class,
+        isIntegerResponse = true
+    )
+    int setDetails(User loggedInUser, Integer channelId, Map<String, String> details);
+
+    /**
+     * Creates a software channel.
+     *
+     * @param loggedInUser the current user
+     * @param label the label of the new channel
+     * @param name the name of the new channel
+     * @param summary the summary of the new channel
+     * @param archLabel the architecture of the new channel
+     * @param parentLabel the label of the parent channel
+     * @param checksumType the checksum type of the new channel
+     * @param gpgKey the GPG key of the new channel
+     * @param gpgCheck whether the GPG check is enabled by default
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Creates a software channel",
+        requestClass = CreateWithGpgCheckRequest.class,
+        isIntegerResponse = true,
+        responseDescription = "1 if the creation operation succeeded, 0 otherwise",
+        legacyDocResponse = @LegacyDocResponse(name = "status")
+    )
+    int create(User loggedInUser, String label, String name, String summary, String archLabel,
+        String parentLabel, String checksumType, Map<String, String> gpgKey, boolean gpgCheck);
+
+    /**
+     * Creates a software channel.
+     *
+     * @param loggedInUser the current user
+     * @param label the label of the new channel
+     * @param name the name of the new channel
+     * @param summary the summary of the new channel
+     * @param archLabel the architecture of the new channel
+     * @param parentLabel the label of the parent channel
+     * @param checksumType the checksum type of the new channel
+     * @param gpgKey the GPG key of the new channel
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Creates a software channel",
+        requestClass = CreateWithGpgKeyRequest.class,
+        isIntegerResponse = true,
+        responseDescription = "1 if the creation operation succeeded, 0 otherwise",
+        legacyDocResponse = @LegacyDocResponse(name = "status")
+    )
+    int create(User loggedInUser, String label, String name, String summary, String archLabel,
+        String parentLabel, String checksumType, Map<String, String> gpgKey);
+
+    /**
+     * Creates a software channel.
+     *
+     * @param loggedInUser the current user
+     * @param label the label of the new channel
+     * @param name the name of the new channel
+     * @param summary the summary of the new channel
+     * @param archLabel the architecture of the new channel
+     * @param parentLabel the label of the parent channel
+     * @param checksumType the checksum type of the new channel
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Creates a software channel",
+        requestClass = CreateWithChecksumRequest.class,
+        isIntegerResponse = true,
+        responseDescription = "1 if the creation operation succeeded, 0 otherwise",
+        legacyDocResponse = @LegacyDocResponse(name = "status")
+    )
+    int create(User loggedInUser, String label, String name, String summary, String archLabel,
+        String parentLabel, String checksumType);
+
+    /**
+     * Creates a software channel.
+     *
+     * @param loggedInUser the current user
+     * @param label the label of the new channel
+     * @param name the name of the new channel
+     * @param summary the summary of the new channel
+     * @param archLabel the architecture of the new channel
+     * @param parentLabel the label of the parent channel
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Creates a software channel",
+        requestClass = CreateRequest.class,
+        isIntegerResponse = true,
+        responseDescription = "1 if the creation operation succeeded, 0 otherwise",
+        legacyDocResponse = @LegacyDocResponse(name = "status")
+    )
+    int create(User loggedInUser, String label, String name, String summary, String archLabel,
+        String parentLabel);
+
+    /**
+     * Sets the contact details of a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel
+     * @param maintainerName the name of the channel maintainer
+     * @param maintainerEmail the email of the channel maintainer
+     * @param maintainerPhone the phone number of the channel maintainer
+     * @param supportPolicy the channel support policy
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set contact/support information for given channel.",
+        requestClass = SetContactDetailsRequest.class,
+        isIntegerResponse = true
+    )
+    int setContactDetails(User loggedInUser, String channelLabel, String maintainerName,
+        String maintainerEmail, String maintainerPhone, String supportPolicy);
+
+    /**
+     * Lists the systems subscribed to a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to query
+     * @return the systems subscribed to the channel
+     */
+    @ApiEndpointDoc(
+        summary = "Returns list of subscribed systems for the given channel label",
+        method = HttpMethod.get,
+        responseClass = SubscribedSystemListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "system")
+    )
+    Object[] listSubscribedSystems(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel to query") String channelLabel);
+
+    /**
+     * Lists the channels a system is subscribed to.
+     *
+     * @param loggedInUser the current user
+     * @param sid the system id
+     * @return the channels the system is subscribed to
+     */
+    @ApiEndpointDoc(
+        summary = "Returns a list of channels that a system is subscribed to for the given " +
+            "system id",
+        method = HttpMethod.get,
+        responseClass = SystemChannelListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    Object[] listSystemChannels(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "sid", in = ParameterIn.QUERY, required = true,
+                description = "system ID") Integer sid);
+
+    /**
+     * Sets the subscribable flag of a channel for a user.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel
+     * @param login the login of the target user
+     * @param value the value of the flag
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set the subscribable flag for a given channel and user. If value is set to " +
+            "'true', this method will give the user subscribe permissions to the channel. " +
+            "Otherwise, that privilege is revoked.",
+        requestClass = SetUserSubscribableRequest.class,
+        isIntegerResponse = true
+    )
+    int setUserSubscribable(User loggedInUser, String channelLabel, String login, Boolean value);
+
+    /**
+     * Sets the manageable flag of a channel for a user.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel
+     * @param login the login of the target user
+     * @param value the value of the flag
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set the manageable flag for a given channel and user. If value is set to " +
+            "'true', this method will give the user manage permissions to the channel. " +
+            "Otherwise, that privilege is revoked.",
+        requestClass = SetUserManageableRequest.class,
+        isIntegerResponse = true
+    )
+    int setUserManageable(User loggedInUser, String channelLabel, String login, Boolean value);
+
+    /**
+     * Returns whether a channel may be subscribed to by a user.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel
+     * @param login the login of the target user
+     * @return 1 if subscribable, 0 if not
+     */
+    @ApiEndpointDoc(
+        summary = "Returns whether the channel may be subscribed to by the given user.",
+        method = HttpMethod.get,
+        isIntegerResponse = true,
+        responseDescription = "1 if subscribable, 0 if not",
+        legacyDocResponse = @LegacyDocResponse(name = "status")
+    )
+    int isUserSubscribable(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "label of the channel") String channelLabel,
+        @Parameter(name = "login", in = ParameterIn.QUERY, required = true,
+                description = "login of the target user") String login);
+
+    /**
+     * Returns whether a channel exists.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel
+     * @return true if the channel exists
+     */
+    @ApiEndpointDoc(
+        summary = "Returns whether is existing",
+        method = HttpMethod.get,
+        responseClass = BooleanResponse.class,
+        responseDescription = "true if the channel exists",
+        legacyDocResponse = @LegacyDocResponse(name = "result")
+    )
+    boolean isExisting(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "label of the channel") String channelLabel);
+
+    /**
+     * Returns whether a channel may be managed by a user.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel
+     * @param login the login of the target user
+     * @return 1 if manageable, 0 if not
+     */
+    @ApiEndpointDoc(
+        summary = "Returns whether the channel may be managed by the given user.",
+        method = HttpMethod.get,
+        isIntegerResponse = true,
+        responseDescription = "1 if manageable, 0 if not",
+        legacyDocResponse = @LegacyDocResponse(name = "status")
+    )
+    int isUserManageable(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "label of the channel") String channelLabel,
+        @Parameter(name = "login", in = ParameterIn.QUERY, required = true,
+                description = "login of the target user") String login);
+
+    /**
+     * Sets the globally subscribable attribute of a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel
+     * @param value whether the channel is globally subscribable
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set globally subscribable attribute for given channel.",
+        requestClass = SetGloballySubscribableRequest.class,
+        isIntegerResponse = true
+    )
+    int setGloballySubscribable(User loggedInUser, String channelLabel, boolean value);
+
+    /**
+     * Adds packages to a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the target channel
+     * @param packageIds the ids of the packages to add
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Adds a given list of packages to the given channel.",
+        requestClass = AddPackagesRequest.class,
+        isIntegerResponse = true
+    )
+    int addPackages(User loggedInUser, String channelLabel, List<Long> packageIds);
+
+    /**
+     * Removes errata from a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the target channel
+     * @param errataNames the names of the errata to remove
+     * @param removePackages whether to remove packages from the channel
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Removes a given list of errata from the given channel.",
+        requestClass = RemoveErrataRequest.class,
+        isIntegerResponse = true
+    )
+    int removeErrata(User loggedInUser, String channelLabel, List<String> errataNames,
+        boolean removePackages);
+
+    /**
+     * Removes packages from a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the target channel
+     * @param packageIds the ids of the packages to remove
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Removes a given list of packages from the given channel.",
+        requestClass = RemovePackagesRequest.class,
+        isIntegerResponse = true
+    )
+    int removePackages(User loggedInUser, String channelLabel, List<Long> packageIds);
+
+    /**
+     * Lists the errata applicable to a channel after a date.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to query
+     * @param startDate the start date
+     * @return the errata applicable to the channel
+     */
+    @ApiEndpointDoc(
+        summary = "List the errata applicable to a channel after given startDate",
+        method = HttpMethod.get,
+        responseClass = ErrataOverviewListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "errata")
+    )
+    List<ErrataOverview> listErrata(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel to query") String channelLabel,
+        @Parameter(name = "startDate", in = ParameterIn.QUERY, required = true) Date startDate);
+
+    /**
+     * Lists the errata applicable to a channel between two dates.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to query
+     * @param startDate the start date
+     * @param endDate the end date
+     * @return the errata applicable to the channel
+     */
+    @ApiEndpointDoc(
+        summary = "List the errata applicable to a channel between startDate and endDate.",
+        method = HttpMethod.get,
+        responseClass = ErrataOverviewListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "errata")
+    )
+    List<ErrataOverview> listErrata(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel to query") String channelLabel,
+        @Parameter(name = "startDate", in = ParameterIn.QUERY, required = true) Date startDate,
+        @Parameter(name = "endDate", in = ParameterIn.QUERY, required = true) Date endDate);
+
+    /**
+     * Lists the errata applicable to a channel between two dates.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to query
+     * @param startDate the start date
+     * @param endDate the end date
+     * @param lastModified whether to select by last modified date
+     * @return the errata applicable to the channel
+     */
+    @ApiEndpointDoc(
+        summary = "List the errata applicable to a channel between startDate and endDate.",
+        method = HttpMethod.get,
+        responseClass = ErrataOverviewListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "errata")
+    )
+    List<ErrataOverview> listErrata(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel to query") String channelLabel,
+        @Parameter(name = "startDate", in = ParameterIn.QUERY, required = true) Date startDate,
+        @Parameter(name = "endDate", in = ParameterIn.QUERY, required = true) Date endDate,
+        @Parameter(name = "lastModified", in = ParameterIn.QUERY, required = true,
+                description = "select by last modified or not") boolean lastModified);
+
+    /**
+     * Lists the errata applicable to a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to query
+     * @return the errata applicable to the channel
+     */
+    @ApiEndpointDoc(
+        summary = "List the errata applicable to a channel",
+        method = HttpMethod.get,
+        responseClass = ErrataOverviewListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "errata")
+    )
+    List<ErrataOverview> listErrata(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel to query") String channelLabel);
+
+    /**
+     * Lists the errata of a given type that are applicable to a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel to query
+     * @param advisoryType the type of advisory
+     * @return the errata applicable to the channel
+     */
+    @ApiEndpointDoc(
+        summary = "List the errata of a specific type that are applicable to a channel",
+        method = HttpMethod.get,
+        responseClass = ErrataByTypeListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "errata")
+    )
+    Object[] listErrataByType(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel to query") String channelLabel,
+        @Parameter(name = "advisoryType", in = ParameterIn.QUERY, required = true,
+                description = "type of advisory (one of of the following: 'Security Advisory', " +
+                    "'Product Enhancement Advisory', 'Bug Fix Advisory'") String advisoryType);
+
+    /**
+     * Lists the packages that are not associated with a channel.
+     *
+     * @param loggedInUser the current user
+     * @return the packages without a channel
+     */
+    @ApiEndpointDoc(
+        summary = "Lists all packages that are not associated with a channel. Typically these " +
+            "are custom packages.",
+        method = HttpMethod.get,
+        responseClass = PackagesHandlerApi.PackageListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "package")
+    )
+    Object[] listPackagesWithoutChannel(@Parameter(hidden = true) User loggedInUser);
+
+    /**
+     * Clones a channel.
+     *
+     * @param loggedInUser the current user
+     * @param originalLabel the label of the channel to clone
+     * @param channelDetails the details of the cloned channel
+     * @param originalState whether to clone the original state
+     * @return the id of the cloned channel
+     */
+    @ApiEndpointDoc(
+        summary = "Clone a channel. If arch_label is omitted, the arch label of the original " +
+            "channel will be used. If parent_label is omitted, the clone will be a base channel.",
+        requestClass = CloneRequest.class,
+        isIntegerResponse = true,
+        responseDescription = "the cloned channel ID",
+        legacyDocResponse = @LegacyDocResponse(name = "id")
+    )
+    int clone(User loggedInUser, String originalLabel, Map<String, String> channelDetails,
+        Boolean originalState);
+
+    /**
+     * Merges all errata from one channel into another.
+     *
+     * @param loggedInUser the current user
+     * @param mergeFromLabel the channel to pull the errata from
+     * @param mergeToLabel the channel to push the errata into
+     * @return the merged errata
+     */
+    @ApiEndpointDoc(
+        summary = "Merges all errata from one channel into another. It does not associate the " +
+            "packages with the channel.",
+        requestClass = MergeErrataRequest.class,
+        responseClass = ErrataListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "errata")
+    )
+    Object[] mergeErrata(User loggedInUser, String mergeFromLabel, String mergeToLabel);
+
+    /**
+     * Merges the errata of a period from one channel into another.
+     *
+     * @param loggedInUser the current user
+     * @param mergeFromLabel the channel to pull the errata from
+     * @param mergeToLabel the channel to push the errata into
+     * @param startDate the start date
+     * @param endDate the end date
+     * @return the merged errata
+     */
+    @ApiEndpointDoc(
+        summary = "Merges all errata from one channel into another based upon a given start/end " +
+            "date. It does not associate the packages with the channel.",
+        requestClass = MergeErrataByDateRequest.class,
+        responseClass = ErrataListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "errata")
+    )
+    Object[] mergeErrata(User loggedInUser, String mergeFromLabel, String mergeToLabel,
+        String startDate, String endDate);
+
+    /**
+     * Merges a list of errata from one channel into another.
+     *
+     * @param loggedInUser the current user
+     * @param mergeFromLabel the channel to pull the errata from
+     * @param mergeToLabel the channel to push the errata into
+     * @param errataNames the advisory names of the errata to merge
+     * @return the merged errata
+     */
+    @ApiEndpointDoc(
+        summary = "Merges a list of errata from one channel into another. It does not associate " +
+            "the packages with the channel.",
+        requestClass = MergeErrataByNameRequest.class,
+        responseClass = ErrataListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "errata")
+    )
+    Object[] mergeErrata(User loggedInUser, String mergeFromLabel, String mergeToLabel,
+        List<String> errataNames);
+
+    /**
+     * Merges all packages from one channel into another.
+     *
+     * @param loggedInUser the current user
+     * @param mergeFromLabel the channel to pull the packages from
+     * @param mergeToLabel the channel to push the packages into
+     * @return the merged packages
+     */
+    @ApiEndpointDoc(
+        summary = "Merges all packages from one channel into another",
+        requestClass = MergePackagesRequest.class,
+        responseClass = PackagesHandlerApi.PackageListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "package")
+    )
+    Object[] mergePackages(User loggedInUser, String mergeFromLabel, String mergeToLabel);
+
+    /**
+     * Merges all packages from one channel into another.
+     *
+     * @param loggedInUser the current user
+     * @param mergeFromLabel the channel to pull the packages from
+     * @param mergeToLabel the channel to push the packages into
+     * @param alignModules whether to align the modular data
+     * @return the merged packages
+     */
+    @ApiEndpointDoc(
+        summary = "Merges all packages from one channel into another",
+        requestClass = MergePackagesAlignedRequest.class,
+        responseClass = PackagesHandlerApi.PackageListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "package")
+    )
+    Object[] mergePackages(User loggedInUser, String mergeFromLabel, String mergeToLabel,
+        boolean alignModules);
+
+    /**
+     * Aligns the metadata of a channel to another channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelFromLabel the label of the source channel
+     * @param channelToLabel the label of the target channel
+     * @param metadataType the metadata type
+     * @return 1 when the metadata has been aligned, 0 otherwise
+     */
+    @ApiEndpointDoc(
+        summary = "Align the metadata of a channel to another channel.",
+        requestClass = AlignMetadataRequest.class,
+        isIntegerResponse = true,
+        responseDescription = "1 when metadata has been aligned, 0 otherwise",
+        legacyDocResponse = @LegacyDocResponse(name = "result code")
+    )
+    int alignMetadata(User loggedInUser, String channelFromLabel, String channelToLabel,
+        String metadataType);
+
+    /**
+     * Regenerates the needed cache of the systems subscribed to a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Completely clear and regenerate the needed Errata and Package cache for all " +
+            "systems subscribed to the specified channel. This should be used only if you " +
+            "believe your cache is incorrect for all the systems in a given channel. This will " +
+            "schedule an asynchronous action to actually do the processing.",
+        requestClass = RegenerateNeededCacheRequest.class,
+        isIntegerResponse = true
+    )
+    int regenerateNeededCache(User loggedInUser, String channelLabel);
+
+    /**
+     * Regenerates the needed cache of all the subscribed systems.
+     *
+     * @param loggedInUser the current user
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Completely clear and regenerate the needed Errata and Package cache for all " +
+            "systems subscribed. You must be a #product() Admin to perform this action. This will " +
+            "schedule an asynchronous action to actually do the processing.",
+        isIntegerResponse = true
+    )
+    int regenerateNeededCache(User loggedInUser);
+
+    /**
+     * Regenerates the yum cache of a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel
+     * @param force whether to force the cache regeneration
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Regenerate yum cache for the specified channel.",
+        requestClass = RegenerateYumCacheRequest.class,
+        isIntegerResponse = true
+    )
+    int regenerateYumCache(User loggedInUser, String channelLabel, Boolean force);
+
+    /**
+     * Lists the children of a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel
+     * @return the children of the channel
+     */
+    @ApiEndpointDoc(
+        summary = "List the children of a channel",
+        method = HttpMethod.get,
+        responseClass = ChannelAppStreamHandlerApi.ChannelListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    Object[] listChildren(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "the label of the channel") String channelLabel);
+
+    /**
+     * Returns the last build date of the repository metadata of a channel.
+     *
+     * @param loggedInUser the current user
+     * @param id the id of the channel
+     * @return the last build date of the repository metadata
+     */
+    @ApiEndpointDoc(
+        summary = "Returns the last build date of the repomd.xml file for the given channel as " +
+            "a localised string.",
+        method = HttpMethod.get,
+        responseClass = StringResponse.class,
+        responseDescription = "the last build date of the repomd.xml file as a localised string",
+        legacyDocResponse = @LegacyDocResponse(type = "date", name = "date")
+    )
+    String getChannelLastBuildById(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "id", in = ParameterIn.QUERY, required = true,
+                description = "id of channel wanted") Integer id);
+
+    /**
+     * Lists the repositories the user can see.
+     *
+     * @param loggedInUser the current user
+     * @return the repositories the user can see
+     */
+    @ApiEndpointDoc(
+        summary = "Returns a list of ContentSource (repos) that the user can see",
+        method = HttpMethod.get,
+        responseClass = UserRepoListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "map")
+    )
+    List<Map<String, Object>> listUserRepos(@Parameter(hidden = true) User loggedInUser);
+
+    /**
+     * Creates a repository.
+     *
+     * @param loggedInUser the current user
+     * @param label the repository label
+     * @param type the repository type
+     * @param url the repository url
+     * @return the created repository
+     */
+    @ApiEndpointDoc(
+        summary = "Creates a repository",
+        requestClass = CreateRepoRequest.class,
+        responseClass = ContentSourceResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    ContentSource createRepo(User loggedInUser, String label, String type, String url);
+
+    /**
+     * Creates a repository.
+     *
+     * @param loggedInUser the current user
+     * @param label the repository label
+     * @param type the repository type
+     * @param url the repository url
+     * @param sslCaCert the SSL CA certificate description
+     * @param sslCliCert the SSL client certificate description
+     * @param sslCliKey the SSL client key description
+     * @return the created repository
+     */
+    @ApiEndpointDoc(
+        summary = "Creates a repository",
+        requestClass = CreateRepoWithSslRequest.class,
+        responseClass = ContentSourceResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    ContentSource createRepo(User loggedInUser, String label, String type, String url,
+        String sslCaCert, String sslCliCert, String sslCliKey);
+
+    /**
+     * Creates a repository.
+     *
+     * @param loggedInUser the current user
+     * @param label the repository label
+     * @param type the repository type
+     * @param url the repository url
+     * @param sslCaCert the SSL CA certificate description
+     * @param sslCliCert the SSL client certificate description
+     * @param sslCliKey the SSL client key description
+     * @param hasSignedMetadata whether the repository has signed metadata
+     * @return the created repository
+     */
+    @ApiEndpointDoc(
+        summary = "Creates a repository",
+        requestClass = CreateRepoWithMetadataRequest.class,
+        responseClass = ContentSourceResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    ContentSource createRepo(User loggedInUser, String label, String type, String url,
+        String sslCaCert, String sslCliCert, String sslCliKey, boolean hasSignedMetadata);
+
+    /**
+     * Removes a repository.
+     *
+     * @param loggedInUser the current user
+     * @param id the id of the repository to remove
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Removes a repository",
+        requestClass = RemoveRepoByIdRequest.class,
+        isIntegerResponse = true
+    )
+    Integer removeRepo(User loggedInUser, Integer id);
+
+    /**
+     * Removes a repository.
+     *
+     * @param loggedInUser the current user
+     * @param label the label of the repository to remove
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Removes a repository",
+        requestClass = RemoveRepoByLabelRequest.class,
+        isIntegerResponse = true
+    )
+    Integer removeRepo(User loggedInUser, String label);
+
+    /**
+     * Associates a repository with a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel label
+     * @param repoLabel the repository label
+     * @return the channel the repository was associated with
+     */
+    @ApiEndpointDoc(
+        summary = "Associates a repository with a channel",
+        requestClass = AssociateRepoRequest.class,
+        responseClass = SoftwareChannelResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    Channel associateRepo(User loggedInUser, String channelLabel, String repoLabel);
+
+    /**
+     * Disassociates a repository from a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel label
+     * @param repoLabel the repository label
+     * @return the channel the repository was disassociated from
+     */
+    @ApiEndpointDoc(
+        summary = "Disassociates a repository from a channel",
+        requestClass = DisassociateRepoRequest.class,
+        responseClass = SoftwareChannelResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    Channel disassociateRepo(User loggedInUser, String channelLabel, String repoLabel);
+
+    /**
+     * Updates the source url of a repository.
+     *
+     * @param loggedInUser the current user
+     * @param id the repository id
+     * @param url the new repository url
+     * @return the updated repository
+     */
+    @ApiEndpointDoc(
+        summary = "Updates repository source URL",
+        requestClass = UpdateRepoUrlByIdRequest.class,
+        responseClass = ContentSourceResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    ContentSource updateRepoUrl(User loggedInUser, Integer id, String url);
+
+    /**
+     * Updates the source url of a repository.
+     *
+     * @param loggedInUser the current user
+     * @param label the repository label
+     * @param url the new repository url
+     * @return the updated repository
+     */
+    @ApiEndpointDoc(
+        summary = "Updates repository source URL",
+        requestClass = UpdateRepoUrlByLabelRequest.class,
+        responseClass = ContentSourceResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    ContentSource updateRepoUrl(User loggedInUser, String label, String url);
+
+    /**
+     * Updates the SSL certificates of a repository.
+     *
+     * @param loggedInUser the current user
+     * @param id the repository id
+     * @param sslCaCert the SSL CA certificate description
+     * @param sslCliCert the SSL client certificate description
+     * @param sslCliKey the SSL client key description
+     * @return the updated repository
+     */
+    @ApiEndpointDoc(
+        summary = "Updates repository SSL certificates",
+        requestClass = UpdateRepoSslByIdRequest.class,
+        responseClass = ContentSourceResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    ContentSource updateRepoSsl(User loggedInUser, Integer id, String sslCaCert, String sslCliCert,
+        String sslCliKey);
+
+    /**
+     * Updates the SSL certificates of a repository.
+     *
+     * @param loggedInUser the current user
+     * @param label the repository label
+     * @param sslCaCert the SSL CA certificate description
+     * @param sslCliCert the SSL client certificate description
+     * @param sslCliKey the SSL client key description
+     * @return the updated repository
+     */
+    @ApiEndpointDoc(
+        summary = "Updates repository SSL certificates",
+        requestClass = UpdateRepoSslByLabelRequest.class,
+        responseClass = ContentSourceResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    ContentSource updateRepoSsl(User loggedInUser, String label, String sslCaCert,
+        String sslCliCert, String sslCliKey);
+
+    /**
+     * Updates the label of a repository.
+     *
+     * @param loggedInUser the current user
+     * @param id the repository id
+     * @param label the new repository label
+     * @return the updated repository
+     */
+    @ApiEndpointDoc(
+        summary = "Updates repository label",
+        requestClass = UpdateRepoLabelByIdRequest.class,
+        responseClass = ContentSourceResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    ContentSource updateRepoLabel(User loggedInUser, Integer id, String label);
+
+    /**
+     * Updates the label of a repository.
+     *
+     * @param loggedInUser the current user
+     * @param label the repository label
+     * @param newLabel the new repository label
+     * @return the updated repository
+     */
+    @ApiEndpointDoc(
+        summary = "Updates repository label",
+        requestClass = UpdateRepoLabelByLabelRequest.class,
+        responseClass = ContentSourceResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    ContentSource updateRepoLabel(User loggedInUser, String label, String newLabel);
+
+    /**
+     * Updates a repository.
+     *
+     * @param loggedInUser the current user
+     * @param id the repository id
+     * @param label the new repository label
+     * @param url the new repository url
+     * @return the updated repository
+     */
+    @ApiEndpointDoc(
+        summary = "Updates a ContentSource (repo)",
+        requestClass = UpdateRepoRequest.class,
+        responseClass = ContentSourceResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    ContentSource updateRepo(User loggedInUser, Integer id, String label, String url);
+
+    /**
+     * Returns the details of a repository.
+     *
+     * @param loggedInUser the current user
+     * @param repoLabel the repository to query
+     * @return the details of the repository
+     */
+    @ApiEndpointDoc(
+        summary = "Returns details of the given repository",
+        method = HttpMethod.get,
+        responseClass = ContentSourceResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    ContentSource getRepoDetails(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "repoLabel", in = ParameterIn.QUERY, required = true,
+                description = "repo to query") String repoLabel);
+
+    /**
+     * Returns the details of a repository.
+     *
+     * @param loggedInUser the current user
+     * @param id the repository id
+     * @return the details of the repository
+     */
+    @ApiEndpointDoc(
+        summary = "Returns details of the given repository",
+        method = HttpMethod.get,
+        responseClass = ContentSourceResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    ContentSource getRepoDetails(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "id", in = ParameterIn.QUERY, required = true,
+                description = "repository ID") Integer id);
+
+    /**
+     * Lists the repositories associated with a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel label
+     * @return the repositories associated with the channel
+     */
+    @ApiEndpointDoc(
+        summary = "Lists associated repos with the given channel",
+        method = HttpMethod.get,
+        responseClass = ContentSourceListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    List<ContentSource> listChannelRepos(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel label") String channelLabel);
+
+    /**
+     * Triggers an immediate repository synchronisation of several channels.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabels the channel labels
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Trigger immediate repo synchronization",
+        requestClass = SyncRepoListRequest.class,
+        isIntegerResponse = true
+    )
+    int syncRepo(User loggedInUser, List<String> channelLabels);
+
+    /**
+     * Triggers an immediate repository synchronisation.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel label
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Trigger immediate repo synchronization",
+        requestClass = SyncRepoRequest.class,
+        isIntegerResponse = true
+    )
+    int syncRepo(User loggedInUser, String channelLabel);
+
+    /**
+     * Triggers an immediate repository synchronisation.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel label
+     * @param params the synchronisation parameters
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Trigger immediate repo synchronization",
+        requestClass = SyncRepoWithParamsRequest.class,
+        isIntegerResponse = true
+    )
+    int syncRepo(User loggedInUser, String channelLabel, Map<String, String> params);
+
+    /**
+     * Schedules a periodic repository synchronisation.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel label
+     * @param cronExpr the cron expression
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Schedule periodic repo synchronization",
+        requestClass = SyncRepoScheduleRequest.class,
+        isIntegerResponse = true
+    )
+    int syncRepo(User loggedInUser, String channelLabel, String cronExpr);
+
+    /**
+     * Schedules a periodic repository synchronisation.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel label
+     * @param cronExpr the cron expression
+     * @param params the synchronisation parameters
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Schedule periodic repo synchronization",
+        requestClass = SyncRepoScheduleWithParamsRequest.class,
+        isIntegerResponse = true
+    )
+    int syncRepo(User loggedInUser, String channelLabel, String cronExpr,
+        Map<String, String> params);
+
+    /**
+     * Returns the cron expression of the repository synchronisation of a channel.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the channel label
+     * @return the cron expression
+     */
+    @ApiEndpointDoc(
+        summary = "Returns repo synchronization cron expression",
+        method = HttpMethod.get,
+        responseClass = StringResponse.class,
+        responseDescription = "quartz expression",
+        legacyDocResponse = @LegacyDocResponse(name = "expression")
+    )
+    String getRepoSyncCronExpression(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "channel label") String channelLabel);
+
+    /**
+     * Lists the filters of a repository.
+     *
+     * @param loggedInUser the current user
+     * @param label the repository label
+     * @return the filters of the repository
+     */
+    @ApiEndpointDoc(
+        summary = "Lists the filters for a repo",
+        method = HttpMethod.get,
+        responseClass = ContentSourceFilterListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "filter")
+    )
+    List<ContentSourceFilter> listRepoFilters(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "label", in = ParameterIn.QUERY, required = true,
+                description = "repository label") String label);
+
+    /**
+     * Adds a filter to a repository.
+     *
+     * @param loggedInUser the current user
+     * @param label the repository label
+     * @param filterProps the filter properties
+     * @return the sort order of the new filter
+     */
+    @ApiEndpointDoc(
+        summary = "Adds a filter for a given repo.",
+        requestClass = AddRepoFilterRequest.class,
+        isIntegerResponse = true,
+        responseDescription = "sort order for new filter",
+        legacyDocResponse = @LegacyDocResponse(name = "order")
+    )
+    int addRepoFilter(User loggedInUser, String label, Map<String, String> filterProps);
+
+    /**
+     * Removes a filter from a repository.
+     *
+     * @param loggedInUser the current user
+     * @param label the repository label
+     * @param filterProps the filter properties
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Removes a filter for a given repo.",
+        requestClass = RemoveRepoFilterRequest.class,
+        isIntegerResponse = true
+    )
+    int removeRepoFilter(User loggedInUser, String label, Map<String, String> filterProps);
+
+    /**
+     * Replaces the filters of a repository.
+     *
+     * @param loggedInUser the current user
+     * @param label the repository label
+     * @param filterProps the filter properties
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Replaces the existing set of filters for a given repo. Filters are ranked by " +
+            "their order in the array.",
+        requestClass = SetRepoFiltersRequest.class,
+        isIntegerResponse = true
+    )
+    int setRepoFilters(User loggedInUser, String label, List<Map<String, String>> filterProps);
+
+    /**
+     * Removes all the filters of a repository.
+     *
+     * @param loggedInUser the current user
+     * @param label the repository label
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Removes the filters for a repo",
+        requestClass = ClearRepoFiltersRequest.class,
+        isIntegerResponse = true
+    )
+    int clearRepoFilters(User loggedInUser, String label);
+
+    /**
+     * Schedules the channels state on the given systems.
+     *
+     * @param user the current user
+     * @param sids the system ids
+     * @return the id of the scheduled action
+     */
+    @ApiEndpointDoc(
+        summary = "Refresh pillar data and then schedule channels state on the provided systems",
+        requestClass = ApplyChannelStateRequest.class,
+        isIntegerResponse = true,
+        legacyDocResponse = @LegacyDocResponse(type = "array", name = "actionId")
+    )
+    long applyChannelState(User user, List<Integer> sids);
+
+    /**
+     * Returns whether a channel is synchronized automatically.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel
+     * @return true if the channel is synchronized automatically
+     */
+    @ApiEndpointDoc(
+        summary = "Returns whether is synchronized automatically",
+        method = HttpMethod.get,
+        responseClass = BooleanResponse.class,
+        responseDescription = "true if the channel is synchronized automatically",
+        legacyDocResponse = @LegacyDocResponse(name = "result")
+    )
+    boolean isAutoSync(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "channelLabel", in = ParameterIn.QUERY, required = true,
+                description = "label of the channel") String channelLabel);
+
+    /**
+     * Sets whether a channel is synchronized automatically.
+     *
+     * @param loggedInUser the current user
+     * @param channelLabel the label of the channel
+     * @param autoSync whether the channel is synchronized automatically
+     * @return the value set on the channel
+     */
+    @ApiEndpointDoc(
+        summary = "Sets whether the channel is synchronized automatically",
+        requestClass = SetAutoSyncRequest.class,
+        responseClass = BooleanResponse.class,
+        responseDescription = "The value set to the channel automatic synchronized option",
+        legacyDocResponse = @LegacyDocResponse(name = "result")
+    )
+    boolean setAutoSync(User loggedInUser, String channelLabel, Boolean autoSync);
+
+    @Schema(name = "ChannelLatestPackage")
+    @JsonPropertyOrder({"name", "version", "release", "epoch", "id", "archLabel"})
+    interface LatestPackageDoc {
+
+        /**
+         * @return the package name
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the package version
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getVersion();
+
+        /**
+         * @return the package release
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getRelease();
+
+        /**
+         * @return the package epoch
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getEpoch();
+
+        /**
+         * @return the package id
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the package architecture label
+         */
+        @Schema(name = "arch_label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getArchLabel();
+    }
+
+    @Schema(name = "ChannelPackageDto")
+    @JsonPropertyOrder({"name", "version", "release", "epoch", "checksum", "checksumType", "id",
+        "archLabel", "lastModifiedDate", "lastModified"})
+    interface PackageDtoDoc {
+
+        /**
+         * @return the package name
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the package version
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getVersion();
+
+        /**
+         * @return the package release
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getRelease();
+
+        /**
+         * @return the package epoch
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getEpoch();
+
+        /**
+         * @return the package checksum
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChecksum();
+
+        /**
+         * @return the package checksum type
+         */
+        @Schema(name = "checksum_type", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChecksumType();
+
+        /**
+         * @return the package id
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the package architecture label
+         */
+        @Schema(name = "arch_label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getArchLabel();
+
+        /**
+         * @return the last modification date of the package
+         */
+        @Schema(name = "last_modified_date", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLastModifiedDate();
+
+        /**
+         * @return the last modification date of the package
+         */
+        @Schema(name = "last_modified", description = "(deprecated)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLastModified();
+    }
+
+    @Schema(name = "ChannelArch")
+    @JsonPropertyOrder({"name", "label"})
+    interface ChannelArchDoc {
+
+        /**
+         * @return the architecture name
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the architecture label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+    }
+
+    @Schema(name = "ChannelSubscribedSystem")
+    @JsonPropertyOrder({"id", "name"})
+    interface SubscribedSystemDoc {
+
+        /**
+         * @return the system id
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the system name
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+    }
+
+    @Schema(name = "ChannelSystemChannel")
+    @JsonPropertyOrder({"id", "label", "name"})
+    interface SystemChannelDoc {
+
+        /**
+         * @return the channel id
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getId();
+
+        /**
+         * @return the channel label
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the channel name
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+    }
+
+    @Schema(name = "ChannelErrataByType")
+    @JsonPropertyOrder({"advisory", "issueDate", "updateDate", "synopsis", "advisoryType",
+        "lastModifiedDate"})
+    interface ErrataByTypeDoc {
+
+        /**
+         * @return the name of the advisory
+         */
+        @Schema(description = "name of the advisory", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdvisory();
+
+        /**
+         * @return the issue date of the erratum
+         */
+        @Schema(name = "issue_date", description = "date format follows YYYY-MM-DD HH24:MI:SS",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getIssueDate();
+
+        /**
+         * @return the update date of the erratum
+         */
+        @Schema(name = "update_date", description = "date format follows YYYY-MM-DD HH24:MI:SS",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUpdateDate();
+
+        /**
+         * @return the synopsis of the erratum
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSynopsis();
+
+        /**
+         * @return the type of the advisory
+         */
+        @Schema(name = "advisory_type", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdvisoryType();
+
+        /**
+         * @return the last modification date of the erratum
+         */
+        @Schema(name = "last_modified_date",
+                description = "date format follows YYYY-MM-DD HH24:MI:SS",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLastModifiedDate();
+    }
+
+    @Schema(name = "ChannelErrata")
+    @JsonPropertyOrder({"id", "date", "advisoryType", "advisoryStatus", "advisoryName",
+        "advisorySynopsis"})
+    interface ErrataDoc {
+
+        /**
+         * @return the id of the erratum
+         */
+        @Schema(description = "errata ID", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the creation date of the erratum
+         */
+        @Schema(description = "the date erratum was created",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getDate();
+
+        /**
+         * @return the type of the advisory
+         */
+        @Schema(name = "advisory_type", description = "type of the advisory",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdvisoryType();
+
+        /**
+         * @return the status of the advisory
+         */
+        @Schema(name = "advisory_status", description = "status of the advisory",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdvisoryStatus();
+
+        /**
+         * @return the name of the advisory
+         */
+        @Schema(name = "advisory_name", description = "name of the advisory",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdvisoryName();
+
+        /**
+         * @return the synopsis of the erratum
+         */
+        @Schema(name = "advisory_synopsis", description = "summary of the erratum",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdvisorySynopsis();
+    }
+
+    @Schema(name = "ChannelUserRepo")
+    @JsonPropertyOrder({"id", "label", "sourceUrl"})
+    interface UserRepoDoc {
+
+        /**
+         * @return the id of the repository
+         */
+        @Schema(description = "ID of the repo", requiredMode = Schema.RequiredMode.REQUIRED)
+        @LegacyDocResponse(type = "long")
+        Long getId();
+
+        /**
+         * @return the label of the repository
+         */
+        @Schema(description = "label of the repo", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the url of the repository
+         */
+        @Schema(description = "URL of the repo", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSourceUrl();
+    }
+
+    @Schema(name = "ContentSourceSslInfo")
+    @JsonPropertyOrder({"sslCaDesc", "sslCertDesc", "sslKeyDesc"})
+    interface ContentSourceSslDoc {
+
+        /**
+         * @return the description of the SSL CA certificate
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSslCaDesc();
+
+        /**
+         * @return the description of the SSL client certificate
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSslCertDesc();
+
+        /**
+         * @return the description of the SSL client key
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSslKeyDesc();
+    }
+
+    @Schema(name = "ContentSourceInfo")
+    @JsonPropertyOrder({"id", "label", "sourceUrl", "type", "hasSignedMetadata",
+        "sslContentSources"})
+    interface ContentSourceDoc {
+
+        /**
+         * @return the id of the repository
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the label of the repository
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the url of the repository
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSourceUrl();
+
+        /**
+         * @return the type of the repository
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getType();
+
+        /**
+         * @return whether the repository has signed metadata
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getHasSignedMetadata();
+
+        /**
+         * @return the SSL content sources of the repository
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @LegacyDocResponse(name = "content source SSL")
+        List<ContentSourceSslDoc> getSslContentSources();
+    }
+
+    @Schema(name = "ContentSourceFilterInfo")
+    @JsonPropertyOrder({"sortOrder", "filter", "flag"})
+    interface ContentSourceFilterDoc {
+
+        /**
+         * @return the sort order of the filter
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getSortOrder();
+
+        /**
+         * @return the filter
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getFilter();
+
+        /**
+         * @return the flag of the filter
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getFlag();
+    }
+
+    @Schema(name = "ChannelSoftwareSyncErrataRequest")
+    interface SyncErrataRequest {
+
+        /**
+         * @return the channel to update
+         */
+        @Schema(description = "channel to update", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+    }
+
+    @Schema(name = "ChannelSoftwareDeleteRequest")
+    interface DeleteRequest {
+
+        /**
+         * @return the channel to delete
+         */
+        @Schema(description = "channel to delete", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+    }
+
+    @Schema(name = "ChannelSoftwareDetails")
+    @JsonPropertyOrder({"checksumLabel", "name", "summary", "description", "maintainerName",
+        "maintainerEmail", "maintainerPhone", "gpgKeyUrl", "gpgKeyId", "gpgKeyFp", "gpgCheck"})
+    interface ChannelDetailsDoc {
+
+        /**
+         * @return the checksum label of the channel repository
+         */
+        @Schema(name = "checksum_label",
+                description = "new channel repository checksum label (optional)")
+        String getChecksumLabel();
+
+        /**
+         * @return the name of the channel
+         */
+        @Schema(description = "new channel name (optional)")
+        String getName();
+
+        /**
+         * @return the summary of the channel
+         */
+        @Schema(description = "new channel summary (optional)")
+        String getSummary();
+
+        /**
+         * @return the description of the channel
+         */
+        @Schema(description = "new channel description (optional)")
+        String getDescription();
+
+        /**
+         * @return the name of the channel maintainer
+         */
+        @Schema(name = "maintainer_name", description = "new channel maintainer name (optional)")
+        String getMaintainerName();
+
+        /**
+         * @return the email of the channel maintainer
+         */
+        @Schema(name = "maintainer_email", description = "new channel email address (optional)")
+        String getMaintainerEmail();
+
+        /**
+         * @return the phone number of the channel maintainer
+         */
+        @Schema(name = "maintainer_phone", description = "new channel phone number (optional)")
+        String getMaintainerPhone();
+
+        /**
+         * @return the GPG key url of the channel
+         */
+        @Schema(name = "gpg_key_url", description = "new channel gpg key url (optional)")
+        String getGpgKeyUrl();
+
+        /**
+         * @return the GPG key id of the channel
+         */
+        @Schema(name = "gpg_key_id", description = "new channel gpg key id (optional)")
+        String getGpgKeyId();
+
+        /**
+         * @return the GPG key fingerprint of the channel
+         */
+        @Schema(name = "gpg_key_fp", description = "new channel gpg key fingerprint (optional)")
+        String getGpgKeyFp();
+
+        /**
+         * @return whether the GPG check is enabled
+         */
+        @Schema(name = "gpg_check", description = "enable/disable gpg check (optional)")
+        String getGpgCheck();
+    }
+
+    @Schema(name = "ChannelSoftwareSetDetailsRequest")
+    @JsonPropertyOrder({"channelLabel", "details"})
+    interface SetDetailsRequest {
+
+        /**
+         * @return the channel label
+         */
+        @Schema(description = "channel label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return the attributes to modify
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        ChannelDetailsDoc getDetails();
+    }
+
+    @Schema(name = "ChannelSoftwareSetDetailsByIdRequest")
+    @JsonPropertyOrder({"channelId", "details"})
+    interface SetDetailsByIdRequest {
+
+        /**
+         * @return the channel id
+         */
+        @Schema(description = "channel id", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getChannelId();
+
+        /**
+         * @return the attributes to modify
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        ChannelDetailsDoc getDetails();
+    }
+
+    @Schema(name = "ChannelSoftwareGpgKey")
+    @JsonPropertyOrder({"url", "id", "fingerprint"})
+    interface GpgKeyDoc {
+
+        /**
+         * @return the GPG key url
+         */
+        @Schema(description = "GPG key URL")
+        String getUrl();
+
+        /**
+         * @return the GPG key id
+         */
+        @Schema(description = "GPG key ID")
+        String getId();
+
+        /**
+         * @return the GPG key fingerprint
+         */
+        @Schema(description = "GPG key Fingerprint")
+        String getFingerprint();
+    }
+
+    @Schema(name = "ChannelSoftwareCreateWithGpgCheckRequest")
+    @JsonPropertyOrder({"label", "name", "summary", "archLabel", "parentLabel", "checksumType",
+        "gpgKey", "gpgCheck"})
+    interface CreateWithGpgCheckRequest extends CreateWithGpgKeyRequest {
+
+        /**
+         * @return whether the GPG check is enabled by default
+         */
+        @Schema(description = "true if the GPG check should be enabled by default, false otherwise",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getGpgCheck();
+    }
+
+    @Schema(name = "ChannelSoftwareCreateWithGpgKeyRequest")
+    @JsonPropertyOrder({"label", "name", "summary", "archLabel", "parentLabel", "checksumType",
+        "gpgKey"})
+    interface CreateWithGpgKeyRequest extends CreateWithChecksumRequest {
+
+        /**
+         * @return the GPG key of the channel
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        GpgKeyDoc getGpgKey();
+    }
+
+    @Schema(name = "ChannelSoftwareCreateWithChecksumRequest")
+    @JsonPropertyOrder({"label", "name", "summary", "archLabel", "parentLabel", "checksumType"})
+    interface CreateWithChecksumRequest extends CreateRequest {
+
+        /**
+         * @return the checksum type of the channel
+         */
+        @Schema(description = "checksum type for this channel, used for yum repository metadata " +
+                    "generation",
+                allowableValues = {"sha1", "sha256"},
+                extensions = @Extension(name = "x-uyuni-doc-option-descriptions", properties = {
+                    @ExtensionProperty(name = "sha1",
+                        value = "offers widest compatibility with clients"),
+                    @ExtensionProperty(name = "sha256",
+                        value = "offers highest security, but is compatible only with newer " +
+                            "clients: Fedora 11 and newer, or Enterprise Linux 6 and newer.")
+                }),
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChecksumType();
+    }
+
+    @Schema(name = "ChannelSoftwareCreateRequest")
+    @JsonPropertyOrder({"label", "name", "summary", "archLabel", "parentLabel"})
+    interface CreateRequest {
+
+        /**
+         * @return the label of the new channel
+         */
+        @Schema(description = "label of the new channel",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the name of the new channel
+         */
+        @Schema(description = "name of the new channel",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the summary of the new channel
+         */
+        @Schema(description = "summary of the channel",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSummary();
+
+        /**
+         * @return the architecture of the new channel
+         */
+        @Schema(description = "the label of the architecture the channel corresponds to, run " +
+                    "channel.software.listArches API for complete listing",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getArchLabel();
+
+        /**
+         * @return the label of the parent channel
+         */
+        @Schema(description = "label of the parent of this channel, an empty string if it does " +
+                    "not have one",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getParentLabel();
+    }
+
+    @Schema(name = "ChannelSoftwareSetContactDetailsRequest")
+    @JsonPropertyOrder({"channelLabel", "maintainerName", "maintainerEmail", "maintainerPhone",
+        "supportPolicy"})
+    interface SetContactDetailsRequest {
+
+        /**
+         * @return the label of the channel
+         */
+        @Schema(description = "label of the channel", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return the name of the channel maintainer
+         */
+        @Schema(description = "name of the channel maintainer",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getMaintainerName();
+
+        /**
+         * @return the email of the channel maintainer
+         */
+        @Schema(description = "email of the channel maintainer",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getMaintainerEmail();
+
+        /**
+         * @return the phone number of the channel maintainer
+         */
+        @Schema(description = "phone number of the channel maintainer",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getMaintainerPhone();
+
+        /**
+         * @return the support policy of the channel
+         */
+        @Schema(description = "channel support policy",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSupportPolicy();
+    }
+
+    @Schema(name = "ChannelSoftwareSetUserSubscribableRequest")
+    @JsonPropertyOrder({"channelLabel", "login", "value"})
+    interface SetUserSubscribableRequest {
+
+        /**
+         * @return the label of the channel
+         */
+        @Schema(description = "label of the channel", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return the login of the target user
+         */
+        @Schema(description = "login of the target user",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLogin();
+
+        /**
+         * @return the value of the flag
+         */
+        @Schema(description = "value of the flag to set",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getValue();
+    }
+
+    @Schema(name = "ChannelSoftwareSetUserManageableRequest")
+    @JsonPropertyOrder({"channelLabel", "login", "value"})
+    interface SetUserManageableRequest {
+
+        /**
+         * @return the label of the channel
+         */
+        @Schema(description = "label of the channel", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return the login of the target user
+         */
+        @Schema(description = "login of the target user",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLogin();
+
+        /**
+         * @return the value of the flag
+         */
+        @Schema(description = "value of the flag to set",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getValue();
+    }
+
+    @Schema(name = "ChannelSoftwareSetGloballySubscribableRequest")
+    @JsonPropertyOrder({"channelLabel", "value"})
+    interface SetGloballySubscribableRequest {
+
+        /**
+         * @return the label of the channel
+         */
+        @Schema(description = "label of the channel", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return whether the channel is globally subscribable
+         */
+        @Schema(description = "true if the channel is to be globally subscribable. False " +
+                    "otherwise.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getValue();
+    }
+
+    @Schema(name = "ChannelSoftwareAddPackagesRequest")
+    @JsonPropertyOrder({"channelLabel", "packageIds"})
+    interface AddPackagesRequest {
+
+        /**
+         * @return the target channel
+         */
+        @Schema(description = "target channel", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return the ids of the packages to add
+         */
+        @Schema(description = "ID of a package to add to the channel",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        List<Long> getPackageIds();
+    }
+
+    @Schema(name = "ChannelSoftwareRemoveErrataRequest")
+    @JsonPropertyOrder({"channelLabel", "errataNames", "removePackages"})
+    interface RemoveErrataRequest {
+
+        /**
+         * @return the target channel
+         */
+        @Schema(description = "target channel", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return the names of the errata to remove
+         */
+        @Schema(description = "name of an erratum to remove",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        List<String> getErrataNames();
+
+        /**
+         * @return whether to remove the packages from the channel
+         */
+        @Schema(description = "true to remove packages from the channel",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getRemovePackages();
+    }
+
+    @Schema(name = "ChannelSoftwareRemovePackagesRequest")
+    @JsonPropertyOrder({"channelLabel", "packageIds"})
+    interface RemovePackagesRequest {
+
+        /**
+         * @return the target channel
+         */
+        @Schema(description = "target channel", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return the ids of the packages to remove
+         */
+        @Schema(description = "ID of a package to remove from the channel",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        List<Long> getPackageIds();
+    }
+
+    @Schema(name = "ChannelSoftwareCloneDetails")
+    @JsonPropertyOrder({"name", "label", "summary", "parentLabel", "archLabel", "gpgKeyUrl",
+        "gpgKeyId", "gpgKeyFp", "gpgCheck", "description", "checksum"})
+    interface CloneDetailsDoc {
+
+        /**
+         * @return the name of the cloned channel
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the label of the cloned channel
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the summary of the cloned channel
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSummary();
+
+        /**
+         * @return the label of the parent channel
+         */
+        @Schema(name = "parent_label", description = "(optional)")
+        String getParentLabel();
+
+        /**
+         * @return the architecture of the cloned channel
+         */
+        @Schema(name = "arch_label", description = "(optional)")
+        String getArchLabel();
+
+        /**
+         * @return the GPG key url of the cloned channel
+         */
+        @Schema(name = "gpg_key_url",
+                description = "(optional), gpg_url might be used as well")
+        String getGpgKeyUrl();
+
+        /**
+         * @return the GPG key id of the cloned channel
+         */
+        @Schema(name = "gpg_key_id", description = "(optional), gpg_id might be used as well")
+        String getGpgKeyId();
+
+        /**
+         * @return the GPG key fingerprint of the cloned channel
+         */
+        @Schema(name = "gpg_key_fp",
+                description = "(optional), gpg_fingerprint might be used as well")
+        String getGpgKeyFp();
+
+        /**
+         * @return whether the GPG check is enabled
+         */
+        @Schema(name = "gpg_check", description = "(optional)")
+        String getGpgCheck();
+
+        /**
+         * @return the description of the cloned channel
+         */
+        @Schema(description = "(optional)")
+        String getDescription();
+
+        /**
+         * @return the checksum type of the cloned channel
+         */
+        @Schema(description = "either sha1 or sha256")
+        String getChecksum();
+    }
+
+    @Schema(name = "ChannelSoftwareCloneRequest")
+    @JsonPropertyOrder({"originalLabel", "channelDetails", "originalState"})
+    interface CloneRequest {
+
+        /**
+         * @return the label of the channel to clone
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getOriginalLabel();
+
+        /**
+         * @return the details of the cloned channel
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        CloneDetailsDoc getChannelDetails();
+
+        /**
+         * @return whether to clone the original state
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getOriginalState();
+    }
+
+    @Schema(name = "ChannelSoftwareMergeErrataRequest")
+    @JsonPropertyOrder({"mergeFromLabel", "mergeToLabel"})
+    interface MergeErrataRequest {
+
+        /**
+         * @return the channel to pull the errata from
+         */
+        @Schema(description = "the label of the channel to pull errata from",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getMergeFromLabel();
+
+        /**
+         * @return the channel to push the errata into
+         */
+        @Schema(description = "the label to push the errata into",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getMergeToLabel();
+    }
+
+    @Schema(name = "ChannelSoftwareMergeErrataByDateRequest")
+    @JsonPropertyOrder({"mergeFromLabel", "mergeToLabel", "startDate", "endDate"})
+    interface MergeErrataByDateRequest extends MergeErrataRequest {
+
+        /**
+         * @return the start date
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getStartDate();
+
+        /**
+         * @return the end date
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getEndDate();
+    }
+
+    @Schema(name = "ChannelSoftwareMergeErrataByNameRequest")
+    @JsonPropertyOrder({"mergeFromLabel", "mergeToLabel", "errataNames"})
+    interface MergeErrataByNameRequest extends MergeErrataRequest {
+
+        /**
+         * @return the advisory names of the errata to merge
+         */
+        @Schema(description = "the advisory name of the errata to merge",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        List<String> getErrataNames();
+    }
+
+    @Schema(name = "ChannelSoftwareMergePackagesRequest")
+    @JsonPropertyOrder({"mergeFromLabel", "mergeToLabel"})
+    interface MergePackagesRequest {
+
+        /**
+         * @return the channel to pull the packages from
+         */
+        @Schema(description = "the label of the channel to pull packages from",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getMergeFromLabel();
+
+        /**
+         * @return the channel to push the packages into
+         */
+        @Schema(description = "the label to push the packages into",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getMergeToLabel();
+    }
+
+    @Schema(name = "ChannelSoftwareMergePackagesAlignedRequest")
+    @JsonPropertyOrder({"mergeFromLabel", "mergeToLabel", "alignModules"})
+    interface MergePackagesAlignedRequest extends MergePackagesRequest {
+
+        /**
+         * @return whether to align the modular data
+         */
+        @Schema(description = "align modular data of the target channel to the source channel " +
+                    "(RHEL8 and higher)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getAlignModules();
+    }
+
+    @Schema(name = "ChannelSoftwareAlignMetadataRequest")
+    @JsonPropertyOrder({"channelFromLabel", "channelToLabel", "metadataType"})
+    interface AlignMetadataRequest {
+
+        /**
+         * @return the label of the source channel
+         */
+        @Schema(description = "the label of the source channel",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelFromLabel();
+
+        /**
+         * @return the label of the target channel
+         */
+        @Schema(description = "the label of the target channel",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelToLabel();
+
+        /**
+         * @return the metadata type
+         */
+        @Schema(description = "the metadata type. Only 'modules' supported currently.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getMetadataType();
+    }
+
+    @Schema(name = "ChannelSoftwareRegenerateNeededCacheRequest")
+    interface RegenerateNeededCacheRequest {
+
+        /**
+         * @return the label of the channel
+         */
+        @Schema(description = "the label of the channel",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+    }
+
+    @Schema(name = "ChannelSoftwareRegenerateYumCacheRequest")
+    @JsonPropertyOrder({"channelLabel", "force"})
+    interface RegenerateYumCacheRequest {
+
+        /**
+         * @return the label of the channel
+         */
+        @Schema(description = "the label of the channel",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return whether to force the cache regeneration
+         */
+        @Schema(description = "force cache regeneration",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getForce();
+    }
+
+    @Schema(name = "ChannelSoftwareCreateRepoRequest")
+    @JsonPropertyOrder({"label", "type", "url"})
+    interface CreateRepoRequest {
+
+        /**
+         * @return the repository label
+         */
+        @Schema(description = "repository label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the repository type
+         */
+        @Schema(description = "repository type (yum, uln...)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getType();
+
+        /**
+         * @return the repository url
+         */
+        @Schema(description = "repository url", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUrl();
+    }
+
+    @Schema(name = "ChannelSoftwareCreateRepoWithSslRequest")
+    @JsonPropertyOrder({"label", "type", "url", "sslCaCert", "sslCliCert", "sslCliKey"})
+    interface CreateRepoWithSslRequest extends CreateRepoRequest {
+
+        /**
+         * @return the description of the SSL CA certificate
+         */
+        @Schema(description = "SSL CA cert description",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSslCaCert();
+
+        /**
+         * @return the description of the SSL client certificate
+         */
+        @Schema(description = "SSL Client cert description",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSslCliCert();
+
+        /**
+         * @return the description of the SSL client key
+         */
+        @Schema(description = "SSL Client key description",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSslCliKey();
+    }
+
+    @Schema(name = "ChannelSoftwareCreateRepoWithMetadataRequest")
+    @JsonPropertyOrder({"label", "type", "url", "sslCaCert", "sslCliCert", "sslCliKey",
+        "hasSignedMetadata"})
+    interface CreateRepoWithMetadataRequest extends CreateRepoWithSslRequest {
+
+        /**
+         * @return whether the repository has signed metadata
+         */
+        @Schema(description = "true if the repository has signed metadata, false otherwise",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getHasSignedMetadata();
+    }
+
+    @Schema(name = "ChannelSoftwareRemoveRepoByIdRequest")
+    interface RemoveRepoByIdRequest {
+
+        /**
+         * @return the id of the repository to remove
+         */
+        @Schema(description = "ID of repo to be removed",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @LegacyDocResponse(type = "long")
+        Integer getId();
+    }
+
+    @Schema(name = "ChannelSoftwareRemoveRepoByLabelRequest")
+    interface RemoveRepoByLabelRequest {
+
+        /**
+         * @return the label of the repository to remove
+         */
+        @Schema(description = "label of repo to be removed",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+    }
+
+    @Schema(name = "ChannelSoftwareAssociateRepoRequest")
+    @JsonPropertyOrder({"channelLabel", "repoLabel"})
+    interface AssociateRepoRequest {
+
+        /**
+         * @return the channel label
+         */
+        @Schema(description = "channel label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return the repository label
+         */
+        @Schema(description = "repository label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getRepoLabel();
+    }
+
+    @Schema(name = "ChannelSoftwareDisassociateRepoRequest")
+    @JsonPropertyOrder({"channelLabel", "repoLabel"})
+    interface DisassociateRepoRequest {
+
+        /**
+         * @return the channel label
+         */
+        @Schema(description = "channel label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return the repository label
+         */
+        @Schema(description = "repository label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getRepoLabel();
+    }
+
+    @Schema(name = "ChannelSoftwareUpdateRepoUrlByIdRequest")
+    @JsonPropertyOrder({"id", "url"})
+    interface UpdateRepoUrlByIdRequest {
+
+        /**
+         * @return the repository id
+         */
+        @Schema(description = "repository ID", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the new repository url
+         */
+        @Schema(description = "new repository URL", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUrl();
+    }
+
+    @Schema(name = "ChannelSoftwareUpdateRepoUrlByLabelRequest")
+    @JsonPropertyOrder({"label", "url"})
+    interface UpdateRepoUrlByLabelRequest {
+
+        /**
+         * @return the repository label
+         */
+        @Schema(description = "repository label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the new repository url
+         */
+        @Schema(description = "new repository URL", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUrl();
+    }
+
+    @Schema(name = "ChannelSoftwareUpdateRepoSslByIdRequest")
+    @JsonPropertyOrder({"id", "sslCaCert", "sslCliCert", "sslCliKey"})
+    interface UpdateRepoSslByIdRequest {
+
+        /**
+         * @return the repository id
+         */
+        @Schema(description = "repository ID", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the description of the SSL CA certificate
+         */
+        @Schema(description = "SSL CA cert description",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSslCaCert();
+
+        /**
+         * @return the description of the SSL client certificate
+         */
+        @Schema(description = "SSL Client cert description",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSslCliCert();
+
+        /**
+         * @return the description of the SSL client key
+         */
+        @Schema(description = "SSL Client key description",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSslCliKey();
+    }
+
+    @Schema(name = "ChannelSoftwareUpdateRepoSslByLabelRequest")
+    @JsonPropertyOrder({"label", "sslCaCert", "sslCliCert", "sslCliKey"})
+    interface UpdateRepoSslByLabelRequest {
+
+        /**
+         * @return the repository label
+         */
+        @Schema(description = "repository label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the description of the SSL CA certificate
+         */
+        @Schema(description = "SSL CA cert description",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSslCaCert();
+
+        /**
+         * @return the description of the SSL client certificate
+         */
+        @Schema(description = "SSL Client cert description",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSslCliCert();
+
+        /**
+         * @return the description of the SSL client key
+         */
+        @Schema(description = "SSL Client key description",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSslCliKey();
+    }
+
+    @Schema(name = "ChannelSoftwareUpdateRepoLabelByIdRequest")
+    @JsonPropertyOrder({"id", "label"})
+    interface UpdateRepoLabelByIdRequest {
+
+        /**
+         * @return the repository id
+         */
+        @Schema(description = "repository ID", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the new repository label
+         */
+        @Schema(description = "new repository label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+    }
+
+    @Schema(name = "ChannelSoftwareUpdateRepoLabelByLabelRequest")
+    @JsonPropertyOrder({"label", "newLabel"})
+    interface UpdateRepoLabelByLabelRequest {
+
+        /**
+         * @return the repository label
+         */
+        @Schema(description = "repository label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the new repository label
+         */
+        @Schema(description = "new repository label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getNewLabel();
+    }
+
+    @Schema(name = "ChannelSoftwareUpdateRepoRequest")
+    @JsonPropertyOrder({"id", "label", "url"})
+    interface UpdateRepoRequest {
+
+        /**
+         * @return the repository id
+         */
+        @Schema(description = "repository ID", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the new repository label
+         */
+        @Schema(description = "new repository label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the new repository url
+         */
+        @Schema(description = "new repository URL", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUrl();
+    }
+
+    @Schema(name = "ChannelSoftwareSyncRepoListRequest")
+    interface SyncRepoListRequest {
+
+        /**
+         * @return the channel labels
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        List<String> getChannelLabels();
+    }
+
+    @Schema(name = "ChannelSoftwareSyncRepoRequest")
+    interface SyncRepoRequest {
+
+        /**
+         * @return the channel label
+         */
+        @Schema(description = "channel label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+    }
+
+    @Schema(name = "ChannelSoftwareSyncParams")
+    @JsonPropertyOrder({"syncKickstart", "noErrata", "fail", "latest"})
+    interface SyncParamsDoc {
+
+        /**
+         * @return whether to create a kickstartable tree
+         */
+        @Schema(name = "sync-kickstart", description = "create kickstartable tree - Optional")
+        Boolean getSyncKickstart();
+
+        /**
+         * @return whether to skip the errata synchronisation
+         */
+        @Schema(name = "no-errata", description = "do not sync errata - Optional")
+        Boolean getNoErrata();
+
+        /**
+         * @return whether to terminate upon any error
+         */
+        @Schema(description = "terminate upon any error - Optional")
+        Boolean getFail();
+
+        /**
+         * @return whether to download only the latest packages
+         */
+        @Schema(description = "only download latest packages - Optional")
+        Boolean getLatest();
+    }
+
+    @Schema(name = "ChannelSoftwareSyncRepoWithParamsRequest")
+    @JsonPropertyOrder({"channelLabel", "params"})
+    interface SyncRepoWithParamsRequest {
+
+        /**
+         * @return the channel label
+         */
+        @Schema(description = "channel label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return the synchronisation parameters
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        SyncParamsDoc getParams();
+    }
+
+    @Schema(name = "ChannelSoftwareSyncRepoScheduleRequest")
+    @JsonPropertyOrder({"channelLabel", "cronExpr"})
+    interface SyncRepoScheduleRequest {
+
+        /**
+         * @return the channel label
+         */
+        @Schema(description = "channel label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return the cron expression
+         */
+        @Schema(description = "cron expression, if empty all periodic schedules will be disabled",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getCronExpr();
+    }
+
+    @Schema(name = "ChannelSoftwareSyncRepoScheduleWithParamsRequest")
+    @JsonPropertyOrder({"channelLabel", "cronExpr", "params"})
+    interface SyncRepoScheduleWithParamsRequest extends SyncRepoScheduleRequest {
+
+        /**
+         * @return the synchronisation parameters
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        SyncParamsDoc getParams();
+    }
+
+    @Schema(name = "ChannelSoftwareRepoFilterProps")
+    @JsonPropertyOrder({"filter", "flag"})
+    interface RepoFilterPropsDoc {
+
+        /**
+         * @return the string to filter on
+         */
+        @Schema(description = "string to filter on")
+        String getFilter();
+
+        /**
+         * @return the flag of the filter
+         */
+        @Schema(description = "+ for include, - for exclude")
+        String getFlag();
+    }
+
+    @Schema(name = "ChannelSoftwareAddRepoFilterRequest")
+    @JsonPropertyOrder({"label", "filterProps"})
+    interface AddRepoFilterRequest {
+
+        /**
+         * @return the repository label
+         */
+        @Schema(description = "repository label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the filter properties
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        RepoFilterPropsDoc getFilterProps();
+    }
+
+    @Schema(name = "ChannelSoftwareRemoveRepoFilterRequest")
+    @JsonPropertyOrder({"label", "filterProps"})
+    interface RemoveRepoFilterRequest {
+
+        /**
+         * @return the repository label
+         */
+        @Schema(description = "repository label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the filter properties
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        RepoFilterPropsDoc getFilterProps();
+    }
+
+    @Schema(name = "ChannelSoftwareSetRepoFiltersRequest")
+    @JsonPropertyOrder({"label", "filterProps"})
+    interface SetRepoFiltersRequest {
+
+        /**
+         * @return the repository label
+         */
+        @Schema(description = "repository label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the filter properties
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @LegacyDocResponse(name = "filter properties")
+        List<RepoFilterPropsDoc> getFilterProps();
+    }
+
+    @Schema(name = "ChannelSoftwareClearRepoFiltersRequest")
+    interface ClearRepoFiltersRequest {
+
+        /**
+         * @return the repository label
+         */
+        @Schema(description = "repository label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+    }
+
+    @Schema(name = "ChannelSoftwareApplyChannelStateRequest")
+    interface ApplyChannelStateRequest {
+
+        /**
+         * @return the system ids
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        List<Integer> getSids();
+    }
+
+    @Schema(name = "ChannelSoftwareSetAutoSyncRequest")
+    @JsonPropertyOrder({"channelLabel", "autoSync"})
+    interface SetAutoSyncRequest {
+
+        /**
+         * @return the label of the channel
+         */
+        @Schema(description = "label of the channel", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChannelLabel();
+
+        /**
+         * @return the value of the automatic synchronization option
+         */
+        @Schema(description = "Value to set on the channel automatic synchronization",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @LegacyDocResponse(type = "Boolean")
+        Boolean getAutoSync();
+    }
+
+    @Schema(name = "ApiResponseString")
+    interface StringResponse extends ApiResponseWrapper<String> { }
+
+    @Schema(name = "ApiResponseBoolean")
+    interface BooleanResponse extends ApiResponseWrapper<Boolean> { }
+
+    @Schema(name = "ApiResponseChannelErrataOverviewList")
+    interface ErrataOverviewListResponse
+        extends ApiResponseWrapper<List<ImageInfoHandlerApi.ErrataOverviewDoc>> { }
+
+    @Schema(name = "ApiResponseChannelLatestPackageList")
+    interface LatestPackageListResponse extends ApiResponseWrapper<List<LatestPackageDoc>> { }
+
+    @Schema(name = "ApiResponseChannelPackageDtoList")
+    interface PackageDtoListResponse extends ApiResponseWrapper<List<PackageDtoDoc>> { }
+
+    @Schema(name = "ApiResponseChannelArchList")
+    interface ChannelArchListResponse extends ApiResponseWrapper<List<ChannelArchDoc>> { }
+
+    @Schema(name = "ApiResponseSoftwareChannel")
+    interface SoftwareChannelResponse
+        extends ApiResponseWrapper<ChannelAppStreamHandlerApi.ChannelDoc> { }
+
+    @Schema(name = "ApiResponseChannelSubscribedSystemList")
+    interface SubscribedSystemListResponse extends ApiResponseWrapper<List<SubscribedSystemDoc>> { }
+
+    @Schema(name = "ApiResponseChannelSystemChannelList")
+    interface SystemChannelListResponse extends ApiResponseWrapper<List<SystemChannelDoc>> { }
+
+    @Schema(name = "ApiResponseChannelErrataByTypeList")
+    interface ErrataByTypeListResponse extends ApiResponseWrapper<List<ErrataByTypeDoc>> { }
+
+    @Schema(name = "ApiResponseChannelErrataList")
+    interface ErrataListResponse extends ApiResponseWrapper<List<ErrataDoc>> { }
+
+    @Schema(name = "ApiResponseChannelUserRepoList")
+    interface UserRepoListResponse extends ApiResponseWrapper<List<UserRepoDoc>> { }
+
+    @Schema(name = "ApiResponseContentSource")
+    interface ContentSourceResponse extends ApiResponseWrapper<ContentSourceDoc> { }
+
+    @Schema(name = "ApiResponseContentSourceList")
+    interface ContentSourceListResponse extends ApiResponseWrapper<List<ContentSourceDoc>> { }
+
+    @Schema(name = "ApiResponseContentSourceFilterList")
+    interface ContentSourceFilterListResponse
+        extends ApiResponseWrapper<List<ContentSourceFilterDoc>> { }
+}

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandlerApi.java
@@ -1501,7 +1501,7 @@ public interface ChannelSoftwareHandlerApi {
 
     @Schema(name = "ChannelPackageDto")
     @JsonPropertyOrder({"name", "version", "release", "epoch", "checksum", "checksumType", "id",
-        "archLabel", "lastModifiedDate", "lastModified"})
+        "archLabel", "lastModifiedDate", "retracted", "lastModified"})
     interface PackageDtoDoc {
 
         /**
@@ -1557,6 +1557,12 @@ public interface ChannelSoftwareHandlerApi {
          */
         @Schema(name = "last_modified_date", requiredMode = Schema.RequiredMode.REQUIRED)
         String getLastModifiedDate();
+
+        /**
+         * @return whether the package has been retracted
+         */
+        @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        Boolean getRetracted();
 
         /**
          * @return the last modification date of the package

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandler.java
@@ -66,7 +66,7 @@ import java.util.stream.Collectors;
  * @apidoc.namespace image
  * @apidoc.doc Provides methods to access and modify images.
  */
-public class ImageInfoHandler extends BaseHandler {
+public class ImageInfoHandler extends BaseHandler implements ImageInfoHandlerApi {
 
     private final SaltApi saltApi;
 

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandler.java
@@ -341,7 +341,7 @@ public class ImageInfoHandler extends BaseHandler implements ImageInfoHandlerApi
      * @param external the file is external
      * @return 1 on success
      *
-     * @apidoc.doc Delete image file
+     * @apidoc.doc Add an image file
      * @apidoc.param #session_key()
      * @apidoc.param #param_desc("int", "imageId", "ID of the image")
      * @apidoc.param #param_desc("string", "file", "the file name, it must exist in the store")
@@ -496,11 +496,7 @@ public class ImageInfoHandler extends BaseHandler implements ImageInfoHandlerApi
      * @apidoc.doc Get the custom data values defined for the image
      * @apidoc.param #session_key()
      * @apidoc.param #param("int", "imageId")
-     * @apidoc.returntype
-     *    #struct_begin("the map of custom labels to custom values")
-     *      #prop("string", "custom info label")
-     *      #prop("string", "value")
-     *    #struct_end()
+     * @apidoc.returntype #param("struct", "the map of custom labels to custom values")
      */
     @ReadOnly
     public Map<String, String> getCustomValues(User loggedInUser, Integer imageId) {

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandlerApi.java
@@ -185,7 +185,7 @@ public interface ImageInfoHandlerApi {
      * @return 1 on success
      */
     @ApiEndpointDoc(
-        summary = "Delete image file",
+        summary = "Add an image file",
         requestClass = AddImageFileRequest.class,
         isIntegerResponse = true
     )
@@ -255,7 +255,7 @@ public interface ImageInfoHandlerApi {
         summary = "Get the custom data values defined for the image",
         method = HttpMethod.get,
         responseClass = ImageCustomValuesResponse.class,
-        legacyDocResponse = @LegacyDocResponse(name = "the map of custom labels to custom values")
+        legacyDocResponse = @LegacyDocResponse(type = "struct", name = "the map of custom labels to custom values")
     )
     Map<String, String> getCustomValues(
         @Parameter(hidden = true) User loggedInUser,
@@ -285,7 +285,7 @@ public interface ImageInfoHandlerApi {
     interface ImagePillarResponse extends ApiResponseWrapper<Map<String, Object>> { }
 
     @Schema(name = "ApiResponseImageActionId")
-    interface ImageActionIdResponse extends ApiResponseWrapper<Integer> { }
+    interface ImageActionIdResponse extends ApiResponseWrapper<Long> { }
 
     @Schema(name = "ApiResponseImageErrataList")
     interface ImageErrataListResponse extends ApiResponseWrapper<List<ErrataOverviewDoc>> { }
@@ -294,7 +294,7 @@ public interface ImageInfoHandlerApi {
     interface ImagePackageListResponse extends ApiResponseWrapper<List<ImagePackageDoc>> { }
 
     @Schema(name = "ApiResponseImageCustomValues")
-    interface ImageCustomValuesResponse extends ApiResponseWrapper<ImageCustomValuesDoc> { }
+    interface ImageCustomValuesResponse extends ApiResponseWrapper<Map<String, String>> { }
 
     @Schema(name = "ImageSetPillarRequest")
     @JsonPropertyOrder({"imageId", "pillarData"})
@@ -573,7 +573,7 @@ public interface ImageInfoHandlerApi {
          * @return whether the image is obsolete
          */
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        String getObsolete();
+        Boolean getObsolete();
     }
 
     @Schema(name = "ImageOverviewInformation")
@@ -656,7 +656,7 @@ public interface ImageInfoHandlerApi {
          */
         @Schema(description = "Available if the build is successful. One of:",
                 allowableValues = {"queued", "picked up", "completed", "failed"},
-                requiredMode = Schema.RequiredMode.REQUIRED)
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         String getInspectStatus();
 
         /**
@@ -696,14 +696,11 @@ public interface ImageInfoHandlerApi {
         Integer getInstalledPackages();
 
         /**
-         * The image files are documented as a free-form struct.
-         *
          * @return the image files
          */
-        @Schema(description = "image files", requiredMode = Schema.RequiredMode.REQUIRED,
-                additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
-        @LegacyDocResponse(type = "struct")
-        Map<String, Object> getFiles();
+        @Schema(description = "image files", requiredMode = Schema.RequiredMode.REQUIRED)
+        @LegacyDocResponse(name = "image information")
+        List<ImageFileDoc> getFiles();
 
         /**
          * @return whether the image has been replaced in the store
@@ -795,6 +792,36 @@ public interface ImageInfoHandlerApi {
         Boolean getRestartSuggested();
     }
 
+    @Schema(name = "ImageFile")
+    @JsonPropertyOrder({"file", "type", "external", "url"})
+    interface ImageFileDoc {
+
+        /**
+         * @return the name of the file
+         */
+        @Schema(description = "file name without path", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getFile();
+
+        /**
+         * @return the type of the file
+         */
+        @Schema(description = "file type", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getType();
+
+        /**
+         * @return whether the file is external
+         */
+        @Schema(description = "true if the file is external, false otherwise",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getExternal();
+
+        /**
+         * @return the URL of the file
+         */
+        @Schema(description = "file url", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUrl();
+    }
+
     @Schema(name = "ImagePackage")
     @JsonPropertyOrder({"name", "version", "release", "epoch", "arch"})
     interface ImagePackageDoc {
@@ -828,22 +855,5 @@ public interface ImageInfoHandlerApi {
          */
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String getArch();
-    }
-
-    @Schema(name = "ImageCustomValues")
-    @JsonPropertyOrder({"customInfoLabel", "value"})
-    interface ImageCustomValuesDoc {
-
-        /**
-         * @return the custom info label
-         */
-        @Schema(name = "custom info label", requiredMode = Schema.RequiredMode.REQUIRED)
-        String getCustomInfoLabel();
-
-        /**
-         * @return the custom value
-         */
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        String getValue();
     }
 }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandlerApi.java
@@ -516,7 +516,7 @@ public interface ImageInfoHandlerApi {
     }
 
     @Schema(name = "ImageInformation")
-    @JsonPropertyOrder({"id", "name", "version", "revision", "arch", "external", "storeLabel", "checksum",
+    @JsonPropertyOrder({"id", "name", "type", "version", "revision", "arch", "external", "storeLabel", "checksum",
         "obsolete"})
     interface ImageInfoDoc {
 
@@ -531,6 +531,12 @@ public interface ImageInfoHandlerApi {
          */
         @Schema(description = "image name", requiredMode = Schema.RequiredMode.REQUIRED)
         String getName();
+
+        /**
+         * @return the type of the image
+         */
+        @Schema(description = "image type", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getType();
 
         /**
          * @return the version of the image

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandlerApi.java
@@ -1,0 +1,849 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.image;
+
+import com.redhat.rhn.domain.image.ImageInfo;
+import com.redhat.rhn.domain.image.ImageOverview;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.dto.ErrataOverview;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+import com.suse.manager.api.docs.LegacyDocResponse;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import spark.route.HttpMethod;
+
+/**
+ * API contract for {@link ImageInfoHandler}.
+ */
+@Tag(name = "image", description = "Provides methods to access and modify images.")
+public interface ImageInfoHandlerApi {
+
+    /**
+     * Lists the available images.
+     *
+     * @param loggedInUser the current user
+     * @return the available images
+     */
+    @ApiEndpointDoc(
+        summary = "List available images",
+        method = HttpMethod.get,
+        responseClass = ImageInfoListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "image information")
+    )
+    List<ImageInfo> listImages(@Parameter(hidden = true) User loggedInUser);
+
+    /**
+     * Gets the details of an image.
+     *
+     * @param loggedInUser the current user
+     * @param imageId the image ID
+     * @return the details of the image
+     */
+    @ApiEndpointDoc(
+        summary = "Get details of an image",
+        method = HttpMethod.get,
+        responseClass = ImageOverviewResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "image overview information")
+    )
+    ImageOverview getDetails(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "imageId", in = ParameterIn.QUERY, required = true) Integer imageId);
+
+    /**
+     * Gets the pillar data of an image.
+     *
+     * @param loggedInUser the current user
+     * @param imageId the image ID
+     * @return the pillar data of the image
+     */
+    @ApiEndpointDoc(
+        summary = "Get pillar data of an image. The \"size\" entries are converted to string.",
+        method = HttpMethod.get,
+        responseClass = ImagePillarResponse.class,
+        legacyDocResponse = @LegacyDocResponse(type = "struct", name = "the pillar data")
+    )
+    Map<String, Object> getPillar(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "imageId", in = ParameterIn.QUERY, required = true) Integer imageId);
+
+    /**
+     * Sets the pillar data of an image.
+     *
+     * @param loggedInUser the current user
+     * @param imageId the image ID
+     * @param pillarData the pillar data
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set pillar data of an image. The \"size\" entries should be passed as string.",
+        requestClass = SetPillarRequest.class,
+        isIntegerResponse = true
+    )
+    int setPillar(User loggedInUser, Integer imageId, Map<String, Object> pillarData);
+
+    /**
+     * Imports an image and schedules an inspect afterwards.
+     *
+     * @param loggedInUser the current user
+     * @param name the image name
+     * @param version the version to import
+     * @param buildHostId the system ID of the build host
+     * @param storeLabel the label of the image store
+     * @param activationKey the activation key
+     * @param earliestOccurrence the earliest the inspect can run
+     * @return the ID of the inspect action created
+     */
+    @ApiEndpointDoc(
+        summary = "Import an image and schedule an inspect afterwards",
+        requestClass = ImportImageRequest.class,
+        responseClass = ImageActionIdResponse.class,
+        legacyDocResponse = @LegacyDocResponse(type = "int", name = "the ID of the inspect action created")
+    )
+    Long importImage(User loggedInUser, String name, String version, Integer buildHostId, String storeLabel,
+        String activationKey, Date earliestOccurrence);
+
+    /**
+     * Imports a container image and schedules an inspect afterwards.
+     *
+     * @param loggedInUser the current user
+     * @param name the image name
+     * @param version the version to import
+     * @param buildHostId the system ID of the build host
+     * @param storeLabel the label of the image store
+     * @param activationKey the activation key
+     * @param earliestOccurrence the earliest the inspect can run
+     * @return the ID of the inspect action created
+     */
+    @ApiEndpointDoc(
+        summary = "Import an image and schedule an inspect afterwards",
+        requestClass = ImportContainerImageRequest.class,
+        responseClass = ImageActionIdResponse.class,
+        legacyDocResponse = @LegacyDocResponse(type = "int", name = "the ID of the inspect action created")
+    )
+    Long importContainerImage(User loggedInUser, String name, String version, Integer buildHostId,
+        String storeLabel, String activationKey, Date earliestOccurrence);
+
+    /**
+     * Imports an OS image.
+     *
+     * @param loggedInUser the current user
+     * @param name the image name
+     * @param version the version to import
+     * @param arch the image architecture
+     * @return the ID of the image
+     */
+    @ApiEndpointDoc(
+        summary = "Import an image and schedule an inspect afterwards",
+        requestClass = ImportOSImageRequest.class,
+        responseClass = ImageActionIdResponse.class,
+        legacyDocResponse = @LegacyDocResponse(type = "int", name = "the ID of the image")
+    )
+    Long importOSImage(User loggedInUser, String name, String version, String arch);
+
+    /**
+     * Deletes an image file.
+     *
+     * @param loggedInUser the current user
+     * @param imageId the image ID
+     * @param file the file name
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Delete image file",
+        requestClass = DeleteImageFileRequest.class,
+        isIntegerResponse = true
+    )
+    int deleteImageFile(User loggedInUser, Integer imageId, String file);
+
+    /**
+     * Adds an image file.
+     *
+     * @param loggedInUser the current user
+     * @param imageId the image ID
+     * @param file the file name
+     * @param type the image type
+     * @param external whether the file is external
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Delete image file",
+        requestClass = AddImageFileRequest.class,
+        isIntegerResponse = true
+    )
+    Long addImageFile(User loggedInUser, Integer imageId, String file, String type, Boolean external);
+
+    /**
+     * Schedules an image build.
+     *
+     * @param loggedInUser the current user
+     * @param profileLabel the label of the image profile
+     * @param version the version to build
+     * @param buildHostId the system ID of the build host
+     * @param earliestOccurrence the earliest the build can run
+     * @return the ID of the build action created
+     */
+    @ApiEndpointDoc(
+        summary = "Schedule an image build",
+        requestClass = ScheduleImageBuildRequest.class,
+        responseClass = ImageActionIdResponse.class,
+        legacyDocResponse = @LegacyDocResponse(type = "int", name = "the ID of the build action created")
+    )
+    Long scheduleImageBuild(User loggedInUser, String profileLabel, String version, Integer buildHostId,
+        Date earliestOccurrence);
+
+    /**
+     * Lists the errata relevant for an image.
+     *
+     * @param loggedInUser the current user
+     * @param imageId the image ID
+     * @return the errata relevant for the image
+     */
+    @ApiEndpointDoc(
+        summary = "Returns a list of all errata that are relevant for the image",
+        method = HttpMethod.get,
+        responseClass = ImageErrataListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "errata")
+    )
+    List<ErrataOverview> getRelevantErrata(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "imageId", in = ParameterIn.QUERY, required = true) Integer imageId);
+
+    /**
+     * Lists the packages installed on an image.
+     *
+     * @param loggedInUser the current user
+     * @param imageId the image ID
+     * @return the packages installed on the image
+     */
+    @ApiEndpointDoc(
+        summary = "List the installed packages on the given image",
+        method = HttpMethod.get,
+        responseClass = ImagePackageListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "package")
+    )
+    List<Map<String, Object>> listPackages(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "imageId", in = ParameterIn.QUERY, required = true) Integer imageId);
+
+    /**
+     * Gets the custom data values of an image.
+     *
+     * @param loggedInUser the current user
+     * @param imageId the image ID
+     * @return the custom data values of the image
+     */
+    @ApiEndpointDoc(
+        summary = "Get the custom data values defined for the image",
+        method = HttpMethod.get,
+        responseClass = ImageCustomValuesResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "the map of custom labels to custom values")
+    )
+    Map<String, String> getCustomValues(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "imageId", in = ParameterIn.QUERY, required = true) Integer imageId);
+
+    /**
+     * Deletes an image.
+     *
+     * @param loggedInUser the current user
+     * @param imageId the image ID
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Delete an image",
+        requestClass = ImageIdRequest.class,
+        isIntegerResponse = true
+    )
+    int delete(User loggedInUser, Integer imageId);
+
+    @Schema(name = "ApiResponseImageInfoList")
+    interface ImageInfoListResponse extends ApiResponseWrapper<List<ImageInfoDoc>> { }
+
+    @Schema(name = "ApiResponseImageOverview")
+    interface ImageOverviewResponse extends ApiResponseWrapper<ImageOverviewDoc> { }
+
+    @Schema(name = "ApiResponseImagePillar")
+    interface ImagePillarResponse extends ApiResponseWrapper<Map<String, Object>> { }
+
+    @Schema(name = "ApiResponseImageActionId")
+    interface ImageActionIdResponse extends ApiResponseWrapper<Integer> { }
+
+    @Schema(name = "ApiResponseImageErrataList")
+    interface ImageErrataListResponse extends ApiResponseWrapper<List<ErrataOverviewDoc>> { }
+
+    @Schema(name = "ApiResponseImagePackageList")
+    interface ImagePackageListResponse extends ApiResponseWrapper<List<ImagePackageDoc>> { }
+
+    @Schema(name = "ApiResponseImageCustomValues")
+    interface ImageCustomValuesResponse extends ApiResponseWrapper<ImageCustomValuesDoc> { }
+
+    @Schema(name = "ImageSetPillarRequest")
+    @JsonPropertyOrder({"imageId", "pillarData"})
+    interface SetPillarRequest {
+
+        /**
+         * @return the image ID
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getImageId();
+
+        /**
+         * The pillar values are documented as free-form, so they are left unconstrained.
+         *
+         * @return the pillar data
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED,
+                additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
+        @LegacyDocResponse(type = "struct")
+        Map<String, Object> getPillarData();
+    }
+
+    @Schema(name = "ImageImportRequest")
+    @JsonPropertyOrder({"name", "version", "buildHostId", "storeLabel", "activationKey", "earliestOccurrence"})
+    interface ImportImageRequest {
+
+        /**
+         * @return the image name
+         */
+        @Schema(description = "image name as specified in the store", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the version to import
+         */
+        @Schema(description = "version to import or empty", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getVersion();
+
+        /**
+         * @return the system ID of the build host
+         */
+        @Schema(description = "system ID of the build host", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getBuildHostId();
+
+        /**
+         * @return the label of the image store
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getStoreLabel();
+
+        /**
+         * @return the activation key
+         */
+        @Schema(description = "activation key to get the channel data from",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getActivationKey();
+
+        /**
+         * @return the earliest the inspect can run
+         */
+        @Schema(description = "earliest the following inspect can run",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @LegacyDocResponse(type = "dateTime.iso8601")
+        Date getEarliestOccurrence();
+    }
+
+    @Schema(name = "ImageImportContainerRequest")
+    @JsonPropertyOrder({"name", "version", "buildHostId", "storeLabel", "activationKey", "earliestOccurrence"})
+    interface ImportContainerImageRequest {
+
+        /**
+         * @return the image name
+         */
+        @Schema(description = "image name as specified in the store", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the version to import
+         */
+        @Schema(description = "version to import or empty", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getVersion();
+
+        /**
+         * @return the system ID of the build host
+         */
+        @Schema(description = "system ID of the build host", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getBuildHostId();
+
+        /**
+         * @return the label of the image store
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getStoreLabel();
+
+        /**
+         * @return the activation key
+         */
+        @Schema(description = "activation key to get the channel data from",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getActivationKey();
+
+        /**
+         * @return the earliest the inspect can run
+         */
+        @Schema(description = "earliest the following inspect can run",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @LegacyDocResponse(type = "dateTime.iso8601")
+        Date getEarliestOccurrence();
+    }
+
+    @Schema(name = "ImageImportOSRequest")
+    @JsonPropertyOrder({"name", "version", "arch"})
+    interface ImportOSImageRequest {
+
+        /**
+         * @return the image name
+         */
+        @Schema(description = "image name as specified in the store", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the version to import
+         */
+        @Schema(description = "version to import", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getVersion();
+
+        /**
+         * @return the image architecture
+         */
+        @Schema(description = "image architecture", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getArch();
+    }
+
+    @Schema(name = "ImageDeleteFileRequest")
+    @JsonPropertyOrder({"imageId", "file"})
+    interface DeleteImageFileRequest {
+
+        /**
+         * @return the image ID
+         */
+        @Schema(description = "ID of the image", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getImageId();
+
+        /**
+         * @return the file name
+         */
+        @Schema(description = "the file name", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getFile();
+    }
+
+    @Schema(name = "ImageAddFileRequest")
+    @JsonPropertyOrder({"imageId", "file", "type", "external"})
+    interface AddImageFileRequest {
+
+        /**
+         * @return the image ID
+         */
+        @Schema(description = "ID of the image", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getImageId();
+
+        /**
+         * @return the file name
+         */
+        @Schema(description = "the file name, it must exist in the store",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getFile();
+
+        /**
+         * @return the image type
+         */
+        @Schema(description = "the image type", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getType();
+
+        /**
+         * @return whether the file is external
+         */
+        @Schema(description = "the file is external", requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getExternal();
+    }
+
+    @Schema(name = "ImageScheduleBuildRequest")
+    @JsonPropertyOrder({"profileLabel", "version", "buildHostId", "earliestOccurrence"})
+    interface ScheduleImageBuildRequest {
+
+        /**
+         * @return the label of the image profile
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getProfileLabel();
+
+        /**
+         * @return the version to build
+         */
+        @Schema(description = "version to build or empty", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getVersion();
+
+        /**
+         * @return the system ID of the build host
+         */
+        @Schema(description = "system id of the build host", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getBuildHostId();
+
+        /**
+         * @return the earliest the build can run
+         */
+        @Schema(description = "earliest the build can run.", requiredMode = Schema.RequiredMode.REQUIRED)
+        @LegacyDocResponse(type = "dateTime.iso8601")
+        Date getEarliestOccurrence();
+    }
+
+    @Schema(name = "ImageIdRequest")
+    interface ImageIdRequest {
+
+        /**
+         * @return the image ID
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getImageId();
+    }
+
+    @Schema(name = "ImageInformation")
+    @JsonPropertyOrder({"id", "name", "version", "revision", "arch", "external", "storeLabel", "checksum",
+        "obsolete"})
+    interface ImageInfoDoc {
+
+        /**
+         * @return the ID of the image
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the name of the image
+         */
+        @Schema(description = "image name", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the version of the image
+         */
+        @Schema(description = "image tag/version", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getVersion();
+
+        /**
+         * @return the build revision number of the image
+         */
+        @Schema(description = "image build revision number", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getRevision();
+
+        /**
+         * @return the architecture of the image
+         */
+        @Schema(description = "image architecture", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getArch();
+
+        /**
+         * @return whether the image is built externally
+         */
+        @Schema(description = "true if the image is built externally, false otherwise",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getExternal();
+
+        /**
+         * @return the label of the image store
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getStoreLabel();
+
+        /**
+         * @return the checksum of the image
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChecksum();
+
+        /**
+         * @return whether the image is obsolete
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getObsolete();
+    }
+
+    @Schema(name = "ImageOverviewInformation")
+    @JsonPropertyOrder({"id", "name", "type", "version", "revision", "arch", "external", "checksum", "profileLabel",
+        "storeLabel", "buildStatus", "inspectStatus", "buildServerId", "securityErrata", "bugErrata",
+        "enhancementErrata", "outdatedPackages", "installedPackages", "files", "obsolete"})
+    interface ImageOverviewDoc {
+
+        /**
+         * @return the ID of the image
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the name of the image
+         */
+        @Schema(description = "image name", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the type of the image
+         */
+        @Schema(description = "image type", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getType();
+
+        /**
+         * @return the version of the image
+         */
+        @Schema(description = "image tag/version", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getVersion();
+
+        /**
+         * @return the build revision number of the image
+         */
+        @Schema(description = "image build revision number", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getRevision();
+
+        /**
+         * @return the architecture of the image
+         */
+        @Schema(description = "image architecture", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getArch();
+
+        /**
+         * @return whether the image is built externally
+         */
+        @Schema(description = "true if the image is built externally, false otherwise",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getExternal();
+
+        /**
+         * @return the checksum of the image
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChecksum();
+
+        /**
+         * @return the label of the image profile
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getProfileLabel();
+
+        /**
+         * @return the label of the image store
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getStoreLabel();
+
+        /**
+         * @return the build status of the image
+         */
+        @Schema(description = "One of:",
+                allowableValues = {"queued", "picked up", "completed", "failed"},
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getBuildStatus();
+
+        /**
+         * @return the inspect status of the image
+         */
+        @Schema(description = "Available if the build is successful. One of:",
+                allowableValues = {"queued", "picked up", "completed", "failed"},
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getInspectStatus();
+
+        /**
+         * @return the ID of the build server
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getBuildServerId();
+
+        /**
+         * @return the number of security errata
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getSecurityErrata();
+
+        /**
+         * @return the number of bug errata
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getBugErrata();
+
+        /**
+         * @return the number of enhancement errata
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getEnhancementErrata();
+
+        /**
+         * @return the number of outdated packages
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getOutdatedPackages();
+
+        /**
+         * @return the number of installed packages
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getInstalledPackages();
+
+        /**
+         * The image files are documented as a free-form struct.
+         *
+         * @return the image files
+         */
+        @Schema(description = "image files", requiredMode = Schema.RequiredMode.REQUIRED,
+                additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
+        @LegacyDocResponse(type = "struct")
+        Map<String, Object> getFiles();
+
+        /**
+         * @return whether the image has been replaced in the store
+         */
+        @Schema(description = "true if the image has been replaced in the store",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getObsolete();
+    }
+
+    @Schema(name = "ErrataOverview")
+    @JsonPropertyOrder({"id", "issueDate", "date", "updateDate", "advisorySynopsis", "advisoryType",
+        "advisoryStatus", "advisoryName", "rebootSuggested", "restartSuggested"})
+    interface ErrataOverviewDoc {
+
+        /**
+         * @return the ID of the erratum
+         */
+        @Schema(description = "errata ID", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the issue date of the erratum
+         */
+        @Schema(name = "issue_date", description = "the date erratum was updated (deprecated)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getIssueDate();
+
+        /**
+         * @return the creation date of the erratum
+         */
+        @Schema(description = "the date erratum was created (deprecated)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getDate();
+
+        /**
+         * @return the update date of the erratum
+         */
+        @Schema(name = "update_date", description = "the date erratum was updated (deprecated)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUpdateDate();
+
+        /**
+         * @return the synopsis of the erratum
+         */
+        @Schema(name = "advisory_synopsis", description = "summary of the erratum",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdvisorySynopsis();
+
+        /**
+         * @return the type of the erratum
+         */
+        @Schema(name = "advisory_type", description = "type label such as 'Security', 'Bug Fix'",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdvisoryType();
+
+        /**
+         * @return the status of the erratum
+         */
+        @Schema(name = "advisory_status",
+                description = "status label such as 'final', 'testing', 'stable', 'pending','retracted' or " +
+                    "'unpushed'",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdvisoryStatus();
+
+        /**
+         * @return the name of the erratum
+         */
+        @Schema(name = "advisory_name", description = "name such as 'RHSA', etc.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdvisoryName();
+
+        /**
+         * @return whether a reboot is suggested
+         */
+        @Schema(name = "reboot_suggested",
+                description = "A boolean flag signaling whether a system reboot is advisable following the " +
+                    "application of the errata. Typical example is upon kernel update.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getRebootSuggested();
+
+        /**
+         * @return whether a package manager restart is suggested
+         */
+        @Schema(name = "restart_suggested",
+                description = "A boolean flag signaling a weather reboot of the package manager is advisable " +
+                    "following the application of the errata. This is commonly used to address update stack " +
+                    "issues before proceeding with other updates.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getRestartSuggested();
+    }
+
+    @Schema(name = "ImagePackage")
+    @JsonPropertyOrder({"name", "version", "release", "epoch", "arch"})
+    interface ImagePackageDoc {
+
+        /**
+         * @return the name of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the version of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getVersion();
+
+        /**
+         * @return the release of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getRelease();
+
+        /**
+         * @return the epoch of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getEpoch();
+
+        /**
+         * @return the architecture of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getArch();
+    }
+
+    @Schema(name = "ImageCustomValues")
+    @JsonPropertyOrder({"customInfoLabel", "value"})
+    interface ImageCustomValuesDoc {
+
+        /**
+         * @return the custom info label
+         */
+        @Schema(name = "custom info label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getCustomInfoLabel();
+
+        /**
+         * @return the custom value
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getValue();
+    }
+}

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandlerApi.java
@@ -282,7 +282,19 @@ public interface ImageInfoHandlerApi {
     interface ImageOverviewResponse extends ApiResponseWrapper<ImageOverviewDoc> { }
 
     @Schema(name = "ApiResponseImagePillar")
-    interface ImagePillarResponse extends ApiResponseWrapper<Map<String, Object>> { }
+    interface ImagePillarResponse extends ApiResponseWrapper<Map<String, Object>> {
+
+        /**
+         * The pillar data is keyed by the pillar entries of the image, which carry scalars as
+         * well as nested structures, so the payload is documented as a free form struct.
+         *
+         * @return the pillar data
+         */
+        @Override
+        @Schema(description = "The payload result", requiredMode = Schema.RequiredMode.REQUIRED,
+                additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
+        Map<String, Object> getResult();
+    }
 
     @Schema(name = "ApiResponseImageActionId")
     interface ImageActionIdResponse extends ApiResponseWrapper<Long> { }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/system/SystemDetailsHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/system/SystemDetailsHandler.java
@@ -54,7 +54,7 @@ import java.util.Set;
 * @apidoc.namespace kickstart.profile.system
 * @apidoc.doc Provides methods to set various properties of a kickstart profile.
 */
-public class SystemDetailsHandler extends BaseHandler {
+public class SystemDetailsHandler extends BaseHandler implements SystemDetailsHandlerApi {
 
     /**
       * Check the configuration management status for a kickstart profile

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/system/SystemDetailsHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/system/SystemDetailsHandlerApi.java
@@ -1,0 +1,606 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.kickstart.profile.system;
+
+import com.redhat.rhn.domain.common.FileList;
+import com.redhat.rhn.domain.kickstart.crypto.CryptoKey;
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+import com.suse.manager.api.docs.LegacyDocResponse;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import spark.route.HttpMethod;
+
+/**
+ * API contract for {@link SystemDetailsHandler}.
+ */
+@Tag(name = "kickstart.profile.system", description = "Provides methods to set various properties of a kickstart " +
+        "profile.")
+public interface SystemDetailsHandlerApi {
+
+    /**
+     * Checks the configuration management status of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @return whether configuration management is enabled
+     */
+    @ApiEndpointDoc(
+        summary = "Check the configuration management status for a kickstart profile.",
+        requestClass = KickstartLabelRequest.class,
+        responseClass = BooleanResponse.class,
+        legacyDocResponse = @LegacyDocResponse(type = "boolean",
+            name = "true if configuration management is enabled; otherwise, false")
+    )
+    boolean checkConfigManagement(User loggedInUser, String ksLabel);
+
+    /**
+     * Enables the configuration management flag of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Enables the configuration management flag in a kickstart profile",
+        requestClass = KickstartLabelRequest.class,
+        isIntegerResponse = true
+    )
+    int enableConfigManagement(User loggedInUser, String ksLabel);
+
+    /**
+     * Disables the configuration management flag of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Disables the configuration management flag in a kickstart profile",
+        requestClass = KickstartLabelRequest.class,
+        isIntegerResponse = true
+    )
+    int disableConfigManagement(User loggedInUser, String ksLabel);
+
+    /**
+     * Checks the remote commands status of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @return whether remote commands support is enabled
+     */
+    @ApiEndpointDoc(
+        summary = "Check the remote commands status flag for a kickstart profile.",
+        requestClass = KickstartLabelRequest.class,
+        responseClass = BooleanResponse.class,
+        legacyDocResponse = @LegacyDocResponse(type = "boolean",
+            name = "true if remote commands support is enabled; otherwise, false")
+    )
+    boolean checkRemoteCommands(User loggedInUser, String ksLabel);
+
+    /**
+     * Enables the remote command flag of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Enables the remote command flag in a kickstart profile",
+        requestClass = KickstartLabelRequest.class,
+        isIntegerResponse = true
+    )
+    int enableRemoteCommands(User loggedInUser, String ksLabel);
+
+    /**
+     * Disables the remote command flag of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Disables the remote command flag in a kickstart profile",
+        requestClass = KickstartLabelRequest.class,
+        isIntegerResponse = true
+    )
+    int disableRemoteCommands(User loggedInUser, String ksLabel);
+
+    /**
+     * Retrieves the SELinux enforcing mode of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @return the SELinux enforcing mode
+     */
+    @ApiEndpointDoc(
+        summary = "Retrieves the SELinux enforcing mode property of a kickstart profile.",
+        method = HttpMethod.get,
+        responseClass = SELinuxModeResponse.class,
+        legacyDocResponse = @LegacyDocResponse(type = "string", name = "enforcing mode")
+    )
+    @Schema(allowableValues = {"enforcing", "permissive", "disabled"})
+    String getSELinux(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "ksLabel", description = "the kickstart profile label",
+            in = ParameterIn.QUERY, required = true) String ksLabel);
+
+    /**
+     * Sets the SELinux enforcing mode of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @param enforcingMode the SELinux enforcing mode
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Sets the SELinux enforcing mode property of a kickstart profile so that a system created " +
+            "using this profile will be have the appropriate SELinux enforcing mode.",
+        requestClass = SetSELinuxRequest.class,
+        isIntegerResponse = true
+    )
+    int setSELinux(User loggedInUser, String ksLabel, String enforcingMode);
+
+    /**
+     * Retrieves the locale of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @return the locale of the profile
+     */
+    @ApiEndpointDoc(
+        summary = "Retrieves the locale for a kickstart profile.",
+        method = HttpMethod.get,
+        responseClass = LocaleResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "locale info")
+    )
+    Map<String, Object> getLocale(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "ksLabel", description = "the kickstart profile label",
+            in = ParameterIn.QUERY, required = true) String ksLabel);
+
+    /**
+     * Sets the locale of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @param locale the locale
+     * @param useUtc whether the hardware clock uses UTC
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Sets the locale for a kickstart profile.",
+        requestClass = SetLocaleRequest.class,
+        isIntegerResponse = true
+    )
+    int setLocale(User loggedInUser, String ksLabel, String locale, Boolean useUtc);
+
+    /**
+     * Sets the partitioning scheme of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @param scheme the partitioning scheme
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set the partitioning scheme for a kickstart profile.",
+        requestClass = SetPartitioningSchemeRequest.class,
+        isIntegerResponse = true
+    )
+    int setPartitioningScheme(User loggedInUser, String ksLabel, List<String> scheme);
+
+    /**
+     * Gets the partitioning scheme of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @return the partitioning scheme
+     */
+    @ApiEndpointDoc(
+        summary = "Get the partitioning scheme for a kickstart profile.",
+        method = HttpMethod.get,
+        responseClass = StringListResponse.class,
+        responseDescription = "a list of partitioning commands used to setup the partitions, logical volumes and " +
+            "volume groups"
+    )
+    List<String> getPartitioningScheme(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "ksLabel", description = "the label of a kickstart profile",
+            in = ParameterIn.QUERY, required = true) String ksLabel);
+
+    /**
+     * Lists the keys associated with a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @return the keys of the profile
+     */
+    @ApiEndpointDoc(
+        summary = "Returns the set of all keys associated with the given kickstart profile.",
+        method = HttpMethod.get,
+        responseClass = CryptoKeyListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "key")
+    )
+    Set<CryptoKey> listKeys(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "ksLabel", description = "the kickstart profile label",
+            in = ParameterIn.QUERY, required = true) String ksLabel);
+
+    /**
+     * Adds keys to a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @param descriptions the keys to add
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Adds the given list of keys to the specified kickstart profile.",
+        requestClass = AddKeysRequest.class,
+        isIntegerResponse = true
+    )
+    int addKeys(User loggedInUser, String ksLabel, List<String> descriptions);
+
+    /**
+     * Removes keys from a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @param descriptions the keys to remove
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Removes the given list of keys from the specified kickstart profile.",
+        requestClass = RemoveKeysRequest.class,
+        isIntegerResponse = true
+    )
+    int removeKeys(User loggedInUser, String ksLabel, List<String> descriptions);
+
+    /**
+     * Lists the file preservations associated with a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @return the file preservations of the profile
+     */
+    @ApiEndpointDoc(
+        summary = "Returns the set of all file preservations associated with the given kickstart profile.",
+        method = HttpMethod.get,
+        responseClass = FileListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "file list")
+    )
+    Set<FileList> listFilePreservations(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "ksLabel", description = "the kickstart profile label",
+            in = ParameterIn.QUERY, required = true) String ksLabel);
+
+    /**
+     * Adds file preservations to a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @param filePreservations the file preservations to add
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Adds the given list of file preservations to the specified kickstart profile.",
+        requestClass = FilePreservationsRequest.class,
+        isIntegerResponse = true
+    )
+    int addFilePreservations(User loggedInUser, String ksLabel, List<String> filePreservations);
+
+    /**
+     * Removes file preservations from a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @param filePreservations the file preservations to remove
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Removes the given list of file preservations from the specified kickstart profile.",
+        requestClass = FilePreservationsRequest.class,
+        isIntegerResponse = true
+    )
+    int removeFilePreservations(User loggedInUser, String ksLabel, List<String> filePreservations);
+
+    /**
+     * Sets the registration type of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @param registrationType the registration type
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Sets the registration type of a given kickstart profile. Registration Type can be one of " +
+            "reactivation/deletion/none These types determine the behaviour of the re registration when using " +
+            "this profile.",
+        requestClass = SetRegistrationTypeRequest.class,
+        isIntegerResponse = true
+    )
+    int setRegistrationType(User loggedInUser, String ksLabel, String registrationType);
+
+    /**
+     * Returns the registration type of a kickstart profile.
+     *
+     * @param loggedInUser the current user
+     * @param ksLabel the kickstart profile label
+     * @return the registration type
+     */
+    @ApiEndpointDoc(
+        summary = "returns the registration type of a given kickstart profile. Registration Type can be one of " +
+            "reactivation/deletion/none These types determine the behaviour of the registration when using this " +
+            "profile for reprovisioning.",
+        requestClass = KickstartLabelRequest.class,
+        responseClass = RegistrationTypeResponse.class,
+        legacyDocResponse = @LegacyDocResponse(type = "string", name = "the registration type")
+    )
+    @Schema(allowableValues = {"reactivation", "deletion", "none"})
+    String getRegistrationType(User loggedInUser, String ksLabel);
+
+    @Schema(name = "ApiResponseBoolean")
+    interface BooleanResponse extends ApiResponseWrapper<Boolean> { }
+
+    @Schema(name = "ApiResponseSELinuxMode")
+    interface SELinuxModeResponse extends ApiResponseWrapper<String> { }
+
+    @Schema(name = "ApiResponseRegistrationType")
+    interface RegistrationTypeResponse extends ApiResponseWrapper<String> { }
+
+    @Schema(name = "ApiResponsePartitioningScheme")
+    interface StringListResponse extends ApiResponseWrapper<List<String>> { }
+
+    @Schema(name = "ApiResponseKickstartLocale")
+    interface LocaleResponse extends ApiResponseWrapper<LocaleInfoDoc> { }
+
+    @Schema(name = "ApiResponseCryptoKeyList")
+    interface CryptoKeyListResponse extends ApiResponseWrapper<List<CryptoKeyDoc>> { }
+
+    @Schema(name = "ApiResponseFileListList")
+    interface FileListResponse extends ApiResponseWrapper<List<FileListDoc>> { }
+
+    @Schema(name = "KickstartProfileLabelRequest")
+    interface KickstartLabelRequest {
+
+        /**
+         * @return the kickstart profile label
+         */
+        @Schema(description = "the kickstart profile label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getKsLabel();
+    }
+
+    @Schema(name = "KickstartSetSELinuxRequest")
+    @JsonPropertyOrder({"ksLabel", "enforcingMode"})
+    interface SetSELinuxRequest {
+
+        /**
+         * @return the kickstart profile label
+         */
+        @Schema(description = "the kickstart profile label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getKsLabel();
+
+        /**
+         * @return the SELinux enforcing mode
+         */
+        @Schema(description = "the SELinux enforcing mode",
+                allowableValues = {"enforcing", "permissive", "disabled"},
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getEnforcingMode();
+    }
+
+    @Schema(name = "KickstartSetLocaleRequest")
+    @JsonPropertyOrder({"ksLabel", "locale", "useUtc"})
+    interface SetLocaleRequest {
+
+        /**
+         * @return the kickstart profile label
+         */
+        @Schema(description = "the kickstart profile label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getKsLabel();
+
+        /**
+         * @return the locale
+         */
+        @Schema(description = "the locale", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLocale();
+
+        /**
+         * @return whether the hardware clock uses UTC
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED,
+                allowableValues = {"true", "false"},
+                extensions = @Extension(name = "x-uyuni-doc-option-descriptions", properties = {
+                    @ExtensionProperty(name = "true", value = "the hardware clock uses UTC"),
+                    @ExtensionProperty(name = "false", value = "the hardware clock does not use UTC")
+                }))
+        Boolean getUseUtc();
+    }
+
+    @Schema(name = "KickstartSetPartitioningSchemeRequest")
+    @JsonPropertyOrder({"ksLabel", "scheme"})
+    interface SetPartitioningSchemeRequest {
+
+        /**
+         * @return the kickstart profile label
+         */
+        @Schema(description = "the label of the kickstart profile to update",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getKsLabel();
+
+        /**
+         * @return the partitioning scheme
+         */
+        @Schema(description = "the partitioning scheme is a list of partitioning command strings used to setup " +
+                    "the partitions, volume groups and logical volumes.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        List<String> getScheme();
+    }
+
+    @Schema(name = "KickstartAddKeysRequest")
+    @JsonPropertyOrder({"ksLabel", "descriptions"})
+    interface AddKeysRequest {
+
+        /**
+         * @return the kickstart profile label
+         */
+        @Schema(description = "the kickstart profile label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getKsLabel();
+
+        /**
+         * @return the keys to add
+         */
+        @Schema(description = "the list identifying the keys to add", requiredMode = Schema.RequiredMode.REQUIRED)
+        List<String> getDescriptions();
+    }
+
+    @Schema(name = "KickstartRemoveKeysRequest")
+    @JsonPropertyOrder({"ksLabel", "descriptions"})
+    interface RemoveKeysRequest {
+
+        /**
+         * @return the kickstart profile label
+         */
+        @Schema(description = "the kickstart profile label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getKsLabel();
+
+        /**
+         * @return the keys to remove
+         */
+        @Schema(description = "the list identifying the keys to remove",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        List<String> getDescriptions();
+    }
+
+    @Schema(name = "KickstartFilePreservationsRequest")
+    @JsonPropertyOrder({"ksLabel", "filePreservations"})
+    interface FilePreservationsRequest {
+
+        /**
+         * @return the kickstart profile label
+         */
+        @Schema(description = "the kickstart profile label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getKsLabel();
+
+        /**
+         * @return the file preservations
+         */
+        @Schema(description = "the list identifying the file preservations to add",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        List<String> getFilePreservations();
+    }
+
+    @Schema(name = "KickstartSetRegistrationTypeRequest")
+    @JsonPropertyOrder({"ksLabel", "registrationType"})
+    interface SetRegistrationTypeRequest {
+
+        /**
+         * @return the kickstart profile label
+         */
+        @Schema(description = "the kickstart profile label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getKsLabel();
+
+        /**
+         * @return the registration type
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED,
+                allowableValues = {"reactivation", "deletion", "none"},
+                extensions = @Extension(name = "x-uyuni-doc-option-descriptions", properties = {
+                    @ExtensionProperty(name = "reactivation",
+                        value = "to try and generate a reactivation key and use that to register the system when " +
+                            "reprovisioning a system."),
+                    @ExtensionProperty(name = "deletion",
+                        value = "to try and delete the existing system profile and reregister the system being " +
+                            "reprovisioned as new"),
+                    @ExtensionProperty(name = "none",
+                        value = "to preserve the status quo and leave the current system as a duplicate on a " +
+                            "reprovision.")
+                }))
+        String getRegistrationType();
+    }
+
+    @Schema(name = "KickstartLocaleInfo")
+    @JsonPropertyOrder({"locale", "useUtc"})
+    interface LocaleInfoDoc {
+
+        /**
+         * @return the locale
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLocale();
+
+        /**
+         * @return whether the hardware clock uses UTC
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED,
+                allowableValues = {"true", "false"},
+                extensions = @Extension(name = "x-uyuni-doc-option-descriptions", properties = {
+                    @ExtensionProperty(name = "true", value = "the hardware clock uses UTC"),
+                    @ExtensionProperty(name = "false", value = "the hardware clock does not use UTC")
+                }))
+        Boolean getUseUtc();
+    }
+
+    @Schema(name = "KickstartCryptoKey")
+    @JsonPropertyOrder({"description", "type", "content"})
+    interface CryptoKeyDoc {
+
+        /**
+         * @return the description of the key
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getDescription();
+
+        /**
+         * @return the type of the key
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getType();
+
+        /**
+         * @return the content of the key
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getContent();
+    }
+
+    @Schema(name = "KickstartFileList")
+    @JsonPropertyOrder({"name", "fileNames"})
+    interface FileListDoc {
+
+        /**
+         * @return the name of the file list
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the file names of the file list
+         */
+        @Schema(name = "file_names", requiredMode = Schema.RequiredMode.REQUIRED)
+        @LegacyDocResponse(name = "the list of file names")
+        List<String> getFileNames();
+    }
+}

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/org/OrgHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/org/OrgHandler.java
@@ -70,7 +70,7 @@ import java.util.Set;
  * @apidoc.doc Contains methods to access common organization management
  * functions available from the web interface.
  */
-public class OrgHandler extends BaseHandler {
+public class OrgHandler extends BaseHandler implements OrgHandlerApi {
 
     private static final String VALIDATION_XSD =
             "/com/redhat/rhn/frontend/action/multiorg/validation/orgCreateForm.xsd";

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/org/OrgHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/org/OrgHandler.java
@@ -33,6 +33,7 @@ import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.dto.MultiOrgUserOverview;
 import com.redhat.rhn.frontend.dto.OrgDto;
 import com.redhat.rhn.frontend.struts.RhnValidationHelper;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
@@ -294,7 +295,7 @@ public class OrgHandler extends BaseHandler implements OrgHandlerApi {
      *   #array_end()
      */
     @ReadOnly
-    public List listUsers(User loggedInUser, Integer orgId) {
+    public List<MultiOrgUserOverview> listUsers(User loggedInUser, Integer orgId) {
         ensureUserRole(loggedInUser, RoleFactory.SAT_ADMIN);
         verifyOrgExists(orgId);
         return OrgManager.activeUsers(Long.valueOf(orgId));

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/org/OrgHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/org/OrgHandlerApi.java
@@ -718,19 +718,21 @@ public interface OrgHandlerApi {
          * @return the number of active users
          */
         @Schema(name = "active_users", description = "number of active users in the organization",
-                requiredMode = Schema.RequiredMode.REQUIRED)
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         Integer getActiveUsers();
 
         /**
          * @return the number of systems
          */
-        @Schema(description = "number of systems in the organization", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "number of systems in the organization",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         Integer getSystems();
 
         /**
          * @return the number of trusted organizations
          */
-        @Schema(description = "number of trusted organizations", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "number of trusted organizations",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         Integer getTrusts();
 
         /**

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/org/OrgHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/org/OrgHandlerApi.java
@@ -1,0 +1,806 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.org;
+
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.dto.OrgDto;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+import com.suse.manager.api.docs.LegacyDocResponse;
+import com.suse.manager.api.docs.PublicApiEndpoint;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import spark.route.HttpMethod;
+
+/**
+ * API contract for {@link OrgHandler}.
+ */
+@Tag(name = "org", description = "Contains methods to access common organization management " +
+    "functions available from the web interface.")
+public interface OrgHandlerApi {
+
+    /**
+     * Creates a new organization.
+     *
+     * @param loggedInUser the current user
+     * @param orgName the organization name
+     * @param adminLogin the new administrator login name
+     * @param adminPassword the new administrator password
+     * @param prefix the new administrator's prefix
+     * @param firstName the new administrator's first name
+     * @param lastName the new administrator's last name
+     * @param email the new administrator's e-mail
+     * @param usePamAuth whether PAM authentication is used for the new account
+     * @return the newly created organization
+     */
+    @ApiEndpointDoc(
+        summary = "Create a new organization and associated administrator account.",
+        requestClass = CreateOrgRequest.class,
+        responseClass = OrgResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "organization info")
+    )
+    OrgDto create(User loggedInUser, String orgName, String adminLogin, String adminPassword, String prefix,
+                  String firstName, String lastName, String email, Boolean usePamAuth);
+
+    /**
+     * Creates the first organization and user after the initial setup.
+     *
+     * @param orgName the organization name
+     * @param adminLogin the new administrator login name
+     * @param adminPassword the new administrator password
+     * @param firstName the new administrator's first name
+     * @param lastName the new administrator's last name
+     * @param email the new administrator's e-mail
+     * @return the newly created organization
+     */
+    @PublicApiEndpoint
+    @ApiEndpointDoc(
+        summary = "Create first organization and user after initial setup without authentication",
+        requestClass = CreateFirstOrgRequest.class,
+        responseClass = OrgResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "organization info")
+    )
+    OrgDto createFirst(String orgName, String adminLogin, String adminPassword, String firstName, String lastName,
+                       String email);
+
+    /**
+     * Deletes an organization.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the id of the organization to delete
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Delete an organization. The default organization (i.e. orgId=1) cannot be deleted.",
+        requestClass = OrgIdRequest.class,
+        isIntegerResponse = true
+    )
+    int delete(User loggedInUser, Integer orgId);
+
+    /**
+     * Reads the content lifecycle management patch synchronization config option.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @return the config option value
+     */
+    @ApiEndpointDoc(
+        summary = "Reads the content lifecycle management patch synchronization config option.",
+        method = HttpMethod.get,
+        responseClass = BooleanResponse.class,
+        responseDescription = "Get the config option value",
+        legacyDocResponse = @LegacyDocResponse(type = "boolean", name = "status")
+    )
+    Boolean getClmSyncPatchesConfig(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "orgId", in = ParameterIn.QUERY, required = true) Integer orgId);
+
+    /**
+     * Returns the detailed information about an organization given its id.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @return the organization details
+     */
+    @ApiEndpointDoc(
+        summary = "The detailed information about an organization given the organization ID or name.",
+        method = HttpMethod.get,
+        responseClass = OrgResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "organization info")
+    )
+    OrgDto getDetails(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "orgId", in = ParameterIn.QUERY, required = true) Integer orgId);
+
+    /**
+     * Returns the detailed information about an organization given its name.
+     *
+     * @param loggedInUser the current user
+     * @param name the organization name
+     * @return the organization details
+     */
+    @ApiEndpointDoc(
+        summary = "The detailed information about an organization given the organization ID or name.",
+        method = HttpMethod.get,
+        responseClass = OrgResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "organization info")
+    )
+    OrgDto getDetails(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "name", in = ParameterIn.QUERY, required = true) String name);
+
+    /**
+     * Returns the status of the SCAP detailed result file upload settings.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @return the SCAP file upload settings
+     */
+    @ApiEndpointDoc(
+        summary = "Get the status of SCAP detailed result file upload settings for the given organization.",
+        method = HttpMethod.get,
+        responseClass = ScapUploadInfoResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "scap_upload_info")
+    )
+    Map<String, Object> getPolicyForScapFileUpload(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "orgId", in = ParameterIn.QUERY, required = true) Integer orgId);
+
+    /**
+     * Returns the status of the SCAP result deletion settings.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @return the SCAP result deletion settings
+     */
+    @ApiEndpointDoc(
+        summary = "Get the status of SCAP result deletion settings for the given organization.",
+        method = HttpMethod.get,
+        responseClass = ScapDeletionInfoResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "scap_deletion_info")
+    )
+    Map<String, Object> getPolicyForScapResultDeletion(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "orgId", in = ParameterIn.QUERY, required = true) Integer orgId);
+
+    /**
+     * Returns the status of the content staging settings.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @return whether content staging is enabled
+     */
+    @ApiEndpointDoc(
+        summary = "Get the status of content staging settings for the given organization. Returns true if " +
+            "enabled, false otherwise.",
+        method = HttpMethod.get,
+        responseClass = BooleanResponse.class,
+        responseDescription = "Get the status of content staging settings",
+        legacyDocResponse = @LegacyDocResponse(type = "boolean", name = "status")
+    )
+    boolean isContentStagingEnabled(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "orgId", in = ParameterIn.QUERY, required = true) Integer orgId);
+
+    /**
+     * Returns whether errata e-mail notifications are enabled for the organization.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @return whether errata e-mail notifications are enabled
+     */
+    @ApiEndpointDoc(
+        summary = "Returns whether errata e-mail notifications are enabled for the organization",
+        method = HttpMethod.get,
+        responseClass = BooleanResponse.class,
+        responseDescription = "Returns the status of the errata e-mail notification setting for the organization",
+        legacyDocResponse = @LegacyDocResponse(type = "boolean", name = "status")
+    )
+    boolean isErrataEmailNotifsForOrg(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "orgId", in = ParameterIn.QUERY, required = true) Integer orgId);
+
+    /**
+     * Returns whether the organization administrator can manage the organization configuration.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @return whether the organization administrator can manage the configuration
+     */
+    @ApiEndpointDoc(
+        summary = "Returns whether Organization Administrator is able to manage his organization configuration. " +
+            "This may have a high impact on general #product() performance.",
+        method = HttpMethod.get,
+        responseClass = BooleanResponse.class,
+        responseDescription = "Returns the status org admin management setting",
+        legacyDocResponse = @LegacyDocResponse(type = "boolean", name = "status")
+    )
+    boolean isOrgConfigManagedByOrgAdmin(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "orgId", in = ParameterIn.QUERY, required = true) Integer orgId);
+
+    /**
+     * Returns the list of organizations.
+     *
+     * @param loggedInUser the current user
+     * @return the organizations
+     */
+    @ApiEndpointDoc(
+        summary = "Returns the list of organizations.",
+        method = HttpMethod.get,
+        responseClass = OrgListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "organization info")
+    )
+    List<OrgDto> listOrgs(User loggedInUser);
+
+    /**
+     * Returns the list of users in a given organization.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @return the users of the organization
+     */
+    @ApiEndpointDoc(
+        summary = "Returns the list of users in a given organization.",
+        method = HttpMethod.get,
+        responseClass = OrgUserListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "user")
+    )
+    List listUsers(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "orgId", in = ParameterIn.QUERY, required = true) Integer orgId);
+
+    /**
+     * Sets the content lifecycle management patch synchronization config option.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @param value the config option value
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Sets the content lifecycle management patch synchronization config option.",
+        requestClass = SetClmSyncPatchesRequest.class,
+        isIntegerResponse = true
+    )
+    Integer setClmSyncPatchesConfig(User loggedInUser, Integer orgId, Boolean value);
+
+    /**
+     * Sets the status of content staging for the given organization.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @param enable whether to enable content staging
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set the status of content staging for the given organization.",
+        requestClass = OrgEnableRequest.class,
+        isIntegerResponse = true
+    )
+    Integer setContentStaging(User loggedInUser, Integer orgId, Boolean enable);
+
+    /**
+     * Enables or disables errata e-mail notifications for the organization.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @param enable whether to enable the notifications
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Dis/enables errata e-mail notifications for the organization",
+        requestClass = OrgEnableRequest.class,
+        isIntegerResponse = true
+    )
+    Integer setErrataEmailNotifsForOrg(User loggedInUser, Integer orgId, Boolean enable);
+
+    /**
+     * Sets whether the organization administrator can manage the organization configuration.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @param enable whether the organization administrator can manage the configuration
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Sets whether Organization Administrator can manage his organization configuration. This may " +
+            "have a high impact on general #product() performance.",
+        requestClass = OrgEnableRequest.class,
+        isIntegerResponse = true
+    )
+    Integer setOrgConfigManagedByOrgAdmin(User loggedInUser, Integer orgId, Boolean enable);
+
+    /**
+     * Sets the status of the SCAP detailed result file upload settings.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @param newSettings the new settings
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set the status of SCAP detailed result file upload settings for the given organization.",
+        requestClass = SetScapFileUploadRequest.class,
+        isIntegerResponse = true
+    )
+    int setPolicyForScapFileUpload(User loggedInUser, Integer orgId, Map<String, Object> newSettings);
+
+    /**
+     * Sets the status of the SCAP result deletion settings.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @param newSettings the new settings
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Set the status of SCAP result deletion settins for the given organization.",
+        requestClass = SetScapDeletionRequest.class,
+        isIntegerResponse = true
+    )
+    int setPolicyForScapResultDeletion(User loggedInUser, Integer orgId, Map<String, Object> newSettings);
+
+    /**
+     * Transfers systems from one organization to another.
+     *
+     * @param loggedInUser the current user
+     * @param toOrgId the id of the destination organization
+     * @param sids the ids of the systems to transfer
+     * @return the ids of the transferred systems
+     */
+    @ApiEndpointDoc(
+        summary = "Transfer systems from one organization to another. If executed by a #product() administrator, " +
+            "the systems will be transferred from their current organization to the organization specified by " +
+            "the toOrgId. If executed by an organization administrator, the systems must exist in the same " +
+            "organization as that administrator and the systems will be transferred to the organization " +
+            "specified by the toOrgId. In any scenario, the origination and destination organizations must be " +
+            "defined in a trust.",
+        requestClass = TransferSystemsRequest.class,
+        responseClass = ServerIdListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "serverIdTransferred")
+    )
+    Object[] transferSystems(User loggedInUser, Integer toOrgId, List<Integer> sids);
+
+    /**
+     * Updates the name of an organization.
+     *
+     * @param loggedInUser the current user
+     * @param orgId the organization id
+     * @param name the new organization name
+     * @return the updated organization
+     */
+    @ApiEndpointDoc(
+        summary = "Updates the name of an organization",
+        requestClass = UpdateNameRequest.class,
+        responseClass = OrgResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "organization info")
+    )
+    OrgDto updateName(User loggedInUser, Integer orgId, String name);
+
+    @Schema(name = "ApiResponseBoolean")
+    interface BooleanResponse extends ApiResponseWrapper<Boolean> { }
+
+    @Schema(name = "ApiResponseOrg")
+    interface OrgResponse extends ApiResponseWrapper<OrgDoc> { }
+
+    @Schema(name = "ApiResponseOrgList")
+    interface OrgListResponse extends ApiResponseWrapper<List<OrgDoc>> { }
+
+    @Schema(name = "ApiResponseOrgUserList")
+    interface OrgUserListResponse extends ApiResponseWrapper<List<OrgUserDoc>> { }
+
+    @Schema(name = "ApiResponseScapUploadInfo")
+    interface ScapUploadInfoResponse extends ApiResponseWrapper<ScapUploadInfoDoc> { }
+
+    @Schema(name = "ApiResponseScapDeletionInfo")
+    interface ScapDeletionInfoResponse extends ApiResponseWrapper<ScapDeletionInfoDoc> { }
+
+    @Schema(name = "ApiResponseServerIdList")
+    interface ServerIdListResponse extends ApiResponseWrapper<List<Integer>> { }
+
+    @Schema(name = "OrgCreateRequest")
+    @JsonPropertyOrder({"orgName", "adminLogin", "adminPassword", "prefix", "firstName", "lastName", "email",
+        "usePamAuth"})
+    interface CreateOrgRequest {
+
+        /**
+         * @return the organization name
+         */
+        @Schema(description = "Organization name. Must meet same\ncriteria as in the web UI.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getOrgName();
+
+        /**
+         * @return the new administrator login name
+         */
+        @Schema(description = "New administrator login name.", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdminLogin();
+
+        /**
+         * @return the new administrator password
+         */
+        @Schema(description = "New administrator password.", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdminPassword();
+
+        /**
+         * @return the new administrator's prefix
+         */
+        @Schema(description = "New administrator's prefix. Must\nmatch one of the values available in the web UI. " +
+            "(i.e. Dr., Mr., Mrs., Sr., etc.)", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getPrefix();
+
+        /**
+         * @return the new administrator's first name
+         */
+        @Schema(description = "New administrator's first name.", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getFirstName();
+
+        /**
+         * @return the new administrator's last name
+         */
+        @Schema(description = "New administrator's first name.", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLastName();
+
+        /**
+         * @return the new administrator's e-mail
+         */
+        @Schema(description = "New administrator's e-mail.", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getEmail();
+
+        /**
+         * @return whether PAM authentication is used
+         */
+        @Schema(description = "True if PAM authentication\nshould be used for the new administrator account.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getUsePamAuth();
+    }
+
+    @Schema(name = "OrgCreateFirstRequest")
+    @JsonPropertyOrder({"orgName", "adminLogin", "adminPassword", "firstName", "lastName", "email"})
+    interface CreateFirstOrgRequest {
+
+        /**
+         * @return the organization name
+         */
+        @Schema(description = "Organization name. Must meet same\ncriteria as in the web UI.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getOrgName();
+
+        /**
+         * @return the new administrator login name
+         */
+        @Schema(description = "New administrator login name.", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdminLogin();
+
+        /**
+         * @return the new administrator password
+         */
+        @Schema(description = "New administrator password.", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdminPassword();
+
+        /**
+         * @return the new administrator's first name
+         */
+        @Schema(description = "New administrator's first name.", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getFirstName();
+
+        /**
+         * @return the new administrator's last name
+         */
+        @Schema(description = "New administrator's first name.", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLastName();
+
+        /**
+         * @return the new administrator's e-mail
+         */
+        @Schema(description = "New administrator's e-mail.", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getEmail();
+    }
+
+    @Schema(name = "OrgIdRequest")
+    interface OrgIdRequest {
+
+        /**
+         * @return the organization id
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getOrgId();
+    }
+
+    @Schema(name = "OrgEnableRequest")
+    @JsonPropertyOrder({"orgId", "enable"})
+    interface OrgEnableRequest {
+
+        /**
+         * @return the organization id
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getOrgId();
+
+        /**
+         * @return whether to enable the setting
+         */
+        @Schema(description = "Use true/false to enable/disable", requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getEnable();
+    }
+
+    @Schema(name = "OrgSetClmSyncPatchesRequest")
+    @JsonPropertyOrder({"orgId", "value"})
+    interface SetClmSyncPatchesRequest {
+
+        /**
+         * @return the organization id
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getOrgId();
+
+        /**
+         * @return the config option value
+         */
+        @Schema(description = "The config option value", requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getValue();
+    }
+
+    @Schema(name = "OrgUpdateNameRequest")
+    @JsonPropertyOrder({"orgId", "name"})
+    interface UpdateNameRequest {
+
+        /**
+         * @return the organization id
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getOrgId();
+
+        /**
+         * @return the new organization name
+         */
+        @Schema(description = "Organization name. Must meet same\ncriteria as in the web UI.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+    }
+
+    @Schema(name = "OrgTransferSystemsRequest")
+    @JsonPropertyOrder({"toOrgId", "sids"})
+    interface TransferSystemsRequest {
+
+        /**
+         * @return the id of the destination organization
+         */
+        @Schema(description = "ID of the organization where the\nsystem(s) will be transferred to.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getToOrgId();
+
+        /**
+         * @return the ids of the systems to transfer
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        List<Integer> getSids();
+    }
+
+    @Schema(name = "OrgSetScapFileUploadRequest")
+    @JsonPropertyOrder({"orgId", "newSettings"})
+    interface SetScapFileUploadRequest {
+
+        /**
+         * @return the organization id
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getOrgId();
+
+        /**
+         * @return the new settings
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        ScapFileUploadSettingsDoc getNewSettings();
+    }
+
+    @Schema(name = "OrgScapFileUploadSettings")
+    interface ScapFileUploadSettingsDoc {
+
+        /**
+         * @return whether the aggregation of detailed SCAP results is enabled
+         */
+        @Schema(description = "Aggregation of detailed SCAP results is enabled.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getEnabled();
+    }
+
+    @Schema(name = "OrgSetScapDeletionRequest")
+    @JsonPropertyOrder({"orgId", "newSettings"})
+    interface SetScapDeletionRequest {
+
+        /**
+         * @return the organization id
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getOrgId();
+
+        /**
+         * @return the new settings
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        ScapDeletionSettingsDoc getNewSettings();
+    }
+
+    @Schema(name = "OrgScapDeletionSettings")
+    @JsonPropertyOrder({"enabled", "retentionPeriod"})
+    interface ScapDeletionSettingsDoc {
+
+        /**
+         * @return whether the deletion of SCAP results is enabled
+         */
+        @Schema(description = "Deletion of SCAP results is enabled", requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getEnabled();
+
+        /**
+         * @return the retention period
+         */
+        @Schema(name = "retention_period",
+                description = "Period (in days) after which a scan can be deleted (if enabled).",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getRetentionPeriod();
+    }
+
+    @Schema(name = "OrgScapUploadInfo", description = "scap_upload_info")
+    @JsonPropertyOrder({"enabled", "sizeLimit"})
+    interface ScapUploadInfoDoc {
+
+        /**
+         * @return whether the aggregation of detailed SCAP results is enabled
+         */
+        @Schema(description = "Aggregation of detailed SCAP results is enabled.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getEnabled();
+
+        /**
+         * @return the size limit for a single SCAP file upload
+         */
+        @Schema(name = "size_limit", description = "Limit (in Bytes) for a single SCAP file upload.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getSizeLimit();
+    }
+
+    @Schema(name = "OrgScapDeletionInfo", description = "scap_deletion_info")
+    @JsonPropertyOrder({"enabled", "retentionPeriod"})
+    interface ScapDeletionInfoDoc {
+
+        /**
+         * @return whether the deletion of SCAP results is enabled
+         */
+        @Schema(description = "Deletion of SCAP results is enabled", requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getEnabled();
+
+        /**
+         * @return the retention period
+         */
+        @Schema(name = "retention_period",
+                description = "Period (in days) after which a scan can be deleted (if enabled).",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getRetentionPeriod();
+    }
+
+    @Schema(name = "OrgInfo", description = "organization info")
+    @JsonPropertyOrder({"id", "name", "activeUsers", "systems", "trusts", "systemGroups", "activationKeys",
+        "kickstartProfiles", "configurationChannels", "stagingContentEnabled"})
+    interface OrgDoc {
+
+        /**
+         * @return the organization id
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the organization name
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the number of active users
+         */
+        @Schema(name = "active_users", description = "number of active users in the organization",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getActiveUsers();
+
+        /**
+         * @return the number of systems
+         */
+        @Schema(description = "number of systems in the organization", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getSystems();
+
+        /**
+         * @return the number of trusted organizations
+         */
+        @Schema(description = "number of trusted organizations", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getTrusts();
+
+        /**
+         * @return the number of system groups
+         */
+        @Schema(name = "system_groups",
+                description = "number of system groups in the organization (optional)")
+        Integer getSystemGroups();
+
+        /**
+         * @return the number of activation keys
+         */
+        @Schema(name = "activation_keys",
+                description = "number of activation keys in the organization (optional)")
+        Integer getActivationKeys();
+
+        /**
+         * @return the number of kickstart profiles
+         */
+        @Schema(name = "kickstart_profiles",
+                description = "number of kickstart profiles in the organization (optional)")
+        Integer getKickstartProfiles();
+
+        /**
+         * @return the number of configuration channels
+         */
+        @Schema(name = "configuration_channels",
+                description = "number of configuration channels in the organization (optional)")
+        Integer getConfigurationChannels();
+
+        /**
+         * @return whether staging content is enabled
+         */
+        @Schema(name = "staging_content_enabled",
+                description = "is staging content enabled in organization (optional)")
+        Boolean getStagingContentEnabled();
+    }
+
+    @Schema(name = "OrgUser", description = "user")
+    @JsonPropertyOrder({"login", "loginUc", "name", "email", "isOrgAdmin"})
+    interface OrgUserDoc {
+
+        /**
+         * @return the login
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLogin();
+
+        /**
+         * @return the uppercase login
+         */
+        @Schema(name = "login_uc", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLoginUc();
+
+        /**
+         * @return the user name
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the e-mail
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getEmail();
+
+        /**
+         * @return whether the user is an organization administrator
+         */
+        @Schema(name = "is_org_admin", requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getIsOrgAdmin();
+    }
+}

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/org/OrgHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/org/OrgHandlerApi.java
@@ -11,6 +11,7 @@
 package com.redhat.rhn.frontend.xmlrpc.org;
 
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.dto.MultiOrgUserOverview;
 import com.redhat.rhn.frontend.dto.OrgDto;
 
 import com.suse.manager.api.ApiResponseWrapper;
@@ -263,7 +264,7 @@ public interface OrgHandlerApi {
         responseClass = OrgUserListResponse.class,
         legacyDocResponse = @LegacyDocResponse(name = "user")
     )
-    List listUsers(
+    List<MultiOrgUserOverview> listUsers(
         @Parameter(hidden = true) User loggedInUser,
         @Parameter(name = "orgId", in = ParameterIn.QUERY, required = true) Integer orgId);
 

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandler.java
@@ -539,7 +539,9 @@ public class PackagesHandler extends BaseHandler implements PackagesHandlerApi {
         if (arch == null) {
              throw new InvalidPackageArchException(archLabel);
         }
-        if (epoch.equals("")) {
+        // An empty epoch arrives as null over HTTP, because an empty query string value parses
+        // to a JSON null, while XML-RPC delivers the empty string the documentation recommends.
+        if (StringUtils.isEmpty(epoch)) {
             epoch = null;
         }
         return PackageFactory.lookupByNevra(loggedInUser.getOrg(), name, version, release, epoch, arch);

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandler.java
@@ -57,7 +57,7 @@ import java.util.Map;
  * @apidoc.doc Methods to retrieve information about the Packages contained
  * within this server.
  */
-public class PackagesHandler extends BaseHandler {
+public class PackagesHandler extends BaseHandler implements PackagesHandlerApi {
 
     private static Logger logger = LogManager.getLogger(PackagesHandler.class);
     private static float freeMemCoeff = 0.9f;

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandlerApi.java
@@ -272,8 +272,10 @@ public interface PackagesHandlerApi {
     @Schema(name = "ApiResponsePackageList")
     interface PackageListResponse extends ApiResponseWrapper<List<PackageDoc>> { }
 
+    // The package file is written to the response as the array of numbers a Java byte array
+    // serializes to, not as the base64 string a Byte element would document.
     @Schema(name = "ApiResponsePackageFile")
-    interface PackageFileResponse extends ApiResponseWrapper<List<Byte>> { }
+    interface PackageFileResponse extends ApiResponseWrapper<List<Integer>> { }
 
     @Schema(name = "PackageIdRequest")
     interface PackageIdRequest {

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandlerApi.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/PackagesHandlerApi.java
@@ -1,0 +1,657 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.frontend.xmlrpc.packages;
+
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.api.ApiResponseWrapper;
+import com.suse.manager.api.docs.ApiEndpointDoc;
+import com.suse.manager.api.docs.LegacyDocResponse;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import spark.route.HttpMethod;
+
+/**
+ * API contract for {@link PackagesHandler}.
+ */
+@Tag(name = "packages", description = "Methods to retrieve information about the Packages contained within this " +
+        "server.")
+public interface PackagesHandlerApi {
+
+    /**
+     * Retrieves the details of a package.
+     *
+     * @param loggedInUser the current user
+     * @param pid the package ID
+     * @return the details of the package
+     */
+    @ApiEndpointDoc(
+        summary = "Retrieve details for the package with the ID.",
+        method = HttpMethod.get,
+        responseClass = PackageDetailsResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "package")
+    )
+    Map<String, Object> getDetails(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "pid", in = ParameterIn.QUERY, required = true) Integer pid);
+
+    /**
+     * Lists the channels providing a package.
+     *
+     * @param loggedInUser the current user
+     * @param pid the package ID
+     * @return the channels providing the package
+     */
+    @ApiEndpointDoc(
+        summary = "List the channels that provide the a package.",
+        method = HttpMethod.get,
+        responseClass = ProvidingChannelListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "channel")
+    )
+    Object[] listProvidingChannels(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "pid", in = ParameterIn.QUERY, required = true) Integer pid);
+
+    /**
+     * Lists the errata providing a package.
+     *
+     * @param loggedInUser the current user
+     * @param pid the package ID
+     * @return the errata providing the package
+     */
+    @ApiEndpointDoc(
+        summary = "List the errata providing the a package.",
+        method = HttpMethod.get,
+        responseClass = ProvidingErrataListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "errata")
+    )
+    Object[] listProvidingErrata(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "pid", in = ParameterIn.QUERY, required = true) Integer pid);
+
+    /**
+     * Lists the files of a package.
+     *
+     * @param loggedInUser the current user
+     * @param pid the package ID
+     * @return the files of the package
+     */
+    @ApiEndpointDoc(
+        summary = "List the files associated with a package.",
+        method = HttpMethod.get,
+        responseClass = PackageFileListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "file info")
+    )
+    Object[] listFiles(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "pid", in = ParameterIn.QUERY, required = true) Integer pid);
+
+    /**
+     * Lists the change log of a package.
+     *
+     * @param loggedInUser the current user
+     * @param pid the package ID
+     * @return the change log of the package
+     */
+    @ApiEndpointDoc(
+        summary = "List the change log for a package.",
+        method = HttpMethod.get,
+        responseClass = StringResponse.class,
+        legacyDocResponse = @LegacyDocResponse(plainText = true)
+    )
+    String listChangelog(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "pid", in = ParameterIn.QUERY, required = true) Integer pid);
+
+    /**
+     * Lists the dependencies of a package.
+     *
+     * @param loggedInUser the current user
+     * @param pid the package ID
+     * @return the dependencies of the package
+     */
+    @ApiEndpointDoc(
+        summary = "List the dependencies for a package.",
+        method = HttpMethod.get,
+        responseClass = PackageDependencyListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "dependency")
+    )
+    Object[] listDependencies(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "pid", in = ParameterIn.QUERY, required = true) Integer pid);
+
+    /**
+     * Removes a package.
+     *
+     * @param loggedInUser the current user
+     * @param pid the package ID
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Remove a package from #product().",
+        requestClass = PackageIdRequest.class,
+        isIntegerResponse = true
+    )
+    int removePackage(User loggedInUser, Integer pid);
+
+    /**
+     * Removes a source package.
+     *
+     * @param loggedInUser the current user
+     * @param psid the package source ID
+     * @return 1 on success
+     */
+    @ApiEndpointDoc(
+        summary = "Remove a source package.",
+        requestClass = SourcePackageIdRequest.class,
+        isIntegerResponse = true
+    )
+    int removeSourcePackage(User loggedInUser, Integer psid);
+
+    /**
+     * Lists all source packages of the organization.
+     *
+     * @param loggedInUser the current user
+     * @return the source packages of the organization
+     */
+    @ApiEndpointDoc(
+        summary = "List all source packages in user's organization.",
+        method = HttpMethod.get,
+        responseClass = SourcePackageListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "source_package")
+    )
+    Object[] listSourcePackages(@Parameter(hidden = true) User loggedInUser);
+
+    /**
+     * Looks up the packages matching the given NVREA.
+     *
+     * @param loggedInUser the current user
+     * @param name the package name
+     * @param version the package version
+     * @param release the package release
+     * @param epoch the package epoch
+     * @param archLabel the architecture label
+     * @return the matching packages
+     */
+    @ApiEndpointDoc(
+        summary = "Lookup the details for packages with the given name, version, release, architecture label, " +
+            "and (optionally) epoch.",
+        method = HttpMethod.get,
+        responseClass = PackageListResponse.class,
+        legacyDocResponse = @LegacyDocResponse(name = "package")
+    )
+    List<Package> findByNvrea(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "name", in = ParameterIn.QUERY, required = true) String name,
+        @Parameter(name = "version", in = ParameterIn.QUERY, required = true) String version,
+        @Parameter(name = "release", in = ParameterIn.QUERY, required = true) String release,
+        @Parameter(name = "epoch", in = ParameterIn.QUERY, required = true,
+            description = "If set to something other than empty string, strict matching will be used and the " +
+                "epoch string must be correct. If set to an empty string, if the epoch is null or there is only " +
+                "one NVRA combination, it will be returned.  (Empty string is recommended.)") String epoch,
+        @Parameter(name = "archLabel", in = ParameterIn.QUERY, required = true) String archLabel);
+
+    /**
+     * Retrieves the download URL of a package.
+     *
+     * @param loggedInUser the current user
+     * @param pid the package ID
+     * @return the download URL
+     */
+    @ApiEndpointDoc(
+        summary = "Retrieve the url that can be used to download a package. This will expire after a certain " +
+            "time period.",
+        method = HttpMethod.get,
+        responseClass = StringResponse.class,
+        responseDescription = "the download url",
+        legacyDocResponse = @LegacyDocResponse(plainText = true)
+    )
+    String getPackageUrl(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "pid", in = ParameterIn.QUERY, required = true) Integer pid);
+
+    /**
+     * Retrieves the package file of a package.
+     *
+     * @param loggedInUser the current user
+     * @param pid the package ID
+     * @return the package file
+     * @throws IOException when the package file cannot be read
+     */
+    @ApiEndpointDoc(
+        summary = "Retrieve the package file associated with a package.",
+        method = HttpMethod.get,
+        responseClass = PackageFileResponse.class,
+        responseDescription = "binary object - package file",
+        legacyDocResponse = @LegacyDocResponse(type = "byte")
+    )
+    byte[] getPackage(
+        @Parameter(hidden = true) User loggedInUser,
+        @Parameter(name = "pid", in = ParameterIn.QUERY, required = true) Integer pid) throws IOException;
+
+    @Schema(name = "ApiResponseString")
+    interface StringResponse extends ApiResponseWrapper<String> { }
+
+    @Schema(name = "ApiResponsePackageDetails")
+    interface PackageDetailsResponse extends ApiResponseWrapper<PackageDetailsDoc> { }
+
+    @Schema(name = "ApiResponsePackageProvidingChannelList")
+    interface ProvidingChannelListResponse extends ApiResponseWrapper<List<ProvidingChannelDoc>> { }
+
+    @Schema(name = "ApiResponsePackageProvidingErrataList")
+    interface ProvidingErrataListResponse extends ApiResponseWrapper<List<ProvidingErrataDoc>> { }
+
+    @Schema(name = "ApiResponsePackageFileList")
+    interface PackageFileListResponse extends ApiResponseWrapper<List<PackageFileDoc>> { }
+
+    @Schema(name = "ApiResponsePackageDependencyList")
+    interface PackageDependencyListResponse extends ApiResponseWrapper<List<PackageDependencyDoc>> { }
+
+    @Schema(name = "ApiResponseSourcePackageList")
+    interface SourcePackageListResponse extends ApiResponseWrapper<List<SourcePackageDoc>> { }
+
+    @Schema(name = "ApiResponsePackageList")
+    interface PackageListResponse extends ApiResponseWrapper<List<PackageDoc>> { }
+
+    @Schema(name = "ApiResponsePackageFile")
+    interface PackageFileResponse extends ApiResponseWrapper<List<Byte>> { }
+
+    @Schema(name = "PackageIdRequest")
+    interface PackageIdRequest {
+
+        /**
+         * @return the package ID
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getPid();
+    }
+
+    @Schema(name = "SourcePackageIdRequest")
+    interface SourcePackageIdRequest {
+
+        /**
+         * @return the package source ID
+         */
+        @Schema(description = "package source ID", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getPsid();
+    }
+
+    @Schema(name = "PackageDetails")
+    @JsonPropertyOrder({"id", "name", "epoch", "version", "release", "archLabel", "providingChannels", "buildHost",
+        "description", "checksum", "checksumType", "vendor", "summary", "cookie", "license", "file", "buildDate",
+        "lastModifiedDate", "size", "path", "payloadSize"})
+    interface PackageDetailsDoc {
+
+        /**
+         * @return the ID of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the name of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the epoch of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getEpoch();
+
+        /**
+         * @return the version of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getVersion();
+
+        /**
+         * @return the release of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getRelease();
+
+        /**
+         * @return the architecture label of the package
+         */
+        @Schema(name = "arch_label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getArchLabel();
+
+        /**
+         * @return the channels providing the package
+         */
+        @Schema(name = "providing_channels", requiredMode = Schema.RequiredMode.REQUIRED)
+        @LegacyDocResponse(name = "Channel label providing this package.")
+        List<String> getProvidingChannels();
+
+        /**
+         * @return the build host of the package
+         */
+        @Schema(name = "build_host", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getBuildHost();
+
+        /**
+         * @return the description of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getDescription();
+
+        /**
+         * @return the checksum of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChecksum();
+
+        /**
+         * @return the checksum type of the package
+         */
+        @Schema(name = "checksum_type", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChecksumType();
+
+        /**
+         * @return the vendor of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getVendor();
+
+        /**
+         * @return the summary of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSummary();
+
+        /**
+         * @return the cookie of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getCookie();
+
+        /**
+         * @return the license of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLicense();
+
+        /**
+         * @return the file of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getFile();
+
+        /**
+         * @return the build date of the package
+         */
+        @Schema(name = "build_date", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getBuildDate();
+
+        /**
+         * @return the last modification date of the package
+         */
+        @Schema(name = "last_modified_date", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLastModifiedDate();
+
+        /**
+         * @return the size of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSize();
+
+        /**
+         * @return the path of the package
+         */
+        @Schema(description = "The path on the #product() server's file system that the package resides.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getPath();
+
+        /**
+         * @return the payload size of the package
+         */
+        @Schema(name = "payload_size", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getPayloadSize();
+    }
+
+    @Schema(name = "PackageProvidingChannel")
+    @JsonPropertyOrder({"label", "parentLabel", "name"})
+    interface ProvidingChannelDoc {
+
+        /**
+         * @return the label of the channel
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLabel();
+
+        /**
+         * @return the label of the parent channel
+         */
+        @Schema(name = "parent_label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getParentLabel();
+
+        /**
+         * @return the name of the channel
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+    }
+
+    @Schema(name = "PackageProvidingErrata")
+    @JsonPropertyOrder({"advisory", "issueDate", "lastModifiedDate", "updateDate", "synopsis", "type"})
+    interface ProvidingErrataDoc {
+
+        /**
+         * @return the advisory of the erratum
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getAdvisory();
+
+        /**
+         * @return the issue date of the erratum
+         */
+        @Schema(name = "issue_date", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getIssueDate();
+
+        /**
+         * @return the last modification date of the erratum
+         */
+        @Schema(name = "last_modified_date", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLastModifiedDate();
+
+        /**
+         * @return the update date of the erratum
+         */
+        @Schema(name = "update_date", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getUpdateDate();
+
+        /**
+         * @return the synopsis of the erratum
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getSynopsis();
+
+        /**
+         * @return the type of the erratum
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getType();
+    }
+
+    @Schema(name = "PackageFileInfo")
+    @JsonPropertyOrder({"path", "type", "lastModifiedDate", "checksum", "checksumType", "size", "linkto"})
+    interface PackageFileDoc {
+
+        /**
+         * @return the path of the file
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getPath();
+
+        /**
+         * @return the type of the file
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getType();
+
+        /**
+         * @return the last modification date of the file
+         */
+        @Schema(name = "last_modified_date", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLastModifiedDate();
+
+        /**
+         * @return the checksum of the file
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChecksum();
+
+        /**
+         * @return the checksum type of the file
+         */
+        @Schema(name = "checksum_type", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getChecksumType();
+
+        /**
+         * @return the size of the file
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getSize();
+
+        /**
+         * @return the link target of the file
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getLinkto();
+    }
+
+    @Schema(name = "PackageDependency")
+    @JsonPropertyOrder({"dependency", "dependencyType", "dependencyModifier"})
+    interface PackageDependencyDoc {
+
+        /**
+         * @return the dependency
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getDependency();
+
+        /**
+         * @return the type of the dependency
+         */
+        @Schema(name = "dependency_type", description = "One of the following:",
+                allowableValues = {"requires", "conflicts", "obsoletes", "provides", "recommends", "suggests",
+                    "supplements", "enhances", "predepends", "breaks"},
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getDependencyType();
+
+        /**
+         * @return the modifier of the dependency
+         */
+        @Schema(name = "dependency_modifier", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getDependencyModifier();
+    }
+
+    @Schema(name = "SourcePackageOverview")
+    @JsonPropertyOrder({"id", "name"})
+    interface SourcePackageDoc {
+
+        /**
+         * @return the ID of the source package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the name of the source package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+    }
+
+    @Schema(name = "PackageInfo")
+    @JsonPropertyOrder({"name", "version", "release", "epoch", "id", "archLabel", "lastModified", "path",
+        "partOfRetractedPatch", "provider"})
+    interface PackageDoc {
+
+        /**
+         * @return the name of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getName();
+
+        /**
+         * @return the version of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getVersion();
+
+        /**
+         * @return the release of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getRelease();
+
+        /**
+         * @return the epoch of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String getEpoch();
+
+        /**
+         * @return the ID of the package
+         */
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer getId();
+
+        /**
+         * @return the architecture label of the package
+         */
+        @Schema(name = "arch_label", requiredMode = Schema.RequiredMode.REQUIRED)
+        String getArchLabel();
+
+        /**
+         * @return the last modification date of the package
+         */
+        @Schema(name = "last_modified", requiredMode = Schema.RequiredMode.REQUIRED)
+        @LegacyDocResponse(type = "dateTime.iso8601")
+        Date getLastModified();
+
+        /**
+         * @return the path of the package
+         */
+        @Schema(description = "the path on that file system that the package resides",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getPath();
+
+        /**
+         * @return whether the package is part of a retracted patch
+         */
+        @Schema(name = "part_of_retracted_patch",
+                description = "true if the package is a part of a retracted patch",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean getPartOfRetractedPatch();
+
+        /**
+         * @return the provider of the package
+         */
+        @Schema(description = "the provider of the package, determined by the gpg key it was signed with.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String getProvider();
+    }
+}

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/serializer/ChannelSerializer.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/serializer/ChannelSerializer.java
@@ -49,6 +49,7 @@ import java.util.List;
  *      #prop("string", "gpg_key_url")
  *      #prop("string", "gpg_key_id")
  *      #prop("string", "gpg_key_fp")
+ *      #prop("boolean", "gpg_check")
  *      #prop_desc("$date", "yumrepo_last_sync", "(optional)")
  *      #prop("string", "end_of_life")
  *      #prop("string", "parent_channel_label")

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/serializer/ImageInfoSerializer.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/serializer/ImageInfoSerializer.java
@@ -28,6 +28,7 @@ import com.suse.manager.api.SerializedApiResponse;
  * #struct_begin("image information")
  *   #prop("int", "id")
  *   #prop_desc("string", "name", "image name")
+ *   #prop_desc("string", "type", "image type")
  *   #prop_desc("string", "version", "image tag/version")
  *   #prop_desc("int", "revision", "image build revision number")
  *   #prop_desc("string", "arch", "image architecture")

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/serializer/ImageInfoSerializer.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/serializer/ImageInfoSerializer.java
@@ -35,7 +35,7 @@ import com.suse.manager.api.SerializedApiResponse;
  *          false otherwise")
  *   #prop("string", "storeLabel")
  *   #prop("string", "checksum")
- *   #prop("string", "obsolete")
+ *   #prop("boolean", "obsolete")
  * #struct_end()
  */
 public class ImageInfoSerializer extends ApiResponseSerializer<ImageInfo> {

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/serializer/ImageOverviewSerializer.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/serializer/ImageOverviewSerializer.java
@@ -60,7 +60,9 @@ import com.suse.manager.api.SerializedApiResponse;
  *   #prop("int", "enhancementErrata")
  *   #prop("int", "outdatedPackages")
  *   #prop("int", "installedPackages")
- *   #prop_desc("struct", "files", "image files")
+ *   #prop_array_begin_desc("files", "image files")
+ *     $ImageFileSerializer
+ *   #prop_array_end()
  *   #prop_desc("boolean", "obsolete", "true if the image has been replaced in the store")
  * #struct_end()
  */

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/serializer/PackageDtoSerializer.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/serializer/PackageDtoSerializer.java
@@ -36,6 +36,7 @@ import java.util.Optional;
  *      #prop("int", "id")
  *      #prop("string", "arch_label")
  *      #prop("string", "last_modified_date")
+ *      #prop("boolean", "retracted")
  *      #prop_desc("string", "last_modified", "(deprecated)")
  *  #struct_end()
  *

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -35,6 +35,7 @@ import com.redhat.rhn.frontend.xmlrpc.image.store.ImageStoreHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.filepreservation.FilePreservationListHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.keys.CryptoKeysHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.profile.software.SoftwareHandler;
+import com.redhat.rhn.frontend.xmlrpc.kickstart.profile.system.SystemDetailsHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.snippet.SnippetHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.tree.KickstartTreeHandler;
 import com.redhat.rhn.frontend.xmlrpc.org.OrgHandler;
@@ -162,6 +163,7 @@ public final class OpenApiConfig {
         handlers.put("kickstart.filepreservation", FilePreservationListHandler.class);
         handlers.put("kickstart.keys", CryptoKeysHandler.class);
         handlers.put("kickstart.profile.software", SoftwareHandler.class);
+        handlers.put("kickstart.profile.system", SystemDetailsHandler.class);
         handlers.put("kickstart.snippet", SnippetHandler.class);
         handlers.put("kickstart.tree", KickstartTreeHandler.class);
         handlers.put("org", OrgHandler.class);

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -28,6 +28,7 @@ import com.redhat.rhn.frontend.xmlrpc.distchannel.DistChannelHandler;
 import com.redhat.rhn.frontend.xmlrpc.errata.ErrataHandler;
 import com.redhat.rhn.frontend.xmlrpc.formula.FormulaHandler;
 import com.redhat.rhn.frontend.xmlrpc.image.DeltaImageInfoHandler;
+import com.redhat.rhn.frontend.xmlrpc.image.ImageInfoHandler;
 import com.redhat.rhn.frontend.xmlrpc.image.profile.ImageProfileHandler;
 import com.redhat.rhn.frontend.xmlrpc.image.store.ImageStoreHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.filepreservation.FilePreservationListHandler;
@@ -150,6 +151,7 @@ public final class OpenApiConfig {
         handlers.put("distchannel", DistChannelHandler.class);
         handlers.put("errata", ErrataHandler.class);
         handlers.put("formula", FormulaHandler.class);
+        handlers.put("image", ImageInfoHandler.class);
         handlers.put("image.delta", DeltaImageInfoHandler.class);
         handlers.put("image.profile", ImageProfileHandler.class);
         handlers.put("image.store", ImageStoreHandler.class);

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.frontend.xmlrpc.channel.ChannelHandler;
 import com.redhat.rhn.frontend.xmlrpc.channel.access.ChannelAccessHandler;
 import com.redhat.rhn.frontend.xmlrpc.channel.appstreams.ChannelAppStreamHandler;
 import com.redhat.rhn.frontend.xmlrpc.channel.org.ChannelOrgHandler;
+import com.redhat.rhn.frontend.xmlrpc.channel.software.ChannelSoftwareHandler;
 import com.redhat.rhn.frontend.xmlrpc.contentmgmt.ContentManagementHandler;
 import com.redhat.rhn.frontend.xmlrpc.distchannel.DistChannelHandler;
 import com.redhat.rhn.frontend.xmlrpc.errata.ErrataHandler;
@@ -148,6 +149,7 @@ public final class OpenApiConfig {
         handlers.put("channel.access", ChannelAccessHandler.class);
         handlers.put("channel.appstreams", ChannelAppStreamHandler.class);
         handlers.put("channel.org", ChannelOrgHandler.class);
+        handlers.put("channel.software", ChannelSoftwareHandler.class);
         handlers.put("contentmanagement", ContentManagementHandler.class);
         handlers.put("distchannel", DistChannelHandler.class);
         handlers.put("errata", ErrataHandler.class);

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -37,6 +37,7 @@ import com.redhat.rhn.frontend.xmlrpc.kickstart.profile.software.SoftwareHandler
 import com.redhat.rhn.frontend.xmlrpc.kickstart.snippet.SnippetHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.tree.KickstartTreeHandler;
 import com.redhat.rhn.frontend.xmlrpc.org.trusts.OrgTrustHandler;
+import com.redhat.rhn.frontend.xmlrpc.packages.PackagesHandler;
 import com.redhat.rhn.frontend.xmlrpc.packages.provider.PackagesProviderHandler;
 import com.redhat.rhn.frontend.xmlrpc.packages.search.PackagesSearchHandler;
 import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
@@ -161,6 +162,7 @@ public final class OpenApiConfig {
         handlers.put("kickstart.snippet", SnippetHandler.class);
         handlers.put("kickstart.tree", KickstartTreeHandler.class);
         handlers.put("org.trusts", OrgTrustHandler.class);
+        handlers.put("packages", PackagesHandler.class);
         handlers.put("packages.provider", PackagesProviderHandler.class);
         handlers.put("packages.search", PackagesSearchHandler.class);
         handlers.put("preferences.locale", PreferencesLocaleHandler.class);

--- a/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
+++ b/java/core/src/main/java/com/suse/manager/api/OpenApiConfig.java
@@ -37,6 +37,7 @@ import com.redhat.rhn.frontend.xmlrpc.kickstart.keys.CryptoKeysHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.profile.software.SoftwareHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.snippet.SnippetHandler;
 import com.redhat.rhn.frontend.xmlrpc.kickstart.tree.KickstartTreeHandler;
+import com.redhat.rhn.frontend.xmlrpc.org.OrgHandler;
 import com.redhat.rhn.frontend.xmlrpc.org.trusts.OrgTrustHandler;
 import com.redhat.rhn.frontend.xmlrpc.packages.PackagesHandler;
 import com.redhat.rhn.frontend.xmlrpc.packages.provider.PackagesProviderHandler;
@@ -163,6 +164,7 @@ public final class OpenApiConfig {
         handlers.put("kickstart.profile.software", SoftwareHandler.class);
         handlers.put("kickstart.snippet", SnippetHandler.class);
         handlers.put("kickstart.tree", KickstartTreeHandler.class);
+        handlers.put("org", OrgHandler.class);
         handlers.put("org.trusts", OrgTrustHandler.class);
         handlers.put("packages", PackagesHandler.class);
         handlers.put("packages.provider", PackagesProviderHandler.class);

--- a/java/core/src/main/java/com/suse/manager/api/docs/LegacyDocResponse.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/LegacyDocResponse.java
@@ -33,4 +33,14 @@ public @interface LegacyDocResponse {
      * @return optional response body type to use when rendering legacy API documentation
      */
     Class<?> responseClass() default Void.class;
+
+    /**
+     * Tells that the legacy documentation renders the return value as a bare type.
+     *
+     * A return value carries no name of its own in the specification, so the parsers label it
+     * with the operation name. A namespace that documents the type alone opts out of that.
+     *
+     * @return whether the legacy documentation renders the return value without a label
+     */
+    boolean unnamed() default false;
 }

--- a/java/core/src/main/java/com/suse/manager/api/docs/LegacyDocResponse.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/LegacyDocResponse.java
@@ -35,12 +35,14 @@ public @interface LegacyDocResponse {
     Class<?> responseClass() default Void.class;
 
     /**
-     * Tells that the legacy documentation renders the return value as a bare type.
+     * Tells that the legacy documentation renders the return value as plain text.
      *
-     * A return value carries no name of its own in the specification, so the parsers label it
-     * with the operation name. A namespace that documents the type alone opts out of that.
+     * The doclet passes a return value documented without a macro through as it was written,
+     * carrying neither the type role a documented one carries nor a label of its own. A return
+     * value has no name in the specification, so the parsers otherwise label it with the
+     * operation name, which such a return value does not show.
      *
-     * @return whether the legacy documentation renders the return value without a label
+     * @return whether the legacy documentation renders the return value as plain text
      */
-    boolean unnamed() default false;
+    boolean plainText() default false;
 }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -141,14 +141,15 @@ public class OpenApiToAsciidocParser {
         }
         String tag = operation.getTags().get(0);
 
-        boolean securityRequired = isSecurityRequired(operation);
         List<String> required = getFieldsByRequirement(operation, true);
         List<String> optional = getFieldsByRequirement(operation, false);
 
         List<DocEntry> entries = operationsByTag.computeIfAbsent(tag, key -> new ArrayList<>());
 
         for (List<String> params : UyuniSwaggerReader.expandOverloads(operation, required, optional)) {
-            entries.add(DocEntry.create(method, operation, params, securityRequired));
+            Operation documentedByOverload = UyuniSwaggerReader.operationForCall(operation, params);
+            entries.add(DocEntry.create(method, operation, documentedByOverload, params,
+                    isSecurityRequired(documentedByOverload)));
         }
     }
 
@@ -193,14 +194,14 @@ public class OpenApiToAsciidocParser {
                     """,
                 tag,
                 entry.anchor(),
-                Boolean.TRUE.equals(operation.getDeprecated()) ?
+                Boolean.TRUE.equals(entry.documentedByOverload().getDeprecated()) ?
                         operation.getOperationId() + " (Deprecated)" : operation.getOperationId(),
                 entry.method(),
                 summary,
                 description
         );
 
-        if (isSecurityRequired(operation)) {
+        if (isSecurityRequired(entry.documentedByOverload())) {
             writer.println("* [.string]#string#  sessionKey\n");
         }
 
@@ -213,7 +214,7 @@ public class OpenApiToAsciidocParser {
         }
 
         writer.println("\nReturns:\n");
-        writeReturn(writer, operation);
+        writeReturn(writer, operation, entry.activeParams());
         writer.print("\n\n\n");
     }
 
@@ -314,8 +315,8 @@ public class OpenApiToAsciidocParser {
         return openAPI.getSecurity() != null && !openAPI.getSecurity().isEmpty();
     }
 
-    private void writeReturn(PrintWriter writer, Operation operation) {
-        var responses = operation.getResponses();
+    private void writeReturn(PrintWriter writer, Operation operation, List<String> activeParams) {
+        var responses = UyuniSwaggerReader.operationForCall(operation, activeParams).getResponses();
         if (responses == null) {
             return;
         }
@@ -819,9 +820,11 @@ public class OpenApiToAsciidocParser {
         return schema.getItems() != null ? findDescription(schema.getItems()) : "";
     }
 
-    private record DocEntry(String method, String anchor, Operation operation, List<String> activeParams) {
+    private record DocEntry(String method, String anchor, Operation operation,
+                           Operation documentedByOverload, List<String> activeParams) {
 
-        static DocEntry create(String method, Operation operation, List<String> params, boolean securityRequired) {
+        static DocEntry create(String method, Operation operation, Operation documentedByOverload,
+                               List<String> params, boolean securityRequired) {
             String suffix = String.join("-", params);
             String authPart = securityRequired ? "loggedInUser" : "";
 
@@ -839,7 +842,7 @@ public class OpenApiToAsciidocParser {
                 anchor += "-";
             }
 
-            return new DocEntry(method, anchor, operation, List.copyOf(params));
+            return new DocEntry(method, anchor, operation, documentedByOverload, List.copyOf(params));
         }
     }
 }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -343,7 +343,10 @@ public class OpenApiToAsciidocParser {
             schema = resolveSchemaReference(docSchema);
         }
 
-        if (docSchema == null && schema.getProperties() != null && schema.getProperties().containsKey("result")) {
+        // The payload of a response is carried beside the status of the call, which tells the
+        // wrapper apart from a documented struct that happens to hold a property called result.
+        if (docSchema == null && schema.getProperties() != null &&
+                schema.getProperties().containsKey("result") && schema.getProperties().containsKey("success")) {
             Schema<?> resultSchema = (Schema<?>) schema.getProperties().get("result");
             refName = extractRefName(resultSchema.get$ref());
             schema = resolveSchemaReference(resultSchema);

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -217,7 +217,7 @@ public class OpenApiToAsciidocParser {
         }
 
         writer.println("\nReturns:\n");
-        writeReturn(writer, operation, entry.activeParams());
+        writeReturn(writer, operation, entry.documentedByOverload());
         writer.print("\n\n\n");
     }
 
@@ -318,8 +318,15 @@ public class OpenApiToAsciidocParser {
         return openAPI.getSecurity() != null && !openAPI.getSecurity().isEmpty();
     }
 
-    private void writeReturn(PrintWriter writer, Operation operation, List<String> activeParams) {
-        var responses = UyuniSwaggerReader.operationForCall(operation, activeParams).getResponses();
+    /**
+     * Writes the return value of a documented call.
+     *
+     * @param writer the writer to write to
+     * @param operation the operation the call belongs to, which names it
+     * @param documentedByOverload the overload documenting the call, which describes what it answers
+     */
+    private void writeReturn(PrintWriter writer, Operation operation, Operation documentedByOverload) {
+        var responses = documentedByOverload.getResponses();
         if (responses == null) {
             return;
         }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -388,8 +388,8 @@ public class OpenApiToAsciidocParser {
                 type,
                 name,
                 Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_PLAIN_TEXT_EXTENSION)),
-                response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_VALUES_EXTENSION)
-                        instanceof Schema<?> values ? values : null
+                response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_VALUES_EXTENSION) instanceof
+                        Schema<?> values ? values : null
         );
     }
 

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -612,7 +612,14 @@ public class OpenApiToAsciidocParser {
     }
 
     private String displayType(Schema<?> schema) {
-        return "integer".equals(schema.getType()) ? "int" : schema.getType();
+        if ("integer".equals(schema.getType())) {
+            return "int";
+        }
+        // The doclet binds $date to its own type name, whichever value carries the date.
+        if ("string".equals(schema.getType()) && "date-time".equals(schema.getFormat())) {
+            return UyuniSwaggerReader.LEGACY_DATE_TYPE;
+        }
+        return schema.getType();
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -54,6 +54,9 @@ public class OpenApiToAsciidocParser {
     /** Bullet level the doclet uses for the element struct of an array-valued parameter. */
     private static final int PARAMETER_ELEMENT_STRUCT_LEVEL = 2;
 
+    /** Bullet level the doclet uses for the documented values of a parameter. */
+    private static final int PARAMETER_OPTION_LEVEL = 2;
+
     /** OpenAPI type name for an array-valued schema. */
     private static final String ARRAY_TYPE = "array";
 
@@ -226,6 +229,7 @@ public class OpenApiToAsciidocParser {
         }
 
         writer.printf("* %s  %s%s%n", parameterType(schema), paramName, suffix);
+        printOptions(writer, resolved == null ? schema : resolved, PARAMETER_OPTION_LEVEL);
         writeParameterElement(writer, resolved == null ? schema : resolved);
         writer.println();
     }
@@ -415,6 +419,7 @@ public class OpenApiToAsciidocParser {
             Schema<?> nested = resolveNestedStruct(prop);
             String label = nested != null && !legacyDocName(prop).isEmpty() ? legacyDocName(prop) : name;
             writeStructProperty(writer, "", label, prop, level);
+            printOptions(writer, prop, level + 1);
             printElementStruct(writer, prop, level + 1);
             printStructProperties(writer, nested, level + 1);
         });
@@ -466,6 +471,65 @@ public class OpenApiToAsciidocParser {
         }
         writer.printf("%s [.struct]#struct#  %s%n", "*".repeat(level), label);
         printStructProperties(writer, resolvedItems, level + 1);
+    }
+
+    /**
+     * Writes the documented values of a parameter or property, one bullet level below it.
+     *
+     * The doclet renders {@code #options()} as a plain bullet list carrying no type marker, and
+     * appends the description after a dash for the {@code #item_desc} form.
+     *
+     * @param writer the writer to write to
+     * @param schema the parameter or property schema
+     * @param level the bullet level of the values
+     */
+    private void printOptions(PrintWriter writer, Schema<?> schema, int level) {
+        Schema<?> documented = optionsSchema(schema);
+        if (documented == null || documented.getEnum() == null) {
+            return;
+        }
+        Map<String, String> descriptions = optionDescriptions(documented);
+        for (Object value : documented.getEnum()) {
+            String option = String.valueOf(value);
+            String description = descriptions.getOrDefault(option, "");
+            writer.printf("%s %s%s%n", "*".repeat(level), option,
+                    description.isEmpty() ? "" : " - " + description);
+        }
+    }
+
+    /**
+     * Resolves the schema that carries the documented values.
+     *
+     * An array documents the values of its element type; every other parameter or property
+     * documents its own.
+     *
+     * @param schema the parameter or property schema
+     * @return the schema holding the values, or null when there is none
+     */
+    private Schema<?> optionsSchema(Schema<?> schema) {
+        if (schema == null) {
+            return null;
+        }
+        return ARRAY_TYPE.equals(schema.getType()) && schema.getItems() != null ?
+                resolveSchemaReference(schema.getItems()) : schema;
+    }
+
+    /**
+     * Reads the descriptions the namespace documented for individual values.
+     *
+     * @param schema the schema holding the values
+     * @return the description of each value, empty when the values carry none
+     */
+    private Map<String, String> optionDescriptions(Schema<?> schema) {
+        Object descriptions = schema.getExtensions() == null ? null :
+                schema.getExtensions().get(UyuniSwaggerReader.DOC_OPTION_DESCRIPTIONS_EXTENSION);
+        if (!(descriptions instanceof Map<?, ?> documented)) {
+            return Map.of();
+        }
+        Map<String, String> byOption = new LinkedHashMap<>();
+        documented.forEach((option, description) ->
+                byOption.put(String.valueOf(option), String.valueOf(description)));
+        return byOption;
     }
 
     private String legacyDocName(Schema<?> schema) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -205,7 +205,10 @@ public class OpenApiToAsciidocParser {
             writer.println("* [.string]#string#  sessionKey\n");
         }
 
+        // A call takes the parameters of the overload documenting it, which describes the ones it
+        // shares with the others as its own signature declares them.
         Map<String, Schema> allProps = getAllPossibleProperties(operation);
+        allProps.putAll(getAllPossibleProperties(entry.documentedByOverload()));
         for (String paramName : entry.activeParams()) {
             Schema schema = allProps.get(paramName);
             if (schema != null) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -368,7 +368,7 @@ public class OpenApiToAsciidocParser {
         // that are not simple: the doclet renders those as a single typed line, without expanding
         // the schema.
         if (isSimpleType(schema) || !legacyDocResponse.type().isBlank()) {
-            writeSimpleReturn(writer, schema, responseLabel, legacyDocResponse.type(), operation,
+            writeSimpleReturn(writer, schema, responseLabel, legacyDocResponse.type(),
                     legacyDocResponse.plainText(), legacyDocResponse.values());
             return;
         }
@@ -595,12 +595,11 @@ public class OpenApiToAsciidocParser {
     }
 
     private void writeSimpleReturn(PrintWriter writer, Schema<?> schema, String responseLabel,
-                                   String legacyType, Operation operation, boolean plainText,
-                                   Schema<?> documentedValues) {
+                                   String legacyType, boolean plainText, Schema<?> documentedValues) {
         String displayType = legacyType.isBlank() ? displayType(schema) : legacyType;
         Schema<?> values = documentedValues == null ? schema : documentedValues;
         // The doclet passes a return value documented without a macro through as written, so it
-        // carries neither the type role nor a label synthesised from the operation.
+        // carries no type role.
         if (plainText) {
             writer.printf("* %s%s %n", displayType, responseLabel.isBlank() ? "" : " - " + responseLabel);
             printOptions(writer, values, RETURN_OPTION_LEVEL);
@@ -608,14 +607,9 @@ public class OpenApiToAsciidocParser {
             return;
         }
 
-        String label = Optional.of(responseLabel)
-                .filter(d -> !d.isBlank())
-                .orElseGet(() -> operation.getOperationId()
-                        .replace("get", "")
-                        .replaceAll("([a-z])([A-Z])", "$1 $2")
-                        .toLowerCase().trim());
-
-        writer.printf("* [.%s]#%s#  %s%n", displayType, displayType, label);
+        // The doclet renders the label the namespace documented and invents none, so a return
+        // value documented without one is a bare typed line.
+        writer.printf("* [.%s]#%s#  %s%n", displayType, displayType, responseLabel);
         printOptions(writer, values, RETURN_OPTION_LEVEL);
         writer.print(" ");
     }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -57,6 +57,8 @@ public class OpenApiToAsciidocParser {
     /** Bullet level the doclet uses for the documented values of a parameter. */
     private static final int PARAMETER_OPTION_LEVEL = 2;
 
+    private static final int RETURN_OPTION_LEVEL = 2;
+
     /** OpenAPI type name for an array-valued schema. */
     private static final String ARRAY_TYPE = "array";
 
@@ -191,7 +193,8 @@ public class OpenApiToAsciidocParser {
                     """,
                 tag,
                 entry.anchor(),
-                operation.getOperationId(),
+                Boolean.TRUE.equals(operation.getDeprecated()) ?
+                        operation.getOperationId() + " (Deprecated)" : operation.getOperationId(),
                 entry.method(),
                 summary,
                 description
@@ -330,7 +333,8 @@ public class OpenApiToAsciidocParser {
         LegacyDocResponseData legacyDocResponse = getLegacyDocResponse(successResponse);
         Schema<?> docSchema = legacyDocResponse.schema();
         String responseDescription = responseDescription(successResponse);
-        String responseLabel = legacyDocResponse.label(responseDescription).orElse(responseDescription);
+        String responseLabel = legacyDocResponse.unnamed() ? "" :
+                legacyDocResponse.label(responseDescription).orElse(responseDescription);
         if (docSchema != null) {
             refName = docSchema.get$ref() != null ? extractRefName(docSchema.get$ref()) : "";
             schema = resolveSchemaReference(docSchema);
@@ -351,7 +355,8 @@ public class OpenApiToAsciidocParser {
         // that are not simple: the doclet renders those as a single typed line, without expanding
         // the schema.
         if (isSimpleType(schema) || !legacyDocResponse.type().isBlank()) {
-            writeSimpleReturn(writer, schema, responseLabel, legacyDocResponse.type(), operation);
+            writeSimpleReturn(writer, schema, responseLabel, legacyDocResponse.type(), operation,
+                    legacyDocResponse.unnamed());
             return;
         }
 
@@ -368,7 +373,8 @@ public class OpenApiToAsciidocParser {
         return new LegacyDocResponseData(
                 schema instanceof Schema<?> docSchema ? docSchema : null,
                 type,
-                name
+                name,
+                Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_UNNAMED_EXTENSION))
         );
     }
 
@@ -417,10 +423,18 @@ public class OpenApiToAsciidocParser {
         }
         resolved.getProperties().forEach((name, prop) -> {
             Schema<?> nested = resolveNestedStruct(prop);
-            String label = nested != null && !legacyDocName(prop).isEmpty() ? legacyDocName(prop) : name;
+            // An array property spends its legacy name on the element struct, so only a scalar or
+            // struct property renames itself with it.
+            String label = ARRAY_TYPE.equals(prop.getType()) || legacyDocName(prop).isEmpty() ?
+                    name : legacyDocName(prop);
             writeStructProperty(writer, "", label, prop, level);
             printOptions(writer, prop, level + 1);
             printElementStruct(writer, prop, level + 1);
+            // A serializer referenced by a struct property brings its own struct label, which the
+            // doclet renders as a sibling of the property before the fields it introduces.
+            if (nested != null && !legacyDocName(nested).isEmpty()) {
+                writer.printf("%s [.struct]#struct#  %s%n", "*".repeat(level), legacyDocName(nested));
+            }
             printStructProperties(writer, nested, level + 1);
         });
     }
@@ -540,9 +554,18 @@ public class OpenApiToAsciidocParser {
         return value == null ? "" : value.toString();
     }
 
-    private void writeSimpleReturn(PrintWriter writer, Schema<?> schema,
-                                   String responseLabel, String legacyType, Operation operation) {
+    private void writeSimpleReturn(PrintWriter writer, Schema<?> schema, String responseLabel,
+                                   String legacyType, Operation operation, boolean unnamed) {
         String displayType = legacyType.isBlank() ? displayType(schema) : legacyType;
+        // The doclet renders a return value documented as a bare type as plain text, without the
+        // type role a named one carries.
+        if (unnamed) {
+            writer.printf("* %s %n", displayType);
+            printOptions(writer, schema, RETURN_OPTION_LEVEL);
+            writer.print(" ");
+            return;
+        }
+
         String label = Optional.of(responseLabel)
                 .filter(d -> !d.isBlank())
                 .orElseGet(() -> operation.getOperationId()
@@ -550,7 +573,9 @@ public class OpenApiToAsciidocParser {
                         .replaceAll("([a-z])([A-Z])", "$1 $2")
                         .toLowerCase().trim());
 
-        writer.printf("* [.%s]#%s#  %s%n ", displayType, displayType, label);
+        writer.printf("* [.%s]#%s#  %s%n", displayType, displayType, label);
+        printOptions(writer, schema, RETURN_OPTION_LEVEL);
+        writer.print(" ");
     }
 
     private Schema<?> resolveSchemaReference(Schema<?> schema) {
@@ -566,8 +591,8 @@ public class OpenApiToAsciidocParser {
                 .orElse("");
     }
 
-    private record LegacyDocResponseData(Schema<?> schema, String type, String name) {
-        private static final LegacyDocResponseData EMPTY = new LegacyDocResponseData(null, "", "");
+    private record LegacyDocResponseData(Schema<?> schema, String type, String name, boolean unnamed) {
+        private static final LegacyDocResponseData EMPTY = new LegacyDocResponseData(null, "", "", false);
 
         Optional<String> label(String description) {
             if (name.isBlank()) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -333,8 +333,7 @@ public class OpenApiToAsciidocParser {
         LegacyDocResponseData legacyDocResponse = getLegacyDocResponse(successResponse);
         Schema<?> docSchema = legacyDocResponse.schema();
         String responseDescription = responseDescription(successResponse);
-        String responseLabel = legacyDocResponse.unnamed() ? "" :
-                legacyDocResponse.label(responseDescription).orElse(responseDescription);
+        String responseLabel = legacyDocResponse.label(responseDescription).orElse(responseDescription);
         if (docSchema != null) {
             refName = docSchema.get$ref() != null ? extractRefName(docSchema.get$ref()) : "";
             schema = resolveSchemaReference(docSchema);
@@ -356,7 +355,7 @@ public class OpenApiToAsciidocParser {
         // the schema.
         if (isSimpleType(schema) || !legacyDocResponse.type().isBlank()) {
             writeSimpleReturn(writer, schema, responseLabel, legacyDocResponse.type(), operation,
-                    legacyDocResponse.unnamed());
+                    legacyDocResponse.plainText(), legacyDocResponse.values());
             return;
         }
 
@@ -374,7 +373,9 @@ public class OpenApiToAsciidocParser {
                 schema instanceof Schema<?> docSchema ? docSchema : null,
                 type,
                 name,
-                Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_UNNAMED_EXTENSION))
+                Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_PLAIN_TEXT_EXTENSION)),
+                response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_VALUES_EXTENSION)
+                        instanceof Schema<?> values ? values : null
         );
     }
 
@@ -555,13 +556,15 @@ public class OpenApiToAsciidocParser {
     }
 
     private void writeSimpleReturn(PrintWriter writer, Schema<?> schema, String responseLabel,
-                                   String legacyType, Operation operation, boolean unnamed) {
+                                   String legacyType, Operation operation, boolean plainText,
+                                   Schema<?> documentedValues) {
         String displayType = legacyType.isBlank() ? displayType(schema) : legacyType;
-        // The doclet renders a return value documented as a bare type as plain text, without the
-        // type role a named one carries.
-        if (unnamed) {
-            writer.printf("* %s %n", displayType);
-            printOptions(writer, schema, RETURN_OPTION_LEVEL);
+        Schema<?> values = documentedValues == null ? schema : documentedValues;
+        // The doclet passes a return value documented without a macro through as written, so it
+        // carries neither the type role nor a label synthesised from the operation.
+        if (plainText) {
+            writer.printf("* %s%s %n", displayType, responseLabel.isBlank() ? "" : " - " + responseLabel);
+            printOptions(writer, values, RETURN_OPTION_LEVEL);
             writer.print(" ");
             return;
         }
@@ -574,7 +577,7 @@ public class OpenApiToAsciidocParser {
                         .toLowerCase().trim());
 
         writer.printf("* [.%s]#%s#  %s%n", displayType, displayType, label);
-        printOptions(writer, schema, RETURN_OPTION_LEVEL);
+        printOptions(writer, values, RETURN_OPTION_LEVEL);
         writer.print(" ");
     }
 
@@ -591,8 +594,10 @@ public class OpenApiToAsciidocParser {
                 .orElse("");
     }
 
-    private record LegacyDocResponseData(Schema<?> schema, String type, String name, boolean unnamed) {
-        private static final LegacyDocResponseData EMPTY = new LegacyDocResponseData(null, "", "", false);
+    private record LegacyDocResponseData(Schema<?> schema, String type, String name, boolean plainText,
+                                         Schema<?> values) {
+        private static final LegacyDocResponseData EMPTY =
+                new LegacyDocResponseData(null, "", "", false, null);
 
         Optional<String> label(String description) {
             if (name.isBlank()) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -435,6 +435,7 @@ public class OpenApiToAsciidocParser {
             writeStructProperty(writer, "", label, prop, level);
             printOptions(writer, prop, level + 1);
             printElementStruct(writer, prop, level + 1);
+            printSimpleElement(writer, prop, level);
             // A serializer referenced by a struct property brings its own struct label, which the
             // doclet renders as a sibling of the property before the fields it introduces.
             if (nested != null && !legacyDocName(nested).isEmpty()) {
@@ -490,6 +491,30 @@ public class OpenApiToAsciidocParser {
         }
         writer.printf("%s [.struct]#struct#  %s%n", "*".repeat(level), label);
         printStructProperties(writer, resolvedItems, level + 1);
+    }
+
+    /**
+     * Writes the named element of an array property that holds a simple type.
+     *
+     * The doclet names such an element with {@code #array_single}, which it renders as an item of
+     * its own beside a property documented as a bare array. A property documenting the element
+     * type on itself, with {@code #prop_array}, names the element there and shows no such item,
+     * so only a property declaring the bare array type carries one.
+     *
+     * @param writer the writer to write to
+     * @param property the array property schema
+     * @param level the bullet level of the property
+     */
+    private void printSimpleElement(PrintWriter writer, Schema<?> property, int level) {
+        String label = legacyDocName(property);
+        if (!ARRAY_TYPE.equals(legacyDocType(property)) || label.isEmpty()) {
+            return;
+        }
+        Schema<?> items = resolveSchemaReference(property.getItems());
+        if (items == null || !isSimpleType(items)) {
+            return;
+        }
+        writer.printf("%s [.array]#%s array#  %s%n", "*".repeat(level), structPropertyType(items), label);
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToAsciidocParser.java
@@ -217,7 +217,7 @@ public class OpenApiToAsciidocParser {
         }
 
         writer.println("\nReturns:\n");
-        writeReturn(writer, operation, entry.documentedByOverload());
+        writeReturn(writer, entry.documentedByOverload());
         writer.print("\n\n\n");
     }
 
@@ -322,10 +322,9 @@ public class OpenApiToAsciidocParser {
      * Writes the return value of a documented call.
      *
      * @param writer the writer to write to
-     * @param operation the operation the call belongs to, which names it
      * @param documentedByOverload the overload documenting the call, which describes what it answers
      */
-    private void writeReturn(PrintWriter writer, Operation operation, Operation documentedByOverload) {
+    private void writeReturn(PrintWriter writer, Operation documentedByOverload) {
         var responses = documentedByOverload.getResponses();
         if (responses == null) {
             return;

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -317,7 +317,8 @@ public class OpenApiToDocBookParser {
             schema = resolveSchemaReference(docSchema);
         }
 
-        String label = legacyDocResponse.label(responseDescription).orElseGet(() ->
+        String label = legacyDocResponse.unnamed() ? "" :
+                legacyDocResponse.label(responseDescription).orElseGet(() ->
                 !responseDescription.isBlank() ?
                 responseDescription :
                 fallbackLabel
@@ -339,7 +340,8 @@ public class OpenApiToDocBookParser {
         return new LegacyDocResponseData(
                 schema instanceof Schema<?> docSchema ? docSchema : null,
                 type,
-                name
+                name,
+                Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_UNNAMED_EXTENSION))
         );
     }
 
@@ -411,7 +413,9 @@ public class OpenApiToDocBookParser {
     private String renderSimpleReturn(Schema<?> schema, String label, String typeOverride) {
         String type = typeOverride.isBlank() ? formatSimpleType(schema) : typeOverride;
         String text = (label == null || label.isBlank()) ? type : type + " - " + label;
-        return String.format("<listitem><para>%s</para></listitem>", escapeXml(text));
+        String item = String.format("<listitem><para>%s</para></listitem>", escapeXml(text));
+        String options = renderOptions(schema);
+        return options.isEmpty() ? item : item + "\n" + options;
     }
 
     private String extensionString(ApiResponse response, String extensionName) {
@@ -491,14 +495,19 @@ public class OpenApiToDocBookParser {
             Schema<?> propSchema = prop;
             String desc = findDescription(propSchema);
             Schema<?> nested = resolveNestedStruct(propSchema);
-            String label = nested != null && !getLegacyDocName(propSchema).isBlank() ?
-                    getLegacyDocName(propSchema) : name;
+            // An array property spends its legacy name on the element struct, so only a scalar or
+            // struct property renames itself with it.
+            String label = "array".equals(propSchema.getType()) || getLegacyDocName(propSchema).isBlank() ?
+                    name : getLegacyDocName(propSchema);
             // the doclet labels a nested struct with #struct_begin, which does not quote the label
             String body = nested != null ? String.format("%s %s", formatType(propSchema), label) :
                     String.format("%s \"%s\"", formatType(propSchema), label);
             if (!desc.isBlank()) {
                 body += " - " + desc;
             }
+            // A serializer referenced by a struct property brings its own struct label, which the
+            // doclet renders as a sibling of the property before the fields it introduces.
+            String structLabel = nested == null ? "" : getLegacyDocName(nested);
             String elementStruct = nested != null ? renderNestedStructProperties(nested) :
                     renderElementStruct(propSchema);
             String options = renderOptions(propSchema);
@@ -506,6 +515,19 @@ public class OpenApiToDocBookParser {
                 sb.append("    <listitem><para>")
                   .append(escapeXml(body))
                   .append("</para></listitem>\n");
+                appendOptions(sb, options);
+                return;
+            }
+            if (!structLabel.isBlank()) {
+                sb.append("    <listitem><para>")
+                  .append(escapeXml(body))
+                  .append("</para></listitem>\n");
+                sb.append("    <listitem>\n");
+                sb.append("      <para>").append(escapeXml(String.format("struct %s", structLabel))).append("</para>\n");
+                sb.append("      <itemizedlist spacing=\"compact\">\n");
+                sb.append(indentLines(elementStruct, 8)).append("\n");
+                sb.append("      </itemizedlist>\n");
+                sb.append("    </listitem>\n");
                 appendOptions(sb, options);
                 return;
             }
@@ -875,8 +897,8 @@ public class OpenApiToDocBookParser {
         return out.toString();
     }
 
-    private record LegacyDocResponseData(Schema<?> schema, String type, String name) {
-        private static final LegacyDocResponseData EMPTY = new LegacyDocResponseData(null, "", "");
+    private record LegacyDocResponseData(Schema<?> schema, String type, String name, boolean unnamed) {
+        private static final LegacyDocResponseData EMPTY = new LegacyDocResponseData(null, "", "", false);
 
         Optional<String> label(String description) {
             if (name.isBlank()) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -349,8 +349,8 @@ public class OpenApiToDocBookParser {
                 type,
                 name,
                 Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_PLAIN_TEXT_EXTENSION)),
-                response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_VALUES_EXTENSION)
-                        instanceof Schema<?> values ? values : null
+                response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_VALUES_EXTENSION) instanceof
+                        Schema<?> values ? values : null
         );
     }
 
@@ -543,7 +543,8 @@ public class OpenApiToDocBookParser {
                   .append(escapeXml(body))
                   .append("</para></listitem>\n");
                 sb.append("    <listitem>\n");
-                sb.append("      <para>").append(escapeXml(String.format("struct %s", structLabel))).append("</para>\n");
+                sb.append("      <para>").append(escapeXml(String.format("struct %s", structLabel)))
+                  .append("</para>\n");
                 sb.append("      <itemizedlist spacing=\"compact\">\n");
                 sb.append(indentLines(elementStruct, 8)).append("\n");
                 sb.append("      </itemizedlist>\n");

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -395,7 +395,10 @@ public class OpenApiToDocBookParser {
     }
 
     private Schema<?> getResultSchema(Schema<?> schema) {
-        if (schema.getProperties() == null || !schema.getProperties().containsKey("result")) {
+        // The payload of a response is carried beside the status of the call, which tells the
+        // wrapper apart from a documented struct that happens to hold a property called result.
+        if (schema.getProperties() == null || !schema.getProperties().containsKey("result") ||
+                !schema.getProperties().containsKey("success")) {
             return null;
         }
         Object resultProp = schema.getProperties().get("result");

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -150,19 +150,19 @@ public class OpenApiToDocBookParser {
         List<String> optional = getFieldsByRequirement(op, false);
 
         for (List<String> params : UyuniSwaggerReader.expandOverloads(op, required, optional)) {
-            handler.calls.add(buildCallDoc(httpMethod, op, params,
-                    isSecurityRequired(UyuniSwaggerReader.operationForCall(op, params))));
+            handler.calls.add(buildCallDoc(httpMethod, op, params));
         }
     }
 
-    private CallDoc buildCallDoc(String httpMethod, Operation op,
-                                 List<String> activeParams, boolean securityRequired) {
+    private CallDoc buildCallDoc(String httpMethod, Operation op, List<String> activeParams) {
+        Operation documentedByOverload = UyuniSwaggerReader.operationForCall(op, activeParams);
         String name = Optional.ofNullable(op.getOperationId())
                 .filter(s -> !s.isBlank())
                 .orElse("");
         String description = buildDescription(op);
-        List<ParamDoc> params = buildParams(op, activeParams, securityRequired);
-        String returnDoc = buildReturnDoc(op, name, activeParams);
+        List<ParamDoc> params = buildParams(op, documentedByOverload, activeParams,
+                isSecurityRequired(documentedByOverload));
+        String returnDoc = buildReturnDoc(documentedByOverload, name);
         return new CallDoc(name, httpMethod, description, params, returnDoc);
     }
 
@@ -187,8 +187,8 @@ public class OpenApiToDocBookParser {
         return fields;
     }
 
-    private List<ParamDoc> buildParams(Operation op, List<String> activeParams,
-                                       boolean securityRequired) {
+    private List<ParamDoc> buildParams(Operation op, Operation documentedByOverload,
+                                       List<String> activeParams, boolean securityRequired) {
         List<ParamDoc> params = new ArrayList<>();
 
         if (securityRequired) {
@@ -196,7 +196,10 @@ public class OpenApiToDocBookParser {
                     "Session token, must be obtained via auth.login."));
         }
 
+        // A call takes the parameters of the overload documenting it, which describes the ones it
+        // shares with the others as its own signature declares them.
         Map<String, Schema<?>> allProps = getAllPossibleProperties(op);
+        allProps.putAll(getAllPossibleProperties(documentedByOverload));
         for (String name : activeParams) {
             Schema<?> schema = allProps.get(name);
             if (schema == null) {
@@ -286,8 +289,8 @@ public class OpenApiToDocBookParser {
         return props;
     }
 
-    private String buildReturnDoc(Operation op, String fallbackLabel, List<String> activeParams) {
-        ApiResponses responses = UyuniSwaggerReader.operationForCall(op, activeParams).getResponses();
+    private String buildReturnDoc(Operation op, String fallbackLabel) {
+        ApiResponses responses = op.getResponses();
         if (responses == null) {
             return "<listitem><para></para></listitem>";
         }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -40,6 +40,7 @@ import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 
 /**
  * Converts the generated OpenAPI specification into DocBook XML files.
@@ -145,12 +146,12 @@ public class OpenApiToDocBookParser {
         HandlerDoc handler = handlers.computeIfAbsent(tag,
                 k -> new HandlerDoc(k, getTagDescription(k)));
 
-        boolean securityRequired = isSecurityRequired(op);
         List<String> required = getFieldsByRequirement(op, true);
         List<String> optional = getFieldsByRequirement(op, false);
 
         for (List<String> params : UyuniSwaggerReader.expandOverloads(op, required, optional)) {
-            handler.calls.add(buildCallDoc(httpMethod, op, params, securityRequired));
+            handler.calls.add(buildCallDoc(httpMethod, op, params,
+                    isSecurityRequired(UyuniSwaggerReader.operationForCall(op, params))));
         }
     }
 
@@ -161,7 +162,7 @@ public class OpenApiToDocBookParser {
                 .orElse("");
         String description = buildDescription(op);
         List<ParamDoc> params = buildParams(op, activeParams, securityRequired);
-        String returnDoc = buildReturnDoc(op, name);
+        String returnDoc = buildReturnDoc(op, name, activeParams);
         return new CallDoc(name, httpMethod, description, params, returnDoc);
     }
 
@@ -285,11 +286,12 @@ public class OpenApiToDocBookParser {
         return props;
     }
 
-    private String buildReturnDoc(Operation op, String fallbackLabel) {
-        if (op.getResponses() == null) {
+    private String buildReturnDoc(Operation op, String fallbackLabel, List<String> activeParams) {
+        ApiResponses responses = UyuniSwaggerReader.operationForCall(op, activeParams).getResponses();
+        if (responses == null) {
             return "<listitem><para></para></listitem>";
         }
-        ApiResponse resp = op.getResponses().entrySet().stream()
+        ApiResponse resp = responses.entrySet().stream()
                 .filter(e -> e.getKey().startsWith("2") || e.getKey().equals("default"))
                 .map(Map.Entry::getValue)
                 .findFirst()

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -531,6 +531,7 @@ public class OpenApiToDocBookParser {
                 sb.append("    <listitem><para>")
                   .append(escapeXml(body))
                   .append("</para></listitem>\n");
+                appendSimpleElement(sb, propSchema);
                 appendOptions(sb, options);
                 return;
             }
@@ -556,6 +557,31 @@ public class OpenApiToDocBookParser {
             appendOptions(sb, options);
         });
         return sb.toString();
+    }
+
+    /**
+     * Appends the named element of an array property that holds a simple type.
+     *
+     * The doclet names such an element with {@code #array_single}, which it renders as an item of
+     * its own beside a property documented as a bare array. A property documenting the element
+     * type on itself, with {@code #prop_array}, names the element there and shows no such item,
+     * so only a property declaring the bare array type carries one.
+     *
+     * @param sb the markup being built
+     * @param property the array property schema
+     */
+    private void appendSimpleElement(StringBuilder sb, Schema<?> property) {
+        String label = getLegacyDocName(property);
+        if (!"array".equals(getLegacyDocType(property)) || label.isBlank()) {
+            return;
+        }
+        Schema<?> items = resolveSchemaReference(property.getItems());
+        if (items == null || !isSimpleType(items)) {
+            return;
+        }
+        sb.append("    <listitem><para>")
+          .append(escapeXml(String.format("array(%s) %s", formatSimpleType(items), label)))
+          .append("</para></listitem>\n");
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -317,7 +317,8 @@ public class OpenApiToDocBookParser {
             schema = resolveSchemaReference(docSchema);
         }
 
-        String label = legacyDocResponse.unnamed() ? "" :
+        String label = legacyDocResponse.plainText() ?
+                legacyDocResponse.label(responseDescription).orElse(responseDescription) :
                 legacyDocResponse.label(responseDescription).orElseGet(() ->
                 !responseDescription.isBlank() ?
                 responseDescription :
@@ -327,7 +328,8 @@ public class OpenApiToDocBookParser {
                         .toLowerCase().trim()
         );
 
-        return renderReturnSchema(schema, label, legacyDocResponse.type(), legacyDocResponse.name());
+        return renderReturnSchema(schema, label, legacyDocResponse.type(), legacyDocResponse.name(),
+                legacyDocResponse.values());
     }
 
     private LegacyDocResponseData getLegacyDocResponse(ApiResponse response) {
@@ -341,16 +343,23 @@ public class OpenApiToDocBookParser {
                 schema instanceof Schema<?> docSchema ? docSchema : null,
                 type,
                 name,
-                Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_UNNAMED_EXTENSION))
+                Boolean.TRUE.equals(response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_PLAIN_TEXT_EXTENSION)),
+                response.getExtensions().get(UyuniSwaggerReader.DOC_RESPONSE_VALUES_EXTENSION)
+                        instanceof Schema<?> values ? values : null
         );
     }
 
     private String renderReturnSchema(Schema<?> schema, String label) {
-        return renderReturnSchema(schema, label, "", "");
+        return renderReturnSchema(schema, label, "", "", null);
     }
 
     private String renderReturnSchema(Schema<?> schema, String label, String typeOverride,
                                       String legacyStructLabel) {
+        return renderReturnSchema(schema, label, typeOverride, legacyStructLabel, null);
+    }
+
+    private String renderReturnSchema(Schema<?> schema, String label, String typeOverride,
+                                      String legacyStructLabel, Schema<?> documentedValues) {
         if (schema == null) {
             return "<listitem><para></para></listitem>";
         }
@@ -360,7 +369,8 @@ public class OpenApiToDocBookParser {
                     resolveSchemaReference(resultSchema),
                     getResultLabel(resultSchema, label),
                     typeOverride,
-                    legacyStructLabel
+                    legacyStructLabel,
+                    documentedValues
             );
         }
         if ("array".equals(schema.getType()) && schema.getItems() != null) {
@@ -370,7 +380,8 @@ public class OpenApiToDocBookParser {
         // that are not simple: the doclet renders those as a single typed line, without expanding
         // the schema.
         if (isSimpleType(schema) || !typeOverride.isBlank()) {
-            return renderSimpleReturn(schema, label, typeOverride);
+            return renderSimpleReturn(documentedValues == null ? schema : documentedValues, label, typeOverride,
+                    schema);
         }
         if (schema.getAdditionalProperties() instanceof Schema<?> inner) {
             return renderAdditionalPropertiesReturn(inner, label);
@@ -410,11 +421,11 @@ public class OpenApiToDocBookParser {
         return sb.toString();
     }
 
-    private String renderSimpleReturn(Schema<?> schema, String label, String typeOverride) {
+    private String renderSimpleReturn(Schema<?> values, String label, String typeOverride, Schema<?> schema) {
         String type = typeOverride.isBlank() ? formatSimpleType(schema) : typeOverride;
         String text = (label == null || label.isBlank()) ? type : type + " - " + label;
         String item = String.format("<listitem><para>%s</para></listitem>", escapeXml(text));
-        String options = renderOptions(schema);
+        String options = renderOptions(values);
         return options.isEmpty() ? item : item + "\n" + options;
     }
 
@@ -897,8 +908,10 @@ public class OpenApiToDocBookParser {
         return out.toString();
     }
 
-    private record LegacyDocResponseData(Schema<?> schema, String type, String name, boolean unnamed) {
-        private static final LegacyDocResponseData EMPTY = new LegacyDocResponseData(null, "", "", false);
+    private record LegacyDocResponseData(Schema<?> schema, String type, String name, boolean plainText,
+                                         Schema<?> values) {
+        private static final LegacyDocResponseData EMPTY =
+                new LegacyDocResponseData(null, "", "", false, null);
 
         Optional<String> label(String description) {
             if (name.isBlank()) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -208,10 +208,12 @@ public class OpenApiToDocBookParser {
                 params.add(new ParamDoc(legacyType.isEmpty() ? "struct" : legacyType, name, desc));
                 resolved.getProperties().forEach((propName, propSchema) ->
                         params.add(new ParamDoc(formatType(propSchema), "\"" + propName + "\"",
-                                findDescription(propSchema), renderParameterElement(propSchema))));
+                                findDescription(propSchema), renderParameterElement(propSchema),
+                                renderOptions(propSchema))));
                 continue;
             }
-            params.add(new ParamDoc(formatType(schema), name, desc, renderParameterElement(schema)));
+            params.add(new ParamDoc(formatType(schema), name, desc, renderParameterElement(schema),
+                    renderOptions(schema)));
         }
         return params;
     }
@@ -499,10 +501,12 @@ public class OpenApiToDocBookParser {
             }
             String elementStruct = nested != null ? renderNestedStructProperties(nested) :
                     renderElementStruct(propSchema);
+            String options = renderOptions(propSchema);
             if (elementStruct.isEmpty()) {
                 sb.append("    <listitem><para>")
                   .append(escapeXml(body))
                   .append("</para></listitem>\n");
+                appendOptions(sb, options);
                 return;
             }
             sb.append("    <listitem>\n");
@@ -511,6 +515,7 @@ public class OpenApiToDocBookParser {
             sb.append(indentLines(elementStruct, 8)).append("\n");
             sb.append("      </itemizedlist>\n");
             sb.append("    </listitem>\n");
+            appendOptions(sb, options);
         });
         return sb.toString();
     }
@@ -534,6 +539,84 @@ public class OpenApiToDocBookParser {
         return renderStructList(resolvedItems,
                 items.get$ref() != null ? extractRefName(items.get$ref()) : "",
                 getLegacyDocName(property));
+    }
+
+    /**
+     * Renders the documented values of a parameter or property as a sibling item list.
+     *
+     * The doclet renders {@code #options()} as a separate {@code <listitem override="none">}
+     * following the item it documents, and appends the description after a dash for the
+     * {@code #item_desc} form.
+     *
+     * @param schema the parameter or property schema
+     * @return the markup for the values, or an empty string when there are none
+     */
+    private void writeOptions(PrintWriter w, String options) {
+        if (!options.isEmpty()) {
+            w.printf("%s%n", indentLines(options, 12));
+        }
+    }
+
+    private void appendOptions(StringBuilder sb, String options) {
+        if (!options.isEmpty()) {
+            sb.append(indentLines(options, 4)).append("\n");
+        }
+    }
+
+    private String renderOptions(Schema<?> schema) {
+        Schema<?> documented = optionsSchema(schema);
+        if (documented == null || documented.getEnum() == null) {
+            return "";
+        }
+        Map<String, String> descriptions = optionDescriptions(documented);
+        StringBuilder sb = new StringBuilder();
+        sb.append("<listitem override=\"none\">\n");
+        sb.append("  <itemizedlist spacing=\"compact\">\n");
+        for (Object value : documented.getEnum()) {
+            String option = String.valueOf(value);
+            String description = descriptions.getOrDefault(option, "");
+            sb.append("  <listitem><para>")
+              .append(escapeXml(description.isEmpty() ? option : option + " - " + description))
+              .append("</para></listitem>\n");
+        }
+        sb.append("  </itemizedlist>\n");
+        sb.append("</listitem>");
+        return sb.toString();
+    }
+
+    /**
+     * Resolves the schema that carries the documented values.
+     *
+     * An array documents the values of its element type; every other parameter or property
+     * documents its own.
+     *
+     * @param schema the parameter or property schema
+     * @return the schema holding the values, or null when there is none
+     */
+    private Schema<?> optionsSchema(Schema<?> schema) {
+        if (schema == null) {
+            return null;
+        }
+        return "array".equals(schema.getType()) && schema.getItems() != null ?
+                resolveSchemaReference(schema.getItems()) : schema;
+    }
+
+    /**
+     * Reads the descriptions the namespace documented for individual values.
+     *
+     * @param schema the schema holding the values
+     * @return the description of each value, empty when the values carry none
+     */
+    private Map<String, String> optionDescriptions(Schema<?> schema) {
+        Object descriptions = schema.getExtensions() == null ? null :
+                schema.getExtensions().get(UyuniSwaggerReader.DOC_OPTION_DESCRIPTIONS_EXTENSION);
+        if (!(descriptions instanceof Map<?, ?> documented)) {
+            return Map.of();
+        }
+        Map<String, String> byOption = new LinkedHashMap<>();
+        documented.forEach((option, description) ->
+                byOption.put(String.valueOf(option), String.valueOf(description)));
+        return byOption;
     }
 
     private String renderHandlerFile(HandlerDoc handler) {
@@ -581,6 +664,7 @@ public class OpenApiToDocBookParser {
                         String.format("%s %s - %s", p.type, p.name, p.description);
                 if (p.nested.isEmpty()) {
                     w.printf("            <listitem><para>%s</para></listitem>%n", escapeXml(body));
+                    writeOptions(w, p.options);
                     continue;
                 }
                 w.printf("            <listitem>%n");
@@ -589,6 +673,7 @@ public class OpenApiToDocBookParser {
                 w.printf("%s%n", indentLines(p.nested, 16));
                 w.printf("              </itemizedlist>%n");
                 w.printf("            </listitem>%n");
+                writeOptions(w, p.options);
             }
         }
         w.printf("          </itemizedlist>%n");
@@ -840,15 +925,20 @@ public class OpenApiToDocBookParser {
         /** Pre-rendered element markup nested under this parameter, empty when there is none. */
         private final String nested;
 
+        /** Pre-rendered value list following this parameter, empty when there is none. */
+        private final String options;
+
         ParamDoc(String paramType, String paramName, String paramDescription) {
-            this(paramType, paramName, paramDescription, "");
+            this(paramType, paramName, paramDescription, "", "");
         }
 
-        ParamDoc(String paramType, String paramName, String paramDescription, String nestedMarkup) {
+        ParamDoc(String paramType, String paramName, String paramDescription, String nestedMarkup,
+                 String optionsMarkup) {
             this.type = paramType;
             this.name = paramName;
             this.description = paramDescription;
             this.nested = nestedMarkup;
+            this.options = optionsMarkup;
         }
     }
 }

--- a/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/OpenApiToDocBookParser.java
@@ -162,7 +162,7 @@ public class OpenApiToDocBookParser {
         String description = buildDescription(op);
         List<ParamDoc> params = buildParams(op, documentedByOverload, activeParams,
                 isSecurityRequired(documentedByOverload));
-        String returnDoc = buildReturnDoc(documentedByOverload, name);
+        String returnDoc = buildReturnDoc(documentedByOverload);
         return new CallDoc(name, httpMethod, description, params, returnDoc);
     }
 
@@ -289,7 +289,7 @@ public class OpenApiToDocBookParser {
         return props;
     }
 
-    private String buildReturnDoc(Operation op, String fallbackLabel) {
+    private String buildReturnDoc(Operation op) {
         ApiResponses responses = op.getResponses();
         if (responses == null) {
             return "<listitem><para></para></listitem>";
@@ -322,16 +322,9 @@ public class OpenApiToDocBookParser {
             schema = resolveSchemaReference(docSchema);
         }
 
-        String label = legacyDocResponse.plainText() ?
-                legacyDocResponse.label(responseDescription).orElse(responseDescription) :
-                legacyDocResponse.label(responseDescription).orElseGet(() ->
-                !responseDescription.isBlank() ?
-                responseDescription :
-                fallbackLabel
-                        .replaceAll("^(get|list|is|set|create|delete|update)", "")
-                        .replaceAll("([a-z])([A-Z])", "$1 $2")
-                        .toLowerCase().trim()
-        );
+        // The doclet renders the label the namespace documented and invents none, so a return
+        // value documented without one carries no label.
+        String label = legacyDocResponse.label(responseDescription).orElse(responseDescription);
 
         return renderReturnSchema(schema, label, legacyDocResponse.type(), legacyDocResponse.name(),
                 legacyDocResponse.values());

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
@@ -75,6 +76,9 @@ public class UyuniSwaggerReader {
     public static final String DOC_OVERLOAD_ARITIES_EXTENSION = "x-uyuni-doc-overload-arities";
 
     public static final String DOC_OVERLOAD_SHAPES_EXTENSION = "x-uyuni-doc-overload-shapes";
+
+    /** Facts a documented call takes from its own overload rather than from the merged operation. */
+    public static final String DOC_OVERLOAD_CALLS_EXTENSION = "x-uyuni-doc-overload-calls";
 
     /** Extension holding the description the namespace documented for each allowed value. */
     public static final String DOC_OPTION_DESCRIPTIONS_EXTENSION = "x-uyuni-doc-option-descriptions";
@@ -662,7 +666,8 @@ public class UyuniSwaggerReader {
      */
     private Operation mergeAlternativeOverload(Operation documented, Operation alternative) {
         List<List<String>> calls = new ArrayList<>(documentedCalls(documented));
-        documentedCalls(alternative).stream().filter(call -> !calls.contains(call)).forEach(calls::add);
+        List<List<String>> alternativeCalls = documentedCalls(alternative);
+        alternativeCalls.stream().filter(call -> !calls.contains(call)).forEach(calls::add);
 
         if (alternative.getParameters() != null) {
             alternative.getParameters().stream()
@@ -685,8 +690,90 @@ public class UyuniSwaggerReader {
                     .toList());
         }
 
+        recordAlternativeCalls(documented, alternative, alternativeCalls);
         documented.addExtension(DOC_OVERLOAD_SHAPES_EXTENSION, calls);
         return documented;
+    }
+
+    /**
+     * Keeps what an overload documents differently from the ones read before it.
+     *
+     * The overloads sharing an endpoint are one operation, which is documented once, while the
+     * legacy doclet documents each overload on its own: overloads may answer with a different
+     * return value, authenticate differently, or be deprecated one at a time. The calls such an
+     * overload stands for are therefore recorded against what it documents, so that each call is
+     * described by the overload it comes from rather than by the first overload read.
+     *
+     * @param documented the operation built from the overloads read so far
+     * @param alternative the operation built from an overload taking different parameters
+     * @param alternativeCalls the calls the alternative overload stands for
+     */
+    private void recordAlternativeCalls(Operation documented, Operation alternative,
+                                        List<List<String>> alternativeCalls) {
+        if (!documentsDifferently(documented, alternative)) {
+            return;
+        }
+        Operation documentedByOverload = new Operation()
+                .responses(alternative.getResponses())
+                .security(alternative.getSecurity())
+                .deprecated(Boolean.TRUE.equals(alternative.getDeprecated()));
+
+        Map<String, Operation> calls = new LinkedHashMap<>(recordedCalls(documented));
+        alternativeCalls.forEach(call -> calls.putIfAbsent(callKey(call), documentedByOverload));
+        documented.addExtension(DOC_OVERLOAD_CALLS_EXTENSION, calls);
+    }
+
+    /**
+     * Tells whether an overload documents anything differently from the operation it folds into.
+     *
+     * @param documented the operation built from the overloads read so far
+     * @param alternative the operation built from an overload taking different parameters
+     * @return whether the alternative overload needs its calls recorded
+     */
+    private boolean documentsDifferently(Operation documented, Operation alternative) {
+        return !Objects.equals(documented.getResponses(), alternative.getResponses()) ||
+                !Objects.equals(documented.getSecurity(), alternative.getSecurity()) ||
+                Boolean.TRUE.equals(documented.getDeprecated()) !=
+                        Boolean.TRUE.equals(alternative.getDeprecated());
+    }
+
+    /**
+     * Reads what the overloads of an operation document for the calls they stand for.
+     *
+     * @param operation the operation to read
+     * @return what each recorded call documents, keyed by call
+     */
+    private static Map<String, Operation> recordedCalls(Operation operation) {
+        Object recorded = operation.getExtensions() == null ?
+                null : operation.getExtensions().get(DOC_OVERLOAD_CALLS_EXTENSION);
+        if (!(recorded instanceof Map<?, ?> byCall)) {
+            return Map.of();
+        }
+        Map<String, Operation> calls = new LinkedHashMap<>();
+        byCall.forEach((call, documented) -> {
+            if (documented instanceof Operation documentedByOverload) {
+                calls.put(String.valueOf(call), documentedByOverload);
+            }
+        });
+        return calls;
+    }
+
+    /**
+     * Reads what a documented call documents of its own.
+     *
+     * A call is described by the overload it comes from, which is the operation itself unless
+     * another overload documented that call differently.
+     *
+     * @param operation the operation the call belongs to
+     * @param call the parameters of the documented call
+     * @return the operation documenting the call
+     */
+    public static Operation operationForCall(Operation operation, List<String> call) {
+        return recordedCalls(operation).getOrDefault(callKey(call), operation);
+    }
+
+    private static String callKey(List<String> call) {
+        return String.join(",", call);
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -24,7 +24,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -69,6 +71,8 @@ public class UyuniSwaggerReader {
     public static final String DOC_RESPONSE_UNNAMED_EXTENSION = "x-uyuni-doc-response-unnamed";
     /** Parameter counts of the handler overloads an operation stands for, longest first. */
     public static final String DOC_OVERLOAD_ARITIES_EXTENSION = "x-uyuni-doc-overload-arities";
+
+    public static final String DOC_OVERLOAD_SHAPES_EXTENSION = "x-uyuni-doc-overload-shapes";
 
     /** Extension holding the description the namespace documented for each allowed value. */
     public static final String DOC_OPTION_DESCRIPTIONS_EXTENSION = "x-uyuni-doc-option-descriptions";
@@ -181,6 +185,46 @@ public class UyuniSwaggerReader {
         }
     }
 
+    private List<String> documentedParameters(Operation operation) {
+        List<String> names = new ArrayList<>();
+        if (operation.getParameters() != null) {
+            operation.getParameters().forEach(parameter -> names.add(parameter.getName()));
+        }
+        Schema<?> body = requestBodySchema(operation);
+        if (body != null && body.getProperties() != null) {
+            names.addAll(body.getProperties().keySet());
+        }
+        return names;
+    }
+
+    private boolean isRequired(Operation operation, String name) {
+        if (operation.getParameters() != null) {
+            for (var parameter : operation.getParameters()) {
+                if (name.equals(parameter.getName())) {
+                    return Boolean.TRUE.equals(parameter.getRequired());
+                }
+            }
+        }
+        Schema<?> body = requestBodySchema(operation);
+        return body != null && body.getRequired() != null && body.getRequired().contains(name);
+    }
+
+    private Schema<?> requestBodySchema(Operation operation) {
+        if (operation.getRequestBody() == null || operation.getRequestBody().getContent() == null) {
+            return null;
+        }
+        MediaType mediaType = operation.getRequestBody().getContent().get(DEFAULT_MEDIA_TYPE);
+        if (mediaType == null || mediaType.getSchema() == null) {
+            return null;
+        }
+        Schema<?> schema = mediaType.getSchema();
+        if (schema.get$ref() == null || this.components.getSchemas() == null) {
+            return schema;
+        }
+        return this.components.getSchemas()
+                .get(schema.get$ref().substring(schema.get$ref().lastIndexOf('/') + 1));
+    }
+
     /**
      * Lists the parameter combinations the legacy doclet documents for an operation.
      *
@@ -196,6 +240,11 @@ public class UyuniSwaggerReader {
      */
     public static List<List<String>> expandOverloads(Operation operation, List<String> required,
                                                      List<String> optional) {
+        List<List<String>> resolved = overloadShapes(operation);
+        if (resolved != null) {
+            return resolved;
+        }
+
         List<List<String>> combinations = new ArrayList<>();
         for (int count : optionalParameterCounts(operation, required.size(), optional.size())) {
             List<String> params = new ArrayList<>(required);
@@ -203,6 +252,27 @@ public class UyuniSwaggerReader {
             combinations.add(params);
         }
         return combinations;
+    }
+
+    /**
+     * Reads the parameters of each documented call, when counting them cannot describe them.
+     *
+     * @param operation the operation to expand
+     * @return the parameters of each documented call, or null when the counts describe them
+     */
+    private static List<List<String>> overloadShapes(Operation operation) {
+        Object shapes = operation.getExtensions() == null ?
+                null : operation.getExtensions().get(DOC_OVERLOAD_SHAPES_EXTENSION);
+        if (!(shapes instanceof List<?> recorded) || recorded.isEmpty()) {
+            return null;
+        }
+        List<List<String>> calls = new ArrayList<>();
+        for (Object shape : recorded) {
+            if (shape instanceof List<?> parameters) {
+                calls.add(parameters.stream().map(String::valueOf).toList());
+            }
+        }
+        return calls.isEmpty() ? null : calls;
     }
 
     /**
@@ -552,7 +622,109 @@ public class UyuniSwaggerReader {
     private void registerOperationOnPath(String namespace, Method method, HttpMethod httpMethod, Operation operation) {
         String path = buildPath(namespace, method.getName());
         PathItem pathItem = openAPI.getPaths().computeIfAbsent(path, key -> new PathItem());
-        setOperationOnPathItem(pathItem, httpMethod, operation);
+        Operation documented = getOperationOnPathItem(pathItem, httpMethod);
+        setOperationOnPathItem(pathItem, httpMethod,
+                documented == null ? operation : mergeAlternativeOverload(documented, operation));
+    }
+
+    /**
+     * Folds an overload taking different parameters into the operation already documented.
+     *
+     * Overloads of a handler method answer on one endpoint, so they are one operation, while the
+     * legacy doclet documents one call per overload. An overload that only takes further
+     * parameters is described by the optional ones it leaves out, but an overload taking a
+     * different parameter instead has to contribute that parameter, and the calls it stands for,
+     * to the operation the others share.
+     *
+     * @param documented the operation built from the overloads read so far
+     * @param alternative the operation built from an overload taking different parameters
+     * @return the operation standing for both
+     */
+    private Operation mergeAlternativeOverload(Operation documented, Operation alternative) {
+        List<List<String>> calls = new ArrayList<>(documentedCalls(documented));
+        documentedCalls(alternative).stream().filter(call -> !calls.contains(call)).forEach(calls::add);
+
+        if (alternative.getParameters() != null) {
+            alternative.getParameters().stream()
+                    .filter(parameter -> !documentedParameters(documented).contains(parameter.getName()))
+                    .forEach(parameter -> documented.addParametersItem(parameter));
+        }
+        mergeRequestBodies(documented, alternative);
+
+        // A parameter the operation does not take in every call is optional, whichever overload
+        // introduced it.
+        if (documented.getParameters() != null) {
+            documented.getParameters().stream()
+                    .filter(parameter -> !calls.stream().allMatch(call -> call.contains(parameter.getName())))
+                    .forEach(parameter -> parameter.setRequired(false));
+        }
+        Schema<?> body = requestBodySchema(documented);
+        if (body != null && body.getRequired() != null) {
+            body.setRequired(body.getRequired().stream()
+                    .filter(name -> calls.stream().allMatch(call -> call.contains(name)))
+                    .toList());
+        }
+
+        documented.addExtension(DOC_OVERLOAD_SHAPES_EXTENSION, calls);
+        return documented;
+    }
+
+    /**
+     * Merges the request body of an alternative overload into the documented one.
+     *
+     * Two overloads sending different bodies describe one payload holding the properties of both,
+     * so the merged body is spelled out rather than referring to either side's schema.
+     *
+     * @param documented the operation built from the overloads read so far
+     * @param alternative the operation built from an overload taking different parameters
+     */
+    private void mergeRequestBodies(Operation documented, Operation alternative) {
+        Schema<?> alternativeBody = requestBodySchema(alternative);
+        if (alternativeBody == null || alternativeBody.getProperties() == null) {
+            return;
+        }
+        if (documented.getRequestBody() == null) {
+            documented.setRequestBody(alternative.getRequestBody());
+            return;
+        }
+        Schema<?> documentedBody = requestBodySchema(documented);
+        if (documentedBody == null || documentedBody.getProperties() == null) {
+            return;
+        }
+
+        Schema<Object> merged = new Schema<>().type("object");
+        merged.setProperties(new LinkedHashMap<>(documentedBody.getProperties()));
+        merged.setRequired(documentedBody.getRequired() == null ?
+                new ArrayList<>() : new ArrayList<>(documentedBody.getRequired()));
+        alternativeBody.getProperties().forEach((name, property) -> {
+            if (!merged.getProperties().containsKey(name)) {
+                merged.addProperty(name, property);
+            }
+        });
+        documented.getRequestBody().getContent().get(DEFAULT_MEDIA_TYPE).setSchema(merged);
+    }
+
+    /**
+     * Lists the calls an operation stands for on its own.
+     *
+     * @param operation the operation to expand
+     * @return the parameters of each documented call
+     */
+    private List<List<String>> documentedCalls(Operation operation) {
+        List<String> documented = documentedParameters(operation);
+        return expandOverloads(operation,
+                documented.stream().filter(name -> isRequired(operation, name)).toList(),
+                documented.stream().filter(name -> !isRequired(operation, name)).toList());
+    }
+
+    private Operation getOperationOnPathItem(PathItem pathItem, HttpMethod httpMethod) {
+        return switch (httpMethod) {
+            case get -> pathItem.getGet();
+            case put -> pathItem.getPut();
+            case delete -> pathItem.getDelete();
+            case patch -> pathItem.getPatch();
+            default -> pathItem.getPost();
+        };
     }
 
     private String buildPath(String namespace, String methodName) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -68,7 +68,9 @@ public class UyuniSwaggerReader {
     public static final String DOC_RESPONSE_TYPE_EXTENSION = "x-uyuni-doc-response-type";
     public static final String DOC_RESPONSE_NAME_EXTENSION = "x-uyuni-doc-response-name";
 
-    public static final String DOC_RESPONSE_UNNAMED_EXTENSION = "x-uyuni-doc-response-unnamed";
+    public static final String DOC_RESPONSE_PLAIN_TEXT_EXTENSION = "x-uyuni-doc-response-plain-text";
+
+    public static final String DOC_RESPONSE_VALUES_EXTENSION = "x-uyuni-doc-response-values";
     /** Parameter counts of the handler overloads an operation stands for, longest first. */
     public static final String DOC_OVERLOAD_ARITIES_EXTENSION = "x-uyuni-doc-overload-arities";
 
@@ -463,12 +465,6 @@ public class UyuniSwaggerReader {
                     default -> new StringSchema();
                 };
 
-                var responseSchemaAnnotation =
-                        findMethodAnnotation(method, io.swagger.v3.oas.annotations.media.Schema.class);
-                if (responseSchemaAnnotation != null) {
-                    applyDocumentedValues(schema, responseSchemaAnnotation);
-                }
-
                 mediaType.setSchema(schema);
                 content.addMediaType(DEFAULT_MEDIA_TYPE, mediaType);
                 response.setContent(content);
@@ -483,7 +479,31 @@ public class UyuniSwaggerReader {
             apiResponses.addApiResponse(HTTP_200, addLegacyDocResponse(apiDoc, response));
         }
 
+        applyDocumentedReturnValues(method, apiResponses);
         operation.setResponses(apiResponses);
+    }
+
+    /**
+     * Carries the values a return value documents into the specification.
+     *
+     * A return value is documented on the operation, the only place an annotation can reach the
+     * result of a wrapped response, and the values it lists travel with the response rather than
+     * with the schema, which a wrapper shares with every other operation returning it.
+     *
+     * @param method the handler method backing the operation
+     * @param apiResponses the responses of the operation
+     */
+    private void applyDocumentedReturnValues(Method method, ApiResponses apiResponses) {
+        var annotation = findMethodAnnotation(method, io.swagger.v3.oas.annotations.media.Schema.class);
+        ApiResponse response = apiResponses.get(HTTP_200);
+        if (annotation == null || response == null) {
+            return;
+        }
+        Schema<?> values = new Schema<>();
+        applyDocumentedValues(values, annotation);
+        if (values.getEnum() != null && !values.getEnum().isEmpty()) {
+            response.addExtension(DOC_RESPONSE_VALUES_EXTENSION, values);
+        }
     }
 
     private void processApiResponseClass(ApiEndpointDoc apiDoc, ApiResponses apiResponses) {
@@ -521,8 +541,8 @@ public class UyuniSwaggerReader {
         if (!legacyDocResponse.name().isBlank()) {
             response.addExtension(DOC_RESPONSE_NAME_EXTENSION, legacyDocResponse.name());
         }
-        if (legacyDocResponse.unnamed()) {
-            response.addExtension(DOC_RESPONSE_UNNAMED_EXTENSION, Boolean.TRUE);
+        if (legacyDocResponse.plainText()) {
+            response.addExtension(DOC_RESPONSE_PLAIN_TEXT_EXTENSION, Boolean.TRUE);
         }
         return response;
     }
@@ -531,7 +551,7 @@ public class UyuniSwaggerReader {
         return legacyDocResponse.responseClass() == Void.class &&
                 legacyDocResponse.type().isBlank() &&
                 legacyDocResponse.name().isBlank() &&
-                !legacyDocResponse.unnamed();
+                !legacyDocResponse.plainText();
     }
 
     private void processLiteralParameters(Method method, Operation operation) {

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.stream.IntStream;
 
 import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.util.AnnotationsUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -441,17 +442,42 @@ public class UyuniSwaggerReader {
     private Parameter mapToOpenApiParameter(
             io.swagger.v3.oas.annotations.Parameter parameterAnnotation,
             Type type) {
+        Schema<?> schema = literalParameterSchema(type);
+        applyDocumentedValues(schema, parameterAnnotation.schema());
         Parameter openApiParam = new Parameter()
                 .name(parameterAnnotation.name())
                 .required(parameterAnnotation.required())
                 .in(parameterAnnotation.in().toString().toLowerCase())
-                .schema(literalParameterSchema(type));
+                .schema(schema);
 
         if (!parameterAnnotation.description().isBlank()) {
             openApiParam.setDescription(parameterAnnotation.description());
         }
 
         return openApiParam;
+    }
+
+    /**
+     * Carries the values a literal parameter documents onto its schema.
+     *
+     * The type of a literal parameter is derived from its declared Java type, so the documented
+     * values are the only part of the annotation left to read. An array parameter documents the
+     * values of its element type, the same way an array property does.
+     *
+     * @param schema the schema built from the declared type
+     * @param annotation the schema annotation of the parameter
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void applyDocumentedValues(Schema<?> schema, io.swagger.v3.oas.annotations.media.Schema annotation) {
+        AnnotationsUtils.getSchemaFromAnnotation(annotation, null)
+                .filter(documented -> documented.getEnum() != null && !documented.getEnum().isEmpty())
+                .ifPresent(documented -> {
+                    Schema target = schema.getItems() != null ? schema.getItems() : schema;
+                    target.setEnum(documented.getEnum());
+                    if (documented.getExtensions() != null) {
+                        target.setExtensions(documented.getExtensions());
+                    }
+                });
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -580,7 +580,7 @@ public class UyuniSwaggerReader {
     private Parameter mapToOpenApiParameter(
             io.swagger.v3.oas.annotations.Parameter parameterAnnotation,
             Type type) {
-        Schema<?> schema = literalParameterSchema(type);
+        Schema<?> schema = documentedParameterSchema(parameterAnnotation, type);
         applyDocumentedValues(schema, parameterAnnotation.schema());
         Parameter openApiParam = new Parameter()
                 .name(parameterAnnotation.name())
@@ -616,6 +616,28 @@ public class UyuniSwaggerReader {
                         target.setExtensions(documented.getExtensions());
                     }
                 });
+    }
+
+    /**
+     * Resolves the schema describing a literal parameter.
+     *
+     * A parameter documented as a struct cannot be described by its declared type, a map naming
+     * none of the properties the namespace documents, so the class standing for the struct is
+     * named on the parameter and its schema is built from that class, the way a request body is.
+     *
+     * @param parameterAnnotation the annotation documenting the parameter
+     * @param type the declared parameter type
+     * @return the schema describing the parameter
+     */
+    private Schema<?> documentedParameterSchema(io.swagger.v3.oas.annotations.Parameter parameterAnnotation,
+                                                Type type) {
+        Class<?> documentedClass = parameterAnnotation.schema().implementation();
+        if (documentedClass == Void.class) {
+            return literalParameterSchema(type);
+        }
+        resolveAndRegisterSchema(documentedClass);
+        applyLegacyDocTypes(documentedClass);
+        return buildSchemaRef(documentedClass);
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -46,6 +46,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.DateTimeSchema;
 import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
@@ -639,6 +640,9 @@ public class UyuniSwaggerReader {
         return switch (typeName) {
             case "int", "java.lang.Integer" -> new IntegerSchema();
             case "boolean", "java.lang.Boolean" -> new BooleanSchema();
+            // A date reaches the specification as a string carrying the date-time format, the
+            // shape the model converter gives a date property of a request body.
+            case "java.util.Date" -> new DateTimeSchema();
             default -> new StringSchema();
         };
     }

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -718,6 +718,8 @@ public class UyuniSwaggerReader {
             return;
         }
         Operation documentedByOverload = new Operation()
+                .parameters(alternative.getParameters())
+                .requestBody(alternative.getRequestBody())
                 .responses(alternative.getResponses())
                 .security(alternative.getSecurity())
                 .deprecated(Boolean.TRUE.equals(alternative.getDeprecated()));
@@ -738,7 +740,44 @@ public class UyuniSwaggerReader {
         return !Objects.equals(documented.getResponses(), alternative.getResponses()) ||
                 !Objects.equals(documented.getSecurity(), alternative.getSecurity()) ||
                 Boolean.TRUE.equals(documented.getDeprecated()) !=
-                        Boolean.TRUE.equals(alternative.getDeprecated());
+                        Boolean.TRUE.equals(alternative.getDeprecated()) ||
+                documentsParameterDifferently(documented, alternative);
+    }
+
+    /**
+     * Tells whether an overload describes a parameter both overloads take differently.
+     *
+     * Overloads taking a parameter of the same name in different types describe one property, so
+     * the operation can only hold one of the two, while the legacy doclet documents each overload
+     * with the type its own signature declares.
+     *
+     * @param documented the operation built from the overloads read so far
+     * @param alternative the operation built from an overload taking different parameters
+     * @return whether a parameter the two overloads share is described differently
+     */
+    private boolean documentsParameterDifferently(Operation documented, Operation alternative) {
+        Map<String, Schema<?>> described = describedParameters(documented);
+        return describedParameters(alternative).entrySet().stream()
+                .anyMatch(parameter -> described.containsKey(parameter.getKey()) &&
+                        !Objects.equals(described.get(parameter.getKey()), parameter.getValue()));
+    }
+
+    /**
+     * Reads the schema describing each parameter of an operation, wherever the parameter is sent.
+     *
+     * @param operation the operation to read
+     * @return the schema of each parameter, keyed by name
+     */
+    private Map<String, Schema<?>> describedParameters(Operation operation) {
+        Map<String, Schema<?>> described = new LinkedHashMap<>();
+        if (operation.getParameters() != null) {
+            operation.getParameters().forEach(parameter -> described.put(parameter.getName(), parameter.getSchema()));
+        }
+        Schema<?> body = requestBodySchema(operation);
+        if (body != null && body.getProperties() != null) {
+            body.getProperties().forEach((name, property) -> described.put(name, property));
+        }
+        return described;
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -66,6 +66,9 @@ public class UyuniSwaggerReader {
     public static final String DOC_RESPONSE_NAME_EXTENSION = "x-uyuni-doc-response-name";
     /** Parameter counts of the handler overloads an operation stands for, longest first. */
     public static final String DOC_OVERLOAD_ARITIES_EXTENSION = "x-uyuni-doc-overload-arities";
+
+    /** Extension holding the description the namespace documented for each allowed value. */
+    public static final String DOC_OPTION_DESCRIPTIONS_EXTENSION = "x-uyuni-doc-option-descriptions";
     public static final String DEFAULT_MEDIA_TYPE = "application/json";
     public static final String HTTP_200 = "200";
     /** Legacy name for a date, bound as {@code $date} in the doclet's macros for both formats. */

--- a/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
+++ b/java/core/src/main/java/com/suse/manager/api/docs/UyuniSwaggerReader.java
@@ -65,6 +65,8 @@ public class UyuniSwaggerReader {
     public static final String DOC_RESPONSE_SCHEMA_EXTENSION = "x-uyuni-doc-response-schema";
     public static final String DOC_RESPONSE_TYPE_EXTENSION = "x-uyuni-doc-response-type";
     public static final String DOC_RESPONSE_NAME_EXTENSION = "x-uyuni-doc-response-name";
+
+    public static final String DOC_RESPONSE_UNNAMED_EXTENSION = "x-uyuni-doc-response-unnamed";
     /** Parameter counts of the handler overloads an operation stands for, longest first. */
     public static final String DOC_OVERLOAD_ARITIES_EXTENSION = "x-uyuni-doc-overload-arities";
 
@@ -130,7 +132,7 @@ public class UyuniSwaggerReader {
         applyOverloadArities(cls, method, openApiOperation);
         applySecurityIfNeeded(method, openApiOperation);
         configureRequestBodyIfPresent(apiDoc, openApiOperation);
-        configureResponses(apiDoc, openApiOperation);
+        configureResponses(apiDoc, method, openApiOperation);
         processLiteralParameters(method, openApiOperation);
         registerOperationOnPath(namespace, method, apiDoc.method(), openApiOperation);
     }
@@ -138,6 +140,9 @@ public class UyuniSwaggerReader {
     private Operation createOperationWithBasicInfo(Method method, Tag tagAnnotation, ApiEndpointDoc apiDoc) {
         Operation operation = new Operation();
         operation.setOperationId(method.getName());
+        if (findMethodAnnotation(method, Deprecated.class) != null) {
+            operation.setDeprecated(true);
+        }
         if (!apiDoc.summary().isEmpty()) {
             operation.setSummary(apiDoc.summary());
         }
@@ -301,13 +306,18 @@ public class UyuniSwaggerReader {
         if (schema == null || schema.getProperties() == null) {
             return;
         }
+        LegacyDocResponse structDoc = documentedClass.getAnnotation(LegacyDocResponse.class);
+        if (structDoc != null && !structDoc.name().isBlank()) {
+            schema.addExtension(DOC_RESPONSE_NAME_EXTENSION, structDoc.name());
+        }
         for (Method getter : documentedClass.getMethods()) {
-            LegacyDocResponse legacyDoc = getter.getAnnotation(LegacyDocResponse.class);
-            if (legacyDoc == null || (legacyDoc.type().isBlank() && legacyDoc.name().isBlank())) {
-                continue;
-            }
             Schema<?> property = schema.getProperties().get(resolvePropertyName(getter));
             if (property == null) {
+                continue;
+            }
+            applyDocumentedValues(property, getter);
+            LegacyDocResponse legacyDoc = getter.getAnnotation(LegacyDocResponse.class);
+            if (legacyDoc == null || (legacyDoc.type().isBlank() && legacyDoc.name().isBlank())) {
                 continue;
             }
             if (!legacyDoc.type().isBlank()) {
@@ -316,6 +326,29 @@ public class UyuniSwaggerReader {
             if (!legacyDoc.name().isBlank()) {
                 property.addExtension(DOC_RESPONSE_NAME_EXTENSION, legacyDoc.name());
             }
+        }
+    }
+
+    /**
+     * Applies the values a property documents to its schema.
+     *
+     * The model converter builds a property schema knowing the declared Java type, and coerces
+     * every documented value to it: a value the type cannot hold is reshaped, or lost. Resolving
+     * the annotation without a type context, the way a documented parameter already does, keeps
+     * the values as the namespace spelled them.
+     *
+     * @param property the property schema built for the getter
+     * @param getter the getter documenting the property
+     */
+    private void applyDocumentedValues(Schema<?> property, Method getter) {
+        var arraySchema = getter.getAnnotation(io.swagger.v3.oas.annotations.media.ArraySchema.class);
+        if (arraySchema != null) {
+            applyDocumentedValues(property, arraySchema.schema());
+            return;
+        }
+        var schemaAnnotation = getter.getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
+        if (schemaAnnotation != null) {
+            applyDocumentedValues(property, schemaAnnotation);
         }
     }
 
@@ -334,7 +367,7 @@ public class UyuniSwaggerReader {
         return Introspector.decapitalize(name);
     }
 
-    private void configureResponses(ApiEndpointDoc apiDoc, Operation operation) {
+    private void configureResponses(ApiEndpointDoc apiDoc, Method method, Operation operation) {
         ApiResponses apiResponses = new ApiResponses();
 
         if (apiDoc.isIntegerResponse()) {
@@ -359,6 +392,12 @@ public class UyuniSwaggerReader {
                     case "Boolean" -> new BooleanSchema();
                     default -> new StringSchema();
                 };
+
+                var responseSchemaAnnotation =
+                        findMethodAnnotation(method, io.swagger.v3.oas.annotations.media.Schema.class);
+                if (responseSchemaAnnotation != null) {
+                    applyDocumentedValues(schema, responseSchemaAnnotation);
+                }
 
                 mediaType.setSchema(schema);
                 content.addMediaType(DEFAULT_MEDIA_TYPE, mediaType);
@@ -412,13 +451,17 @@ public class UyuniSwaggerReader {
         if (!legacyDocResponse.name().isBlank()) {
             response.addExtension(DOC_RESPONSE_NAME_EXTENSION, legacyDocResponse.name());
         }
+        if (legacyDocResponse.unnamed()) {
+            response.addExtension(DOC_RESPONSE_UNNAMED_EXTENSION, Boolean.TRUE);
+        }
         return response;
     }
 
     private boolean isEmptyLegacyDocResponse(LegacyDocResponse legacyDocResponse) {
         return legacyDocResponse.responseClass() == Void.class &&
                 legacyDocResponse.type().isBlank() &&
-                legacyDocResponse.name().isBlank();
+                legacyDocResponse.name().isBlank() &&
+                !legacyDocResponse.unnamed();
     }
 
     private void processLiteralParameters(Method method, Operation operation) {

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
@@ -515,12 +515,25 @@ public class ApiDocumentationCompatibilityTest {
                 .replace("&amp;", "&");
     }
 
+    /**
+     * Tells whether a line ends the text of the item before it.
+     *
+     * @param trimmed the trimmed line
+     * @return true when the line starts something else
+     */
+    private boolean isBoundary(String trimmed) {
+        return trimmed.startsWith("*") || trimmed.startsWith("==") || trimmed.startsWith("[#") ||
+                trimmed.startsWith("HTTP ") || trimmed.endsWith(":");
+    }
+
     private Optional<ApiMethodDoc> parseMethod(List<String> lines) {
         String method = "";
         String httpMethod = "";
         List<DocItem> parameters = new ArrayList<>();
         List<DocItem> returns = new ArrayList<>();
         Section section = Section.NONE;
+        String itemText = "";
+        boolean continues = false;
 
         for (String line : lines) {
             Matcher methodMatcher = METHOD_TITLE.matcher(line);
@@ -545,19 +558,31 @@ public class ApiDocumentationCompatibilityTest {
                 continue;
             }
 
+            List<DocItem> items = section == Section.PARAMETERS ? parameters : returns;
             Matcher itemMatcher = LIST_ITEM.matcher(line);
             if (itemMatcher.matches() && section != Section.NONE) {
-                DocItem item = new DocItem(
+                itemText = itemMatcher.group(3);
+                items.add(new DocItem(
                         itemMatcher.group(1).length(),
                         normalize(itemMatcher.group(2)),
-                        normalizeLabel(itemMatcher.group(3))
-                );
-                if (section == Section.PARAMETERS) {
-                    parameters.add(item);
-                }
-                else {
-                    returns.add(item);
-                }
+                        normalizeLabel(itemText)
+                ));
+                continues = true;
+                continue;
+            }
+            if (trimmed.isEmpty() || isBoundary(trimmed)) {
+                continues = false;
+                continue;
+            }
+
+            // The doclet keeps the line breaks of the documentation it copies, so an item whose
+            // text runs over several lines arrives as the item followed by the rest of its text.
+            // The DocBook renderer joins them, and so does this one, or the text would be read
+            // only as far as the break.
+            if (continues && section != Section.NONE && !items.isEmpty()) {
+                itemText = itemText + " " + trimmed;
+                DocItem previous = items.remove(items.size() - 1);
+                items.add(new DocItem(previous.level(), previous.type(), normalizeLabel(itemText)));
             }
         }
 

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
@@ -343,8 +343,14 @@ public class ApiDocumentationCompatibilityTest {
 
         List<DocItem> aligned = new ArrayList<>(items.size());
         aligned.add(array);
-        items.subList(1, items.size())
-                .forEach(item -> aligned.add(new DocItem(item.level() - 1, item.type(), item.name())));
+        boolean rebasing = true;
+        for (DocItem item : items.subList(1, items.size())) {
+            // The doclet resets its bullet level when it inlines a serializer reference, so the
+            // struct it expands there and everything below it are numbered from the top again,
+            // independently of the element struct this rebases.
+            rebasing = rebasing && !(aligned.size() > 1 && "struct".equals(item.type()) && item.level() == 1);
+            aligned.add(rebasing ? new DocItem(item.level() - 1, item.type(), item.name()) : item);
+        }
         return aligned;
     }
 

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ApiDocumentationCompatibilityTest.java
@@ -294,7 +294,33 @@ public class ApiDocumentationCompatibilityTest {
      * @return the items with the element struct and its contents rebased, when indented
      */
     private List<DocItem> alignArrayElementNesting(List<DocItem> items) {
-        return alignSerializerStructs(alignNestedElementStructs(alignLeadingArrayElement(items)));
+        return alignSerializerStructs(
+                alignNestedElementStructs(alignLeadingArrayElement(dropElementListMarkers(items))));
+    }
+
+    /**
+     * Drops the marker the doclet writes when a property opens the list of its elements.
+     *
+     * A namespace documents an array valued property either with {@code #prop_array_begin}, which
+     * expands straight into the element, or as a bare array followed by {@code #return_array_begin}
+     * , which writes an unnamed array marker before it. The schema describes the property the same
+     * way either way, so the marker is dropped before comparing.
+     *
+     * @param items the parsed return value items
+     * @return the items without the element list markers
+     */
+    private List<DocItem> dropElementListMarkers(List<DocItem> items) {
+        List<DocItem> kept = new ArrayList<>(items.size());
+        for (int i = 0; i < items.size(); i++) {
+            DocItem item = items.get(i);
+            DocItem property = i == 0 ? null : items.get(i - 1);
+            if (property != null && "array".equals(item.type()) && item.name().isEmpty() &&
+                    "array".equals(property.type()) && !property.name().isEmpty()) {
+                continue;
+            }
+            kept.add(item);
+        }
+        return kept;
     }
 
     /**

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ChannelSoftwareHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ChannelSoftwareHandlerContractTest.java
@@ -1,0 +1,1352 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.channel.ChannelArch;
+import com.redhat.rhn.domain.channel.ContentSource;
+import com.redhat.rhn.domain.channel.ContentSourceFilter;
+import com.redhat.rhn.domain.channel.ContentSourceType;
+import com.redhat.rhn.domain.channel.SslContentSource;
+import com.redhat.rhn.domain.errata.AdvisoryStatus;
+import com.redhat.rhn.domain.kickstart.crypto.SslCryptoKey;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.dto.ErrataOverview;
+import com.redhat.rhn.frontend.dto.PackageDto;
+import com.redhat.rhn.frontend.xmlrpc.channel.software.ChannelSoftwareHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Covers every documented channel.software operation except the three answering a channel:
+ * getDetails, associateRepo and disassociateRepo. ChannelSerializer resolves the clone origin
+ * through ChannelFactory#lookupOriginalChannel, which opens a Hibernate session, so those three
+ * cannot be exercised without a database.
+ */
+public class ChannelSoftwareHandlerContractTest extends BaseOpenApiTest {
+
+    private static final String CHANNEL_LABEL = "test-channel";
+    private static final String REPO_LABEL = "test-repo";
+    private static final Integer REPO_ID = 501;
+    private static final Date START_DATE = new Date(0);
+    private static final Date END_DATE = new Date(86400000L);
+    private static final String START_DATE_JSON = "1970-01-01T00:00:00Z";
+    private static final String END_DATE_JSON = "1970-01-02T00:00:00Z";
+
+    @Override
+    protected String getApiNamespace() {
+        return "channel.software";
+    }
+
+    @Override
+    protected Class<ChannelSoftwareHandler> getHandlerClass() {
+        return ChannelSoftwareHandler.class;
+    }
+
+    private ChannelSoftwareHandler handler() {
+        return (ChannelSoftwareHandler) handlerMock;
+    }
+
+    /**
+     * Builds a repository serialized by the registered ContentSourceSerializer.
+     *
+     * @param name a unique mock name, so several repositories can coexist in one test run
+     * @return the repository
+     */
+    private ContentSource contentSource(String name) {
+        ContentSource source = context.mock(ContentSource.class, name);
+        ContentSourceType type = context.mock(ContentSourceType.class, name + "Type");
+
+        context.checking(new Expectations() {{
+            allowing(type).getLabel();
+            will(returnValue("yum"));
+            allowing(source).getId();
+            will(returnValue(REPO_ID.longValue()));
+            allowing(source).getLabel();
+            will(returnValue(REPO_LABEL));
+            allowing(source).getSourceUrl();
+            will(returnValue("https://example.com/repo"));
+            allowing(source).getType();
+            will(returnValue(type));
+            allowing(source).getMetadataSigned();
+            will(returnValue(true));
+            allowing(source).getSslSets();
+            will(returnValue(Set.of(sslContentSource(name + "Ssl"))));
+        }});
+
+        return source;
+    }
+
+    /**
+     * Builds an SSL set serialized by the registered SslContentSourceSerializer.
+     *
+     * @param name a unique mock name
+     * @return the SSL content source
+     */
+    private SslContentSource sslContentSource(String name) {
+        SslContentSource ssl = context.mock(SslContentSource.class, name);
+        SslCryptoKey caCert = context.mock(SslCryptoKey.class, name + "Ca");
+
+        context.checking(new Expectations() {{
+            allowing(caCert).getDescription();
+            will(returnValue("test-ca"));
+            allowing(ssl).getCaCert();
+            will(returnValue(caCert));
+            allowing(ssl).getClientCert();
+            will(returnValue(null));
+            allowing(ssl).getClientKey();
+            will(returnValue(null));
+        }});
+
+        return ssl;
+    }
+
+    /**
+     * Builds a repository filter serialized by the registered ContentSourceFilterSerializer.
+     *
+     * @return the repository filter
+     */
+    private ContentSourceFilter contentSourceFilter() {
+        ContentSourceFilter filter = context.mock(ContentSourceFilter.class, "contentSourceFilter");
+
+        context.checking(new Expectations() {{
+            allowing(filter).getSortOrder();
+            will(returnValue(1));
+            allowing(filter).getFilter();
+            will(returnValue("test-package"));
+            allowing(filter).getFlag();
+            will(returnValue("+"));
+        }});
+
+        return filter;
+    }
+
+    /**
+     * Builds a channel architecture serialized by the registered ChannelArchSerializer.
+     *
+     * @return the channel architecture
+     */
+    private ChannelArch channelArch() {
+        ChannelArch arch = context.mock(ChannelArch.class, "channelArch");
+
+        context.checking(new Expectations() {{
+            allowing(arch).getName();
+            will(returnValue("x86_64"));
+            allowing(arch).getLabel();
+            will(returnValue("channel-x86_64"));
+        }});
+
+        return arch;
+    }
+
+    /**
+     * Builds an erratum serialized by the registered ErrataOverviewSerializer.
+     *
+     * @param name a unique mock name
+     * @return the erratum overview
+     */
+    private ErrataOverview errataOverview(String name) {
+        ErrataOverview errata = context.mock(ErrataOverview.class, name);
+
+        context.checking(new Expectations() {{
+            allowing(errata).getId();
+            will(returnValue(201L));
+            allowing(errata).getIssueDateIsoFormat();
+            will(returnValue("2026-01-01 00:00:00"));
+            allowing(errata).getUpdateDateIsoFormat();
+            will(returnValue("2026-01-02 00:00:00"));
+            allowing(errata).getAdvisorySynopsis();
+            will(returnValue("A test erratum"));
+            allowing(errata).getAdvisoryType();
+            will(returnValue("Security Advisory"));
+            allowing(errata).getAdvisoryStatus();
+            will(returnValue(AdvisoryStatus.FINAL));
+            allowing(errata).getAdvisoryName();
+            will(returnValue("SUSE-2026-0001"));
+            allowing(errata).isRebootSuggested();
+            will(returnValue(false));
+            allowing(errata).isRestartSuggested();
+            will(returnValue(false));
+        }});
+
+        return errata;
+    }
+
+    /**
+     * Builds a package serialized by the registered PackageDtoSerializer. The retracted flag is
+     * set, so the property the serializer only adds when it is not null is present.
+     *
+     * @return the package
+     */
+    private PackageDto packageDto() {
+        PackageDto pkg = context.mock(PackageDto.class, "packageDto");
+
+        context.checking(new Expectations() {{
+            allowing(pkg).getName();
+            will(returnValue("test-package"));
+            allowing(pkg).getEpoch();
+            will(returnValue(null));
+            allowing(pkg).getVersion();
+            will(returnValue("1.0.0"));
+            allowing(pkg).getRelease();
+            will(returnValue("1"));
+            allowing(pkg).getChecksum();
+            will(returnValue("0123456789abcdef"));
+            allowing(pkg).getChecksumType();
+            will(returnValue("sha256"));
+            allowing(pkg).getId();
+            will(returnValue(101L));
+            allowing(pkg).getArchLabel();
+            will(returnValue("x86_64"));
+            allowing(pkg).getLastModified();
+            will(returnValue("2026-01-02 00:00:00"));
+            allowing(pkg).getRetracted();
+            will(returnValue(false));
+        }});
+
+        return pkg;
+    }
+
+    /**
+     * Builds a package as the registered PackageSerializer writes it, which is the shape the
+     * orphan package listing and the package merge both answer with.
+     *
+     * @return the serialized package
+     */
+    private Map<String, Object> packageInfo() {
+        return Map.of(
+                "name", "test-package",
+                "version", "1.0.0",
+                "release", "1",
+                "epoch", "",
+                "id", 101,
+                "arch_label", "x86_64",
+                "last_modified", "2026-01-02T00:00:00Z",
+                "path", "redhat/1/abc/test-package-1.0.0-1.x86_64.rpm",
+                "part_of_retracted_patch", false,
+                "provider", "SUSE");
+    }
+
+    /**
+     * Presents an integer list as the long list a handler parameter declares, so an expectation can
+     * name the values the router actually hands over.
+     *
+     * @param values the values the router parses out of the request
+     * @return the same list, seen as the declared parameter type
+     */
+    @SuppressWarnings("unchecked")
+    private List<Long> asLongList(List<Integer> values) {
+        return (List<Long>) (List<?>) values;
+    }
+
+    /**
+     * Presents a boolean map as the string map a handler parameter declares. The synchronisation
+     * options are documented as booleans and the router keeps them as such, so the handler is
+     * handed booleans however its parameter is declared.
+     *
+     * @param values the values the router parses out of the request
+     * @return the same map, seen as the declared parameter type
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, String> asStringMap(Map<String, Boolean> values) {
+        return (Map<String, String>) (Map<?, ?>) values;
+    }
+
+    @Test
+    public void testListErrataNeedingSync() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listErrataNeedingSync(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue(List.of(errataOverview("needingSync"))));
+        }});
+
+        validateApiContract("/channel.software/listErrataNeedingSync", "GET")
+                .withParams(Map.of("channelLabel", new String[]{CHANNEL_LABEL}))
+                .onHandlerMethod("listErrataNeedingSync", User.class, String.class);
+    }
+
+    @Test
+    public void testSyncErrata() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).syncErrata(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/syncErrata", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL))
+                .onHandlerMethod("syncErrata", User.class, String.class);
+    }
+
+    @Test
+    public void testListLatestPackages() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listLatestPackages(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue(new Object[]{Map.of(
+                    "name", "test-package",
+                    "version", "1.0.0",
+                    "release", "1",
+                    "epoch", "",
+                    "id", 101,
+                    "arch_label", "x86_64")}));
+        }});
+
+        validateApiContract("/channel.software/listLatestPackages", "GET")
+                .withParams(Map.of("channelLabel", new String[]{CHANNEL_LABEL}))
+                .onHandlerMethod("listLatestPackages", User.class, String.class);
+    }
+
+    @Test
+    public void testListAllPackages() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listAllPackages(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue(List.of(packageDto())));
+        }});
+
+        validateApiContract("/channel.software/listAllPackages", "GET")
+                .withParams(Map.of("channelLabel", new String[]{CHANNEL_LABEL}))
+                .onHandlerMethod("listAllPackages", User.class, String.class);
+    }
+
+    /**
+     * A start date alone selects the overload that leaves the end date open.
+     */
+    @Test
+    public void testListAllPackagesFromStartDate() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listAllPackages(with(mockUser), with(CHANNEL_LABEL), with(START_DATE));
+            will(returnValue(List.of(packageDto())));
+        }});
+
+        validateApiContract("/channel.software/listAllPackages", "GET")
+                .withParams(Map.of(
+                        "channelLabel", new String[]{CHANNEL_LABEL},
+                        "startDate", new String[]{START_DATE_JSON}))
+                .onHandlerMethod("listAllPackages", User.class, String.class, Date.class);
+    }
+
+    @Test
+    public void testListAllPackagesBetweenDates() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listAllPackages(with(mockUser), with(CHANNEL_LABEL), with(START_DATE),
+                    with(END_DATE));
+            will(returnValue(List.of(packageDto())));
+        }});
+
+        validateApiContract("/channel.software/listAllPackages", "GET")
+                .withParams(Map.of(
+                        "channelLabel", new String[]{CHANNEL_LABEL},
+                        "startDate", new String[]{START_DATE_JSON},
+                        "endDate", new String[]{END_DATE_JSON}))
+                .onHandlerMethod("listAllPackages", User.class, String.class, Date.class, Date.class);
+    }
+
+    @Test
+    public void testListArches() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listArches(with(mockUser));
+            will(returnValue(List.of(channelArch())));
+        }});
+
+        validateApiContract("/channel.software/listArches", "GET")
+                .onHandlerMethod("listArches", User.class);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).delete(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/delete", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL))
+                .onHandlerMethod("delete", User.class, String.class);
+    }
+
+    @Test
+    public void testIsGloballySubscribable() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).isGloballySubscribable(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/isGloballySubscribable", "GET")
+                .withParams(Map.of("channelLabel", new String[]{CHANNEL_LABEL}))
+                .onHandlerMethod("isGloballySubscribable", User.class, String.class);
+    }
+
+    @Test
+    public void testSetDetailsByLabel() throws Exception {
+        var details = Map.of("name", "Renamed Channel", "summary", "A renamed channel");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setDetails(with(mockUser), with(CHANNEL_LABEL), with(details));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/setDetails", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL, "details", details))
+                .onHandlerMethod("setDetails", User.class, String.class, Map.class);
+    }
+
+    /**
+     * A request naming the channel by id has to reach the overload taking the id.
+     */
+    @Test
+    public void testSetDetailsById() throws Exception {
+        var details = Map.of("name", "Renamed Channel");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setDetails(with(mockUser), with(101), with(details));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/setDetails", "POST")
+                .withBody(Map.of("channelId", 101, "details", details))
+                .onHandlerMethod("setDetails", User.class, Integer.class, Map.class);
+    }
+
+    @Test
+    public void testCreate() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).create(with(mockUser), with(CHANNEL_LABEL), with("Test Channel"),
+                    with("A test channel"), with("channel-x86_64"), with(""));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/create", "POST")
+                .withBody(Map.of(
+                        "label", CHANNEL_LABEL,
+                        "name", "Test Channel",
+                        "summary", "A test channel",
+                        "archLabel", "channel-x86_64",
+                        "parentLabel", ""))
+                .onHandlerMethod("create", User.class, String.class, String.class, String.class,
+                        String.class, String.class);
+    }
+
+    @Test
+    public void testCreateWithChecksumType() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).create(with(mockUser), with(CHANNEL_LABEL), with("Test Channel"),
+                    with("A test channel"), with("channel-x86_64"), with(""), with("sha256"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/create", "POST")
+                .withBody(Map.of(
+                        "label", CHANNEL_LABEL,
+                        "name", "Test Channel",
+                        "summary", "A test channel",
+                        "archLabel", "channel-x86_64",
+                        "parentLabel", "",
+                        "checksumType", "sha256"))
+                .onHandlerMethod("create", User.class, String.class, String.class, String.class,
+                        String.class, String.class, String.class);
+    }
+
+    @Test
+    public void testCreateWithGpgKey() throws Exception {
+        var gpgKey = Map.of("url", "https://example.com/key.gpg", "id", "ABCDEF12",
+                "fingerprint", "0123 4567 89AB CDEF");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).create(with(mockUser), with(CHANNEL_LABEL), with("Test Channel"),
+                    with("A test channel"), with("channel-x86_64"), with(""), with("sha256"),
+                    with(gpgKey));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/create", "POST")
+                .withBody(Map.of(
+                        "label", CHANNEL_LABEL,
+                        "name", "Test Channel",
+                        "summary", "A test channel",
+                        "archLabel", "channel-x86_64",
+                        "parentLabel", "",
+                        "checksumType", "sha256",
+                        "gpgKey", gpgKey))
+                .onHandlerMethod("create", User.class, String.class, String.class, String.class,
+                        String.class, String.class, String.class, Map.class);
+    }
+
+    @Test
+    public void testCreateWithGpgCheck() throws Exception {
+        var gpgKey = Map.of("url", "https://example.com/key.gpg");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).create(with(mockUser), with(CHANNEL_LABEL), with("Test Channel"),
+                    with("A test channel"), with("channel-x86_64"), with(""), with("sha256"),
+                    with(gpgKey), with(true));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/create", "POST")
+                .withBody(Map.of(
+                        "label", CHANNEL_LABEL,
+                        "name", "Test Channel",
+                        "summary", "A test channel",
+                        "archLabel", "channel-x86_64",
+                        "parentLabel", "",
+                        "checksumType", "sha256",
+                        "gpgKey", gpgKey,
+                        "gpgCheck", true))
+                .onHandlerMethod("create", User.class, String.class, String.class, String.class,
+                        String.class, String.class, String.class, Map.class, boolean.class);
+    }
+
+    @Test
+    public void testSetContactDetails() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).setContactDetails(with(mockUser), with(CHANNEL_LABEL), with("Test Maintainer"),
+                    with("maintainer@example.com"), with("+49 000 000000"), with("Best effort"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/setContactDetails", "POST")
+                .withBody(Map.of(
+                        "channelLabel", CHANNEL_LABEL,
+                        "maintainerName", "Test Maintainer",
+                        "maintainerEmail", "maintainer@example.com",
+                        "maintainerPhone", "+49 000 000000",
+                        "supportPolicy", "Best effort"))
+                .onHandlerMethod("setContactDetails", User.class, String.class, String.class, String.class,
+                        String.class, String.class);
+    }
+
+    @Test
+    public void testListSubscribedSystems() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listSubscribedSystems(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue(new Object[]{Map.of("id", 1001, "name", "test-system")}));
+        }});
+
+        validateApiContract("/channel.software/listSubscribedSystems", "GET")
+                .withParams(Map.of("channelLabel", new String[]{CHANNEL_LABEL}))
+                .onHandlerMethod("listSubscribedSystems", User.class, String.class);
+    }
+
+    @Test
+    public void testListSystemChannels() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listSystemChannels(with(mockUser), with(1001));
+            will(returnValue(new Object[]{Map.of(
+                    "id", "101", "label", CHANNEL_LABEL, "name", "Test Channel")}));
+        }});
+
+        validateApiContract("/channel.software/listSystemChannels", "GET")
+                .withParams(Map.of("sid", new String[]{"1001"}))
+                .onHandlerMethod("listSystemChannels", User.class, Integer.class);
+    }
+
+    @Test
+    public void testSetUserSubscribable() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).setUserSubscribable(with(mockUser), with(CHANNEL_LABEL), with("testuser"),
+                    with(true));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/setUserSubscribable", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL, "login", "testuser", "value", true))
+                .onHandlerMethod("setUserSubscribable", User.class, String.class, String.class, Boolean.class);
+    }
+
+    @Test
+    public void testSetUserManageable() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).setUserManageable(with(mockUser), with(CHANNEL_LABEL), with("testuser"),
+                    with(true));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/setUserManageable", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL, "login", "testuser", "value", true))
+                .onHandlerMethod("setUserManageable", User.class, String.class, String.class, Boolean.class);
+    }
+
+    @Test
+    public void testIsUserSubscribable() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).isUserSubscribable(with(mockUser), with(CHANNEL_LABEL), with("testuser"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/isUserSubscribable", "GET")
+                .withParams(Map.of(
+                        "channelLabel", new String[]{CHANNEL_LABEL},
+                        "login", new String[]{"testuser"}))
+                .onHandlerMethod("isUserSubscribable", User.class, String.class, String.class);
+    }
+
+    @Test
+    public void testIsExisting() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).isExisting(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue(true));
+        }});
+
+        validateApiContract("/channel.software/isExisting", "GET")
+                .withParams(Map.of("channelLabel", new String[]{CHANNEL_LABEL}))
+                .onHandlerMethod("isExisting", User.class, String.class);
+    }
+
+    @Test
+    public void testIsUserManageable() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).isUserManageable(with(mockUser), with(CHANNEL_LABEL), with("testuser"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/isUserManageable", "GET")
+                .withParams(Map.of(
+                        "channelLabel", new String[]{CHANNEL_LABEL},
+                        "login", new String[]{"testuser"}))
+                .onHandlerMethod("isUserManageable", User.class, String.class, String.class);
+    }
+
+    @Test
+    public void testSetGloballySubscribable() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).setGloballySubscribable(with(mockUser), with(CHANNEL_LABEL), with(true));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/setGloballySubscribable", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL, "value", true))
+                .onHandlerMethod("setGloballySubscribable", User.class, String.class, boolean.class);
+    }
+
+    /**
+     * The package ids are declared as longs, but the router deserializes a JSON array without the
+     * declared element type, so values that fit an int reach the handler as integers.
+     */
+    @Test
+    public void testAddPackages() throws Exception {
+        var packageIds = List.of(101, 102);
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).addPackages(with(mockUser), with(CHANNEL_LABEL), with(asLongList(packageIds)));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/addPackages", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL, "packageIds", packageIds))
+                .onHandlerMethod("addPackages", User.class, String.class, List.class);
+    }
+
+    @Test
+    public void testRemoveErrata() throws Exception {
+        var errataNames = List.of("SUSE-2026-0001");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).removeErrata(with(mockUser), with(CHANNEL_LABEL), with(errataNames), with(true));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/removeErrata", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL, "errataNames", errataNames,
+                        "removePackages", true))
+                .onHandlerMethod("removeErrata", User.class, String.class, List.class, boolean.class);
+    }
+
+    @Test
+    public void testRemovePackages() throws Exception {
+        var packageIds = List.of(101, 102);
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).removePackages(with(mockUser), with(CHANNEL_LABEL), with(asLongList(packageIds)));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/removePackages", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL, "packageIds", packageIds))
+                .onHandlerMethod("removePackages", User.class, String.class, List.class);
+    }
+
+    @Test
+    public void testListErrata() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listErrata(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue(List.of(errataOverview("listed"))));
+        }});
+
+        validateApiContract("/channel.software/listErrata", "GET")
+                .withParams(Map.of("channelLabel", new String[]{CHANNEL_LABEL}))
+                .onHandlerMethod("listErrata", User.class, String.class);
+    }
+
+    @Test
+    public void testListErrataFromStartDate() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listErrata(with(mockUser), with(CHANNEL_LABEL), with(START_DATE));
+            will(returnValue(List.of(errataOverview("listedFrom"))));
+        }});
+
+        validateApiContract("/channel.software/listErrata", "GET")
+                .withParams(Map.of(
+                        "channelLabel", new String[]{CHANNEL_LABEL},
+                        "startDate", new String[]{START_DATE_JSON}))
+                .onHandlerMethod("listErrata", User.class, String.class, Date.class);
+    }
+
+    @Test
+    public void testListErrataBetweenDates() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listErrata(with(mockUser), with(CHANNEL_LABEL), with(START_DATE), with(END_DATE));
+            will(returnValue(List.of(errataOverview("listedBetween"))));
+        }});
+
+        validateApiContract("/channel.software/listErrata", "GET")
+                .withParams(Map.of(
+                        "channelLabel", new String[]{CHANNEL_LABEL},
+                        "startDate", new String[]{START_DATE_JSON},
+                        "endDate", new String[]{END_DATE_JSON}))
+                .onHandlerMethod("listErrata", User.class, String.class, Date.class, Date.class);
+    }
+
+    @Test
+    public void testListErrataByLastModified() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listErrata(with(mockUser), with(CHANNEL_LABEL), with(START_DATE), with(END_DATE),
+                    with(true));
+            will(returnValue(List.of(errataOverview("listedModified"))));
+        }});
+
+        validateApiContract("/channel.software/listErrata", "GET")
+                .withParams(Map.of(
+                        "channelLabel", new String[]{CHANNEL_LABEL},
+                        "startDate", new String[]{START_DATE_JSON},
+                        "endDate", new String[]{END_DATE_JSON},
+                        "lastModified", new String[]{"true"}))
+                .onHandlerMethod("listErrata", User.class, String.class, Date.class, Date.class, boolean.class);
+    }
+
+    @Test
+    public void testListErrataByType() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listErrataByType(with(mockUser), with(CHANNEL_LABEL), with("Security Advisory"));
+            will(returnValue(new Object[]{Map.of(
+                    "advisory", "SUSE-2026-0001",
+                    "issue_date", "2026-01-01 00:00:00",
+                    "update_date", "2026-01-02 00:00:00",
+                    "synopsis", "A test erratum",
+                    "advisory_type", "Security Advisory",
+                    "last_modified_date", "2026-01-02 00:00:00")}));
+        }});
+
+        validateApiContract("/channel.software/listErrataByType", "GET")
+                .withParams(Map.of(
+                        "channelLabel", new String[]{CHANNEL_LABEL},
+                        "advisoryType", new String[]{"Security Advisory"}))
+                .onHandlerMethod("listErrataByType", User.class, String.class, String.class);
+    }
+
+    @Test
+    public void testListPackagesWithoutChannel() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listPackagesWithoutChannel(with(mockUser));
+            will(returnValue(new Object[]{packageInfo()}));
+        }});
+
+        validateApiContract("/channel.software/listPackagesWithoutChannel", "GET")
+                .onHandlerMethod("listPackagesWithoutChannel", User.class);
+    }
+
+    @Test
+    public void testClone() throws Exception {
+        var channelDetails = Map.of("name", "Cloned Channel", "label", "cloned-channel",
+                "summary", "A cloned channel");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).clone(with(mockUser), with(CHANNEL_LABEL), with(channelDetails), with(true));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/clone", "POST")
+                .withBody(Map.of("originalLabel", CHANNEL_LABEL, "channelDetails", channelDetails,
+                        "originalState", true))
+                .onHandlerMethod("clone", User.class, String.class, Map.class, Boolean.class);
+    }
+
+    @Test
+    public void testMergeErrata() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).mergeErrata(with(mockUser), with(CHANNEL_LABEL), with("other-channel"));
+            will(returnValue(new Object[]{Map.of(
+                    "id", 201,
+                    "date", "2026-01-01 00:00:00",
+                    "advisory_type", "Security Advisory",
+                    "advisory_status", "final",
+                    "advisory_name", "SUSE-2026-0001",
+                    "advisory_synopsis", "A test erratum")}));
+        }});
+
+        validateApiContract("/channel.software/mergeErrata", "POST")
+                .withBody(Map.of("mergeFromLabel", CHANNEL_LABEL, "mergeToLabel", "other-channel"))
+                .onHandlerMethod("mergeErrata", User.class, String.class, String.class);
+    }
+
+    @Test
+    public void testMergeErrataByName() throws Exception {
+        var errataNames = List.of("SUSE-2026-0001");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).mergeErrata(with(mockUser), with(CHANNEL_LABEL), with("other-channel"),
+                    with(errataNames));
+            will(returnValue(new Object[]{}));
+        }});
+
+        validateApiContract("/channel.software/mergeErrata", "POST")
+                .withBody(Map.of("mergeFromLabel", CHANNEL_LABEL, "mergeToLabel", "other-channel",
+                        "errataNames", errataNames))
+                .onHandlerMethod("mergeErrata", User.class, String.class, String.class, List.class);
+    }
+
+    /**
+     * The date bounded merge documents its dates as strings, so they reach the handler unparsed.
+     */
+    @Test
+    public void testMergeErrataByDate() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).mergeErrata(with(mockUser), with(CHANNEL_LABEL), with("other-channel"),
+                    with("2026-01-01"), with("2026-01-31"));
+            will(returnValue(new Object[]{}));
+        }});
+
+        validateApiContract("/channel.software/mergeErrata", "POST")
+                .withBody(Map.of("mergeFromLabel", CHANNEL_LABEL, "mergeToLabel", "other-channel",
+                        "startDate", "2026-01-01", "endDate", "2026-01-31"))
+                .onHandlerMethod("mergeErrata", User.class, String.class, String.class, String.class,
+                        String.class);
+    }
+
+    @Test
+    public void testMergePackages() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).mergePackages(with(mockUser), with(CHANNEL_LABEL), with("other-channel"));
+            will(returnValue(new Object[]{Map.of(
+                    "name", "test-package",
+                    "version", "1.0.0",
+                    "release", "1",
+                    "epoch", "",
+                    "id", 101,
+                    "arch_label", "x86_64",
+                    "last_modified", "2026-01-02T00:00:00Z",
+                    "path", "redhat/1/abc/test-package-1.0.0-1.x86_64.rpm",
+                    "part_of_retracted_patch", false,
+                    "provider", "SUSE")}));
+        }});
+
+        validateApiContract("/channel.software/mergePackages", "POST")
+                .withBody(Map.of("mergeFromLabel", CHANNEL_LABEL, "mergeToLabel", "other-channel"))
+                .onHandlerMethod("mergePackages", User.class, String.class, String.class);
+    }
+
+    @Test
+    public void testMergePackagesAligningModules() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).mergePackages(with(mockUser), with(CHANNEL_LABEL), with("other-channel"),
+                    with(true));
+            will(returnValue(new Object[]{}));
+        }});
+
+        validateApiContract("/channel.software/mergePackages", "POST")
+                .withBody(Map.of("mergeFromLabel", CHANNEL_LABEL, "mergeToLabel", "other-channel",
+                        "alignModules", true))
+                .onHandlerMethod("mergePackages", User.class, String.class, String.class, boolean.class);
+    }
+
+    @Test
+    public void testAlignMetadata() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).alignMetadata(with(mockUser), with(CHANNEL_LABEL), with("other-channel"),
+                    with("modules"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/alignMetadata", "POST")
+                .withBody(Map.of("channelFromLabel", CHANNEL_LABEL, "channelToLabel", "other-channel",
+                        "metadataType", "modules"))
+                .onHandlerMethod("alignMetadata", User.class, String.class, String.class, String.class);
+    }
+
+    @Test
+    public void testRegenerateNeededCacheForChannel() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).regenerateNeededCache(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/regenerateNeededCache", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL))
+                .onHandlerMethod("regenerateNeededCache", User.class, String.class);
+    }
+
+    /**
+     * The channel label is optional, so a request omitting it regenerates every cache.
+     */
+    @Test
+    public void testRegenerateNeededCacheForAllChannels() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).regenerateNeededCache(with(mockUser));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/regenerateNeededCache", "POST")
+                .withBody(Map.of())
+                .onHandlerMethod("regenerateNeededCache", User.class);
+    }
+
+    @Test
+    public void testRegenerateYumCache() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).regenerateYumCache(with(mockUser), with(CHANNEL_LABEL), with(true));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/regenerateYumCache", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL, "force", true))
+                .onHandlerMethod("regenerateYumCache", User.class, String.class, Boolean.class);
+    }
+
+    @Test
+    public void testListChildren() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listChildren(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue(new Object[]{}));
+        }});
+
+        validateApiContract("/channel.software/listChildren", "GET")
+                .withParams(Map.of("channelLabel", new String[]{CHANNEL_LABEL}))
+                .onHandlerMethod("listChildren", User.class, String.class);
+    }
+
+    @Test
+    public void testGetChannelLastBuildById() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getChannelLastBuildById(with(mockUser), with(101));
+            will(returnValue("2026-01-02 00:00:00"));
+        }});
+
+        validateApiContract("/channel.software/getChannelLastBuildById", "GET")
+                .withParams(Map.of("id", new String[]{"101"}))
+                .onHandlerMethod("getChannelLastBuildById", User.class, Integer.class);
+    }
+
+    @Test
+    public void testListUserRepos() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listUserRepos(with(mockUser));
+            will(returnValue(List.of(Map.<String, Object>of(
+                    "id", REPO_ID,
+                    "label", REPO_LABEL,
+                    "sourceUrl", "https://example.com/repo"))));
+        }});
+
+        validateApiContract("/channel.software/listUserRepos", "GET")
+                .onHandlerMethod("listUserRepos", User.class);
+    }
+
+    @Test
+    public void testCreateRepo() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).createRepo(with(mockUser), with(REPO_LABEL), with("yum"),
+                    with("https://example.com/repo"));
+            will(returnValue(contentSource("createdRepo")));
+        }});
+
+        validateApiContract("/channel.software/createRepo", "POST")
+                .withBody(Map.of("label", REPO_LABEL, "type", "yum", "url", "https://example.com/repo"))
+                .onHandlerMethod("createRepo", User.class, String.class, String.class, String.class);
+    }
+
+    @Test
+    public void testCreateRepoWithSsl() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).createRepo(with(mockUser), with(REPO_LABEL), with("yum"),
+                    with("https://example.com/repo"), with("test-ca"), with("test-cert"), with("test-key"));
+            will(returnValue(contentSource("createdSslRepo")));
+        }});
+
+        validateApiContract("/channel.software/createRepo", "POST")
+                .withBody(Map.of(
+                        "label", REPO_LABEL,
+                        "type", "yum",
+                        "url", "https://example.com/repo",
+                        "sslCaCert", "test-ca",
+                        "sslCliCert", "test-cert",
+                        "sslCliKey", "test-key"))
+                .onHandlerMethod("createRepo", User.class, String.class, String.class, String.class,
+                        String.class, String.class, String.class);
+    }
+
+    @Test
+    public void testCreateRepoWithSignedMetadata() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).createRepo(with(mockUser), with(REPO_LABEL), with("yum"),
+                    with("https://example.com/repo"), with("test-ca"), with("test-cert"), with("test-key"),
+                    with(true));
+            will(returnValue(contentSource("createdSignedRepo")));
+        }});
+
+        validateApiContract("/channel.software/createRepo", "POST")
+                .withBody(Map.of(
+                        "label", REPO_LABEL,
+                        "type", "yum",
+                        "url", "https://example.com/repo",
+                        "sslCaCert", "test-ca",
+                        "sslCliCert", "test-cert",
+                        "sslCliKey", "test-key",
+                        "hasSignedMetadata", true))
+                .onHandlerMethod("createRepo", User.class, String.class, String.class, String.class,
+                        String.class, String.class, String.class, boolean.class);
+    }
+
+    @Test
+    public void testRemoveRepoByLabel() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).removeRepo(with(mockUser), with(REPO_LABEL));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/removeRepo", "POST")
+                .withBody(Map.of("label", REPO_LABEL))
+                .onHandlerMethod("removeRepo", User.class, String.class);
+    }
+
+    @Test
+    public void testRemoveRepoById() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).removeRepo(with(mockUser), with(REPO_ID));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/removeRepo", "POST")
+                .withBody(Map.of("id", REPO_ID))
+                .onHandlerMethod("removeRepo", User.class, Integer.class);
+    }
+
+    @Test
+    public void testUpdateRepoUrlByLabel() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).updateRepoUrl(with(mockUser), with(REPO_LABEL),
+                    with("https://example.com/other"));
+            will(returnValue(contentSource("updatedUrlByLabel")));
+        }});
+
+        validateApiContract("/channel.software/updateRepoUrl", "POST")
+                .withBody(Map.of("label", REPO_LABEL, "url", "https://example.com/other"))
+                .onHandlerMethod("updateRepoUrl", User.class, String.class, String.class);
+    }
+
+    @Test
+    public void testUpdateRepoUrlById() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).updateRepoUrl(with(mockUser), with(REPO_ID), with("https://example.com/other"));
+            will(returnValue(contentSource("updatedUrlById")));
+        }});
+
+        validateApiContract("/channel.software/updateRepoUrl", "POST")
+                .withBody(Map.of("id", REPO_ID, "url", "https://example.com/other"))
+                .onHandlerMethod("updateRepoUrl", User.class, Integer.class, String.class);
+    }
+
+    @Test
+    public void testUpdateRepoSslByLabel() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).updateRepoSsl(with(mockUser), with(REPO_LABEL), with("test-ca"),
+                    with("test-cert"), with("test-key"));
+            will(returnValue(contentSource("updatedSslByLabel")));
+        }});
+
+        validateApiContract("/channel.software/updateRepoSsl", "POST")
+                .withBody(Map.of("label", REPO_LABEL, "sslCaCert", "test-ca", "sslCliCert", "test-cert",
+                        "sslCliKey", "test-key"))
+                .onHandlerMethod("updateRepoSsl", User.class, String.class, String.class, String.class,
+                        String.class);
+    }
+
+    @Test
+    public void testUpdateRepoSslById() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).updateRepoSsl(with(mockUser), with(REPO_ID), with("test-ca"),
+                    with("test-cert"), with("test-key"));
+            will(returnValue(contentSource("updatedSslById")));
+        }});
+
+        validateApiContract("/channel.software/updateRepoSsl", "POST")
+                .withBody(Map.of("id", REPO_ID, "sslCaCert", "test-ca", "sslCliCert", "test-cert",
+                        "sslCliKey", "test-key"))
+                .onHandlerMethod("updateRepoSsl", User.class, Integer.class, String.class, String.class,
+                        String.class);
+    }
+
+    @Test
+    public void testUpdateRepoLabelByLabel() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).updateRepoLabel(with(mockUser), with(REPO_LABEL), with("renamed-repo"));
+            will(returnValue(contentSource("relabelledByLabel")));
+        }});
+
+        validateApiContract("/channel.software/updateRepoLabel", "POST")
+                .withBody(Map.of("label", REPO_LABEL, "newLabel", "renamed-repo"))
+                .onHandlerMethod("updateRepoLabel", User.class, String.class, String.class);
+    }
+
+    @Test
+    public void testUpdateRepoLabelById() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).updateRepoLabel(with(mockUser), with(REPO_ID), with("renamed-repo"));
+            will(returnValue(contentSource("relabelledById")));
+        }});
+
+        validateApiContract("/channel.software/updateRepoLabel", "POST")
+                .withBody(Map.of("id", REPO_ID, "label", "renamed-repo"))
+                .onHandlerMethod("updateRepoLabel", User.class, Integer.class, String.class);
+    }
+
+    @Test
+    public void testUpdateRepo() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).updateRepo(with(mockUser), with(REPO_ID), with("renamed-repo"),
+                    with("https://example.com/other"));
+            will(returnValue(contentSource("updatedRepo")));
+        }});
+
+        validateApiContract("/channel.software/updateRepo", "POST")
+                .withBody(Map.of("id", REPO_ID, "label", "renamed-repo", "url", "https://example.com/other"))
+                .onHandlerMethod("updateRepo", User.class, Integer.class, String.class, String.class);
+    }
+
+    @Test
+    public void testGetRepoDetailsByLabel() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getRepoDetails(with(mockUser), with(REPO_LABEL));
+            will(returnValue(contentSource("repoByLabel")));
+        }});
+
+        validateApiContract("/channel.software/getRepoDetails", "GET")
+                .withParams(Map.of("repoLabel", new String[]{REPO_LABEL}))
+                .onHandlerMethod("getRepoDetails", User.class, String.class);
+    }
+
+    @Test
+    public void testGetRepoDetailsById() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getRepoDetails(with(mockUser), with(REPO_ID));
+            will(returnValue(contentSource("repoById")));
+        }});
+
+        validateApiContract("/channel.software/getRepoDetails", "GET")
+                .withParams(Map.of("id", new String[]{REPO_ID.toString()}))
+                .onHandlerMethod("getRepoDetails", User.class, Integer.class);
+    }
+
+    @Test
+    public void testListChannelRepos() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listChannelRepos(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue(List.of(contentSource("channelRepo"))));
+        }});
+
+        validateApiContract("/channel.software/listChannelRepos", "GET")
+                .withParams(Map.of("channelLabel", new String[]{CHANNEL_LABEL}))
+                .onHandlerMethod("listChannelRepos", User.class, String.class);
+    }
+
+    @Test
+    public void testSyncRepo() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).syncRepo(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/syncRepo", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL))
+                .onHandlerMethod("syncRepo", User.class, String.class);
+    }
+
+    @Test
+    public void testSyncRepoForChannelList() throws Exception {
+        var channelLabels = List.of(CHANNEL_LABEL, "other-channel");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).syncRepo(with(mockUser), with(channelLabels));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/syncRepo", "POST")
+                .withBody(Map.of("channelLabels", channelLabels))
+                .onHandlerMethod("syncRepo", User.class, List.class);
+    }
+
+    @Test
+    public void testSyncRepoWithParams() throws Exception {
+        var params = Map.of("sync-kickstart", true, "no-errata", false);
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).syncRepo(with(mockUser), with(CHANNEL_LABEL), with(asStringMap(params)));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/syncRepo", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL, "params", params))
+                .onHandlerMethod("syncRepo", User.class, String.class, Map.class);
+    }
+
+    @Test
+    public void testSyncRepoOnSchedule() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).syncRepo(with(mockUser), with(CHANNEL_LABEL), with("0 0 3 ? * *"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/syncRepo", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL, "cronExpr", "0 0 3 ? * *"))
+                .onHandlerMethod("syncRepo", User.class, String.class, String.class);
+    }
+
+    @Test
+    public void testSyncRepoOnScheduleWithParams() throws Exception {
+        var params = Map.of("latest", true);
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).syncRepo(with(mockUser), with(CHANNEL_LABEL), with("0 0 3 ? * *"),
+                    with(asStringMap(params)));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/syncRepo", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL, "cronExpr", "0 0 3 ? * *", "params", params))
+                .onHandlerMethod("syncRepo", User.class, String.class, String.class, Map.class);
+    }
+
+    @Test
+    public void testGetRepoSyncCronExpression() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getRepoSyncCronExpression(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue("0 0 3 ? * *"));
+        }});
+
+        validateApiContract("/channel.software/getRepoSyncCronExpression", "GET")
+                .withParams(Map.of("channelLabel", new String[]{CHANNEL_LABEL}))
+                .onHandlerMethod("getRepoSyncCronExpression", User.class, String.class);
+    }
+
+    @Test
+    public void testListRepoFilters() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listRepoFilters(with(mockUser), with(REPO_LABEL));
+            will(returnValue(List.of(contentSourceFilter())));
+        }});
+
+        validateApiContract("/channel.software/listRepoFilters", "GET")
+                .withParams(Map.of("label", new String[]{REPO_LABEL}))
+                .onHandlerMethod("listRepoFilters", User.class, String.class);
+    }
+
+    @Test
+    public void testAddRepoFilter() throws Exception {
+        var filterProps = Map.of("filter", "test-package", "flag", "+");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).addRepoFilter(with(mockUser), with(REPO_LABEL), with(filterProps));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/addRepoFilter", "POST")
+                .withBody(Map.of("label", REPO_LABEL, "filterProps", filterProps))
+                .onHandlerMethod("addRepoFilter", User.class, String.class, Map.class);
+    }
+
+    @Test
+    public void testRemoveRepoFilter() throws Exception {
+        var filterProps = Map.of("filter", "test-package", "flag", "+");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).removeRepoFilter(with(mockUser), with(REPO_LABEL), with(filterProps));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/removeRepoFilter", "POST")
+                .withBody(Map.of("label", REPO_LABEL, "filterProps", filterProps))
+                .onHandlerMethod("removeRepoFilter", User.class, String.class, Map.class);
+    }
+
+    @Test
+    public void testSetRepoFilters() throws Exception {
+        var filterProps = List.of(Map.of("filter", "test-package", "flag", "+"));
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setRepoFilters(with(mockUser), with(REPO_LABEL), with(filterProps));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/setRepoFilters", "POST")
+                .withBody(Map.of("label", REPO_LABEL, "filterProps", filterProps))
+                .onHandlerMethod("setRepoFilters", User.class, String.class, List.class);
+    }
+
+    @Test
+    public void testClearRepoFilters() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).clearRepoFilters(with(mockUser), with(REPO_LABEL));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/channel.software/clearRepoFilters", "POST")
+                .withBody(Map.of("label", REPO_LABEL))
+                .onHandlerMethod("clearRepoFilters", User.class, String.class);
+    }
+
+    @Test
+    public void testApplyChannelState() throws Exception {
+        var sids = List.of(1001, 1002);
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).applyChannelState(with(mockUser), with(sids));
+            will(returnValue(401L));
+        }});
+
+        validateApiContract("/channel.software/applyChannelState", "POST")
+                .withBody(Map.of("sids", sids))
+                .onHandlerMethod("applyChannelState", User.class, List.class);
+    }
+
+    @Test
+    public void testIsAutoSync() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).isAutoSync(with(mockUser), with(CHANNEL_LABEL));
+            will(returnValue(true));
+        }});
+
+        validateApiContract("/channel.software/isAutoSync", "GET")
+                .withParams(Map.of("channelLabel", new String[]{CHANNEL_LABEL}))
+                .onHandlerMethod("isAutoSync", User.class, String.class);
+    }
+
+    @Test
+    public void testSetAutoSync() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).setAutoSync(with(mockUser), with(CHANNEL_LABEL), with(true));
+            will(returnValue(true));
+        }});
+
+        validateApiContract("/channel.software/setAutoSync", "POST")
+                .withBody(Map.of("channelLabel", CHANNEL_LABEL, "autoSync", true))
+                .onHandlerMethod("setAutoSync", User.class, String.class, Boolean.class);
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/ImageInfoHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/ImageInfoHandlerContractTest.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.action.ActionStatus;
+import com.redhat.rhn.domain.action.server.ServerAction;
+import com.redhat.rhn.domain.common.Checksum;
+import com.redhat.rhn.domain.errata.AdvisoryStatus;
+import com.redhat.rhn.domain.image.ImageFile;
+import com.redhat.rhn.domain.image.ImageInfo;
+import com.redhat.rhn.domain.image.ImageOverview;
+import com.redhat.rhn.domain.image.ImageProfile;
+import com.redhat.rhn.domain.image.ImageStore;
+import com.redhat.rhn.domain.server.ServerArch;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.dto.ErrataOverview;
+import com.redhat.rhn.frontend.xmlrpc.image.ImageInfoHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class ImageInfoHandlerContractTest extends BaseOpenApiTest {
+
+    private static final Integer IMAGE_ID = 101;
+    private static final Date EARLIEST = new Date(0);
+
+    @Override
+    protected String getApiNamespace() {
+        return "image";
+    }
+
+    @Override
+    protected Class<ImageInfoHandler> getHandlerClass() {
+        return ImageInfoHandler.class;
+    }
+
+    private ImageInfoHandler handler() {
+        return (ImageInfoHandler) handlerMock;
+    }
+
+    /**
+     * Builds an image serialized by the registered ImageInfoSerializer.
+     *
+     * @return the image
+     */
+    private ImageInfo imageInfo() {
+        ImageInfo info = context.mock(ImageInfo.class, "imageInfo");
+        var arch = context.mock(ServerArch.class, "imageArch");
+        var store = context.mock(ImageStore.class, "imageInfoStore");
+        var checksum = context.mock(Checksum.class, "imageInfoChecksum");
+
+        context.checking(new Expectations() {{
+            allowing(arch).getLabel();
+            will(returnValue("x86_64"));
+            allowing(store).getLabel();
+            will(returnValue("test-store"));
+            allowing(checksum).getChecksum();
+            will(returnValue("0123456789abcdef"));
+
+            allowing(info).getId();
+            will(returnValue(IMAGE_ID.longValue()));
+            allowing(info).getName();
+            will(returnValue("test-image"));
+            allowing(info).getImageType();
+            will(returnValue("dockerfile"));
+            allowing(info).getVersion();
+            will(returnValue("1.0.0"));
+            allowing(info).getRevisionNumber();
+            will(returnValue(1));
+            allowing(info).getImageArch();
+            will(returnValue(arch));
+            allowing(info).isExternalImage();
+            will(returnValue(false));
+            allowing(info).getStore();
+            will(returnValue(store));
+            allowing(info).getChecksum();
+            will(returnValue(checksum));
+            allowing(info).isObsolete();
+            will(returnValue(false));
+        }});
+
+        return info;
+    }
+
+    /**
+     * Builds an image overview serialized by the registered ImageOverviewSerializer. The inspect
+     * action is left empty, which is the state the conditional inspectStatus documents as absent,
+     * and the build server is unset, so buildServerId takes the serializer's zero.
+     *
+     * @return the image overview
+     */
+    private ImageOverview imageOverview() {
+        ImageOverview overview = context.mock(ImageOverview.class, "imageOverview");
+        var checksum = context.mock(Checksum.class, "overviewChecksum");
+        var profile = context.mock(ImageProfile.class, "overviewProfile");
+        var store = context.mock(ImageStore.class, "overviewStore");
+        var buildAction = context.mock(ServerAction.class, "overviewBuildAction");
+        var buildStatus = context.mock(ActionStatus.class, "overviewBuildStatus");
+
+        context.checking(new Expectations() {{
+            allowing(checksum).getChecksum();
+            will(returnValue("0123456789abcdef"));
+            allowing(profile).getLabel();
+            will(returnValue("test-profile"));
+            allowing(store).getLabel();
+            will(returnValue("test-store"));
+            allowing(buildStatus).getName();
+            will(returnValue("Completed"));
+            allowing(buildAction).getStatus();
+            will(returnValue(buildStatus));
+
+            allowing(overview).getId();
+            will(returnValue(IMAGE_ID.longValue()));
+            allowing(overview).getName();
+            will(returnValue("test-image"));
+            allowing(overview).getImageType();
+            will(returnValue("dockerfile"));
+            allowing(overview).getVersion();
+            will(returnValue("1.0.0"));
+            allowing(overview).getCurrRevisionNum();
+            will(returnValue(1));
+            allowing(overview).getArch();
+            will(returnValue("x86_64"));
+            allowing(overview).isExternalImage();
+            will(returnValue(false));
+            allowing(overview).getChecksum();
+            will(returnValue(checksum));
+            allowing(overview).getProfile();
+            will(returnValue(profile));
+            allowing(overview).getStore();
+            will(returnValue(store));
+            allowing(overview).getBuildServer();
+            will(returnValue(null));
+            allowing(overview).getSecurityErrata();
+            will(returnValue(1));
+            allowing(overview).getBugErrata();
+            will(returnValue(2));
+            allowing(overview).getEnhancementErrata();
+            will(returnValue(3));
+            allowing(overview).getOutdatedPackages();
+            will(returnValue(4));
+            allowing(overview).getInstalledPackages();
+            will(returnValue(5));
+            allowing(overview).getBuildServerAction();
+            will(returnValue(Optional.of(buildAction)));
+            allowing(overview).getInspectServerAction();
+            will(returnValue(Optional.empty()));
+            allowing(overview).getImageFiles();
+            will(returnValue(Set.of(imageFile())));
+            allowing(overview).isObsolete();
+            will(returnValue(false));
+        }});
+
+        return overview;
+    }
+
+    /**
+     * Builds an image file serialized by the registered ImageFileSerializer. The file is external,
+     * so its url is the file name itself rather than a path below the OS image store.
+     *
+     * @return the image file
+     */
+    private ImageFile imageFile() {
+        ImageFile file = context.mock(ImageFile.class, "imageFile");
+
+        context.checking(new Expectations() {{
+            allowing(file).getFile();
+            will(returnValue("test-image-1.0.0.tar"));
+            allowing(file).getType();
+            will(returnValue("tar"));
+            allowing(file).isExternal();
+            will(returnValue(true));
+        }});
+
+        return file;
+    }
+
+    /**
+     * Builds an erratum serialized by the registered ErrataOverviewSerializer.
+     *
+     * @return the erratum overview
+     */
+    private ErrataOverview errataOverview() {
+        ErrataOverview errata = context.mock(ErrataOverview.class, "errataOverview");
+
+        context.checking(new Expectations() {{
+            allowing(errata).getId();
+            will(returnValue(201L));
+            allowing(errata).getIssueDateIsoFormat();
+            will(returnValue("2026-01-01 00:00:00"));
+            allowing(errata).getUpdateDateIsoFormat();
+            will(returnValue("2026-01-02 00:00:00"));
+            allowing(errata).getAdvisorySynopsis();
+            will(returnValue("A test erratum"));
+            allowing(errata).getAdvisoryType();
+            will(returnValue("Security Advisory"));
+            allowing(errata).getAdvisoryStatus();
+            will(returnValue(AdvisoryStatus.FINAL));
+            allowing(errata).getAdvisoryName();
+            will(returnValue("SUSE-2026-0001"));
+            allowing(errata).isRebootSuggested();
+            will(returnValue(false));
+            allowing(errata).isRestartSuggested();
+            will(returnValue(false));
+        }});
+
+        return errata;
+    }
+
+    @Test
+    public void testListImages() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listImages(with(mockUser));
+            will(returnValue(List.of(imageInfo())));
+        }});
+
+        validateApiContract("/image/listImages", "GET")
+                .onHandlerMethod("listImages", User.class);
+    }
+
+    @Test
+    public void testGetDetails() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getDetails(with(mockUser), with(IMAGE_ID));
+            will(returnValue(imageOverview()));
+        }});
+
+        validateApiContract("/image/getDetails", "GET")
+                .withParams(Map.of("imageId", new String[]{IMAGE_ID.toString()}))
+                .onHandlerMethod("getDetails", User.class, Integer.class);
+    }
+
+    @Test
+    public void testGetPillar() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getPillar(with(mockUser), with(IMAGE_ID));
+            will(returnValue(Map.of("size", "1024", "boot_image", "test-image")));
+        }});
+
+        validateApiContract("/image/getPillar", "GET")
+                .withParams(Map.of("imageId", new String[]{IMAGE_ID.toString()}))
+                .onHandlerMethod("getPillar", User.class, Integer.class);
+    }
+
+    @Test
+    public void testSetPillar() throws Exception {
+        var pillarData = Map.<String, Object>of("size", "1024");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setPillar(with(mockUser), with(IMAGE_ID), with(pillarData));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/image/setPillar", "POST")
+                .withBody(Map.of("imageId", IMAGE_ID, "pillarData", pillarData))
+                .onHandlerMethod("setPillar", User.class, Integer.class, Map.class);
+    }
+
+    @Test
+    public void testImportImage() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).importImage(with(mockUser), with("test-image"), with("1.0.0"),
+                    with(1001), with("test-store"), with("1-activation-key"), with(EARLIEST));
+            will(returnValue(301L));
+        }});
+
+        validateApiContract("/image/importImage", "POST")
+                .withBody(Map.of(
+                        "name", "test-image",
+                        "version", "1.0.0",
+                        "buildHostId", 1001,
+                        "storeLabel", "test-store",
+                        "activationKey", "1-activation-key",
+                        "earliestOccurrence", "1970-01-01T00:00:00Z"))
+                .onHandlerMethod("importImage", User.class, String.class, String.class, Integer.class,
+                        String.class, String.class, Date.class);
+    }
+
+    @Test
+    public void testImportContainerImage() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).importContainerImage(with(mockUser), with("test-image"), with("1.0.0"),
+                    with(1001), with("test-store"), with("1-activation-key"), with(EARLIEST));
+            will(returnValue(302L));
+        }});
+
+        validateApiContract("/image/importContainerImage", "POST")
+                .withBody(Map.of(
+                        "name", "test-image",
+                        "version", "1.0.0",
+                        "buildHostId", 1001,
+                        "storeLabel", "test-store",
+                        "activationKey", "1-activation-key",
+                        "earliestOccurrence", "1970-01-01T00:00:00Z"))
+                .onHandlerMethod("importContainerImage", User.class, String.class, String.class, Integer.class,
+                        String.class, String.class, Date.class);
+    }
+
+    @Test
+    public void testImportOSImage() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).importOSImage(with(mockUser), with("test-image"), with("1.0.0"),
+                    with("x86_64"));
+            will(returnValue(303L));
+        }});
+
+        validateApiContract("/image/importOSImage", "POST")
+                .withBody(Map.of("name", "test-image", "version", "1.0.0", "arch", "x86_64"))
+                .onHandlerMethod("importOSImage", User.class, String.class, String.class, String.class);
+    }
+
+    @Test
+    public void testScheduleImageBuild() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).scheduleImageBuild(with(mockUser), with("test-profile"), with("1.0.0"),
+                    with(1001), with(EARLIEST));
+            will(returnValue(304L));
+        }});
+
+        validateApiContract("/image/scheduleImageBuild", "POST")
+                .withBody(Map.of(
+                        "profileLabel", "test-profile",
+                        "version", "1.0.0",
+                        "buildHostId", 1001,
+                        "earliestOccurrence", "1970-01-01T00:00:00Z"))
+                .onHandlerMethod("scheduleImageBuild", User.class, String.class, String.class, Integer.class,
+                        Date.class);
+    }
+
+    @Test
+    public void testAddImageFile() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).addImageFile(with(mockUser), with(IMAGE_ID), with("test-image-1.0.0.tar"),
+                    with("tar"), with(false));
+            will(returnValue(305L));
+        }});
+
+        validateApiContract("/image/addImageFile", "POST")
+                .withBody(Map.of(
+                        "imageId", IMAGE_ID,
+                        "file", "test-image-1.0.0.tar",
+                        "type", "tar",
+                        "external", false))
+                .onHandlerMethod("addImageFile", User.class, Integer.class, String.class, String.class,
+                        Boolean.class);
+    }
+
+    @Test
+    public void testDeleteImageFile() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).deleteImageFile(with(mockUser), with(IMAGE_ID), with("test-image-1.0.0.tar"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/image/deleteImageFile", "POST")
+                .withBody(Map.of("imageId", IMAGE_ID, "file", "test-image-1.0.0.tar"))
+                .onHandlerMethod("deleteImageFile", User.class, Integer.class, String.class);
+    }
+
+    @Test
+    public void testGetRelevantErrata() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getRelevantErrata(with(mockUser), with(IMAGE_ID));
+            will(returnValue(List.of(errataOverview())));
+        }});
+
+        validateApiContract("/image/getRelevantErrata", "GET")
+                .withParams(Map.of("imageId", new String[]{IMAGE_ID.toString()}))
+                .onHandlerMethod("getRelevantErrata", User.class, Integer.class);
+    }
+
+    @Test
+    public void testListPackages() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listPackages(with(mockUser), with(IMAGE_ID));
+            will(returnValue(List.of(Map.<String, Object>of(
+                    "name", "test-package",
+                    "version", "1.0.0",
+                    "release", "1",
+                    "epoch", "",
+                    "arch", "x86_64"))));
+        }});
+
+        validateApiContract("/image/listPackages", "GET")
+                .withParams(Map.of("imageId", new String[]{IMAGE_ID.toString()}))
+                .onHandlerMethod("listPackages", User.class, Integer.class);
+    }
+
+    /**
+     * The custom values are a free-form map keyed by the custom info label, so the response is
+     * only constrained to be an object.
+     */
+    @Test
+    public void testGetCustomValues() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getCustomValues(with(mockUser), with(IMAGE_ID));
+            will(returnValue(Map.of("test-key", "test-value")));
+        }});
+
+        validateApiContract("/image/getCustomValues", "GET")
+                .withParams(Map.of("imageId", new String[]{IMAGE_ID.toString()}))
+                .onHandlerMethod("getCustomValues", User.class, Integer.class);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).delete(with(mockUser), with(IMAGE_ID));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/image/delete", "POST")
+                .withBody(Map.of("imageId", IMAGE_ID))
+                .onHandlerMethod("delete", User.class, Integer.class);
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/KickstartProfileSystemHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/KickstartProfileSystemHandlerContractTest.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.common.FileList;
+import com.redhat.rhn.domain.config.ConfigFileName;
+import com.redhat.rhn.domain.kickstart.crypto.CryptoKey;
+import com.redhat.rhn.domain.kickstart.crypto.CryptoKeyType;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.kickstart.profile.system.SystemDetailsHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class KickstartProfileSystemHandlerContractTest extends BaseOpenApiTest {
+
+    private static final String KS_LABEL = "test-profile";
+
+    @Override
+    protected String getApiNamespace() {
+        return "kickstart.profile.system";
+    }
+
+    @Override
+    protected Class<SystemDetailsHandler> getHandlerClass() {
+        return SystemDetailsHandler.class;
+    }
+
+    private SystemDetailsHandler handler() {
+        return (SystemDetailsHandler) handlerMock;
+    }
+
+    /**
+     * Builds a crypto key serialized by the registered CryptoKeySerializer.
+     *
+     * @return the crypto key
+     */
+    private CryptoKey cryptoKey() {
+        CryptoKey key = context.mock(CryptoKey.class, "cryptoKey");
+        CryptoKeyType type = context.mock(CryptoKeyType.class, "cryptoKeyType");
+
+        context.checking(new Expectations() {{
+            allowing(type).getLabel();
+            will(returnValue("GPG"));
+            allowing(key).getDescription();
+            will(returnValue("test-key"));
+            allowing(key).getCryptoKeyType();
+            will(returnValue(type));
+            allowing(key).getKeyString();
+            will(returnValue("-----BEGIN PGP PUBLIC KEY BLOCK-----"));
+        }});
+
+        return key;
+    }
+
+    /**
+     * Builds a file preservation list serialized by the registered FileListSerializer.
+     *
+     * @return the file list
+     */
+    private FileList fileList() {
+        FileList list = context.mock(FileList.class, "fileList");
+        ConfigFileName fileName = context.mock(ConfigFileName.class, "configFileName");
+
+        context.checking(new Expectations() {{
+            allowing(fileName).getPath();
+            will(returnValue("/etc/hosts"));
+            allowing(list).getLabel();
+            will(returnValue("test-file-list"));
+            allowing(list).getFileNames();
+            will(returnValue(Set.of(fileName)));
+        }});
+
+        return list;
+    }
+
+    @Test
+    public void testCheckConfigManagement() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).checkConfigManagement(with(mockUser), with(KS_LABEL));
+            will(returnValue(true));
+        }});
+
+        validateApiContract("/kickstart.profile.system/checkConfigManagement", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL))
+                .onHandlerMethod("checkConfigManagement", User.class, String.class);
+    }
+
+    @Test
+    public void testEnableConfigManagement() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).enableConfigManagement(with(mockUser), with(KS_LABEL));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.system/enableConfigManagement", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL))
+                .onHandlerMethod("enableConfigManagement", User.class, String.class);
+    }
+
+    @Test
+    public void testDisableConfigManagement() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).disableConfigManagement(with(mockUser), with(KS_LABEL));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.system/disableConfigManagement", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL))
+                .onHandlerMethod("disableConfigManagement", User.class, String.class);
+    }
+
+    @Test
+    public void testCheckRemoteCommands() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).checkRemoteCommands(with(mockUser), with(KS_LABEL));
+            will(returnValue(true));
+        }});
+
+        validateApiContract("/kickstart.profile.system/checkRemoteCommands", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL))
+                .onHandlerMethod("checkRemoteCommands", User.class, String.class);
+    }
+
+    @Test
+    public void testEnableRemoteCommands() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).enableRemoteCommands(with(mockUser), with(KS_LABEL));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.system/enableRemoteCommands", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL))
+                .onHandlerMethod("enableRemoteCommands", User.class, String.class);
+    }
+
+    @Test
+    public void testDisableRemoteCommands() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).disableRemoteCommands(with(mockUser), with(KS_LABEL));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.system/disableRemoteCommands", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL))
+                .onHandlerMethod("disableRemoteCommands", User.class, String.class);
+    }
+
+    @Test
+    public void testGetSELinux() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getSELinux(with(mockUser), with(KS_LABEL));
+            will(returnValue("enforcing"));
+        }});
+
+        validateApiContract("/kickstart.profile.system/getSELinux", "GET")
+                .withParams(Map.of("ksLabel", new String[]{KS_LABEL}))
+                .onHandlerMethod("getSELinux", User.class, String.class);
+    }
+
+    @Test
+    public void testSetSELinux() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).setSELinux(with(mockUser), with(KS_LABEL), with("enforcing"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.system/setSELinux", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL, "enforcingMode", "enforcing"))
+                .onHandlerMethod("setSELinux", User.class, String.class, String.class);
+    }
+
+    /**
+     * useUtc documents both boolean values, but the generated schema carries the enum [false, false]
+     * because the documented values are copied onto the boolean schema as the strings the annotation
+     * declares, so only false validates. See the note on testSetLocale.
+     */
+    @Test
+    public void testGetLocale() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getLocale(with(mockUser), with(KS_LABEL));
+            will(returnValue(Map.of("locale", "Europe/Berlin", "useUtc", false)));
+        }});
+
+        validateApiContract("/kickstart.profile.system/getLocale", "GET")
+                .withParams(Map.of("ksLabel", new String[]{KS_LABEL}))
+                .onHandlerMethod("getLocale", User.class, String.class);
+    }
+
+    /**
+     * The request is sent with useUtc false, the only value the generated schema accepts today:
+     * UyuniSwaggerReader#applyDocumentedValues copies the annotation's allowableValues onto the
+     * property schema without casting them to its type, so a boolean property documenting options
+     * ends up with the enum [false, false] and rejects true.
+     */
+    @Test
+    public void testSetLocale() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).setLocale(with(mockUser), with(KS_LABEL), with("Europe/Berlin"), with(false));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.system/setLocale", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL, "locale", "Europe/Berlin", "useUtc", false))
+                .onHandlerMethod("setLocale", User.class, String.class, String.class, Boolean.class);
+    }
+
+    @Test
+    public void testGetPartitioningScheme() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getPartitioningScheme(with(mockUser), with(KS_LABEL));
+            will(returnValue(List.of("part /boot --fstype=ext4 --size=200", "part / --size=1024")));
+        }});
+
+        validateApiContract("/kickstart.profile.system/getPartitioningScheme", "GET")
+                .withParams(Map.of("ksLabel", new String[]{KS_LABEL}))
+                .onHandlerMethod("getPartitioningScheme", User.class, String.class);
+    }
+
+    @Test
+    public void testSetPartitioningScheme() throws Exception {
+        var scheme = List.of("part /boot --fstype=ext4 --size=200", "part / --size=1024");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setPartitioningScheme(with(mockUser), with(KS_LABEL), with(scheme));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.system/setPartitioningScheme", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL, "scheme", scheme))
+                .onHandlerMethod("setPartitioningScheme", User.class, String.class, List.class);
+    }
+
+    @Test
+    public void testListKeys() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listKeys(with(mockUser), with(KS_LABEL));
+            will(returnValue(Set.of(cryptoKey())));
+        }});
+
+        validateApiContract("/kickstart.profile.system/listKeys", "GET")
+                .withParams(Map.of("ksLabel", new String[]{KS_LABEL}))
+                .onHandlerMethod("listKeys", User.class, String.class);
+    }
+
+    @Test
+    public void testAddKeys() throws Exception {
+        var descriptions = List.of("test-key");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).addKeys(with(mockUser), with(KS_LABEL), with(descriptions));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.system/addKeys", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL, "descriptions", descriptions))
+                .onHandlerMethod("addKeys", User.class, String.class, List.class);
+    }
+
+    @Test
+    public void testRemoveKeys() throws Exception {
+        var descriptions = List.of("test-key");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).removeKeys(with(mockUser), with(KS_LABEL), with(descriptions));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.system/removeKeys", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL, "descriptions", descriptions))
+                .onHandlerMethod("removeKeys", User.class, String.class, List.class);
+    }
+
+    @Test
+    public void testListFilePreservations() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listFilePreservations(with(mockUser), with(KS_LABEL));
+            will(returnValue(Set.of(fileList())));
+        }});
+
+        validateApiContract("/kickstart.profile.system/listFilePreservations", "GET")
+                .withParams(Map.of("ksLabel", new String[]{KS_LABEL}))
+                .onHandlerMethod("listFilePreservations", User.class, String.class);
+    }
+
+    @Test
+    public void testAddFilePreservations() throws Exception {
+        var filePreservations = List.of("test-file-list");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).addFilePreservations(with(mockUser), with(KS_LABEL), with(filePreservations));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.system/addFilePreservations", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL, "filePreservations", filePreservations))
+                .onHandlerMethod("addFilePreservations", User.class, String.class, List.class);
+    }
+
+    @Test
+    public void testRemoveFilePreservations() throws Exception {
+        var filePreservations = List.of("test-file-list");
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).removeFilePreservations(with(mockUser), with(KS_LABEL), with(filePreservations));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.system/removeFilePreservations", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL, "filePreservations", filePreservations))
+                .onHandlerMethod("removeFilePreservations", User.class, String.class, List.class);
+    }
+
+    @Test
+    public void testGetRegistrationType() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getRegistrationType(with(mockUser), with(KS_LABEL));
+            will(returnValue("reactivation"));
+        }});
+
+        validateApiContract("/kickstart.profile.system/getRegistrationType", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL))
+                .onHandlerMethod("getRegistrationType", User.class, String.class);
+    }
+
+    @Test
+    public void testSetRegistrationType() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).setRegistrationType(with(mockUser), with(KS_LABEL), with("reactivation"));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/kickstart.profile.system/setRegistrationType", "POST")
+                .withBody(Map.of("ksLabel", KS_LABEL, "registrationType", "reactivation"))
+                .onHandlerMethod("setRegistrationType", User.class, String.class, String.class);
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/OrgHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/OrgHandlerContractTest.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.dto.MultiOrgUserOverview;
+import com.redhat.rhn.frontend.dto.OrgDto;
+import com.redhat.rhn.frontend.xmlrpc.org.OrgHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class OrgHandlerContractTest extends BaseOpenApiTest {
+
+    private static final Integer ORG_ID = 1;
+    private static final String ORG_NAME = "Test Organization";
+
+    @Override
+    protected String getApiNamespace() {
+        return "org";
+    }
+
+    @Override
+    protected Class<OrgHandler> getHandlerClass() {
+        return OrgHandler.class;
+    }
+
+    private OrgHandler handler() {
+        return (OrgHandler) handlerMock;
+    }
+
+    /**
+     * Builds an organization serialized by the registered OrgDtoSerializer. Every count is set,
+     * so the properties the serializer only adds when they are not null are all present.
+     *
+     * @param name a unique mock name, so several organizations can coexist in one test run
+     * @return the organization
+     */
+    private OrgDto orgDto(String name) {
+        OrgDto org = context.mock(OrgDto.class, name);
+
+        context.checking(new Expectations() {{
+            allowing(org).getId();
+            will(returnValue(ORG_ID.longValue()));
+            allowing(org).getName();
+            will(returnValue(ORG_NAME));
+            allowing(org).getUsers();
+            will(returnValue(3L));
+            allowing(org).getSystems();
+            will(returnValue(4L));
+            allowing(org).getTrusts();
+            will(returnValue(1L));
+            allowing(org).getActivationKeys();
+            will(returnValue(2L));
+            allowing(org).getServerGroups();
+            will(returnValue(5L));
+            allowing(org).getKickstartProfiles();
+            will(returnValue(6L));
+            allowing(org).getConfigChannels();
+            will(returnValue(7L));
+            allowing(org).isStagingContentEnabled();
+            will(returnValue(true));
+        }});
+
+        return org;
+    }
+
+    /**
+     * Builds a user serialized by the registered MultiOrgUserOverviewSerializer.
+     *
+     * @return the organization user
+     */
+    private MultiOrgUserOverview orgUser() {
+        MultiOrgUserOverview user = context.mock(MultiOrgUserOverview.class, "orgUser");
+
+        context.checking(new Expectations() {{
+            allowing(user).getLogin();
+            will(returnValue("testuser"));
+            allowing(user).getLoginUc();
+            will(returnValue("TESTUSER"));
+            allowing(user).getUserDisplayName();
+            will(returnValue("Test User"));
+            allowing(user).getAddress();
+            will(returnValue("testuser@example.com"));
+            allowing(user).getOrgAdmin();
+            will(returnValue(1L));
+        }});
+
+        return user;
+    }
+
+    @Test
+    public void testCreate() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).create(with(mockUser), with(ORG_NAME), with("testadmin"), with("testpassword"),
+                    with("Mr."), with("Test"), with("Admin"), with("testadmin@example.com"), with(false));
+            will(returnValue(orgDto("createdOrg")));
+        }});
+
+        validateApiContract("/org/create", "POST")
+                .withBody(Map.of(
+                        "orgName", ORG_NAME,
+                        "adminLogin", "testadmin",
+                        "adminPassword", "testpassword",
+                        "prefix", "Mr.",
+                        "firstName", "Test",
+                        "lastName", "Admin",
+                        "email", "testadmin@example.com",
+                        "usePamAuth", false))
+                .onHandlerMethod("create", User.class, String.class, String.class, String.class, String.class,
+                        String.class, String.class, String.class, Boolean.class);
+    }
+
+    /**
+     * The first organization is created before any user exists, so the endpoint is public and the
+     * handler method takes no session user.
+     */
+    @Test
+    public void testCreateFirst() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).createFirst(with(ORG_NAME), with("testadmin"), with("testpassword"),
+                    with("Test"), with("Admin"), with("testadmin@example.com"));
+            will(returnValue(orgDto("firstOrg")));
+        }});
+
+        validateApiContract("/org/createFirst", "POST")
+                .withBody(Map.of(
+                        "orgName", ORG_NAME,
+                        "adminLogin", "testadmin",
+                        "adminPassword", "testpassword",
+                        "firstName", "Test",
+                        "lastName", "Admin",
+                        "email", "testadmin@example.com"))
+                .onHandlerMethod("createFirst", String.class, String.class, String.class, String.class,
+                        String.class, String.class);
+    }
+
+    @Test
+    public void testListOrgs() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listOrgs(with(mockUser));
+            will(returnValue(List.of(orgDto("listedOrg"))));
+        }});
+
+        validateApiContract("/org/listOrgs", "GET")
+                .onHandlerMethod("listOrgs", User.class);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).delete(with(mockUser), with(ORG_ID));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/org/delete", "POST")
+                .withBody(Map.of("orgId", ORG_ID))
+                .onHandlerMethod("delete", User.class, Integer.class);
+    }
+
+    @Test
+    public void testListUsers() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listUsers(with(mockUser), with(ORG_ID));
+            will(returnValue(List.of(orgUser())));
+        }});
+
+        validateApiContract("/org/listUsers", "GET")
+                .withParams(Map.of("orgId", new String[]{ORG_ID.toString()}))
+                .onHandlerMethod("listUsers", User.class, Integer.class);
+    }
+
+    @Test
+    public void testGetDetailsById() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getDetails(with(mockUser), with(ORG_ID));
+            will(returnValue(orgDto("orgById")));
+        }});
+
+        validateApiContract("/org/getDetails", "GET")
+                .withParams(Map.of("orgId", new String[]{ORG_ID.toString()}))
+                .onHandlerMethod("getDetails", User.class, Integer.class);
+    }
+
+    /**
+     * The two lookups share one path, so a request naming the organization has to reach the
+     * overload taking the name rather than the one taking the id.
+     */
+    @Test
+    public void testGetDetailsByName() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getDetails(with(mockUser), with(ORG_NAME));
+            will(returnValue(orgDto("orgByName")));
+        }});
+
+        validateApiContract("/org/getDetails", "GET")
+                .withParams(Map.of("name", new String[]{ORG_NAME}))
+                .onHandlerMethod("getDetails", User.class, String.class);
+    }
+
+    @Test
+    public void testUpdateName() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).updateName(with(mockUser), with(ORG_ID), with("Renamed Organization"));
+            will(returnValue(orgDto("renamedOrg")));
+        }});
+
+        validateApiContract("/org/updateName", "POST")
+                .withBody(Map.of("orgId", ORG_ID, "name", "Renamed Organization"))
+                .onHandlerMethod("updateName", User.class, Integer.class, String.class);
+    }
+
+    @Test
+    public void testTransferSystems() throws Exception {
+        var sids = List.of(1001, 1002);
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).transferSystems(with(mockUser), with(ORG_ID), with(sids));
+            will(returnValue(new Object[]{1001L, 1002L}));
+        }});
+
+        validateApiContract("/org/transferSystems", "POST")
+                .withBody(Map.of("toOrgId", ORG_ID, "sids", sids))
+                .onHandlerMethod("transferSystems", User.class, Integer.class, List.class);
+    }
+
+    @Test
+    public void testGetPolicyForScapFileUpload() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getPolicyForScapFileUpload(with(mockUser), with(ORG_ID));
+            will(returnValue(Map.of("enabled", true, "size_limit", 1048576L)));
+        }});
+
+        validateApiContract("/org/getPolicyForScapFileUpload", "GET")
+                .withParams(Map.of("orgId", new String[]{ORG_ID.toString()}))
+                .onHandlerMethod("getPolicyForScapFileUpload", User.class, Integer.class);
+    }
+
+    @Test
+    public void testSetPolicyForScapFileUpload() throws Exception {
+        var newSettings = Map.<String, Object>of("enabled", true);
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setPolicyForScapFileUpload(with(mockUser), with(ORG_ID), with(newSettings));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/org/setPolicyForScapFileUpload", "POST")
+                .withBody(Map.of("orgId", ORG_ID, "newSettings", newSettings))
+                .onHandlerMethod("setPolicyForScapFileUpload", User.class, Integer.class, Map.class);
+    }
+
+    @Test
+    public void testGetPolicyForScapResultDeletion() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getPolicyForScapResultDeletion(with(mockUser), with(ORG_ID));
+            will(returnValue(Map.of("enabled", true, "retention_period", 90L)));
+        }});
+
+        validateApiContract("/org/getPolicyForScapResultDeletion", "GET")
+                .withParams(Map.of("orgId", new String[]{ORG_ID.toString()}))
+                .onHandlerMethod("getPolicyForScapResultDeletion", User.class, Integer.class);
+    }
+
+    @Test
+    public void testSetPolicyForScapResultDeletion() throws Exception {
+        var newSettings = Map.<String, Object>of("enabled", true, "retention_period", 90);
+
+        context.checking(new Expectations() {{
+            oneOf(handler()).setPolicyForScapResultDeletion(with(mockUser), with(ORG_ID), with(newSettings));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/org/setPolicyForScapResultDeletion", "POST")
+                .withBody(Map.of("orgId", ORG_ID, "newSettings", newSettings))
+                .onHandlerMethod("setPolicyForScapResultDeletion", User.class, Integer.class, Map.class);
+    }
+
+    @Test
+    public void testIsOrgConfigManagedByOrgAdmin() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).isOrgConfigManagedByOrgAdmin(with(mockUser), with(ORG_ID));
+            will(returnValue(true));
+        }});
+
+        validateApiContract("/org/isOrgConfigManagedByOrgAdmin", "GET")
+                .withParams(Map.of("orgId", new String[]{ORG_ID.toString()}))
+                .onHandlerMethod("isOrgConfigManagedByOrgAdmin", User.class, Integer.class);
+    }
+
+    @Test
+    public void testSetOrgConfigManagedByOrgAdmin() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).setOrgConfigManagedByOrgAdmin(with(mockUser), with(ORG_ID), with(true));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/org/setOrgConfigManagedByOrgAdmin", "POST")
+                .withBody(Map.of("orgId", ORG_ID, "enable", true))
+                .onHandlerMethod("setOrgConfigManagedByOrgAdmin", User.class, Integer.class, Boolean.class);
+    }
+
+    @Test
+    public void testIsErrataEmailNotifsForOrg() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).isErrataEmailNotifsForOrg(with(mockUser), with(ORG_ID));
+            will(returnValue(true));
+        }});
+
+        validateApiContract("/org/isErrataEmailNotifsForOrg", "GET")
+                .withParams(Map.of("orgId", new String[]{ORG_ID.toString()}))
+                .onHandlerMethod("isErrataEmailNotifsForOrg", User.class, Integer.class);
+    }
+
+    @Test
+    public void testSetErrataEmailNotifsForOrg() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).setErrataEmailNotifsForOrg(with(mockUser), with(ORG_ID), with(true));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/org/setErrataEmailNotifsForOrg", "POST")
+                .withBody(Map.of("orgId", ORG_ID, "enable", true))
+                .onHandlerMethod("setErrataEmailNotifsForOrg", User.class, Integer.class, Boolean.class);
+    }
+
+    @Test
+    public void testIsContentStagingEnabled() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).isContentStagingEnabled(with(mockUser), with(ORG_ID));
+            will(returnValue(true));
+        }});
+
+        validateApiContract("/org/isContentStagingEnabled", "GET")
+                .withParams(Map.of("orgId", new String[]{ORG_ID.toString()}))
+                .onHandlerMethod("isContentStagingEnabled", User.class, Integer.class);
+    }
+
+    @Test
+    public void testSetContentStaging() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).setContentStaging(with(mockUser), with(ORG_ID), with(true));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/org/setContentStaging", "POST")
+                .withBody(Map.of("orgId", ORG_ID, "enable", true))
+                .onHandlerMethod("setContentStaging", User.class, Integer.class, Boolean.class);
+    }
+
+    @Test
+    public void testGetClmSyncPatchesConfig() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getClmSyncPatchesConfig(with(mockUser), with(ORG_ID));
+            will(returnValue(true));
+        }});
+
+        validateApiContract("/org/getClmSyncPatchesConfig", "GET")
+                .withParams(Map.of("orgId", new String[]{ORG_ID.toString()}))
+                .onHandlerMethod("getClmSyncPatchesConfig", User.class, Integer.class);
+    }
+
+    @Test
+    public void testSetClmSyncPatchesConfig() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).setClmSyncPatchesConfig(with(mockUser), with(ORG_ID), with(true));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/org/setClmSyncPatchesConfig", "POST")
+                .withBody(Map.of("orgId", ORG_ID, "value", true))
+                .onHandlerMethod("setClmSyncPatchesConfig", User.class, Integer.class, Boolean.class);
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/api/test/contract/PackagesHandlerContractTest.java
+++ b/java/core/src/test/java/com/suse/manager/api/test/contract/PackagesHandlerContractTest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.api.test.contract;
+
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageArch;
+import com.redhat.rhn.domain.rhnpackage.PackageEvr;
+import com.redhat.rhn.domain.rhnpackage.PackageName;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.dto.PackageOverview;
+import com.redhat.rhn.frontend.xmlrpc.packages.PackagesHandler;
+
+import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+public class PackagesHandlerContractTest extends BaseOpenApiTest {
+
+    private static final Integer PACKAGE_ID = 101;
+
+    @Override
+    protected String getApiNamespace() {
+        return "packages";
+    }
+
+    @Override
+    protected Class<PackagesHandler> getHandlerClass() {
+        return PackagesHandler.class;
+    }
+
+    private PackagesHandler handler() {
+        return (PackagesHandler) handlerMock;
+    }
+
+    /**
+     * Builds a package serialized by the registered PackageSerializer. The domain object is
+     * mocked because the serializer reads through four associations that would otherwise need
+     * a session to resolve.
+     *
+     * @return the package
+     */
+    private Package packageObject() {
+        Package pkg = context.mock(Package.class, "package");
+        PackageName name = context.mock(PackageName.class, "packageName");
+        PackageEvr evr = context.mock(PackageEvr.class, "packageEvr");
+        PackageArch arch = context.mock(PackageArch.class, "packageArch");
+
+        context.checking(new Expectations() {{
+            allowing(name).getName();
+            will(returnValue("test-package"));
+            allowing(evr).getVersion();
+            will(returnValue("1.0.0"));
+            allowing(evr).getRelease();
+            will(returnValue("1"));
+            allowing(evr).getEpoch();
+            will(returnValue(null));
+            allowing(arch).getLabel();
+            will(returnValue("x86_64"));
+
+            allowing(pkg).getPackageName();
+            will(returnValue(name));
+            allowing(pkg).getPackageEvr();
+            will(returnValue(evr));
+            allowing(pkg).getPackageArch();
+            will(returnValue(arch));
+            allowing(pkg).getId();
+            will(returnValue(PACKAGE_ID.longValue()));
+            allowing(pkg).getLastModified();
+            will(returnValue(new Date(0)));
+            allowing(pkg).getPath();
+            will(returnValue("redhat/1/abc/test-package-1.0.0-1.x86_64.rpm"));
+            allowing(pkg).isPartOfRetractedPatch();
+            will(returnValue(false));
+            allowing(pkg).getPackageKeys();
+            will(returnValue(Collections.emptySet()));
+        }});
+
+        return pkg;
+    }
+
+    /**
+     * Builds a package overview serialized by the registered PackageOverviewSerializer.
+     *
+     * @return the package overview
+     */
+    private PackageOverview packageOverview() {
+        PackageOverview overview = context.mock(PackageOverview.class, "packageOverview");
+
+        context.checking(new Expectations() {{
+            allowing(overview).getId();
+            will(returnValue(PACKAGE_ID.longValue()));
+            allowing(overview).getPackageName();
+            will(returnValue("test-package"));
+            allowing(overview).getSummary();
+            will(returnValue("A test package"));
+            allowing(overview).getDescription();
+            will(returnValue("A package used by the contract tests"));
+            allowing(overview).getVersion();
+            will(returnValue("1.0.0"));
+            allowing(overview).getRelease();
+            will(returnValue("1"));
+            allowing(overview).getEpoch();
+            will(returnValue(null));
+            allowing(overview).getPackageArch();
+            will(returnValue("x86_64"));
+            allowing(overview).getPackageNvre();
+            will(returnValue("test-package-1.0.0-1"));
+            allowing(overview).getNvrea();
+            will(returnValue("test-package-1.0.0-1.x86_64"));
+            allowing(overview).getPackageChannels();
+            will(returnValue(List.of()));
+            allowing(overview).getProvider();
+            will(returnValue("SUSE"));
+        }});
+
+        return overview;
+    }
+
+    @Test
+    public void testGetDetails() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getDetails(with(mockUser), with(PACKAGE_ID));
+            will(returnValue(Map.ofEntries(
+                    Map.entry("id", PACKAGE_ID),
+                    Map.entry("name", "test-package"),
+                    Map.entry("epoch", ""),
+                    Map.entry("version", "1.0.0"),
+                    Map.entry("release", "1"),
+                    Map.entry("arch_label", "x86_64"),
+                    Map.entry("providing_channels", List.of("test-channel")),
+                    Map.entry("build_host", "build.example.com"),
+                    Map.entry("description", "A package used by the contract tests"),
+                    Map.entry("checksum", "0123456789abcdef"),
+                    Map.entry("checksum_type", "sha256"),
+                    Map.entry("vendor", "SUSE"),
+                    Map.entry("summary", "A test package"),
+                    Map.entry("cookie", "build.example.com 1600000000"),
+                    Map.entry("license", "GPL-2.0"),
+                    Map.entry("file", "test-package-1.0.0-1.x86_64.rpm"),
+                    Map.entry("build_date", "2026-01-01 00:00:00"),
+                    Map.entry("last_modified_date", "2026-01-02 00:00:00"),
+                    Map.entry("size", "12345"),
+                    Map.entry("path", "redhat/1/abc/test-package-1.0.0-1.x86_64.rpm"),
+                    Map.entry("payload_size", "23456"))));
+        }});
+
+        validateApiContract("/packages/getDetails", "GET")
+                .withParams(Map.of("pid", new String[]{PACKAGE_ID.toString()}))
+                .onHandlerMethod("getDetails", User.class, Integer.class);
+    }
+
+    @Test
+    public void testListProvidingChannels() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listProvidingChannels(with(mockUser), with(PACKAGE_ID));
+            will(returnValue(new Object[]{Map.of(
+                    "label", "test-channel",
+                    "parent_label", "test-parent-channel",
+                    "name", "Test Channel")}));
+        }});
+
+        validateApiContract("/packages/listProvidingChannels", "GET")
+                .withParams(Map.of("pid", new String[]{PACKAGE_ID.toString()}))
+                .onHandlerMethod("listProvidingChannels", User.class, Integer.class);
+    }
+
+    @Test
+    public void testListProvidingErrata() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listProvidingErrata(with(mockUser), with(PACKAGE_ID));
+            will(returnValue(new Object[]{Map.of(
+                    "advisory", "test-advisory",
+                    "issue_date", "2026-01-01 00:00:00",
+                    "last_modified_date", "2026-01-02 00:00:00",
+                    "update_date", "2026-01-03 00:00:00",
+                    "synopsis", "A test erratum",
+                    "type", "Security Advisory")}));
+        }});
+
+        validateApiContract("/packages/listProvidingErrata", "GET")
+                .withParams(Map.of("pid", new String[]{PACKAGE_ID.toString()}))
+                .onHandlerMethod("listProvidingErrata", User.class, Integer.class);
+    }
+
+    @Test
+    public void testListFiles() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listFiles(with(mockUser), with(PACKAGE_ID));
+            will(returnValue(new Object[]{Map.of(
+                    "path", "/usr/bin/test-package",
+                    "type", "file",
+                    "last_modified_date", "2026-01-02 00:00:00",
+                    "checksum", "0123456789abcdef",
+                    "checksum_type", "sha256",
+                    "size", 12345L,
+                    "linkto", "")}));
+        }});
+
+        validateApiContract("/packages/listFiles", "GET")
+                .withParams(Map.of("pid", new String[]{PACKAGE_ID.toString()}))
+                .onHandlerMethod("listFiles", User.class, Integer.class);
+    }
+
+    @Test
+    public void testListChangelog() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listChangelog(with(mockUser), with(PACKAGE_ID));
+            will(returnValue("* Thu Jan 01 2026 packager@example.com\n- initial build\n"));
+        }});
+
+        validateApiContract("/packages/listChangelog", "GET")
+                .withParams(Map.of("pid", new String[]{PACKAGE_ID.toString()}))
+                .onHandlerMethod("listChangelog", User.class, Integer.class);
+    }
+
+    @Test
+    public void testListDependencies() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listDependencies(with(mockUser), with(PACKAGE_ID));
+            will(returnValue(new Object[]{Map.of(
+                    "dependency", "libtest.so.1",
+                    "dependency_type", "requires",
+                    "dependency_modifier", ">= 1.0.0")}));
+        }});
+
+        validateApiContract("/packages/listDependencies", "GET")
+                .withParams(Map.of("pid", new String[]{PACKAGE_ID.toString()}))
+                .onHandlerMethod("listDependencies", User.class, Integer.class);
+    }
+
+    @Test
+    public void testListSourcePackages() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).listSourcePackages(with(mockUser));
+            will(returnValue(new Object[]{packageOverview()}));
+        }});
+
+        validateApiContract("/packages/listSourcePackages", "GET")
+                .onHandlerMethod("listSourcePackages", User.class);
+    }
+
+    /**
+     * The documentation recommends an empty epoch. An empty query string value parses to a JSON
+     * null, so the handler is handed null rather than the empty string XML-RPC would deliver.
+     */
+    @Test
+    public void testFindByNvrea() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).findByNvrea(with(mockUser), with("test-package"), with("1.0.0"),
+                    with("1"), with(aNull(String.class)), with("x86_64"));
+            will(returnValue(List.of(packageObject())));
+        }});
+
+        validateApiContract("/packages/findByNvrea", "GET")
+                .withParams(Map.of(
+                        "name", new String[]{"test-package"},
+                        "version", new String[]{"1.0.0"},
+                        "release", new String[]{"1"},
+                        "epoch", new String[]{""},
+                        "archLabel", new String[]{"x86_64"}))
+                .onHandlerMethod("findByNvrea", User.class, String.class, String.class, String.class,
+                        String.class, String.class);
+    }
+
+    @Test
+    public void testGetPackageUrl() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getPackageUrl(with(mockUser), with(PACKAGE_ID));
+            will(returnValue("https://example.com/rpc/api/packages/101/download"));
+        }});
+
+        validateApiContract("/packages/getPackageUrl", "GET")
+                .withParams(Map.of("pid", new String[]{PACKAGE_ID.toString()}))
+                .onHandlerMethod("getPackageUrl", User.class, Integer.class);
+    }
+
+    @Test
+    public void testGetPackage() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).getPackage(with(mockUser), with(PACKAGE_ID));
+            will(returnValue(new byte[]{1, 2, 3, 4}));
+        }});
+
+        validateApiContract("/packages/getPackage", "GET")
+                .withParams(Map.of("pid", new String[]{PACKAGE_ID.toString()}))
+                .onHandlerMethod("getPackage", User.class, Integer.class);
+    }
+
+    @Test
+    public void testRemovePackage() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).removePackage(with(mockUser), with(PACKAGE_ID));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/packages/removePackage", "POST")
+                .withBody(Map.of("pid", PACKAGE_ID))
+                .onHandlerMethod("removePackage", User.class, Integer.class);
+    }
+
+    @Test
+    public void testRemoveSourcePackage() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(handler()).removeSourcePackage(with(mockUser), with(PACKAGE_ID));
+            will(returnValue(1));
+        }});
+
+        validateApiContract("/packages/removeSourcePackage", "POST")
+                .withBody(Map.of("psid", PACKAGE_ID))
+                .onHandlerMethod("removeSourcePackage", User.class, Integer.class);
+    }
+}


### PR DESCRIPTION
Five namespaces move to the OpenAPI contract, one commit each. They are grouped together because channel.software reuses the package and image doc types, so they have to land in one piece to compile.

This sits on top of #12487 and only the last five commits belong to it. The parser commits disappear from the diff once that one merges.

