### PR TITLE
Fail the tests when a partial reposync leaves a channel empty

### DIFF
--- a/testsuite/features/build_validation/add_non_MU_repositories/ubuntu2404_minion_add_noble_universe_and_main.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/ubuntu2404_minion_add_noble_universe_and_main.feature
@@ -54,6 +54,7 @@ Feature: Ubuntu 24.04: Universe and Main Noble Repositories Integration
   Scenario: Perform partial sync of python3-rpm and its dependencies into the Noble channel
     And I use spacewalk-repo-sync to sync channel "ubuntu-2404-noble-amd64" including "python3-rpm librpm9t64 librpmbuild9t64 librpmio9t64 librpmsign9t64 rpm-common liblua5.3-0 libfsverity0" packages
     When I wait until the channel "ubuntu-2404-noble-amd64" has been synced
+    Then the channel "ubuntu-2404-noble-amd64" should not be empty
 
   Scenario: Verify that all synchronized channels have their dependencies solved
     When I wait until all synchronized channels have solved their dependencies

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -80,7 +80,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I use spacewalk-common-channel to add channel "opensuse_tumbleweed" with arch "x86_64"
     And I kill running spacewalk-repo-sync for "opensuse_tumbleweed-x86_64" channel
     And I use spacewalk-repo-sync to sync channel "opensuse_tumbleweed-x86_64" including only client tools dependencies
-    And I use spacewalk-common-channel to add all "tumbleweed-client-tools-x86_64" channels with arch "x86_64"
+    Then the channel "opensuse_tumbleweed-x86_64" should not be empty
+    When I use spacewalk-common-channel to add all "tumbleweed-client-tools-x86_64" channels with arch "x86_64"
     When I wait until all synchronized channels for "tumbleweed" have finished
 
 @containerized_server

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -137,6 +137,16 @@ Then(/^The amount of packages in channel "([^"]*)" should be the same as before$
   end
 end
 
+Then(/^the channel "([^"]*)" should not be empty$/) do |channel_label|
+  channels = $api_test.channel.list_all_channels
+  raise ScriptError, "Channel #{channel_label} does not exist" unless channels.key?(channel_label)
+
+  packages = channels[channel_label]['packages'].to_i
+  raise ScriptError, "Channel #{channel_label} is empty, its synchronization stored no package" if packages.zero?
+
+  log "Channel #{channel_label} contains #{packages} packages"
+end
+
 Then(/^The amount of packages in channel "([^"]*)" should be fewer than before$/) do |channel_label|
   add_context('channels', $api_test.channel.list_all_channels)
   if get_context('channels').key?(channel_label) && get_context('channels')[channel_label]['packages'] >= $package_amount
@@ -192,14 +202,11 @@ When(/^I use spacewalk-repo-sync to sync channel "([^"]*)"$/) do |channel|
 end
 
 When(/^I use spacewalk-repo-sync to sync channel "([^"]*)" including "([^"]*)" packages?$/) do |channel, packages|
-  append_includes = packages.split.map { |pkg| "--include #{pkg}" }.join(' ')
-  $command_output, _code = get_target('server').run("spacewalk-repo-sync -c #{channel} #{append_includes}", check_errors: false, verbose: true)
+  $command_output = sync_channel_including_packages(channel, packages.split)
 end
 
 When(/^I use spacewalk-repo-sync to sync channel "([^"]*)" including only client tools dependencies$/) do |channel|
-  packages = CLIENT_TOOLS_DEPENDENCIES_BY_BASE_CHANNEL[channel]
-  append_includes = packages.map { |pkg| "--include #{pkg}" }.join(' ')
-  $command_output, _code = get_target('server').run("spacewalk-repo-sync -c #{channel} #{append_includes}", check_errors: false, verbose: true)
+  $command_output = sync_channel_including_packages(channel, CLIENT_TOOLS_DEPENDENCIES_BY_BASE_CHANNEL[channel])
 end
 
 Then(/^I should get "([^"]*)"$/) do |value|

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -399,36 +399,150 @@ def generate_repository_name(repo_url)
   repo_name[0...64] # HACK: Due to the 64 characters size limit of a repository label
 end
 
+# Get the channel a spacewalk-repo-sync process is synchronizing
+#
+# @param process [String] A line of the output of "ps axo pid,cmd"
+# @return [String, nil] The label of the channel, or nil if the line synchronizes no channel
+def reposync_channel(process)
+  process[/\s(?:--channel|-c)[ =](\S+)/, 1]
+end
+
 # Kill spacewalk-repo-sync execution for a given channel
 #
 # @param channel [String] The channel label of the channel to kill reposync execution
 def kill_reposync_for_channel(channel)
   time_spent = 0
   checking_rate = 5
+  node = get_target('server')
+  killed_pid = nil
   repeat_until_timeout(timeout: 60, message: 'Some reposync processes were not killed properly', dont_raise: true) do
