### PR TITLE
QE: Follow-ups on the RKE2 installation features

### DIFF
--- a/testsuite/features/kubernetes/srv_install_mlm_dependencies_on_rke2.feature
+++ b/testsuite/features/kubernetes/srv_install_mlm_dependencies_on_rke2.feature
@@ -7,7 +7,7 @@
 Feature: Install MLM dependencies on RKE2
 
   Scenario: Check the RKE2 configuration
-    And the environment variable "CERT_MANAGER_VERSION" is set on "server"
+    Then the environment variable "CERT_MANAGER_VERSION" is set on "server"
     And the environment variable "CERT_MANAGER_NAMESPACE" is set on "server"
     And the environment variable "TRAEFIK_FILE" is set on "server"
     And the environment variable "LOCAL_PATH_PROVISIONER_PATH" is set on "server"
@@ -18,7 +18,7 @@ Feature: Install MLM dependencies on RKE2
 
   ## Install helm
   Scenario: Install Helm
-    When I run "set -o pipefail; curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash" on "server"
+    When I run "set -o pipefail; curl -sfL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash" on "server"
 
   Scenario: Install cert-manager and trust-manager
     When I run "helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager --version $CERT_MANAGER_VERSION --namespace $CERT_MANAGER_NAMESPACE --create-namespace --set crds.enabled=true --timeout 10m0s --wait" on "server"

--- a/testsuite/features/kubernetes/srv_install_mlm_dependencies_on_rke2.feature
+++ b/testsuite/features/kubernetes/srv_install_mlm_dependencies_on_rke2.feature
@@ -4,8 +4,8 @@
 @transactional_server
 @rke2
 @no_user_creation
-Feature: Install MLM dependencies on RKE2  
-  
+Feature: Install MLM dependencies on RKE2
+
   Scenario: Check the RKE2 configuration
     And the environment variable "CERT_MANAGER_VERSION" is set on "server"
     And the environment variable "CERT_MANAGER_NAMESPACE" is set on "server"
@@ -23,15 +23,14 @@ Feature: Install MLM dependencies on RKE2
   Scenario: Install cert-manager and trust-manager
     When I run "helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager --version $CERT_MANAGER_VERSION --namespace $CERT_MANAGER_NAMESPACE --create-namespace --set crds.enabled=true --timeout 10m0s --wait" on "server"
     Then I wait until "cert-manager" helm chart is deployed in namespace "cert-manager" on "server"
-    When I run "helm upgrade --install trust-manager oci://quay.io/jetstack/charts/trust-manager --install --namespace $CERT_MANAGER_NAMESPACE --wait" on "server"
+    When I run "helm upgrade --install trust-manager oci://quay.io/jetstack/charts/trust-manager --namespace $CERT_MANAGER_NAMESPACE --wait" on "server"
     Then I wait until "trust-manager" helm chart is deployed in namespace "cert-manager" on "server"
 
-## Install Traefik
-
+  ## Install Traefik
   Scenario: Install Traefik
     When I apply the RKE2 YAML file "$TRAEFIK_FILE" on "server"
 
-## Set local-path-provisioner
+  ## Set local-path-provisioner
   Scenario: Install local path provisioner
     When I apply the RKE2 YAML file "$LOCAL_PATH_PROVISIONER_PATH" on "server"
     And I set "$LOCAL_PATH_PROVISIONER_STORAGE_CLASS" storage class as default on "server"

