### PR TITLE
Add support for AlmaLinux 8 ppc64le

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1509,6 +1509,11 @@ DATA = {
         "PKGLIST": RES8 + RES8_X86,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/almalinux/8/bootstrap/",
     },
+    "almalinux-8-ppc64le-uyuni": {
+        "BASECHANNEL": "almalinux8-ppc64le",
+        "PKGLIST": RES8,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/almalinux/8/bootstrap/",
+    },
     "almalinux-8-aarch64-uyuni": {
         "BASECHANNEL": "almalinux8-aarch64",
         "PKGLIST": RES8,

--- a/susemanager/susemanager.changes.ebischoff.alma-8-ppc64le
+++ b/susemanager/susemanager.changes.ebischoff.alma-8-ppc64le
@@ -1,0 +1,1 @@
+- Add AlmaLinux 8 ppc64le bootstrap data

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3261,7 +3261,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/
 
 [almalinux8]
-archs    = x86_64, aarch64
+archs    = x86_64, ppc64le, aarch64
 checksum = sha256
 name     = AlmaLinux 8 (%(arch)s)
 gpgkey_url = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
@@ -3272,7 +3272,7 @@ dist_map_release = 8
 
 [almalinux8-appstream]
 label    = %(base_channel)s-appstream
-archs    = x86_64, aarch64
+archs    = x86_64, ppc64le, aarch64
 checksum = sha256
 name     = AlmaLinux 8 AppStream (%(arch)s)
 base_channels = almalinux8-%(arch)s
@@ -3280,7 +3280,7 @@ repo_url = https://mirrors.almalinux.org/mirrorlist/8/appstream
 
 [almalinux8-extras]
 label    = %(base_channel)s-extras
-archs    = x86_64, aarch64
+archs    = x86_64, ppc64le, aarch64
 checksum = sha256
 name     = AlmaLinux 8 Extras (%(arch)s)
 base_channels = almalinux8-%(arch)s
@@ -3288,7 +3288,7 @@ repo_url = https://mirrors.almalinux.org/mirrorlist/8/extras
 
 [almalinux8-powertools]
 label    = %(base_channel)s-powertools
-archs    = x86_64, aarch64
+archs    = x86_64, ppc64le, aarch64
 checksum = sha256
 name     = AlmaLinux 8 PowerTools (%(arch)s)
 base_channels = almalinux8-%(arch)s
@@ -3296,7 +3296,7 @@ repo_url = https://mirrors.almalinux.org/mirrorlist/8/powertools
 
 [almalinux8-ha]
 label    = %(base_channel)s-ha
-archs    = x86_64, aarch64
+archs    = x86_64, ppc64le, aarch64
 checksum = sha256
 name     = AlmaLinux 8 High Availability (%(arch)s)
 base_channels = almalinux8-%(arch)s
@@ -3304,7 +3304,7 @@ repo_url = https://mirrors.almalinux.org/mirrorlist/8/ha
 
 [almalinux8-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
-archs    = %(_x86_archs)s, aarch64
+archs    = %(_x86_archs)s, ppc64le, aarch64
 checksum = sha256
 base_channels = almalinux8-%(arch)s
 gpgkey_url = %(_uyuni_gpgkey_url)s
@@ -3314,7 +3314,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 
 [almalinux8-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = %(_x86_archs)s, aarch64
+archs    = %(_x86_archs)s, ppc64le, aarch64
 checksum = sha256
 base_channels = almalinux8-%(arch)s
 gpgkey_url = %(_uyuni_gpgkey_url)s

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3632,7 +3632,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 [rockylinux8-epel8]
 label    = epel8-%(base_channel)s
 name     = EPEL 8 for %(base_channel_name)s
-archs    = x86_64, ppc64le, aarch64
+archs    = x86_64, aarch64
 checksum = sha256
 base_channels = rockylinux8-%(arch)s
 gpgkey_url = http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8

--- a/utils/spacewalk-utils.changes.ebischoff.alma-8-ppc64le
+++ b/utils/spacewalk-utils.changes.ebischoff.alma-8-ppc64le
@@ -1,0 +1,1 @@
+- Add AlmaLinux 8 ppc64le repositories

--- a/utils/spacewalk-utils.changes.ebischoff.rocky8-epel8-ppc64le
+++ b/utils/spacewalk-utils.changes.ebischoff.rocky8-epel8-ppc64le
@@ -1,0 +1,2 @@
+- Drop ppc64le from the Rocky Linux 8 EPEL channel, as Rocky
+  Linux 8 has no ppc64le build upstream


### PR DESCRIPTION
## What does this PR change?

Add AlmaLinux 8 ppc64le.

Piggyback: Drop ppc64le from the Rocky Linux 8 EPEL channel,
as Rocky Linux 8 has no ppc64le build upstream.


## End-User Impact & Release Notes

Release notes details that might need to be added:

`Added ppc64le support for AlmaLinux 8`

Ping @uyuni-project/release-engineering .


- [x] **DONE**


## GUI diff

No difference.

- [x] **DONE**


## Documentation

* https://github.com/uyuni-project/uyuni-docs/pull/5220

- [x] **DONE**


## Test coverage

Tested manually as part of https://github.com/SUSE/spacewalk/issues/31045 (no automation).

- [x] **DONE**


## Links

Issue(s): #11864
Spin-off issue: #12503

- [x] **DONE**


## Changelogs

* `utils/spacewalk-utils.changes.ebischoff.alma-8-ppc64le`
* `susemanager/susemanager.changes.ebischoff.alma-8-ppc64le`

- [ ] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
