### PR TITLE
Generate the metadata of the mirrored Tumbleweed packages

### DIFF
--- a/testsuite/dockerfiles/server-all-in-one-dev/Dockerfile
+++ b/testsuite/dockerfiles/server-all-in-one-dev/Dockerfile
@@ -25,6 +25,7 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then \
       openssh-server \
       git \
       hostname \
+      createrepo_c \
       apache-ivy \
       ant \
       ant-junit && \
@@ -78,38 +79,22 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then \
     export RPM_DIR="${RPM_DIR_PREFIX}/${RPM_PATH_SUFFIX}" && \
     mkdir -p "${RPM_DIR}" && \
     cd "${RPM_DIR}" && \
+    echo "Listing ${TUMBLEWEED_REPO}${RPM_PATH_SUFFIX}/..." && \
+    PACKAGE_LIST=$(curl -sSfL --retry 5 --retry-delay 5 --retry-all-errors "${TUMBLEWEED_REPO}${RPM_PATH_SUFFIX}/") && \
     for PACKAGE in openSUSE-release-20 dmidecode libunwind golang-github-prometheus-node_exporter golang-github-lusitaniae-apache_exporter prometheus-postgres_exporter golang-github-QubitProducts-exporter_exporter; do \
         echo "Searching for latest version of ${PACKAGE}..." && \
         FULL_URL=$( \
-            curl -sL "${TUMBLEWEED_REPO}${RPM_PATH_SUFFIX}/" | \
+            echo "${PACKAGE_LIST}" | \
             grep -oP "${PACKAGE}[^\"']+\.rpm" | \
             head -n 1 | \
             awk -v repo="${TUMBLEWEED_REPO}${RPM_PATH_SUFFIX}/" '{print repo $1}' \
         ) && \
         if [ -n "$FULL_URL" ]; then \
             echo "Downloading ${FULL_URL}..." && \
-            curl -L -O "${FULL_URL}"; \
+            { curl -fL --retry 5 --retry-delay 5 --retry-all-errors -O "${FULL_URL}" || exit 1; }; \
         else \
-            echo "Warning: Could not find RPM for ${PACKAGE}. Skipping."; \
+            echo "Could not find the RPM of ${PACKAGE} in ${TUMBLEWEED_REPO}${RPM_PATH_SUFFIX}/." && exit 1; \
         fi \
     done && \
-    export METADATA_DIR="${RPM_DIR_PREFIX}/repodata" && \
-    mkdir -p "${METADATA_DIR}" && \
-    cd "${METADATA_DIR}" && \
-    echo "Downloading repomd.xml..." && \
-    curl -L -O "${TUMBLEWEED_REPO}repodata/repomd.xml" && \
-    for METADATA_TYPE in primary filelists other; do \
-        echo "Searching for latest ${METADATA_TYPE}.xml.zst..." && \
-        FULL_URL=$( \
-            curl -sL "${TUMBLEWEED_REPO}repodata/" | \
-            grep -oP '[0-9a-f]{40}-'"${METADATA_TYPE}"'\.xml\.zst' | \
-            head -n 1 | \
-            awk -v repo="${TUMBLEWEED_REPO}repodata/" '{print repo $1}' \
-        ) && \
-        if [ -n "$FULL_URL" ]; then \
-            echo "Downloading ${FULL_URL}..." && \
-            curl -L -O "${FULL_URL}"; \
-        else \
-            echo "Warning: Could not find ${METADATA_TYPE} metadata. Skipping."; \
-        fi \
-    done
+    echo "Generating the metadata of the mirrored packages..." && \
+    createrepo_c "${RPM_DIR_PREFIX}"


### PR DESCRIPTION
## What does this PR change?

Generates the metadata of the mirrored Tumbleweed packages with `createrepo_c` instead of copying the `repomd.xml` of the upstream repository.

The mirror at `/mirror/download.opensuse.org/tumbleweed/repo/oss/` holds a handful of packages, but its `repomd.xml` came from `download.opensuse.org` and lists `appdata`, `appdata-icons`, `license` and every `susedata` file, none of which were downloaded. Any refresh of that repository failed on the first missing file, so the reposync of `opensuse_tumbleweed-x86_64` stored no package. The metadata now describes exactly the packages that are mirrored, and a package that cannot be downloaded fails the image build instead of leaving an HTML error page behind as an `.rpm`. The repository listing is fetched once before the loop and reused, and both it and the package downloads retry transient errors and abort the build on a permanent one, so a hiccup on `download.opensuse.org` does not break the build and a real failure is not reported as a missing package. The image is built by the `Create and publish docker images used for the CI` workflow, so it has to be run for the change to reach the test suite.

```
17:36:24 RepoMDError: Cannot access repository.
[opensuse_tumbleweed-x86_64|file:/mirror/download.opensuse.org/tumbleweed/repo/oss/] Failed to retrieve new repository metadata.
History:
 - File './repodata/87dbf4e2...-appdata.xml.gz' not found on medium 'file:/mirror/download.opensuse.org/tumbleweed/repo/oss/'
```

## End-User Impact & Release Notes

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s):
Port(s):
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31857

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!