--- a/testsuite/features/kubernetes/srv_install_mlm_dependencies_on_rke2.feature
+++ b/testsuite/features/kubernetes/srv_install_mlm_dependencies_on_rke2.feature
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@transactional_server
+@rke2
+@no_user_creation
+Feature: Install MLM dependencies on RKE2  
+  
+  Scenario: Check the RKE2 configuration
+    And the environment variable "CERT_MANAGER_VERSION" is set on "server"
+    And the environment variable "CERT_MANAGER_NAMESPACE" is set on "server"
+    And the environment variable "TRAEFIK_FILE" is set on "server"
+    And the environment variable "LOCAL_PATH_PROVISIONER_PATH" is set on "server"
+    And the environment variable "LOCAL_PATH_PROVISIONER_STORAGE_CLASS" is set on "server"
+    And the environment variable "LOCAL_PATH" is set on "server"
+    And the environment variable "LOCAL_PATH_NAMESPACE" is set on "server"
+    And file "/etc/rancher/rke2/config.yaml" should exist on "server"
+
+  ## Install helm
+  Scenario: Install Helm
+    When I run "curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash" on "server"
+
+  Scenario: Install cert-manager and trust-manager
+    When I run "helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager --version $CERT_MANAGER_VERSION --namespace $CERT_MANAGER_NAMESPACE --create-namespace --set crds.enabled=true --timeout 10m0s --wait" on "server"
+    Then I wait until "cert-manager" helm chart is deployed in namespace "cert-manager" on "server"
+    When I run "helm upgrade --install trust-manager oci://quay.io/jetstack/charts/trust-manager --install --namespace $CERT_MANAGER_NAMESPACE --wait" on "server"
+    Then I wait until "trust-manager" helm chart is deployed in namespace "cert-manager" on "server"
+
+## Install Traefik
+
+  Scenario: Install Traefik
+    When I apply the RKE2 YAML file "$TRAEFIK_FILE" on "server"
+
+## Set local-path-provisioner
+  Scenario: Install local path provisioner
+    When I apply the RKE2 YAML file "$LOCAL_PATH_PROVISIONER_PATH" on "server"
+    And I set "$LOCAL_PATH_PROVISIONER_STORAGE_CLASS" storage class as default on "server"
+    And I run "mkdir -p $LOCAL_PATH" on "server"
+    And I run "restorecon -R -v $LOCAL_PATH" on "server"
+    And I run "kubectl delete pods --all -n $LOCAL_PATH_NAMESPACE" on "server"

--- a/testsuite/features/kubernetes/srv_install_mlm_dependencies_on_rke2.feature
+++ b/testsuite/features/kubernetes/srv_install_mlm_dependencies_on_rke2.feature
@@ -18,7 +18,7 @@ Feature: Install MLM dependencies on RKE2
 
   ## Install helm
   Scenario: Install Helm
-    When I run "curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash" on "server"
+    When I run "set -o pipefail; curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash" on "server"
 
   Scenario: Install cert-manager and trust-manager
     When I run "helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager --version $CERT_MANAGER_VERSION --namespace $CERT_MANAGER_NAMESPACE --create-namespace --set crds.enabled=true --timeout 10m0s --wait" on "server"

--- a/testsuite/features/kubernetes/srv_install_mlm_on_rke2.feature
+++ b/testsuite/features/kubernetes/srv_install_mlm_on_rke2.feature
@@ -7,16 +7,18 @@
 Feature: Install MLM on RKE2
 
   Scenario: Check the RKE2 configuration
-    And the environment variable "PYTHON_HELM_CHART_PATH" is set on "server"
+    Then the environment variable "PYTHON_HELM_CHART_PATH" is set on "server"
     And the environment variable "HELM_CHART_DIRECTORY" is set on "server"
+    And the environment variable "HELM_CHART_URL" is set on "server"
+    And the environment variable "HELM_CHART_NAME" is set on "server"
     And the environment variable "SELF_SIGNED_PATH" is set on "server"
     And file "/etc/rancher/rke2/config.yaml" should exist on "server"
 
   Scenario: Update OCI app version
-    And I run "python3 $PYTHON_HELM_CHART_PATH -o $HELM_CHART_URL/$HELM_CHART_NAME --chart-file $SELF_SIGNED_PATH/Chart.yaml $DEVEL_FLAG" on "server"
+    When I run "python3 $PYTHON_HELM_CHART_PATH -o $HELM_CHART_URL/$HELM_CHART_NAME --chart-file $SELF_SIGNED_PATH/Chart.yaml $DEVEL_FLAG" on "server"
 
-@install_mlm_on_rke2
+  @install_mlm_on_rke2
   Scenario: Install Uyuni
