### PR TITLE
Fix CLM promotion race by publishing alignment after commit (bsc#1275315)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -31,6 +31,7 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static org.hibernate.resource.transaction.spi.TransactionStatus.COMMITTED;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.hibernate.LookupException;
@@ -1163,7 +1164,15 @@ public class ContentManager {
 
         AlignSoftwareTargetMsg msg = new AlignSoftwareTargetMsg(src, tgt, filters, user);
         if (async) {
-            MessageQueue.publish(msg);
+            msg.getTransaction().runAfterCompletion(status -> {
+                if (status == COMMITTED) {
+                    MessageQueue.publish(msg);
+                }
+                else {
+                    LOG.warn("Skipping alignment for target {}: transaction completed with status {}",
+                        tgt.getId(), status);
+                }
+            });
         }
         else {
             new AlignSoftwareTargetAction().execute(msg);

--- a/java/spacewalk-java.changes.cbbayburt.bsc1275315
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1275315
@@ -1,0 +1,2 @@
+- Fix CLM promotion race by publishing alignment after commit
+  (bsc#1275315)


### PR DESCRIPTION
Defers asynchronous CLM alignment messages until the transaction creating their environment targets has properly finished committing, preventing intermittent missing-target errors, empty channels, and environments stuck in Building.

See: https://bugzilla.suse.com/show_bug.cgi?id=1275315

Port of: https://github.com/SUSE/spacewalk/pull/31733

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
