### PR TITLE
Report the endpoint and body when an API call fails with a non-JSON response

### DIFF
--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -11,6 +11,10 @@ Faraday::Utils.default_params_encoder = Faraday::FlatParamsEncoder
 
 # Wrapper class for HTTP client library (Faraday)
 class HttpClient
+  # Number of characters of a non-JSON response body kept in the error message.
+  MAX_ERROR_BODY_LENGTH = 200
+  private_constant :MAX_ERROR_BODY_LENGTH
+
   # Creates a new HTTP client using the Faraday library.
   #
   # @param host [String] The host to connect to.
@@ -84,10 +88,9 @@ class HttpClient
         end
       end
     unless answer.status == 200
-      raise ScriptError, "Unexpected HTTP status code #{answer.status}" if answer.body.empty?
+      raise ScriptError, "Unexpected HTTP status code #{answer.status} for #{call_type} #{url}" if answer.body.empty?
 
-      json_body = JSON.parse(answer.body)
-      raise ScriptError, "Unexpected HTTP status code #{answer.status}, message: #{json_body['message']}"
+      raise ScriptError, "Unexpected HTTP status code #{answer.status} for #{call_type} #{url}, message: #{error_message(answer.body)}"
     end
 
     # Return either new session cookie or HTTP body
@@ -107,5 +110,19 @@ class HttpClient
 
       json_body['result']
     end
+  end
+
+  private
+
+  # Extracts the failure message from a response body, falling back to a summary of the
+  # body itself when it is not the JSON the API contract promises.
+  #
+  # @param body [String] The body of the HTTP response.
+  # @return [String] The message describing the failure.
+  def error_message(body)
+    JSON.parse(body)['message']
+  rescue JSON::ParserError
+    summary = body.scrub.gsub(/\s+/, ' ').strip
+    summary.length > MAX_ERROR_BODY_LENGTH ? "#{summary[0, MAX_ERROR_BODY_LENGTH]}..." : summary
   end
 end


### PR DESCRIPTION
## What does this PR change?

Reports the method, the URL and the body of the response when an API call fails with something other than JSON.

The failure branch of the HTTP API client parsed every error body as JSON to pull the message out of it. An endpoint the server does not know about answers with an HTML error page instead, so the parse raised before the intended `ScriptError` could, and the scenario failed with a parse error pointing at the client rather than at the call. The body is now summarized as it is when it does not parse, and both messages name the method and the URL.

Before:

```
unexpected character: '<!DOCTYPE' at line 17 column 1 (JSON::ParserError)
./features/support/http_client.rb:93:in 'HttpClient#call'
```

After:

```
Unexpected HTTP status code 404 for GET /rhn/manager/api/admin/gpg/listGpgKeys, message: <!DOCTYPE html> <html> <head> <title>HTTP Status 404 – Not Found</title> </head> ... (ScriptError)
```

## End-User Impact & Release Notes

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s):
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31840
Manager-5.1: https://github.com/SUSE/spacewalk/pull/31841

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