-    And I run "kubectl create namespace uyuni --dry-run=client -o yaml | kubectl apply -f -" on "server"
+    When I run "kubectl create namespace uyuni --dry-run=client -o yaml | kubectl apply -f -" on "server"
     And I run "cd $SELF_SIGNED_PATH && helm dependencies build" on "server"
     And I run "cd $HELM_CHART_DIRECTORY && helm upgrade --install uyuni ./selfsigned -f ./selfsigned/values.yaml -n uyuni" on "server"

--- a/testsuite/features/kubernetes/srv_install_mlm_on_rke2.feature
+++ b/testsuite/features/kubernetes/srv_install_mlm_on_rke2.feature
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@transactional_server
+@rke2
+@no_user_creation
+Feature: Install MLM on RKE2
+
+  Scenario: Check the RKE2 configuration
+    And the environment variable "PYTHON_HELM_CHART_PATH" is set on "server"
+    And the environment variable "HELM_CHART_DIRECTORY" is set on "server"
+    And the environment variable "SELF_SIGNED_PATH" is set on "server"
+    And file "/etc/rancher/rke2/config.yaml" should exist on "server"
+
+  Scenario: Update OCI app version
+    And I run "python3 $PYTHON_HELM_CHART_PATH -o $HELM_CHART_URL/$HELM_CHART_NAME --chart-file $SELF_SIGNED_PATH/Chart.yaml $DEVEL_FLAG" on "server"
+
+@install_mlm_on_rke2
+  Scenario: Install Uyuni
+    And I run "kubectl create namespace uyuni --dry-run=client -o yaml | kubectl apply -f -" on "server"
+    And I run "cd $SELF_SIGNED_PATH && helm dependencies build" on "server"
+    And I run "cd $HELM_CHART_DIRECTORY && helm upgrade --install uyuni ./selfsigned -f ./selfsigned/values.yaml -n uyuni" on "server"

--- a/testsuite/features/kubernetes/srv_install_rke2.feature
+++ b/testsuite/features/kubernetes/srv_install_rke2.feature
@@ -14,7 +14,7 @@ Feature: Install RKE2 on transactional systems
     And file "/etc/rancher/rke2/config.yaml" should exist on "server"
 
   Scenario: Install RKE2 via RPM method
-    When I run "curl -sfL https://get.rke2.io | sudo INSTALL_RKE2_VERSION=$RKE2_VERSION INSTALL_RKE2_METHOD=rpm sh -" on "server"
+    When I run "set -o pipefail; curl -sfL https://get.rke2.io | sudo INSTALL_RKE2_VERSION=$RKE2_VERSION INSTALL_RKE2_METHOD=rpm sh -" on "server"
 
   Scenario: Reboot the server to activate the transaction with the RKE2 content
     When I reboot the "server" host through SSH, waiting until it comes back

--- a/testsuite/features/kubernetes/srv_install_rke2.feature
+++ b/testsuite/features/kubernetes/srv_install_rke2.feature
@@ -30,4 +30,3 @@ Feature: Install RKE2 on transactional systems
     When I run "ln -sf /var/lib/rancher/rke2/bin/kubectl /usr/local/bin/kubectl" on "server"
     And I run "ln -sf /var/lib/rancher/rke2/bin/crictl /usr/local/bin/crictl" on "server"
     And I run "ln -sf /var/lib/rancher/rke2/bin/ctr /usr/local/bin/ctr" on "server"
-

