### PR TITLE
Fix dotted errata version handling in reposync

### DIFF
--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -2101,7 +2101,7 @@ class RepoSync(object):
             new_version = 0
             for n in notice["version"].split("."):
                 new_version = (new_version + int(n)) * 100
-            notice["version"] = new_version / 100
+            notice["version"] = new_version // 100
         if RepoSync._is_old_suse_style(notice):
             # old suse style; we need to append the version to id
             # to get a seperate patch for every issue

--- a/python/spacewalk/spacewalk-backend.changes.sj54600.dotted_version
+++ b/python/spacewalk/spacewalk-backend.changes.sj54600.dotted_version
@@ -1,0 +1,1 @@
+- Fix repository synchronization of dotted errata versions

--- a/python/test/unit/spacewalk/satellite_tools/test_reposync.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_reposync.py
@@ -106,6 +106,27 @@ class RepoSyncTest(unittest.TestCase):
         importlib.reload(spacewalk.satellite_tools.reposync)
         importlib.reload(spacewalk.satellite_tools.appstreams)
 
+    def test_fix_notice_uses_integer_version_for_dotted_versions(self):
+        test_cases = [
+            ("1.2", "SUSE-2024-001", 102, "SUSE-2024-001"),
+            ("10.12", "SUSE-2024-002", 1012, "SUSE-2024-002-1012"),
+            ("2.0", "res5-PATCH-1234", 200, "res5-PATCH-1234-200"),
+        ]
+
+        for version, update_id, expected_version, expected_update_id in test_cases:
+            notice = {
+                "version": version,
+                "update_id": update_id,
+                "from": "security@suse.de",
+            }
+
+            self.reposync.RepoSync.fix_notice(notice)
+
+            self.assertEqual(notice["version"], expected_version)
+            self.assertIs(type(notice["version"]), int)
+            self.assertEqual(notice["update_id"], expected_update_id)
+            self.assertNotIn(".0", notice["update_id"])
+
     def test_init_succeeds_with_correct_attributes(self):
         rs = _init_reposync(self.reposync, "Label", RTYPE)
 


### PR DESCRIPTION
## What does this PR change?

Fix dotted errata version handling in `reposync.py`.

The version conversion in `RepoSync.fix_notice()` uses `/ 100`.
With Python 3, this performs true division and produces a `float`
instead of an integer.

For old-style SUSE errata, the converted version is appended to
the advisory identifier. The float value can therefore introduce
an unintended `.0` suffix and change the resulting advisory
identifier.

This changes the division to `// 100` so converted dotted versions
remain integers and the expected advisory naming is preserved.

## End-User Impact & Release Notes

Repository synchronization now preserves the expected advisory
identifiers for errata with dotted versions.

No changes to WebUI, API, CLI, configuration, or migrations.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation

- No documentation needed: **add explanation. This can't be used if there is a GUI diff**

  This fixes the existing handling of dotted errata versions during
  repository synchronization and does not introduce new functionality
  requiring documentation.

- [ ] No documentation needed: only internal and user invisible changes
- [ ] Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- [ ] API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- [ ] (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage

- [ ] No tests: **add explanation**
- [ ] No tests: already covered
- [x] Unit tests were added
- [ ] Cucumber tests were added

A regression test was added covering dotted versions and advisory
identifier generation.

- The regression test fails with the old implementation.
- The regression test passes with the fixed implementation.
- Full `test_reposync.py`: 48 tests passed.
- `git diff --check` passes.
- Python syntax compilation passes.

- [x] **DONE**

## Links

Issue(s): none

Port(s): none

- [x] **DONE**

## Changelogs

A `spacewalk-backend` changelog entry is included:

`python/spacewalk/spacewalk-backend.changes.sj54600.dotted_version`

Changelog entry:

`- Fix repository synchronization of dotted errata versions`

- [ ] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!