### PR TITLE
Remove /var/lib/spacewalk/gpgdir from spacewalk-java

### DIFF
--- a/java/spacewalk-java.changes.mfriedrich.remove-gpgdir-from-spec
+++ b/java/spacewalk-java.changes.mfriedrich.remove-gpgdir-from-spec
@@ -1,0 +1,1 @@
+- Remove /var/lib/spacewalk/gpgdir from spacewalk-java

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -515,7 +515,6 @@ install -d -m 755 %{buildroot}%{cobprofdir}
 install -d -m 755 %{buildroot}%{cobprofdirup}
 install -d -m 755 %{buildroot}%{cobprofdirwiz}
 install -d -m 755 %{buildroot}%{cobdirsnippets}
-install -d -m 700 %{buildroot}%{_localstatedir}/lib/spacewalk/gpgdir
 install -d -m 755 %{buildroot}%{_localstatedir}/lib/spacewalk/scc
 install -d -m 755 %{buildroot}%{_localstatedir}/lib/spacewalk/subscription-matcher
 
@@ -742,7 +741,6 @@ fi
 %endif
 %attr(755,root,root) %dir %{cobblerdir}
 
-%attr(700, tomcat, susemanager) %dir %{_localstatedir}/lib/spacewalk/gpgdir
 %attr(755, tomcat, root) %dir %{_localstatedir}/lib/spacewalk/scc
 %attr(755, tomcat, root) %dir %{_localstatedir}/lib/spacewalk/subscription-matcher
 %dir %{serverdir}/tomcat/webapps/rhn/WEB-INF


### PR DESCRIPTION
## What does this PR change?

This was mistakenly added to `spacewalk-java`, but the directory is already owned by `{susemanager,uyuni}-build-keys` packages.

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
