### PR TITLE
Drop the unmirrored Tumbleweed repositories on the sle_minion container

### DIFF
--- a/testsuite/podman_runner/12_run_salt_sle_minion.sh
+++ b/testsuite/podman_runner/12_run_salt_sle_minion.sh
@@ -22,3 +22,6 @@ $PODMAN_CMD exec -d sle_minion bash -c "exporter_exporter -config.file /etc/expo
 
 $PODMAN_CMD exec sle_minion bash -c "sed -e 's/http:\/\/download.opensuse.org/http:\/\/server\/pub\/mirror\/download.opensuse.org/g' -i /etc/zypp/repos.d/*"
 $PODMAN_CMD exec sle_minion bash -c "sed -e 's/https:\/\/download.opensuse.org/http:\/\/server\/pub\/mirror\/download.opensuse.org/g' -i /etc/zypp/repos.d/*"
+
+$PODMAN_CMD exec sle_minion bash -c "zypper --non-interactive modifyrepo --disable repo-non-oss repo-update Uyuni-Server-POOL-x86_64"
+$PODMAN_CMD exec sle_minion bash -c "zypper --non-interactive modifyrepo --no-gpgcheck repo-oss"


### PR DESCRIPTION
## What does this PR change?

Disables the openSUSE Tumbleweed repositories that are not mirrored on the server, and turns off the GPG check on the one that is, on the `sle_minion` container.

The script rewrites every `download.opensuse.org` URL on the minion to the server's mirror, but that mirror only carries a small unsigned subset of `tumbleweed/repo/oss`, and `repo-non-oss`, `repo-update` and `Uyuni-Server-POOL-x86_64` are not there at all. Every `zypper refresh` then fails, which aborts the Salt onboarding run before it writes `/etc/zypp/repos.d/susemanager:channels.repo` — the minion has its channels assigned on the server but no channel repository locally.

`test_repo_rpm_pool` and `tools_pool_repo` are mirrored and refresh cleanly, so they stay enabled.

```
Repository 'openSUSE-Tumbleweed-Update' is invalid.
 - [repo-update|http://server/pub/mirror/download.opensuse.org/update/tumbleweed/] Repository type can't be determined.
Repository 'openSUSE-Tumbleweed-Oss' is invalid.
 - Signature verification failed for repomd.xml
```

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): No issue — direct fix for the GitHub validation tests
Port(s): None needed — the GitHub validation tests only run on master

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
