### PR TITLE
Forward the oscap rule and content options to the scanned system

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/action/scap/ScapAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/scap/ScapAction.java
@@ -33,6 +33,7 @@ import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.audit.ScapManager;
 
+import com.suse.manager.webui.utils.ScapUtils;
 import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.calls.modules.Openscap;
 import com.suse.salt.netapi.calls.modules.State;
@@ -149,11 +150,10 @@ public class ScapAction extends Action {
      */
     private Map<LocalCall<?>, List<MinionSummary>> buildSaltCallsBeta(List<MinionSummary> minionSummaries) {
         Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        Map<String, Object> pillar = new HashMap<>();
+        Map<String, Object> pillar = new HashMap<>(
+                ScapUtils.parseOscapParameters(scapActionDetails.getParametersContents()));
 
         Matcher profileMatcher = Pattern.compile("--profile (([\\w.-])+)")
-                .matcher(scapActionDetails.getParametersContents());
-        Matcher ruleMatcher = Pattern.compile("--rule (([\\w.-])+)")
                 .matcher(scapActionDetails.getParametersContents());
         Matcher tailoringFileMatcher = Pattern.compile("--tailoring-file (([\\w./-])+)")
                 .matcher(scapActionDetails.getParametersContents());
@@ -204,19 +204,10 @@ public class ScapAction extends Action {
             pillar.put("profile", profileMatcher.group(1));
         }
 
-        if (ruleMatcher.find()) {
-            pillar.put("rule", ruleMatcher.group(1));
-        }
         if (tailoringFileMatcher.find()) {
             String tailoringPath = tailoringFileMatcher.group(1);
             String tailoringFilename = new File(tailoringPath).getName();
             pillar.put("tailoring_filename", tailoringFilename);
-        }
-        if (scapActionDetails.getParametersContents().contains("--fetch-remote-resources")) {
-            pillar.put("fetch_remote_resources", true);
-        }
-        if (scapActionDetails.getParametersContents().contains("--remediate")) {
-            pillar.put("remediate", true);
         }
 
         ret.put(State.apply(singletonList("scap_beta.scan"),
@@ -233,11 +224,10 @@ public class ScapAction extends Action {
      */
     private Map<LocalCall<?>, List<MinionSummary>> buildSaltCalls(List<MinionSummary> minionSummaries) {
         Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        Map<String, Object> pillar = new HashMap<>();
+        Map<String, Object> pillar = new HashMap<>(
+                ScapUtils.parseOscapParameters(scapActionDetails.getParametersContents()));
 
         Matcher profileMatcher = Pattern.compile("--profile (([\\w.-])+)")
-                .matcher(scapActionDetails.getParametersContents());
-        Matcher ruleMatcher = Pattern.compile("--rule (([\\w.-])+)")
                 .matcher(scapActionDetails.getParametersContents());
         Matcher tailoringFileMatcher = Pattern.compile("--tailoring-file (([\\w./-])+)")
                 .matcher(scapActionDetails.getParametersContents());
@@ -257,20 +247,11 @@ public class ScapAction extends Action {
         if (profileMatcher.find()) {
             pillar.put("profile", profileMatcher.group(1));
         }
-        if (ruleMatcher.find()) {
-            pillar.put("rule", ruleMatcher.group(1));
-        }
         if (tailoringFileMatcher.find()) {
             pillar.put("tailoring_file", tailoringFileMatcher.group(1));
         }
         if (tailoringIdMatcher.find()) {
             pillar.put("tailoring_id", tailoringIdMatcher.group(1));
-        }
-        if (scapActionDetails.getParametersContents().contains("--fetch-remote-resources")) {
-            pillar.put("fetch_remote_resources", true);
-        }
-        if (scapActionDetails.getParametersContents().contains("--remediate")) {
-            pillar.put("remediate", true);
         }
 
         ret.put(State.apply(singletonList("scap"),

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/scap/SystemScapHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/scap/SystemScapHandler.java
@@ -139,7 +139,12 @@ public class SystemScapHandler extends BaseHandler {
      * @apidoc.param #session_key()
      * @apidoc.param #array_single("int", "sids")
      * @apidoc.param #param_desc("string", "xccdfPath", "path to xccdf content on targeted systems.")
-     * @apidoc.param #param_desc("string", "oscapParams", "additional parameters for oscap tool.")
+     * @apidoc.param #param_desc("string", "oscapParams", "additional parameters for the oscap
+     * tool. Only the options selecting the rules to evaluate and the content to use are passed
+     * on: --profile, --rule, --skip-rule, --reference, --cpe, --local-files, --datastream-id,
+     * --xccdf-id, --benchmark-id, --tailoring-file, --tailoring-id, --fetch-remote-resources
+     * and --remediate. Any other option is ignored, the result files being written by the
+     * scan itself.")
      * @apidoc.returntype #param_desc("int", "id", "ID if SCAP action created")
      */
     public int scheduleXccdfScan(User loggedInUser, List sids,
@@ -161,7 +166,12 @@ public class SystemScapHandler extends BaseHandler {
      * @apidoc.param #session_key()
      * @apidoc.param #array_single("int", "sids")
      * @apidoc.param #param_desc("string", "xccdfPath", "path to xccdf content on targeted systems.")
-     * @apidoc.param #param_desc("string", "oscapParams", "additional parameters for oscap tool.")
+     * @apidoc.param #param_desc("string", "oscapParams", "additional parameters for the oscap
+     * tool. Only the options selecting the rules to evaluate and the content to use are passed
+     * on: --profile, --rule, --skip-rule, --reference, --cpe, --local-files, --datastream-id,
+     * --xccdf-id, --benchmark-id, --tailoring-file, --tailoring-id, --fetch-remote-resources
+     * and --remediate. Any other option is ignored, the result files being written by the
+     * scan itself.")
      * @apidoc.param #param_desc("$date","date",
      *                       "The date to schedule the action")
      * @apidoc.returntype #param_desc("int", "id", "ID if SCAP action created")
@@ -186,7 +196,12 @@ public class SystemScapHandler extends BaseHandler {
      * @apidoc.param #session_key()
      * @apidoc.param #array_single("int", "sids")
      * @apidoc.param #param_desc("string", "xccdfPath", "Path to xccdf content on targeted systems.")
-     * @apidoc.param #param_desc("string", "oscapPrams", "Additional parameters for oscap tool.")
+     * @apidoc.param #param_desc("string", "oscapParams", "additional parameters for the oscap
+     * tool. Only the options selecting the rules to evaluate and the content to use are passed
+     * on: --profile, --rule, --skip-rule, --reference, --cpe, --local-files, --datastream-id,
+     * --xccdf-id, --benchmark-id, --tailoring-file, --tailoring-id, --fetch-remote-resources
+     * and --remediate. Any other option is ignored, the result files being written by the
+     * scan itself.")
      * @apidoc.param #param_desc("string", "ovalFiles", "Additional OVAL files for oscap tool.")
      * @apidoc.param #param_desc("$date","date",
      *                       "The date to schedule the action")
@@ -233,7 +248,12 @@ public class SystemScapHandler extends BaseHandler {
      * @apidoc.param #session_key()
      * @apidoc.param #param("int", "sid")
      * @apidoc.param #param_desc("string", "xccdfPath", "Path to xccdf content on targeted systems.")
-     * @apidoc.param #param_desc("string", "oscapPrams", "Additional parameters for oscap tool.")
+     * @apidoc.param #param_desc("string", "oscapParams", "additional parameters for the oscap
+     * tool. Only the options selecting the rules to evaluate and the content to use are passed
+     * on: --profile, --rule, --skip-rule, --reference, --cpe, --local-files, --datastream-id,
+     * --xccdf-id, --benchmark-id, --tailoring-file, --tailoring-id, --fetch-remote-resources
+     * and --remediate. Any other option is ignored, the result files being written by the
+     * scan itself.")
      * @apidoc.returntype #param_desc("int", "id", "ID of the scap action created")
      */
     public int scheduleXccdfScan(User loggedInUser, Integer sid,
@@ -254,7 +274,12 @@ public class SystemScapHandler extends BaseHandler {
      * @apidoc.param #session_key()
      * @apidoc.param #param("int", "sid")
      * @apidoc.param #param_desc("string", "xccdfPath", "Path to xccdf content on targeted systems.")
-     * @apidoc.param #param_desc("string", "oscapPrams", "Additional parameters for oscap tool.")
+     * @apidoc.param #param_desc("string", "oscapParams", "additional parameters for the oscap
+     * tool. Only the options selecting the rules to evaluate and the content to use are passed
+     * on: --profile, --rule, --skip-rule, --reference, --cpe, --local-files, --datastream-id,
+     * --xccdf-id, --benchmark-id, --tailoring-file, --tailoring-id, --fetch-remote-resources
+     * and --remediate. Any other option is ignored, the result files being written by the
+     * scan itself.")
      * @apidoc.param #param_desc("$date","date",
      *                       "The date to schedule the action")
      * @apidoc.returntype #param_desc("int", "id", "ID of the scap action created")

--- a/java/core/src/main/java/com/suse/manager/webui/utils/ScapUtils.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/ScapUtils.java
@@ -16,13 +16,33 @@ package com.suse.manager.webui.utils;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * Utility class for SCAP-related operations
  */
 public class ScapUtils {
 
+    private static final Pattern RULE = optionPattern("--rule", "[\\w.-]+");
+    private static final Pattern SKIP_RULE = optionPattern("--skip-rule", "[\\w.-]+");
+    private static final Pattern REFERENCE = optionPattern("--reference", "[\\w.:-]+");
+    private static final Pattern CPE = optionPattern("--cpe", "[\\w./-]+");
+    private static final Pattern LOCAL_FILES = optionPattern("--local-files", "[\\w./-]+");
+    private static final Pattern DATASTREAM_ID = optionPattern("--datastream-id", "[\\w.-]+");
+    private static final Pattern XCCDF_ID = optionPattern("--xccdf-id", "[\\w.-]+");
+    private static final Pattern BENCHMARK_ID = optionPattern("--benchmark-id", "[\\w.-]+");
+
     private ScapUtils() {
         // Utility class, no instantiation
+    }
+
+    private static Pattern optionPattern(String option, String valuePattern) {
+        return Pattern.compile("(?:^|\\s)" + option + "\\s+(" + valuePattern + ")");
     }
 
     /**
@@ -56,5 +76,65 @@ public class ScapUtils {
         }
 
         return params.toString().trim();
+    }
+
+    /**
+     * Extracts the oscap options that the Salt states can forward to the scanned system.
+     *
+     * The oscap command line is rebuilt on the minion from the pillar, it is not passed through, so
+     * an option that is not extracted here never reaches oscap. Only the options selecting which
+     * rules are evaluated and where the content comes from are extracted: the ones writing the
+     * result files are set by the state itself, since the server collects and parses them.
+     *
+     * @param parameters the oscap parameters, as entered by the user
+     * @return the parsed options, keyed by the pillar entry name
+     */
+    public static Map<String, Object> parseOscapParameters(String parameters) {
+        Map<String, Object> parsed = new HashMap<>();
+        if (StringUtils.isEmpty(parameters)) {
+            return parsed;
+        }
+
+        putRepeatable(parsed, "rule", RULE, parameters);
+        putRepeatable(parsed, "skip_rule", SKIP_RULE, parameters);
+        putSingle(parsed, "reference", REFERENCE, parameters);
+        putSingle(parsed, "cpe", CPE, parameters);
+        putSingle(parsed, "local_files", LOCAL_FILES, parameters);
+        putSingle(parsed, "datastream_id", DATASTREAM_ID, parameters);
+        putSingle(parsed, "xccdf_id", XCCDF_ID, parameters);
+        putSingle(parsed, "benchmark_id", BENCHMARK_ID, parameters);
+
+        if (parameters.contains("--fetch-remote-resources")) {
+            parsed.put("fetch_remote_resources", true);
+        }
+        if (parameters.contains("--remediate")) {
+            parsed.put("remediate", true);
+        }
+
+        return parsed;
+    }
+
+    private static void putSingle(Map<String, Object> parsed, String key, Pattern pattern, String parameters) {
+        Matcher matcher = pattern.matcher(parameters);
+        if (matcher.find()) {
+            parsed.put(key, matcher.group(1));
+        }
+    }
+
+    private static void putRepeatable(Map<String, Object> parsed, String key, Pattern pattern, String parameters) {
+        List<String> values = new ArrayList<>();
+        Matcher matcher = pattern.matcher(parameters);
+        while (matcher.find()) {
+            values.add(matcher.group(1));
+        }
+
+        if (values.size() == 1) {
+            // A single value stays a plain string: a minion whose Salt module does not support
+            // lists yet then keeps building the very same command as before.
+            parsed.put(key, values.get(0));
+        }
+        else if (!values.isEmpty()) {
+            parsed.put(key, values);
+        }
     }
 }

--- a/java/core/src/test/java/com/suse/manager/webui/utils/ScapUtilsTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/utils/ScapUtilsTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for the parsing of the oscap parameters.
+ */
+public class ScapUtilsTest {
+
+    private static final String PROFILE = "--profile xccdf_org.ssgproject.content_profile_cis";
+    private static final String RULE = "xccdf_org.ssgproject.content_rule_package_telnet_removed";
+    private static final String OTHER_RULE = "xccdf_org.ssgproject.content_rule_package_tftp_removed";
+
+    @Test
+    public void testEmptyParameters() {
+        assertTrue(ScapUtils.parseOscapParameters(null).isEmpty());
+        assertTrue(ScapUtils.parseOscapParameters("").isEmpty());
+    }
+
+    @Test
+    public void testSingleSkipRuleIsAString() {
+        Map<String, Object> parsed = ScapUtils.parseOscapParameters(PROFILE + " --skip-rule " + RULE);
+        assertEquals(RULE, parsed.get("skip_rule"));
+    }
+
+    @Test
+    public void testRepeatedSkipRulesAreAList() {
+        Map<String, Object> parsed = ScapUtils.parseOscapParameters(
+                PROFILE + " --skip-rule " + RULE + " --skip-rule " + OTHER_RULE);
+        assertEquals(List.of(RULE, OTHER_RULE), parsed.get("skip_rule"));
+    }
+
+    @Test
+    public void testRepeatedRulesAreAList() {
+        Map<String, Object> parsed = ScapUtils.parseOscapParameters("--rule " + RULE + " --rule " + OTHER_RULE);
+        assertEquals(List.of(RULE, OTHER_RULE), parsed.get("rule"));
+    }
+
+    @Test
+    public void testSingleRuleStaysAStringForOlderMinions() {
+        Map<String, Object> parsed = ScapUtils.parseOscapParameters("--rule " + RULE);
+        assertEquals(RULE, parsed.get("rule"));
+    }
+
+    @Test
+    public void testSkipRuleIsNotParsedAsARule() {
+        Map<String, Object> parsed = ScapUtils.parseOscapParameters(PROFILE + " --skip-rule " + RULE);
+        assertFalse(parsed.containsKey("rule"));
+    }
+
+    @Test
+    public void testContentSelectionOptions() {
+        Map<String, Object> parsed = ScapUtils.parseOscapParameters(
+                "--reference stigid:RHEL-09-211010 " +
+                "--cpe /usr/share/openscap/cpe/openscap-cpe-dict.xml " +
+                "--local-files /var/cache/openscap " +
+                "--datastream-id scap_org.open-scap_datastream_from_xccdf " +
+                "--xccdf-id scap_org.open-scap_cref_xccdf.xml " +
+                "--benchmark-id xccdf_org.ssgproject.content_benchmark_RHEL-9");
+
+        assertEquals("stigid:RHEL-09-211010", parsed.get("reference"));
+        assertEquals("/usr/share/openscap/cpe/openscap-cpe-dict.xml", parsed.get("cpe"));
+        assertEquals("/var/cache/openscap", parsed.get("local_files"));
+        assertEquals("scap_org.open-scap_datastream_from_xccdf", parsed.get("datastream_id"));
+        assertEquals("scap_org.open-scap_cref_xccdf.xml", parsed.get("xccdf_id"));
+        assertEquals("xccdf_org.ssgproject.content_benchmark_RHEL-9", parsed.get("benchmark_id"));
+    }
+
+    @Test
+    public void testFlags() {
+        Map<String, Object> parsed = ScapUtils.parseOscapParameters(
+                PROFILE + " --fetch-remote-resources --remediate");
+        assertEquals(true, parsed.get("fetch_remote_resources"));
+        assertEquals(true, parsed.get("remediate"));
+
+        Map<String, Object> withoutFlags = ScapUtils.parseOscapParameters(PROFILE);
+        assertFalse(withoutFlags.containsKey("fetch_remote_resources"));
+        assertFalse(withoutFlags.containsKey("remediate"));
+    }
+
+    @Test
+    public void testUnsupportedOptionsAreIgnored() {
+        Map<String, Object> parsed = ScapUtils.parseOscapParameters(PROFILE + " --results-arf /tmp/arf.xml");
+        assertFalse(parsed.containsKey("results_arf"));
+        assertTrue(parsed.isEmpty());
+    }
+
+    @Test
+    public void testProfileAndTailoringAreLeftToTheCaller() {
+        // Both callers map those to different pillar entries, so they are not parsed here.
+        Map<String, Object> parsed = ScapUtils.parseOscapParameters(
+                PROFILE + " --tailoring-file /etc/openscap/tailoring.xml --tailoring-id component");
+        assertFalse(parsed.containsKey("profile"));
+        assertFalse(parsed.containsKey("tailoring_file"));
+        assertFalse(parsed.containsKey("tailoring_id"));
+    }
+
+    @Test
+    public void testRoundTripWithTheParametersBuiltByTheUi() {
+        String parameters = ScapUtils.buildOscapParameters("xccdf_org.ssgproject.content_profile_cis",
+                "/etc/openscap/tailoring.xml", "xccdf_tailoring_profile", "--skip-rule " + RULE, true);
+        Map<String, Object> parsed = ScapUtils.parseOscapParameters(parameters);
+
+        assertEquals(RULE, parsed.get("skip_rule"));
+        assertEquals(true, parsed.get("fetch_remote_resources"));
+    }
+}

--- a/java/spacewalk-java.changes.jniedergang.openscap-rule-and-content-options
+++ b/java/spacewalk-java.changes.jniedergang.openscap-rule-and-content-options
@@ -1,0 +1,3 @@
+- Forward the oscap options that select rules and content, such as
+  --skip-rule, to the scanned system instead of dropping them
+  silently, and document the supported options in the API

--- a/susemanager-utils/susemanager-sls/salt/scap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/scap/init.sls
@@ -22,6 +22,27 @@ mgr_scap:
         {%- if "rule" in pillar.get('mgr_scap_params') %}
         rule: {{ pillar['mgr_scap_params']['rule'] }}
         {%- endif %}
+        {%- if "skip_rule" in pillar.get('mgr_scap_params') %}
+        skip_rule: {{ pillar['mgr_scap_params']['skip_rule'] }}
+        {%- endif %}
+        {%- if "reference" in pillar.get('mgr_scap_params') %}
+        reference: "{{ pillar['mgr_scap_params']['reference'] }}"
+        {%- endif %}
+        {%- if "cpe" in pillar.get('mgr_scap_params') %}
+        cpe: {{ pillar['mgr_scap_params']['cpe'] }}
+        {%- endif %}
+        {%- if "local_files" in pillar.get('mgr_scap_params') %}
+        local_files: {{ pillar['mgr_scap_params']['local_files'] }}
+        {%- endif %}
+        {%- if "datastream_id" in pillar.get('mgr_scap_params') %}
+        datastream_id: {{ pillar['mgr_scap_params']['datastream_id'] }}
+        {%- endif %}
+        {%- if "xccdf_id" in pillar.get('mgr_scap_params') %}
+        xccdf_id: {{ pillar['mgr_scap_params']['xccdf_id'] }}
+        {%- endif %}
+        {%- if "benchmark_id" in pillar.get('mgr_scap_params') %}
+        benchmark_id: {{ pillar['mgr_scap_params']['benchmark_id'] }}
+        {%- endif %}
         {%- if "remediate" in pillar.get('mgr_scap_params') %}
         remediate: {{ pillar['mgr_scap_params']['remediate'] }}
         {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/scap_beta/scan.sls
+++ b/susemanager-utils/susemanager-sls/salt/scap_beta/scan.sls
@@ -51,6 +51,27 @@ mgr_scap:
         {%- if "rule" in pillar.get('mgr_scap_params') %}
         rule: {{ pillar['mgr_scap_params']['rule'] }}
         {%- endif %}
+        {%- if "skip_rule" in pillar.get('mgr_scap_params') %}
+        skip_rule: {{ pillar['mgr_scap_params']['skip_rule'] }}
+        {%- endif %}
+        {%- if "reference" in pillar.get('mgr_scap_params') %}
+        reference: "{{ pillar['mgr_scap_params']['reference'] }}"
+        {%- endif %}
+        {%- if "cpe" in pillar.get('mgr_scap_params') %}
+        cpe: {{ pillar['mgr_scap_params']['cpe'] }}
+        {%- endif %}
+        {%- if "local_files" in pillar.get('mgr_scap_params') %}
+        local_files: {{ pillar['mgr_scap_params']['local_files'] }}
+        {%- endif %}
+        {%- if "datastream_id" in pillar.get('mgr_scap_params') %}
+        datastream_id: {{ pillar['mgr_scap_params']['datastream_id'] }}
+        {%- endif %}
+        {%- if "xccdf_id" in pillar.get('mgr_scap_params') %}
+        xccdf_id: {{ pillar['mgr_scap_params']['xccdf_id'] }}
+        {%- endif %}
+        {%- if "benchmark_id" in pillar.get('mgr_scap_params') %}
+        benchmark_id: {{ pillar['mgr_scap_params']['benchmark_id'] }}
+        {%- endif %}
         {%- if "remediate" in pillar.get('mgr_scap_params') %}
         remediate: {{ pillar['mgr_scap_params']['remediate'] }}
         {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.jniedergang.openscap-rule-and-content-options
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.jniedergang.openscap-rule-and-content-options
@@ -1,0 +1,2 @@
+- Pass the oscap options selecting rules and content to the
+  openscap module when running an XCCDF scan


### PR DESCRIPTION
## What does this PR change?

The oscap arguments entered when scheduling an OpenSCAP scan are not passed to `oscap`. The server
re-parses them and rebuilds the command line from six options only (`--profile`, `--rule`,
`--tailoring-file`, `--tailoring-id`, `--fetch-remote-resources`, `--remediate`); everything else is
dropped with no error and no warning, while the scan details keep displaying it. Someone asking to
skip a rule gets a compliance report where that rule was evaluated anyway. `--fetch-remote-resources`
had the same problem in #3222, fixed in #3914 by adding it to the list.

This adds the options that select which rules are evaluated and where the content comes from:
`--skip-rule`, `--reference`, `--cpe`, `--local-files`, `--datastream-id`, `--xccdf-id` and
`--benchmark-id`. The options writing the result files (`--results`, `--results-arf`, `--report`,
`--oval-results`, `--stig-viewer`, `--thin-results`, `--progress`, `--verbose`) are deliberately left
out, since the state sets them itself and the server collects and parses those files.

The API documentation of `oscapParams` is updated accordingly: it promised that any parameter was
passed to oscap, which is what made the silent drop so easy to miss.

The parsing moves to `ScapUtils.parseOscapParameters()`, shared by `buildSaltCalls()` and
`buildSaltCallsBeta()`, which duplicated the same six regular expressions. Without that, every option
would have had to be added twice and none of it would be unit-testable.

`--rule` and `--skip-rule` are collected into a list when they appear more than once, since oscap
accepts them repeatedly. A single occurrence stays a plain string, so a minion whose `openscap` Salt
module is not updated yet keeps building exactly the same command as before.

**Requires the matching change in the `openscap` Salt module** (openSUSE/salt PR linked below), which
is what actually adds the options to the oscap command line on the minion. Until a minion has it, the
new pillar entries land in the module's `**kwargs` and are ignored, which is the current behavior.

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

The "Command-line arguments" / "Advanced Arguments" field of an OpenSCAP scan now honors seven more
oscap options: `--skip-rule`, `--reference`, `--cpe`, `--local-files`, `--datastream-id`,
`--xccdf-id`, `--benchmark-id`, and accepts `--rule` and `--skip-rule` more than once. Options that
were silently ignored before will now take effect, which can change the content of a compliance
report for a scan that already used them. Requires a client with the updated `openscap` Salt module.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference: the arguments field already exists, only what it does with its content changes.

- [x] **DONE**

## Documentation
- API documentation added: the `oscapParams` description of `system.scap.scheduleXccdfScan` now
  lists the options that are actually passed on, instead of promising that any oscap parameter is.
  It also fixes the `oscapPrams` typo in three of the five overloads.

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Unit tests were added

`ScapUtilsTest` covers the repeated options, the single occurrence staying a string, each new option,
the fact that `--skip-rule` is not mistaken for `--rule`, and that unsupported options are still
ignored.

Also checked end to end on SUSE Multi-Linux Manager 5.1 with a RHEL 9.7 minion. The change was
backported to the 5.1 sources, compiled against the deployed jars, the two classes were replaced in
the server `rhn.jar`, and a scan was then scheduled through the API, which is the code path the Web UI
uses. `/usr/bin/oscap` on the minion was replaced by a wrapper logging the real argv, which shows:

```
[xccdf] [eval] [--oval-results] [--results] [results.xml] [--report] [report.html]
[--profile] [<profile>] [--skip-rule] [<rule 1>] [--skip-rule] [<rule 2>]
[--xccdf-id] [scap_org.open-scap_cref_ssg-rhel9-xccdf.xml] [<data stream>]
```

The action completes, and the same scan without the new options produces exactly the command built
before this change.

- [x] **DONE**

## Links

Issue(s): #12538
Port(s): #

Salt module counterpart: https://github.com/openSUSE/salt/pull/780

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
