### PR TITLE
Improve channel sync query performance

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
@@ -48,15 +48,17 @@ public class AlignSoftwareTargetAction implements MessageAction {
     public void execute(EventMessage msgIn) {
         ContentManager contentManager = new ContentManager();
         AlignSoftwareTargetMsg msg = (AlignSoftwareTargetMsg) msgIn;
-        Channel sourceChannel = ChannelFactory.lookupById(msg.getSource().getId());
         Long targetId = msg.getTarget().getId();
-        SoftwareEnvironmentTarget target = ContentProjectFactory
-                .lookupSwEnvironmentTargetById(targetId)
-                .orElseThrow(() -> new EntityNotExistsException(targetId));
-        Channel targetChannel = target.getChannel();
         List<ContentFilter> filters = msg.getFilters();
 
+        SoftwareEnvironmentTarget target = null;
         try {
+            Channel sourceChannel = ChannelFactory.lookupById(msg.getSource().getId());
+            target = ContentProjectFactory
+                    .lookupSwEnvironmentTargetById(targetId)
+                    .orElseThrow(() -> new EntityNotExistsException(targetId));
+            Channel targetChannel = target.getChannel();
+
             if (!UserManager.verifyChannelAdmin(msg.getUser(), targetChannel)) {
                 throw new PermissionException("User " + msg.getUser().getLogin() + " has no permission for channel " +
                         targetChannel.getLabel());
@@ -82,9 +84,15 @@ public class AlignSoftwareTargetAction implements MessageAction {
     public Consumer<Exception> getExceptionHandler() {
         return (e) -> {
             if (e instanceof AlignSoftwareTargetException exc) {
-                LOG.error("Error aligning target {}", exc.getTarget().getId(), e);
-                exc.getTarget().setStatus(Status.FAILED);
-                ContentProjectFactory.save(exc.getTarget());
+                SoftwareEnvironmentTarget target = exc.getTarget();
+                if (target == null) {
+                    LOG.error("Error aligning target: target does not exist", e);
+                    return;
+                }
+
+                LOG.error("Error aligning target {}", target.getId(), e);
+                target.setStatus(Status.FAILED);
+                ContentProjectFactory.save(target);
             }
         };
     }

--- a/java/core/src/main/resources/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
@@ -1450,29 +1450,23 @@ SELECT E.id, E.advisory, E.synopsis
 SELECT
     DISTINCT e.id, e.advisory_name, e.advisory, e.advisory_type, e.advisory_status,
              e.synopsis as advisory_synopsis, e.update_date, e.issue_date
-FROM
-(
-    SELECT
-        oep.package_id, ec.id AS clone_errata_id
-    FROM rhnChannelPackage ocp
-        JOIN rhnChannelErrata oce ON oce.channel_id = ocp.channel_id
-        JOIN rhnErrataPackage oep ON oep.errata_id = oce.errata_id
-            AND oep.package_id = ocp.package_id
-        JOIN rhnErrataCloned ec ON ec.original_id = oep.errata_id
-    WHERE   ocp.channel_id = :ocid
-) O
-LEFT JOIN (
-    SELECT
-        cep.package_id, cep.errata_id
+FROM rhnChannelPackage ocp
+    JOIN rhnChannelErrata oce ON oce.channel_id = ocp.channel_id
+    JOIN rhnErrataPackage oep ON oep.errata_id = oce.errata_id AND oep.package_id = ocp.package_id
+    JOIN rhnErrataCloned ec ON ec.original_id = oep.errata_id
+    JOIN rhnErrata e ON e.id = ec.id
+    -- following line ensures the errata clone is already published in the cloned channel
+    JOIN rhnChannelErrata ce ON ce.errata_id = e.id AND ce.channel_id = :cid
+WHERE ocp.channel_id = :ocid
+  AND NOT EXISTS (
+    SELECT 1
     FROM rhnChannelPackage ccp
         JOIN rhnChannelErrata cce ON cce.channel_id = ccp.channel_id
         JOIN rhnErrataPackage cep ON cep.errata_id = cce.errata_id AND cep.package_id = ccp.package_id
-WHERE ccp.channel_id = :cid
-) C ON C.errata_id = O.clone_errata_id AND C.package_id = O.package_id
-JOIN rhnErrata e ON e.id = O.clone_errata_id
--- following line ensures the errata clone is already published in the cloned channel
-JOIN rhnChannelErrata ce ON ce.errata_id = e.id AND ce.channel_id = :cid
-WHERE C.package_id IS NULL
+    WHERE ccp.channel_id = :cid
+      AND cep.errata_id = ec.id
+      AND cep.package_id = oep.package_id
+  )
 UNION -- orig and cloned erratas in the channels, exactly one of them has 'retracted' status
     SELECT DISTINCT
         clone.id, clone.advisory_name, clone.advisory, clone.advisory_type, clone.advisory_status,
@@ -1494,34 +1488,27 @@ UNION -- orig and cloned erratas in the channels, exactly one of them has 'retra
 SELECT p.id, pn.name AS package_name,
        pn.name || '-' || evr_t_as_vre_simple(pevr.evr) || '.' || pa.label AS nvrea,
        p.summary
-FROM
-(
-    SELECT
-        oep.package_id, ec.id AS clone_errata_id
-    FROM rhnChannelPackage ocp
-        JOIN rhnChannelErrata oce ON oce.channel_id = ocp.channel_id
-        JOIN rhnErrataPackage oep ON oep.errata_id = oce.errata_id
-            AND oep.package_id = ocp.package_id
-        JOIN rhnErrataCloned ec ON ec.original_id = oep.errata_id
+FROM rhnChannelPackage ocp
+    JOIN rhnChannelErrata oce ON oce.channel_id = ocp.channel_id
+    JOIN rhnErrataPackage oep ON oep.errata_id = oce.errata_id AND oep.package_id = ocp.package_id
+    JOIN rhnErrataCloned ec ON ec.original_id = oep.errata_id
+    JOIN rhnErrata e ON e.id = ec.id
+    -- following line ensures the errata clone is already published in the cloned channel
+    JOIN rhnChannelErrata ce ON ce.errata_id = e.id AND ce.channel_id = :cid
+    JOIN rhnPackage p ON p.id = oep.package_id
+    JOIN rhnPackageName pn ON pn.id = p.name_id
+    JOIN rhnPackageEVR pevr ON pevr.id = p.evr_id
+    JOIN rhnPackageArch pa ON pa.id = p.package_arch_id
 WHERE ocp.channel_id = :ocid
-) O
-LEFT JOIN (
-    SELECT
-        cep.package_id, cep.errata_id
+  AND NOT EXISTS (
+    SELECT 1
     FROM rhnChannelPackage ccp
         JOIN rhnChannelErrata cce ON cce.channel_id = ccp.channel_id
-        JOIN rhnErrataPackage cep ON cep.errata_id = cce.errata_id
-            AND cep.package_id = ccp.package_id
-WHERE ccp.channel_id = :cid
-) C ON C.errata_id = O.clone_errata_id AND C.package_id = O.package_id
-JOIN rhnErrata e ON e.id = O.clone_errata_id
--- following line ensures the errata clone is already published in the cloned channel
-JOIN rhnChannelErrata ce ON ce.errata_id = e.id AND ce.channel_id = :cid
-JOIN rhnPackage p ON p.id = O.package_id
-JOIN rhnPackageName pn ON pn.id = p.name_id
-JOIN rhnPackageEVR pevr ON pevr.id = p.evr_id
-JOIN rhnPackageArch pa ON pa.id = p.package_arch_id
-WHERE C.package_id IS NULL
+        JOIN rhnErrataPackage cep ON cep.errata_id = cce.errata_id AND cep.package_id = ccp.package_id
+    WHERE ccp.channel_id = :cid
+      AND cep.errata_id = ec.id
+      AND cep.package_id = oep.package_id
+  )
   </query>
 </mode>
 
@@ -1530,35 +1517,28 @@ WHERE C.package_id IS NULL
 SELECT p.id, pn.name AS package_name,
        pn.name || '-' || evr_t_as_vre_simple(pevr.evr) || '.' || pa.label AS nvrea,
        p.summary
-FROM
-(
-    SELECT
-        oep.package_id, ec.id AS clone_errata_id
-    FROM rhnChannelPackage ocp
-        JOIN rhnChannelErrata oce ON oce.channel_id = ocp.channel_id
-        JOIN rhnErrataPackage oep ON oep.errata_id = oce.errata_id
-            AND oep.package_id = ocp.package_id
-        JOIN rhnErrataCloned ec ON ec.original_id = oep.errata_id
+FROM rhnChannelPackage ocp
+    JOIN rhnChannelErrata oce ON oce.channel_id = ocp.channel_id
+    JOIN rhnErrataPackage oep ON oep.errata_id = oce.errata_id AND oep.package_id = ocp.package_id
+    JOIN rhnErrataCloned ec ON ec.original_id = oep.errata_id
+    JOIN rhnPackage p ON p.id = oep.package_id
+    JOIN rhnPackageName pn ON pn.id = p.name_id
+    JOIN rhnPackageEVR pevr ON pevr.id = p.evr_id
+    JOIN rhnPackageArch pa ON pa.id = p.package_arch_id
 WHERE ocp.channel_id = :ocid
-) O
-LEFT JOIN (
-    SELECT
-        cep.package_id, cep.errata_id
-    FROM rhnChannelPackage ccp
-        JOIN rhnChannelErrata cce ON cce.channel_id = ccp.channel_id
-        JOIN rhnErrataPackage cep ON cep.errata_id = cce.errata_id
-            AND cep.package_id = ccp.package_id
-WHERE ccp.channel_id = :cid
-) C ON C.errata_id = O.clone_errata_id AND C.package_id = O.package_id
-JOIN rhnPackage p ON p.id = O.package_id
-JOIN rhnPackageName pn ON pn.id = p.name_id
-JOIN rhnPackageEVR pevr ON pevr.id = p.evr_id
-JOIN rhnPackageArch pa ON pa.id = p.package_arch_id
-WHERE C.package_id IS NULL
-AND O.clone_errata_id IN (
+  AND ec.id IN (
         SELECT element
         FROM rhnSet S
         WHERE S.label = :set_label)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM rhnChannelPackage ccp
+        JOIN rhnChannelErrata cce ON cce.channel_id = ccp.channel_id
+        JOIN rhnErrataPackage cep ON cep.errata_id = cce.errata_id AND cep.package_id = ccp.package_id
+    WHERE ccp.channel_id = :cid
+      AND cep.errata_id = ec.id
+      AND cep.package_id = oep.package_id
+  )
   </query>
 </mode>
 

--- a/java/spacewalk-java.changes.parlt.improve-clm-new-env-build
+++ b/java/spacewalk-java.changes.parlt.improve-clm-new-env-build
@@ -1,0 +1,2 @@
+- Optimize cloned channel sync queries in
+  `Errata_queries.xml` to avoid nested loops (bsc#1273071)


### PR DESCRIPTION
## What does this PR change?

Optimize cloned channel sync queries in Errata_queries.xml (bsc#1273071)
    
Use `NOT EXISTS` instead of `LEFT JOIN` for cloned channel sync queries
to force the query planner to use a `Hash Anti-Join` instead of a
`Nested Loop Join`.
    
A recent change (bsc#1261753) made updating table statistics after
CLM build or promote asynchronous, which could cause table statistics
for newly created channels to be unpopulated.
Without these statistics, the query planner would choose a poorly
performing Nested Loop plan, leading to 8-hour build times on new
CLM environments.
    
Flatten subqueries to simplify join structure.

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Performance improvement**

- [x] **DONE**

## Test coverage

- No tests: **Performance improvement**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31477

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
