### PR TITLE
Fix GPG status decoding for non-UTF-8 output

### DIFF
--- a/python/spacewalk/common/gpgverify.py
+++ b/python/spacewalk/common/gpgverify.py
@@ -70,6 +70,9 @@ def _run(
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
         encoding="utf-8",
+        # GPG status output may include arbitrary bytes in NOTATION_DATA records.
+        # Those records are ignored by the parser, so replace undecodable bytes.
+        errors="replace",
         check=False,  # checked by caller
     )
 

--- a/python/spacewalk/spacewalk-backend.changes.salluexez.gpg-non-utf8
+++ b/python/spacewalk/spacewalk-backend.changes.salluexez.gpg-non-utf8
@@ -1,0 +1,2 @@
+- Handle non-UTF-8 bytes in GPG status output during Debian
+  repository sync

--- a/python/test/unit/spacewalk/common/test_gpgverify.py
+++ b/python/test/unit/spacewalk/common/test_gpgverify.py
@@ -97,6 +97,34 @@ class MockSubprocessCompletedProcess:
         self.stderr = stderr
 
 
+def test_run_replaces_non_utf8_status_output(monkeypatch):
+    status_output = (
+        b"[GNUPG:] GOODSIG E6266D4AC0962C7D Datadog, Inc. APT key\n"
+        b"[GNUPG:] NOTATION_DATA \xef\xa4%0B\xa2%00\n"
+    )
+
+    def mock_run(*_args, **kwargs):
+        stdout = status_output.decode(kwargs["encoding"], errors=kwargs["errors"])
+        return MockSubprocessCompletedProcess(stdout=stdout)
+
+    monkeypatch.setattr(gpgverify.subprocess, "run", mock_run)
+
+    # pylint: disable-next=protected-access
+    completed = gpgverify._run(
+        signed_file="signed-file", signature_file=None, keyring=None
+    )
+
+    assert "\ufffd" in completed.stdout
+    assert gpgverify.parse_signatures(completed.stdout) == [
+        gpgverify.Signature(
+            keyid="E6266D4AC0962C7D",
+            fingerprint="",
+            status="GOOD",
+            username="Datadog, Inc. APT key",
+        )
+    ]
+
+
 @pytest.mark.parametrize("short_circuit,expected", [(True, True), (False, False)])
 def test_verify_file_short_circuit(
     short_circuit, expected, gpg_verify_output, monkeypatch


### PR DESCRIPTION
## What does this PR change?

GPG's machine-readable status stream can contain arbitrary non-UTF-8 bytes in
`NOTATION_DATA` records. Python previously decoded the entire stream strictly,
so those bytes raised `UnicodeDecodeError` before a valid signature could be
parsed.

This change decodes the status stream with replacement for malformed bytes.
Unknown records such as `NOTATION_DATA` remain ignored, while valid records
such as `GOODSIG` are still parsed normally.

## End-User Impact & Release Notes

Debian repositories whose GPG status output contains non-UTF-8 notation data
can now complete signature verification and repository synchronization.

- [x] **DONE**

## Codespace

Not used; the focused Python unit tests were run locally.

## GUI diff

No difference.

Before: N/A

After: N/A

- [x] **DONE**

## Documentation

No documentation needed: this is an internal robustness fix with no API or
configuration changes.

- [x] **DONE**

## Test coverage

Unit tests were added for status output containing invalid UTF-8 bytes. The
test also verifies that the valid `GOODSIG` record remains parseable.

- [x] **DONE**

## Links

Issue(s): Fixes #12034

Port(s): N/A

- [x] **DONE**

## Changelogs

Added `python/spacewalk/spacewalk-backend.changes.salluexez.gpg-non-utf8`.

- [ ] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

The contribution and branch guidelines were reviewed.