--- a/testsuite/features/kubernetes/srv_install_rke2.feature
+++ b/testsuite/features/kubernetes/srv_install_rke2.feature
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@transactional_server
+@rke2
+@no_user_creation
+Feature: Install RKE2 on transactional systems
+
+  Scenario: Reboot the server to activate everything before starting
+    When I reboot the "server" host through SSH, waiting until it comes back
+
+  Scenario: Check the RKE2 configuration
+    Then the environment variable "RKE2_VERSION" is set on "server"
+    And file "/etc/rancher/rke2/config.yaml" should exist on "server"
+
+  Scenario: Install RKE2 via RPM method
+    When I run "curl -sfL https://get.rke2.io | sudo INSTALL_RKE2_VERSION=$RKE2_VERSION INSTALL_RKE2_METHOD=rpm sh -" on "server"
+
+  Scenario: Reboot the server to activate the transaction with the RKE2 content
+    When I reboot the "server" host through SSH, waiting until it comes back
+
+  Scenario: Enable and start the RKE2 server service
+    When I enable the "rke2-server" service on "server"
+    And I start the "rke2-server" service on "server"
+    And I wait until "rke2-server" service is active on "server"
+    Then service "rke2-server" is enabled on "server"
+    And service "rke2-server" is active on "server"
+
+  Scenario: Create symlinks for RKE2 tools
+    When I run "ln -sf /var/lib/rancher/rke2/bin/kubectl /usr/local/bin/kubectl" on "server"
+    And I run "ln -sf /var/lib/rancher/rke2/bin/crictl /usr/local/bin/crictl" on "server"
+    And I run "ln -sf /var/lib/rancher/rke2/bin/ctr /usr/local/bin/ctr" on "server"
+

--- a/testsuite/features/kubernetes/srv_rke2_check_installation.feature
+++ b/testsuite/features/kubernetes/srv_rke2_check_installation.feature
@@ -2,6 +2,7 @@
 # Licensed under the terms of the MIT license.
 #
 @rke2
+@no_user_creation
 Feature: RKE2 Server Health
   In order to manage systems using a Kubernetes installation
   As the system administrator

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -2,8 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 ### This file contains the definitions for all steps concerning Cobbler.
-
-$cobbler_test = CobblerTest.new
+$cobbler_test = CobblerTest.new unless ENV.key?('UYUNI_NOT_INSTALLED') && ENV['UYUNI_NOT_INSTALLED'] == 'true'
 
 # cobbler daemon
 Given(/^cobblerd is running$/) do

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -2,7 +2,8 @@
 # Licensed under the terms of the MIT license.
 
 ### This file contains the definitions for all steps concerning Cobbler.
-$cobbler_test = CobblerTest.new unless ENV.key?('UYUNI_NOT_INSTALLED') && ENV['UYUNI_NOT_INSTALLED'] == 'true'
+
+$cobbler_test = CobblerTest.new unless uyuni_not_installed?
 
 # cobbler daemon
 Given(/^cobblerd is running$/) do

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1746,7 +1746,7 @@ When(/^I run spacewalk-hostname-rename command on the server$/) do
 
   # Reset the API client to take the new CA into account
   log 'Resetting the API client'
-  $api_test = new_api_client
+  $api_test = new_api_client unless ENV.key?('UYUNI_NOT_INSTALLED') && ENV['UYUNI_NOT_INSTALLED'] == 'true'
 
   raise SystemCallError, 'Error while running spacewalk-hostname-rename command - see logs above' unless result_code.zero?
   raise ScriptError, 'Error in the output logs - see logs above' if out_spacewalk.include? 'No such file or directory'

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1746,7 +1746,7 @@ When(/^I run spacewalk-hostname-rename command on the server$/) do
 
   # Reset the API client to take the new CA into account
   log 'Resetting the API client'
-  $api_test = new_api_client unless ENV.key?('UYUNI_NOT_INSTALLED') && ENV['UYUNI_NOT_INSTALLED'] == 'true'
+  $api_test = new_api_client unless uyuni_not_installed?
 
   raise SystemCallError, 'Error while running spacewalk-hostname-rename command - see logs above' unless result_code.zero?
   raise ScriptError, 'Error in the output logs - see logs above' if out_spacewalk.include? 'No such file or directory'

--- a/testsuite/features/step_definitions/rke2_steps.rb
+++ b/testsuite/features/step_definitions/rke2_steps.rb
@@ -9,6 +9,12 @@ Then('the setup marker file should exist on "server"') do
   raise 'Server setup marker file does not exist' unless status.include? 'EXISTS'
 end
 