-    command_output, _code = get_target('server').run('ps axo pid,cmd | grep spacewalk-repo-sync | grep -v grep', verbose: true, check_errors: false)
-    process = command_output.split("\n")[0]
-    channel_synchronizing = process.split[5].strip
+    command_output, _code = node.run('ps axo pid,cmd | grep spacewalk-repo-sync | grep -v grep', verbose: true, check_errors: false)
+    processes = command_output.split("\n").reject { |line| line.strip.empty? }
+    process = processes.find { |line| reposync_channel(line) == channel }
     if process.nil?
+      other_channels = processes.map { |line| reposync_channel(line) }.compact
+      log "Warning: Repo-sync processes running for the channels #{other_channels.join(', ')}." unless other_channels.empty?
       log "#{time_spent / 60} minutes waiting for '#{channel}' channel to start its repo-sync processes." if ((time_spent += checking_rate) % 60).zero?
       sleep checking_rate
       next
-    elsif channel_synchronizing == channel
-      pid = process.split[0]
-      node = get_target('server')
-      node.run("kill #{pid}", verbose: true, check_errors: false)
-      # Even if spacewalk-repo-sync is killed, it is possible that zypper
-      # is still running for some moments while refreshing metadata.
-      # If there is another execution of spacewalk-repo-sync again while
-      # zypper is still running, then the reposync will fail.
-      # We need to wait until zypper is finished
-      node.wait_while_process_running('zypper')
-      log "Reposync of channel #{channel} killed"
-      break
-    else
-      log "Warning: Repo-sync process for channel '#{channel_synchronizing}' running."
     end
+
+    killed_pid = process.split[0]
+    node.run("kill #{killed_pid}", verbose: true, check_errors: false)
+    break
   end
+  return if killed_pid.nil?
+
+  # The wait is done outside of the loop above on purpose: that loop swallows any error,
+  # while a zypp lock that is never released has to fail the scenario
+  wait_for_reposync_termination(node, killed_pid)
+  log "Reposync of channel #{channel} killed"
+end
+
+# Wait until a killed spacewalk-repo-sync and the zypper it spawned are really gone
+#
+# Killing spacewalk-repo-sync only signals the Python process: the zypper it spawned to
+# refresh the metadata keeps running for some moments and keeps the zypp lock. A new
+# spacewalk-repo-sync started while that lock is held dies immediately with
+# "RepoMDError: Cannot access repository", which leaves the channel empty.
+#
+# @param node [RemoteNode] The server node
+# @param pid [String] The PID of the spacewalk-repo-sync process that was killed
+def wait_for_reposync_termination(node, pid)
+  repeat_until_timeout(timeout: 120, message: "The spacewalk-repo-sync process #{pid} is still running after being killed") do
+    _output, code = node.run("kill -0 #{pid}", check_errors: false)
+    break if code.nonzero?
+
+    sleep 2
+  end
+  wait_for_zypp_lock_release(node)
+end
+
+# Wait until no zypper is running on a node and the zypp lock is free
+#
+# The zypper spawned by a reposync can still be starting up when we look, so the node has
+# to come back idle several times in a row before we conclude the lock is free.
+#
+# @param node [RemoteNode] The node to check
+def wait_for_zypp_lock_release(node)
+  settled_checks = 0
+  repeat_until_timeout(timeout: 300, message: 'The zypp lock is still held, a new reposync would fail immediately') do
+    settled_checks = zypp_locked?(node) ? 0 : settled_checks + 1
+    break if settled_checks >= 3
+
+    sleep 2
+  end
+end
+
+# Check whether zypper is running on a node, or the zypp lock is held by a process still alive
+#
+# The reposync uses its own zypper root, so its lock file is not the system one.
+#
+# @param node [RemoteNode] The node to check
+# @return [Boolean] Whether the zypp lock is taken
+def zypp_locked?(node)
+  _output, code = node.run('pgrep -x zypper > /dev/null', check_errors: false)
+  return true if code.zero?
+
+  ZYPP_LOCK_FILES.any? { |lock_file| zypp_lock_file_held?(node, lock_file) }
+end
+
+# Check whether a zypp lock file holds the PID of a process that is still alive
+#
+# A lock file left behind holds a PID that is already gone, and its first line is not
+# necessarily a PID at all, so its content is validated before being used. Zero is rejected
+# along with the rest: "kill -0 0" signals our own process group and would always succeed.
+#
+# @param node [RemoteNode] The node to check
+# @param lock_file [String] The path of the zypp lock file
+# @return [Boolean] Whether the lock file is held
+def zypp_lock_file_held?(node, lock_file)
+  content, code = node.run("head -n 1 #{lock_file}", check_errors: false)
+  pid = content.to_s.strip
+  return false unless code.zero? && pid.match?(/\A[1-9]\d*\z/)
+
+  _output, alive = node.run("kill -0 #{pid}", check_errors: false)
+  alive.zero?
+end
+
+# Check whether a failed synchronization was blocked by the zypp lock
+#
+# The lock is the reason to retry, so the lock state is what decides. The output is only
+# looked at as well to cover the window where the lock is released between the failure and
+# the check.
+#
+# @param node [RemoteNode] The node the synchronization ran on
+# @param output [String] The output of the failed synchronization
+# @return [Boolean] Whether the synchronization is worth retrying
+def blocked_by_zypp_lock?(node, output)
+  zypp_locked?(node) || ZYPP_LOCK_FAILURE_MARKERS.any? { |marker| output.to_s.include?(marker) }
+end
+
+# Synchronize a channel with spacewalk-repo-sync, restricted to a list of packages
+#
+# A synchronization blocked by the zypp lock fails in no time, so it is worth retrying.
+# Any other failure is raised: a channel that stays empty makes every scenario using its
+# packages fail much later, with a symptom that says nothing about the synchronization.
+#
+# @param channel [String] The label of the channel to synchronize
+# @param packages [Array<String>] The packages to include in the synchronization
+# @return [String] The output of the synchronization
+def sync_channel_including_packages(channel, packages)
+  raise ScriptError, "No package to include in the synchronization of channel #{channel}" if packages.nil? || packages.empty?
+
+  node = get_target('server')
+  append_includes = packages.map { |pkg| "--include #{pkg}" }.join(' ')
+  output = nil
+  3.times do |attempt|
+    output, code = node.run("spacewalk-repo-sync -c #{channel} #{append_includes}", check_errors: false, verbose: true)
+    return output if code.zero?
+
+    raise ScriptError, "Synchronization of channel #{channel} failed:\n#{output}" unless blocked_by_zypp_lock?(node, output)
+
+    log "Attempt #{attempt + 1} to synchronize #{channel} found the zypp lock held, waiting for it to be released"
+    wait_for_zypp_lock_release(node)
+  end
+  raise ScriptError, "Synchronization of channel #{channel} lost the race for the zypp lock on every attempt:\n#{output}"
 end
 
 # Update the URL for a given repository
