### PR TITLE
Skip block discard when creating XFS filesystems

### DIFF
--- a/uyuni/uyuni-storage-setup/scripts/susemanager-storage-setup-functions.sh
+++ b/uyuni/uyuni-storage-setup/scripts/susemanager-storage-setup-functions.sh
@@ -109,7 +109,12 @@ create_filesystem() {
     local part=$(get_first_partition_device $1)
     local fs=$2
     local tool=mkfs.$fs
-    result=$($tool -f $part 2>&1)
+    local opts=(-f)
+    # Do not discard blocks at mkfs time: on large, thin-provisioned or
+    # SAN backed disks the discard can take very long, and the disk is
+    # dedicated and empty anyway. Regular TRIM is left to fstrim.
+    [ "$fs" = "xfs" ] && opts+=(-K)
+    result=$($tool "${opts[@]}" $part 2>&1)
     if [ $? != 0 ]; then
         die "$fs filesystem setup failed: $result"
     fi

--- a/uyuni/uyuni-storage-setup/uyuni-storage-setup.changes.jniedergang.mkfs-nodiscard
+++ b/uyuni/uyuni-storage-setup/uyuni-storage-setup.changes.jniedergang.mkfs-nodiscard
@@ -1,0 +1,3 @@
+- Skip the block discard when creating the XFS filesystems with
+  mgr-storage-server and mgr-storage-proxy, as it can take very
+  long on large, thin-provisioned or SAN backed disks


### PR DESCRIPTION
## What does this PR change?

`mgr-storage-server` and `mgr-storage-proxy` create the XFS filesystems with `mkfs.xfs -f <device>`. By default `mkfs.xfs` discards every block of the device first. On large, thin-provisioned or SAN backed disks this can take many minutes, and the tools look stuck at `--> Creating xfs filesystem` because the mkfs output is captured.

This PR passes `-K` (do not attempt to discard blocks at mkfs time) to `mkfs.xfs` in `create_filesystem()`. The disks handled by these tools are dedicated and required to be empty, so the discard brings nothing, and regular TRIM of the mounted filesystems is still done by `fstrim.timer` (enabled by the SUSE systemd presets). Both tools only create XFS filesystems, so the option is added for XFS only and any other type passed to the helper keeps the current behavior.

```bash
    local opts=(-f)
    # Do not discard blocks at mkfs time: on large, thin-provisioned or
    # SAN backed disks the discard can take very long, and the disk is
    # dedicated and empty anyway. Regular TRIM is left to fstrim.
    [ "$fs" = "xfs" ] && opts+=(-K)
    result=$($tool "${opts[@]}" $part 2>&1)
```

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

Release note: `mgr-storage-server` and `mgr-storage-proxy` no longer discard the blocks of the storage disks when creating the XFS filesystems (`mkfs.xfs -K`). This makes the storage setup much faster on large, thin-provisioned or SAN backed disks. TRIM of the mounted filesystems is unchanged and handled by `fstrim.timer`.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: the tools still create XFS filesystems on the given devices as documented. Skipping the discard at mkfs time is an implementation detail without any user facing option.

- [x] **DONE**

## Test coverage
- No tests: manual. There is no test infrastructure for this package. Verified with:
  - unit check of `create_filesystem()` on a loop device: XFS really created, `mkfs.xfs` invoked with exactly `-f -K <device>`, and any other filesystem type still gets the previous `-f` only;
  - full run of `mgr-storage-server <storage-disk> <database-disk>` on two loop devices in a privileged SLE 15 SP7 container (xfsprogs 6.7.0): exit 0, both XFS filesystems created with `-K`, `/etc/fstab` entries and final mount points unchanged, data migrated;
  - `shellcheck` reports no new finding on the modified file.

- [x] **DONE**

## Links

Issue(s): #12495
Port(s): none

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
