### PR TITLE
Document createOrUpdatePath permissions as a string #7968

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
@@ -496,9 +496,10 @@ public class ConfigChannelHandler extends BaseHandler {
      * @param isDir true if this is a directory path, false if its to be a file path
      * @param pathInfo a map containing properties pertaining to the given path..
      * for directory paths - 'pathInfo' will hold values for -&gt;
-     *  owner, group, permissions
+     *  owner, group, permissions (all required; permissions is a string such as "644")
      * for file paths -  'pathInfo' will hold values for-&gt;
-     *  contents, owner, group, permissions, macro-start-delimiter, macro-end-delimiter
+     *  contents, owner, group, permissions (required),
+     *  macro-start-delimiter, macro-end-delimiter (optional)
      * @return returns the new created or updated config revision..
      * @since 10.2
      *
@@ -513,13 +514,14 @@ public class ConfigChannelHandler extends BaseHandler {
      *  #struct_begin("pathInfo", "the path info")
      *      #prop_desc("string","contents",
      *              "contents of the file (text or base64 encoded if binary or want to preserve
-     *                         control characters like LF, CR etc.)(only for non-directories)")
+     *                         control characters like LF, CR etc.)
+     *                         (required for files, only for non-directories)")
      *      #prop_desc("boolean","contents_enc64", "identifies base64 encoded content
      *                   (default: disabled, only for non-directories)")
-     *      #prop_desc("string", "owner", "owner of the file/directory")
-     *      #prop_desc("string", "group", "group name of the file/directory")
+     *      #prop_desc("string", "owner", "owner of the file/directory (required)")
+     *      #prop_desc("string", "group", "group name of the file/directory (required)")
      *      #prop_desc("string", "permissions",
-     *                              "octal file/directory permissions (eg: 644)")
+     *                              "octal permissions as a string (eg: \"644\"), not an integer (required)")
      *      #prop_desc("string", "selinux_ctx", "SELinux Security context (optional)")
      *      #prop_desc("string", "macro-start-delimiter",
      *                  "config file macro start delimiter. Use null or empty

--- a/java/spacewalk-java.changes.AzazelSensei.api-docs-createOrUpdatePath
+++ b/java/spacewalk-java.changes.AzazelSensei.api-docs-createOrUpdatePath
@@ -1,0 +1,1 @@
+- Document createOrUpdatePath permissions as a string ("644")


### PR DESCRIPTION
## What does this PR change?

`configchannel.createOrUpdatePath` API docs listed permissions as `eg: 644`. That reads as an integer. The handler stores the value as a String (`"644"`), which is what the API tests already pass.

Also mark `contents` (files), `owner`, `group`, and `permissions` as required. Optional fields (`selinux_ctx`, macros, `revision`, `binary`) were already labeled.

Fixes #7968

## End-User Impact & Release Notes

API documentation only. No runtime change.

- [x] **DONE**

## Codespace

<!-- Button to create CodeSpace -->

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation

- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.

- [x] **DONE**

## Test coverage

- No tests: docs-only change to `@apidoc` comments

- [x] **DONE**

## Links

Issue(s): #7968
Port(s): #

- [x] **DONE**

## Changelogs

Changelog added under `java/spacewalk-java.changes.AzazelSensei.api-docs-createOrUpdatePath`.

- [ ] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