@@ -834,6 +948,10 @@ def channel_packages_are_downloaded?(channel_name)
       log "DEBUG: Found a different channel header before completion for #{channel_name} at line #{i + 1}."
       break
     end
+
+    # spacewalk-repo-sync logs the completion message whatever the outcome of the
+    # synchronization, so an error here still counts as completed
+    log "WARN: Error while synchronizing #{channel_name} at line #{i + 1}: #{line.strip}" if line.include?('ERROR') || line.include?('RepoMDError')
 
     next unless line.include?('Sync of channel completed.')
 

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -1562,6 +1562,21 @@ CLIENT_TOOLS_DEPENDENCIES_BY_BASE_CHANNEL = {
   ]
 }.freeze
 
+# Lock files of the zypp instances a reposync can be blocked by:
+# the one of its own zypper root, and the system one
+ZYPP_LOCK_FILES = %w[
+  /var/lib/spacewalk/reposync/root/run/zypp.pid
+  /var/lib/spacewalk/reposync/root/var/run/zypp.pid
+  /run/zypp.pid
+].freeze
+
+# Errors of a reposync that lost the race for the zypp lock. Only what zypper says about
+# the lock itself belongs here: a metadata error like RepoMDError is just as often a
+# repository that is really broken, and retrying it hides the actual reason
+ZYPP_LOCK_FAILURE_MARKERS = [
+  'System management is locked'
+].freeze
+
 # The timeouts are determining experimentally, by looking at the files in /var/log/rhn/reposync on the server
 # Formula: (end date - startup date) * 2, rounded to upper 60 seconds
 # Please keep this list sorted alphabetically


### PR DESCRIPTION
## What does this PR change?

Fails the reposync scenarios when a partial synchronization leaves a channel empty, instead of running the rest of the suite against a channel with no packages in it.

Killing a running `spacewalk-repo-sync` only signals the Python process: the zypper it spawned to refresh the metadata keeps the zypp lock for a few moments, and the filtered synchronization started right after dies immediately with `RepoMDError: Cannot access repository`. Nothing checked its exit code, so the channel silently stayed empty. `kill_reposync_for_channel` now waits for the killed PID to be gone and then for the zypp lock of the reposync zypper root to be free three checks in a row, instead of looking once for a running zypper, and it no longer crashes when no reposync is running. The include-only synchronization retries while the lock is held and raises on any other failure, and a new step asserts the channel is not empty afterwards.

The lock is considered held when a zypper is running, or when one of the zypp lock files holds a PID that is still alive. Only the first line of the lock file is read and it is checked to be a plain PID before it is used, so a lock file holding something else is not mistaken for a released lock. A failed synchronization is retried when that lock state says so, with the `System management is locked` wording as a fallback for the window where the lock is released between the failure and the check. Only what zypper says about the lock itself counts: a metadata error is just as often a repository that is really broken, and retrying it would hide the actual reason.

```
Channel opensuse_tumbleweed-x86_64 is empty, its synchronization stored no package (ScriptError)
```

## End-User Impact & Release Notes

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s):
SUSE/spacewalk#31847
SUSE/spacewalk#31848
SUSE/spacewalk#31849
SUSE/spacewalk#31850
SUSE/spacewalk#31851

Port(s):
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31855
Manager-5.1: https://github.com/SUSE/spacewalk/pull/31856

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!


