### PR TITLE
Retry API calls that fail with a transport-level error

### DIFF
--- a/testsuite/features/support/api_retry.rb
+++ b/testsuite/features/support/api_retry.rb
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 SUSE LLC.
+# Licensed under the terms of the MIT license.
+
+require 'faraday'
+require 'net/protocol'
+require 'openssl'
+
+# Retry policy shared by the XML-RPC and the HTTP API clients.
+#
+# Both clients only translate the application-level faults the server returns. A
+# transport-level failure - a connection reset during the TLS handshake, a truncated
+# response, a timeout - propagates to the caller instead, and aborts the scenario even
+# when the next attempt would have succeeded. Parallel workers opening their first
+# connection at the same moment hit this regularly.
+module ApiRetry
+  # Number of attempts, the first one included.
+  MAX_ATTEMPTS = 3
+  private_constant :MAX_ATTEMPTS
+
+  # Delay in seconds before a retry, multiplied by the number of the attempt that failed.
+  RETRY_DELAY = 2
+  private_constant :RETRY_DELAY
+
+  # Errors raised before the request reached the server. The call had no effect, so any
+  # call can be retried.
+  UNSENT_REQUEST_ERRORS = [Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Net::OpenTimeout].freeze
+  private_constant :UNSENT_REQUEST_ERRORS
+
+  # Errors that can also be raised once the request is on the wire. The server may have
+  # processed it already, so only calls that can be repeated are retried. Faraday raises
+  # its own errors for both cases, and carries the original one to tell them apart.
+  UNKNOWN_OUTCOME_ERRORS = [
+    Errno::ECONNRESET,
+    EOFError,
+    Net::ReadTimeout,
+    OpenSSL::SSL::SSLError,
+    Faraday::ConnectionFailed,
+    Faraday::SSLError,
+    Faraday::TimeoutError
+  ].freeze
+  private_constant :UNKNOWN_OUTCOME_ERRORS
+
+  # Every error a retry is considered for.
+  TRANSPORT_ERRORS = (UNSENT_REQUEST_ERRORS + UNKNOWN_OUTCOME_ERRORS).freeze
+  private_constant :TRANSPORT_ERRORS
+
+  module_function
+
+  # Returns whether an API call has no side effect on the server.
+  # This is also what tells apart a GET from a POST in the HTTP client.
+  #
+  # @param name [String] The name of the API call.
+  # @return [Boolean] Whether the call is read-only or not.
+  def read_only?(name)
+    short_name = name.split('.').last
+    short_name.start_with?('list', 'get', 'is', 'find') ||
+      name.start_with?('system.search.', 'packages.search.') ||
+      %w[auth.logout errata.applicableToChannels].include?(name)
+  end
+
+  # Returns whether an API call can be sent a second time without changing the outcome.
+  # Read-only calls qualify, and so does auth.login: an extra session is harmless, and
+  # the caller closes the session it ends up with anyway.
+  #
+  # @param name [String] The name of the API call.
+  # @return [Boolean] Whether the call can be repeated or not.
+  def repeatable?(name)
+    read_only?(name) || name == 'auth.login'
+  end
+
+  # Returns whether an error was raised before the request reached the server.
+  # Faraday wraps the error the adapter raised rather than letting it through, so the
+  # original one is what the answer depends on.
+  #
+  # @param error [StandardError] The error the call failed with.
+  # @return [Boolean] Whether the request is known not to have been sent or not.
+  def unsent_request?(error)
+    cause = error.is_a?(Faraday::Error) ? error.wrapped_exception || error : error
+    UNSENT_REQUEST_ERRORS.any? { |klass| cause.is_a?(klass) }
+  end
+
+  # Runs the given block, and retries it when it fails with a transport-level error.
+  # A call that is not repeatable is only retried while the request is known not to have
+  # reached the server, so that it can never be applied twice.
+  #
+  # @param name [String] The name of the API call, used to tell what is safe to retry.
+  # @return [Object] The value returned by the block.
+  def with_retries(name)
+    attempt = 1
+    begin
+      yield
+    rescue *TRANSPORT_ERRORS => e
+      raise if attempt >= MAX_ATTEMPTS
+      raise unless repeatable?(name) || unsent_request?(e)
+
+      delay = attempt * RETRY_DELAY
+      attempt += 1
+      warn "API call '#{name}' failed with #{e.class}: #{e.message}. Retrying in #{delay} seconds (attempt #{attempt}/#{MAX_ATTEMPTS})."
+      sleep delay
+      retry
+    end
+  end
+end

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -2,6 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 require 'faraday'
+require_relative 'api_retry'
 
 # When we pass a list of values in the query string of an HTTP request, the defaul encoder will only update the key for that param
 # As an example: sids=1000010027&sids=1000010010&sids=1000010012 maps to params={"sids"=>"1000010012"}
