### PR TITLE
Honour the caller's timeout when waiting for an event in the history

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -221,6 +221,7 @@ For a test with a regular expression, there is ```I should see a text like "..."
 
 ```gherkin
   When I wait until I see "Software Updates Available" text, refreshing the page
+  When I wait at most 300 seconds until I see "Software Updates Available" text, refreshing the page
   When I wait until I do not see "Apply highstate scheduled by admin" text, refreshing the page
   When I wait until I see the name of "sle_minion", refreshing the page
   When I wait until I do not see the name of "sle_minion", refreshing the page
@@ -521,12 +522,14 @@ Note that the text area variant handles the new lines characters while the other
 
 ```gherkin
   When I wait until onboarding is completed for "rhlike_minion"
+  When I wait at most 300 seconds until onboarding is completed for "rhlike_minion"
   When I wait until event "Package Install/Upgrade scheduled by admin" is completed
 ```
 
 Both of the above give the event `DEFAULT_TIMEOUT` seconds to leave the pending
 list and `DEFAULT_TIMEOUT` seconds again to reach Completed, so the total wait can
-be twice that.
+be twice that. Onboarding takes an explicit budget in place of the default, and
+gives each of the events it waits for that budget per phase.
 When that phase can take longer than the execution itself — an action chain that
 reboots the system, or anything on a Salt SSH minion, where the chain resumes
 only on the next `ssh-service-default` push — wait for each phase on its own

--- a/testsuite/features/init_clients/min_deblike_salt.feature
+++ b/testsuite/features/init_clients/min_deblike_salt.feature
@@ -23,7 +23,7 @@ Feature: Bootstrap a Debian-like minion and do some basic operations on it
     And I wait until I see "Bootstrap process initiated." text
     And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "deblike_minion", refreshing the page
-    And I wait until onboarding is completed for "deblike_minion"
+    And I wait at most 300 seconds until onboarding is completed for "deblike_minion"
     And I query latest Salt changes on Debian-like system "deblike_minion"
 
 @proxy

--- a/testsuite/features/init_clients/min_rhlike_salt.feature
+++ b/testsuite/features/init_clients/min_rhlike_salt.feature
@@ -23,7 +23,7 @@ Feature: Bootstrap a Red Hat-like minion and do some basic operations on it
     And I wait until I see "Bootstrap process initiated." text
     And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "rhlike_minion", refreshing the page
-    And I wait until onboarding is completed for "rhlike_minion"
+    And I wait at most 300 seconds until onboarding is completed for "rhlike_minion"
 
 @proxy
   Scenario: Check connection from Red Hat-like minion to proxy

--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -29,7 +29,7 @@ Feature: Bootstrap a Salt minion via the GUI
     Then I should see a "accepted" text
     When I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "sle_minion", refreshing the page
-    And I wait until onboarding is completed for "sle_minion"
+    And I wait at most 300 seconds until onboarding is completed for "sle_minion"
     Then the Salt master can reach "sle_minion"
     And I report the onboarding duration for "sle_minion"
 

--- a/testsuite/features/init_clients/sle_sshminion.feature
+++ b/testsuite/features/init_clients/sle_sshminion.feature
@@ -21,7 +21,7 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I wait until I see "Bootstrap process initiated." text
     And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "sshminion", refreshing the page
