### PR TITLE
Allow contributor copyright notices in RuboCop

### DIFF
--- a/testsuite/.rubocop.yml
+++ b/testsuite/.rubocop.yml
@@ -140,7 +140,7 @@ Style/Copyright:
   AutocorrectNotice: |
     # Copyright (c) 2024 SUSE LLC.
     # Licensed under the terms of the MIT license.
-  Notice: '.*Copyright.*SUSE LLC.*'
+  Notice: '.*Copyright.*'
 
 Style/DisableCopsWithinSourceCodeDirective:
   Enabled: false


### PR DESCRIPTION
## What does this PR change?

Broadens the testsuite RuboCop copyright rule to accept notices from any copyright holder instead of requiring `SUSE LLC`.

The copyright cop remains enabled and the existing SUSE autocorrect template is unchanged. This allows contributor-owned files to keep accurate attribution and unblocks the RuboCop checks on #12077 and #12341.

## End-User Impact & Release Notes

No end-user impact. This only changes testsuite lint configuration.

- [x] **DONE**

## Codespace

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user-invisible lint configuration changes.

- [x] **DONE**

## Test coverage

- RuboCop 1.82.1 passes on all testsuite Ruby files scanned by the workflow.
- A contributor-owned copyright notice passes.
- A Ruby file without a copyright notice is still rejected by `Style/Copyright`.

- [x] **DONE**

## Links

Issue(s): none
Related PRs: #12077, #12341
Port(s): none

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