@@ -26,14 +27,7 @@ class HttpClient
   # @param params [Hash] The parameters for the call.
   # @return [Array] An array containing the call type and the URL.
   def prepare_call(name, params)
-    short_name = name.split('.')[-1]
-    call_type =
-      if short_name.start_with?('list', 'get', 'is', 'find') || name.start_with?('system.search.', 'packages.search.') || %w[auth.logout errata.applicableToChannels].include?(name)
-
-        'GET'
-      else
-        'POST'
-      end
+    call_type = ApiRetry.read_only?(name) ? 'GET' : 'POST'
     url = "/rhn/manager/api/#{name.tr('.', '/')}"
     if call_type == 'GET'
       url += '?'
@@ -75,16 +69,18 @@ class HttpClient
     # Call API
     call_type, url = prepare_call(name, params)
     answer =
-      if call_type == 'GET'
-        @http_client.get(url) do |request|
-          request.headers['Content-Type'] = 'application/json'
-          request.headers['Cookie'] = session_cookie unless session_cookie.nil?
-        end
-      else
-        @http_client.post(url) do |request|
-          request.headers['Content-Type'] = 'application/json'
-          request.headers['Cookie'] = session_cookie unless session_cookie.nil?
-          request.body = params.to_json unless params.nil?
+      ApiRetry.with_retries(name) do
+        if call_type == 'GET'
+          @http_client.get(url) do |request|
+            request.headers['Content-Type'] = 'application/json'
+            request.headers['Cookie'] = session_cookie unless session_cookie.nil?
+          end
+        else
+          @http_client.post(url) do |request|
+            request.headers['Content-Type'] = 'application/json'
+            request.headers['Cookie'] = session_cookie unless session_cookie.nil?
+            request.body = params.to_json unless params.nil?
+          end
         end
       end
     unless answer.status == 200

--- a/testsuite/features/support/xmlrpc_client.rb
+++ b/testsuite/features/support/xmlrpc_client.rb
@@ -2,6 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 require 'xmlrpc/client'
+require_relative 'api_retry'
 
 # Represents an XMLRPC client object that is used to communicate with the Spacewalk server.
 class XmlrpcClient
@@ -23,7 +24,7 @@ class XmlrpcClient
   # @raise [SystemCallError] If there is an API failure.
   def call(name, params)
     begin
-      @xmlrpc_client.call(name, *params.values)
+      ApiRetry.with_retries(name) { @xmlrpc_client.call(name, *params.values) }
     rescue XMLRPC::FaultException => e
       raise SystemCallError, "API failure: #{e.message}"
     end


### PR DESCRIPTION
## What does this PR change?

Retries an API call when it fails with a transport-level error, for both the XML-RPC and the HTTP client.

Both clients only translated the application-level faults the server returns, so a connection reset, a truncated response or a timeout propagated to the caller and aborted the scenario even when the next attempt would have succeeded. They now share one retry policy, which splits the transport errors by whether the request can already have been applied: errors raised before the request reached the server are always retried, while the ones that can also be raised once it is on the wire are only retried for calls that can be repeated. Three attempts, backing off two then four seconds.

Faraday reports both kinds through errors of its own rather than letting the adapter's through, so the split goes by the exception it carries: a `Faraday::ConnectionFailed` wrapping `Errno::ECONNREFUSED` is retried for any call, one wrapping `Errno::ECONNRESET` only for a repeatable one.

Each retry prints why it happened:

```
API call 'auth.login' failed with OpenSSL::SSL::SSLError: SSL_read: unexpected eof while reading. Retrying in 2 seconds (attempt 2/3).
```

## End-User Impact & Release Notes

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s):
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31837
Manager-5.1: https://github.com/SUSE/spacewalk/pull/31838

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