-    And I wait until onboarding is completed for "sshminion"
+    And I wait at most 300 seconds until onboarding is completed for "sshminion"
 
 @susemanager
   Scenario: Use correct kernel image on the SSH minion

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -165,7 +165,7 @@ When(/^I wait at most (\d+) seconds until the event "([^"]*)" is completed in th
   steps %(
     When I follow "History"
     And I wait until I see "System History" text
-    And I wait until I see "#{event}" text, refreshing the page
+    And I wait at most #{timeout} seconds until I see "#{event}" text, refreshing the page
     And I follow first "#{event}"
     And I wait until I see "This action will be executed after" text
     And I wait until I see "#{event}" text

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -67,11 +67,11 @@ When(/^I wait until I see "([^"]*)" text or "([^"]*)" text(?:, (refreshing the p
   end
 end
 
-When(/^I wait until I see "([^"]*)" (text|regex), refreshing the page$/) do |text, type|
+When(/^I wait (?:at most (\d+) seconds )?until I see "([^"]*)" (text|regex), refreshing the page$/) do |seconds, text, type|
   text = Regexp.new(text) if type == 'regex'
   next if has_content?(text, wait: 3)
 
-  repeat_until_timeout(message: "Couldn't find text '#{text}'") do
+  repeat_until_timeout(message: "Couldn't find text '#{text}'", timeout: seconds ? seconds.to_i : DEFAULT_TIMEOUT) do
     break if has_content?(text, wait: 3)
 
     refresh_page

--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -245,10 +245,11 @@ When(/^I wait at most (\d+) seconds until I see the name of "([^"]*)", refreshin
   end
 end
 
-When(/^I wait at most (\d+) seconds until onboarding is completed for "([^"]*)"$/) do |seconds, host|
+When(/^I wait (?:at most (\d+) seconds )?until onboarding is completed for "([^"]*)"$/) do |seconds, host|
+  seconds ||= DEFAULT_TIMEOUT
   steps %(
     When I follow the left menu "Systems > System List > All"
-    And I wait until I see the name of "#{host}", refreshing the page
+    And I wait at most #{seconds} seconds until I see the name of "#{host}", refreshing the page
     And I follow this "#{host}" link
     And I wait until I see "System Status" text
     And I wait at most #{seconds} seconds until the event "Apply states" is picked up
@@ -258,10 +259,6 @@ When(/^I wait at most (\d+) seconds until onboarding is completed for "([^"]*)"$
     And I wait at most #{seconds} seconds until the event "Package List Refresh" is picked up
     And I wait at most #{seconds} seconds until the event "Package List Refresh" is completed in the history
   )
-end
-
-When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|
-  step %(I wait at most #{DEFAULT_TIMEOUT} seconds until onboarding is completed for "#{host}")
 end
 
 Then(/^I should see "([^"]*)" via spacecmd$/) do |host|


### PR DESCRIPTION
## What does this PR change?

Passes the caller's timeout down to the wait for an event to appear in the system history, instead of pinning that wait to `DEFAULT_TIMEOUT`, and gives the `init_clients` features an explicit 300 second onboarding budget.

`I wait at most N seconds until the event "X" is completed in the history` forwarded `N` to the final "is completed" wait, but the wait for the event to show up in the History tab was hardcoded to `DEFAULT_TIMEOUT`. The pickup wait ahead of it short-circuits when the action has not been scheduled yet, so the history wait is where the action's runtime is actually spent, and the step's real ceiling was `DEFAULT_TIMEOUT` no matter what the feature asked for.

`I wait until I see "..." text, refreshing the page` gains an optional `at most N seconds` clause, the way `I wait until I see "..." text or "..." text` already takes an optional `refreshing the page`, and the composite passes its own timeout through it. `I wait until onboarding is completed for "X"` takes the same optional clause in place of the separate bare wrapper it used to carry, and now also forwards the timeout to the system list wait it starts with, which was still on the bare form. Without the clause both steps fall back to `DEFAULT_TIMEOUT`, so existing call sites on the bare phrasing are unaffected.

The four features in `init_clients.yml` that onboarded on the bare step now ask for 300 seconds, the way `buildhost_bootstrap.feature` already asks for 500. Onboarding several clients at once regularly pushes `Apply states` past the 250 second default:

```
   3.0s  [passed]  I wait at most 300 seconds until the event "Apply states" is picked up
 297.4s  [passed]  I wait at most 300 seconds until the event "Apply states" is completed in the history
```

## End-User Impact & Release Notes

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s):
Ports:
Manager-5.2: https://github.com/SUSE/spacewalk/pull/31873
Manager-5.1: https://github.com/SUSE/spacewalk/pull/31874

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