+Then(/^the environment variable "([^"]*)" is set on "([^"]*)"$/) do |var_name, host|
+  node = get_target(host)
+  _out, code = node.run("printenv #{var_name}", check_errors: false, runs_in_container: false)
+  raise "Environment variable '#{var_name}' is not set on #{host}" unless code.zero?
+end
+
 Given(/^The Kubernetes cluster is ready on "(.*)"$/) do |target|
   _out, code = get_target(target).run_local('kubectl get nodes && kubectl get namespace uyuni')
   raise "Kubernetes cluster is not ready or uyuni namespace is missing on #{target}" unless code.zero?
@@ -20,6 +26,22 @@ end
 
 And(/^(?:the|I wait until the) "(.*)" pod on "(.*)" in the namespace "(.*)" (?:becomes|should become) ready within (.*) minutes$/) do |name, target, namespace, mins|
   wait_for_pods(target, name, namespace, mins.to_i)
+end
+
+When(/^I apply the RKE2 YAML file "([^"]*)" on "([^"]*)"$/) do |filename, target|
+  _out, code = get_target(target).run_local("kubectl apply -f #{filename}")
+  raise ScriptError, "Failed to apply #{filename} on #{target}" unless code.zero?
+end
+
+When(/^I wait until "([^"]*)" helm chart is deployed in namespace "([^"]*)" on "([^"]*)"$/) do |chart, namespace, target|
+  node = get_target(target)
+  node.run_until_ok("helm status #{chart} --namespace #{namespace} | grep -q 'STATUS: deployed'", runs_in_container: false)
+end
+
+When(/^I set "([^"]*)" storage class as default on "([^"]*)"$/) do |storage_class, target|
+  cmd = "kubectl patch storageclass #{storage_class} -p '{\"metadata\": {\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"true\"}}}'"
+  _out, code = get_target(target).run_local(cmd)
+  raise ScriptError, "Failed to set #{storage_class} as default storage class on #{target}" unless code.zero?
 end
 
 ### External CA setup and teardown steps

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -49,6 +49,7 @@ end
 # @return [String] The product name.
 def product
   return $product unless $product.nil?
+  return if ENV.key?('UYUNI_NOT_INSTALLED') && ENV['UYUNI_NOT_INSTALLED'] == 'true'
 
   patterns = { 'patterns-uyuni_server' => 'Uyuni', 'patterns-suma_server' => 'SUSE Manager' }
   server = get_target('server')

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -44,12 +44,20 @@ def count_table_items
   items_label.split('of ')[1].strip
 end
 
+# Tells whether the run happens before the server has been deployed, so that the steps
+# and hooks that talk to the server are skipped instead of failing at load time.
+#
+# @return [Boolean] True if the UYUNI_NOT_INSTALLED environment variable is set to 'true'.
+def uyuni_not_installed?
+  ENV['UYUNI_NOT_INSTALLED'] == 'true'
+end
+
 # Determines the product type (Uyuni or SUSE Manager) based on installed patterns, raises error if undetermined.
 #
 # @return [String, nil] The product name, or nil when UYUNI_NOT_INSTALLED is set.
 def product
   return $product unless $product.nil?
-  return if ENV.key?('UYUNI_NOT_INSTALLED') && ENV['UYUNI_NOT_INSTALLED'] == 'true'
+  return if uyuni_not_installed?
 
   patterns = { 'patterns-uyuni_server' => 'Uyuni', 'patterns-suma_server' => 'SUSE Manager' }
   server = get_target('server')

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -46,7 +46,7 @@ end
 
 # Determines the product type (Uyuni or SUSE Manager) based on installed patterns, raises error if undetermined.
 #
-# @return [String] The product name.
+# @return [String, nil] The product name, or nil when UYUNI_NOT_INSTALLED is set.
 def product
   return $product unless $product.nil?
   return if ENV.key?('UYUNI_NOT_INSTALLED') && ENV['UYUNI_NOT_INSTALLED'] == 'true'

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -153,7 +153,8 @@ $stdout.puts "Capybara APP Host: #{Capybara.app_host}:#{Capybara.server_port}"
 World(MiniTest::Assertions)
 
 # Initialize the API client
-$api_test = new_api_client unless ENV.key?('UYUNI_NOT_INSTALLED') && ENV['UYUNI_NOT_INSTALLED'] == 'true'
+$api_test = new_api_client unless uyuni_not_installed?
+
 # Init CodeCoverage Handler
 $code_coverage = CodeCoverage.new if $code_coverage_mode
 
@@ -295,8 +296,12 @@ end
 After('@install_mlm_on_rke2') do |scenario|
   next unless scenario.passed?
 
+  # Rewrite the line rather than substituting it, so the flag is cleared whatever the
+  # controller put there, and also when it put nothing at all.
   bashrc_file = '/root/.bashrc'
-  get_target('localhost').run("sed -i 's/export UYUNI_NOT_INSTALLED=true/export UYUNI_NOT_INSTALLED=false/g' #{bashrc_file}")
+  localhost = get_target('localhost')
+  localhost.run("sed -i '/^export UYUNI_NOT_INSTALLED=/d' #{bashrc_file}")
+  localhost.run("echo 'export UYUNI_NOT_INSTALLED=false' >> #{bashrc_file}")
 end
 
 # get the Cobbler log output when it fails

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -153,8 +153,7 @@ $stdout.puts "Capybara APP Host: #{Capybara.app_host}:#{Capybara.server_port}"
 World(MiniTest::Assertions)
 
 # Initialize the API client
-$api_test = new_api_client
-
+$api_test = new_api_client unless ENV.key?('UYUNI_NOT_INSTALLED') && ENV['UYUNI_NOT_INSTALLED'] == 'true'
 # Init CodeCoverage Handler
 $code_coverage = CodeCoverage.new if $code_coverage_mode
 
@@ -293,6 +292,13 @@ AfterAll do
   process_code_coverage
 end
 
+After('@install_mlm_on_rke2') do |scenario|
+  next unless scenario.passed?
+
+  bashrc_file = '/root/.bashrc'
+  get_target('localhost').run("sed -i 's/export UYUNI_NOT_INSTALLED=true/export UYUNI_NOT_INSTALLED=false/g' #{bashrc_file}")
+end
+
 # get the Cobbler log output when it fails
 After('@scope_cobbler') do |scenario|
   if scenario.failed?
@@ -408,7 +414,7 @@ Before('@skip_known_issue') do
 end
 
 # Create a user for each feature
-Before do |scenario|
+Before('not @no_user_creation') do |scenario|
   feature_path = scenario.location.file
   $feature_filename = feature_path.split(%r{(\.feature|/)})[-2]
   next if get_context('user_created') == true

--- a/testsuite/features/support/remote_node.rb
+++ b/testsuite/features/support/remote_node.rb
@@ -32,13 +32,16 @@ class RemoteNode
     @hostname = out.strip
     raise LoadError, "We can't connect to #{@host} through SSH." if @hostname.empty?
 
+    # A Bare Host has no container to exec into, even though the mgrctl binary ships in the base image.
+    uyuni_not_installed = !ssh('kubectl get deployment uyuni -n uyuni', host: @target).last.zero? && !ssh('podman container exists uyuni-server', host: @target).last.zero?
+
     $named_nodes[host] = @hostname
     if @host == 'server'
-      @has_mgrctl = ssh('which mgrctl', host: @target).last.zero?
+      @has_mgrctl = ssh('which mgrctl', host: @target).last.zero? && !uyuni_not_installed
       @has_kubectl = ssh('which kubectl', host: @target).last.zero?
     end
 
-    if @host == 'server' && !@has_kubectl
+    if @host == 'server' && !@has_kubectl && !uyuni_not_installed
       # Remove /etc/motd inside the container, or any output from run will contain the content of /etc/motd
       run('rm -f /etc/motd && touch /etc/motd')
       out, code = run('sed -n \'s/^java.hostname *= *\(.\+\)$/\1/p\' /etc/rhn/rhn.conf')
@@ -52,8 +55,13 @@ class RemoteNode
 
     # Determine OS version and OS family both inside the container and on the local host
     # in the case of non-containerized systems, both fields will be identical:
-    @os_version, @os_family = get_os_version
     @local_os_version, @local_os_family = get_os_version(runs_in_container: false)
+    if uyuni_not_installed
+      @os_version = @local_os_version
+      @os_family = @local_os_family
+    else
+      @os_version, @os_family = get_os_version
+    end
 
     if (PRIVATE_ADDRESSES.key? host) && !$private_net.nil?
       @private_ip = net_prefix + PRIVATE_ADDRESSES[host]

--- a/testsuite/features/support/remote_node.rb
+++ b/testsuite/features/support/remote_node.rb
@@ -32,11 +32,11 @@ class RemoteNode
     @hostname = out.strip
     raise LoadError, "We can't connect to #{@host} through SSH." if @hostname.empty?
 
-    # A Bare Host has no container to exec into, even though the mgrctl binary ships in the base image.
-    uyuni_not_installed = !ssh('kubectl get deployment uyuni -n uyuni', host: @target).last.zero? && !ssh('podman container exists uyuni-server', host: @target).last.zero?
-
     $named_nodes[host] = @hostname
+    uyuni_not_installed = false
     if @host == 'server'
+      uyuni_not_installed = !ssh('kubectl get deployment uyuni -n uyuni', host: @target).last.zero? && !ssh('podman container exists uyuni-server', host: @target).last.zero?
+
       @has_mgrctl = ssh('which mgrctl', host: @target).last.zero? && !uyuni_not_installed
       @has_kubectl = ssh('which kubectl', host: @target).last.zero?
     end
@@ -48,10 +48,6 @@ class RemoteNode
     else
       out, _err, code = ssh('hostname -f', host: @target)
     end
-    @full_hostname = out.strip
-    raise StandardError, "No FQDN for '#{@hostname}'. Response code: #{code}" if @full_hostname.empty?
-
-    $stdout.puts "Host '#{@host}' is alive with determined hostname #{@hostname} and FQDN #{@full_hostname}" unless $build_validation
 
     # Determine OS version and OS family both inside the container and on the local host
     # in the case of non-containerized systems, both fields will be identical:
@@ -62,6 +58,11 @@ class RemoteNode
     else
       @os_version, @os_family = get_os_version
     end
+
+    @full_hostname = out.strip
+    raise StandardError, "No FQDN for '#{@hostname}'. Response code: #{code}" if @full_hostname.empty?
+
+    $stdout.puts "Host '#{@host}' is alive with determined hostname #{@hostname} and FQDN #{@full_hostname}" unless $build_validation
 
     if (PRIVATE_ADDRESSES.key? host) && !$private_net.nil?
       @private_ip = net_prefix + PRIVATE_ADDRESSES[host]

--- a/testsuite/features/support/remote_node.rb
+++ b/testsuite/features/support/remote_node.rb
@@ -35,6 +35,9 @@ class RemoteNode
     $named_nodes[host] = @hostname
     uyuni_not_installed = false
     if @host == 'server'
+      # The server runs either as a Kubernetes deployment or as a podman container. A bare host
+      # has neither, and mgrctl alone does not tell them apart because the binary already ships
+      # in the base image of a transactional server, with nothing to exec into yet.
       uyuni_not_installed = !ssh('kubectl get deployment uyuni -n uyuni', host: @target).last.zero? && !ssh('podman container exists uyuni-server', host: @target).last.zero?
 
       @has_mgrctl = ssh('which mgrctl', host: @target).last.zero? && !uyuni_not_installed

--- a/testsuite/run_sets/install_mlm_on_rke2.yml
+++ b/testsuite/run_sets/install_mlm_on_rke2.yml
@@ -4,10 +4,12 @@
 # feature files in testsuite/documentation/guidelines.md in "Rules for features" chapter,
 # as well as guidelines about idempotency in "Idempotency" chapter.
 
-## Secondary features BEGIN ##
+## Install MLM on RKE2 BEGIN ##
 
 # IDEMPOTENT
 
 - features/kubernetes/srv_install_mlm_dependencies_on_rke2.feature
 - features/kubernetes/srv_install_mlm_on_rke2.feature
 - features/kubernetes/srv_rke2_check_installation.feature
+
+## Install MLM on RKE2 END ##

--- a/testsuite/run_sets/install_mlm_on_rke2.yml
+++ b/testsuite/run_sets/install_mlm_on_rke2.yml
@@ -8,6 +8,6 @@
 
 # IDEMPOTENT
 
+- features/kubernetes/srv_install_mlm_dependencies_on_rke2.feature
+- features/kubernetes/srv_install_mlm_on_rke2.feature
 - features/kubernetes/srv_rke2_check_installation.feature
-- features/kubernetes/proxy_rke2_install.feature
-- features/kubernetes/srv_rke2_tftpd_sanity.feature

--- a/testsuite/run_sets/install_rke2.yml
+++ b/testsuite/run_sets/install_rke2.yml
@@ -8,6 +8,4 @@
 
 # IDEMPOTENT
 
-- features/kubernetes/srv_rke2_check_installation.feature
-- features/kubernetes/proxy_rke2_install.feature
-- features/kubernetes/srv_rke2_tftpd_sanity.feature
+- features/kubernetes/srv_install_rke2.feature

--- a/testsuite/run_sets/install_rke2.yml
+++ b/testsuite/run_sets/install_rke2.yml
@@ -4,8 +4,10 @@
 # feature files in testsuite/documentation/guidelines.md in "Rules for features" chapter,
 # as well as guidelines about idempotency in "Idempotency" chapter.
 
-## Secondary features BEGIN ##
+## Install RKE2 BEGIN ##
 
 # IDEMPOTENT
 
 - features/kubernetes/srv_install_rke2.feature
+
+## Install RKE2 END ##

--- a/testsuite/run_sets/kubernetes_sanity_checks.yml
+++ b/testsuite/run_sets/kubernetes_sanity_checks.yml
@@ -4,10 +4,12 @@
 # feature files in testsuite/documentation/guidelines.md in "Rules for features" chapter,
 # as well as guidelines about idempotency in "Idempotency" chapter.
 
-## Secondary features BEGIN ##
+## Kubernetes sanity checks BEGIN ##
 
 # IDEMPOTENT
 
 - features/kubernetes/srv_rke2_check_installation.feature
 - features/kubernetes/proxy_rke2_install.feature
 - features/kubernetes/srv_rke2_tftpd_sanity.feature
+
+## Kubernetes sanity checks END ##

--- a/testsuite/run_sets/kubernetes_tests.yml
+++ b/testsuite/run_sets/kubernetes_tests.yml
@@ -4,8 +4,10 @@
 # feature files in testsuite/documentation/guidelines.md in "Rules for features" chapter,
 # as well as guidelines about idempotency in "Idempotency" chapter.
 
-## Secondary features BEGIN ##
+## Kubernetes tests BEGIN ##
 
 # IDEMPOTENT
 
 - features/kubernetes/srv_rke2_external_ca.feature
+
+## Kubernetes tests END ##


### PR DESCRIPTION
## What does this PR change?

Follow-up cleanups on the RKE2 installation features added by #12529.

`UYUNI_NOT_INSTALLED` was read inline at four call sites, so it now goes through a
single `uyuni_not_installed?` helper in `commonlib.rb`. The `After` hook that clears
the flag rewrote `/root/.bashrc` with a substitution on one exact string, which
silently did nothing if the controller had written anything else, or nothing at all;
it now deletes the line and appends the new value. The helm installer is fetched with
`curl -sfL`, so an HTTP error page is no longer piped into `bash` — `set -o pipefail`
alone does not catch that, since curl exits 0 on a 404 without `-f`. The rest is the
new feature files: `Given`/`When`/`Then` on the first step of each scenario instead of
`And`, the `@install_mlm_on_rke2` tag indented like its scenario, and checks for
`HELM_CHART_URL` and `HELM_CHART_NAME`, which the steps use but nothing asserted.

Also restores the comment explaining why the server probe tests both `kubectl` and
`podman`: `mgrctl` already ships in the base image of a transactional server, so its
presence alone does not mean there is a container to exec into.

**This is stacked on #12529** and shows its commits until that one merges. Nothing here
belongs to it; the diff of my own commit is the last one on the branch.

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31335
Port(s):

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
