### PR TITLE
Only restart Apache once when the cobbler configuration changes

### DIFF
--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -1,6 +1,7 @@
 # Copyright (c) 2010-2023 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
+require 'digest'
 require 'xmlrpc/client'
 require 'pp'
 
@@ -40,12 +41,7 @@ class CobblerTest
     # expose cobbler api to public
     source = "#{File.dirname(__FILE__)}/../upload_files/zz-cobblerapi.conf"
     dest = '/etc/apache2/conf.d/zz-cobblerapi.conf'
-    success = file_inject(node, source, dest)
-    raise(ScriptError, 'Apache config injection failed') unless success
-
-    # restart apache to reload the configuration
-    output, retcode = node.run('systemctl restart apache2')
-    raise(SystemCallError, "Failed to restart apache2 (rc=#{retcode}): #{output}") unless retcode.zero?
+    expose_cobbler_api(node, source, dest)
 
     # check running and connection
     server_address = node.full_hostname
@@ -409,5 +405,54 @@ class CobblerTest
       raise(::StandardError, "Distribution with name #{name} not found. #{$ERROR_INFO}")
     end
     system
+  end
+
+  private
+
+  # Path of the lock that serializes the parallel workers while they expose the cobbler API.
+  # It lives in the run directory of the test suite, like the other locks, rather than in a
+  # world writable one.
+  APACHE_CONFIG_LOCK = 'cobbler_apache_config.lock'.freeze
+  private_constant :APACHE_CONFIG_LOCK
+
+  # Puts the cobbler API configuration on the node and restarts Apache, unless it is already
+  # there.
+  #
+  # Apache belongs to the whole environment rather than to this worker, and restarting it
+  # drops the connections every other parallel worker has in flight, so it must happen at
+  # most once. Every worker runs this, so the check and the injection are done under a lock
+  # held on the controller: the first worker in does the work, and the ones that follow
+  # re-check inside the lock and find nothing left to do.
+  #
+  # @param node [Node] The node to configure.
+  # @param source [String] The path of the local configuration file.
+  # @param dest [String] The path the configuration takes on the node.
+  # @raise [ScriptError] If the injection of the configuration fails.
+  # @raise [SystemCallError] If Apache fails to restart.
+  def expose_cobbler_api(node, source, dest)
+    File.open(APACHE_CONFIG_LOCK, File::CREAT | File::RDWR | File::NOFOLLOW, 0o600) do |lock|
+      lock.flock(File::LOCK_EX)
+      unless same_file?(node, source, dest)
+        success = file_inject(node, source, dest)
+        raise(ScriptError, 'Apache config injection failed') unless success
+
+        # restart apache to reload the configuration
+        output, retcode = node.run('systemctl restart apache2')
+        raise(SystemCallError, "Failed to restart apache2 (rc=#{retcode}): #{output}") unless retcode.zero?
+      end
+    end
+  end
+
+  # Returns whether the node already holds a copy of a local file, byte for byte.
+  #
+  # @param node [Node] The node to look at.
+  # @param local_file [String] The path of the local file.
+  # @param remote_file [String] The path of the file on the node.
+  # @return [Boolean] Whether the two files have the same content or not.
+  def same_file?(node, local_file, remote_file)
+    output, retcode = node.run("sha256sum #{remote_file}", check_errors: false)
+    return false unless retcode.zero?
+
+    output.to_s.split.first == Digest::SHA256.file(local_file).hexdigest
   end
 end


### PR DESCRIPTION
## What does this PR change?

Only injects the cobbler API configuration and restarts Apache when the file on the server does not already match the one we would write.

`CobblerTest#initialize` is run by every parallel worker, and each of them did the injection and the restart unconditionally. Apache is `PartOf` `spacewalk.target`, so every restart took the whole stack down with it and killed the requests the other workers had in flight, failing their scenarios with a connection reset or a truncated response. On a five-worker run this showed up as five `mgrctl cp` and five `systemctl restart apache2` within two seconds, collapsed by systemd into three full stop/start cycles of the target.

The workers all start at once, so on a fresh environment they would all find the file missing and all restart anyway. The check and the injection therefore run under an exclusive lock held on the controller, and the check is repeated inside it: the first worker in does the work, and the ones that follow find nothing left to do.

## End-User Impact & Release Notes

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s):
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31839

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
