### PR TITLE
Refresh the SSH minion profile before checking its system details

### DIFF
--- a/testsuite/features/secondary/allcli_overview_systems_details.feature
+++ b/testsuite/features/secondary/allcli_overview_systems_details.feature
@@ -107,7 +107,10 @@ Feature: The system details of each minion and client provides an overview of th
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    And I wait until event "Hardware List Refresh scheduled" is completed
+    When I wait until event "Hardware List Refresh scheduled" is completed
+    And I wait until there is no Salt job calling the module "hardware.profileupdate" on "sshminion"
+    When I refresh packages list via spacecmd on "sshminion"
+    And I wait until refresh package list on "sshminion" is finished
 
   @sshminion
   Scenario: SSH-managed minion grains are displayed correctly on the details page


### PR DESCRIPTION
## What does this PR change?

Schedules a package list refresh for the SSH-managed minion before the system details of that minion are checked, and waits for the `hardware.profileupdate` Salt job to finish.

The scenario that checks the system details asserts on the OS version, which is read from the Installed Products row of the page. Only a package list refresh writes that row, and Salt SSH systems have no pkgset beacon, so nothing schedules one for them automatically — the row stayed at "unknown" unless an earlier feature in another stage happened to trigger a refresh. The feature now schedules the refresh itself and waits for it. The hardware refresh scenario also gains the wait for the Salt job calling `hardware.profileupdate` that the SLE, Red Hat-like and Debian-like scenarios already have.

```gherkin
    When I wait until event "Hardware List Refresh scheduled" is completed
    And I wait until there is no Salt job calling the module "hardware.profileupdate" on "sshminion"
    When I refresh packages list via spacecmd on "sshminion"
    And I wait until refresh package list on "sshminion" is finished
```

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): Closes SUSE/spacewalk#31815
Port(s):
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31823
Manager-5.1: https://github.com/SUSE/spacewalk/pull/31824

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
