### PR TITLE
Uyuni: Remove activation keys when a base channel is deleted (bsc#1233592)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/token/ActivationKeyFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/token/ActivationKeyFactory.java
@@ -33,6 +33,7 @@ import com.redhat.rhn.frontend.struts.Scrubber;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.type.StandardBasicTypes;
 
 import java.util.HashMap;
 import java.util.List;
@@ -322,5 +323,74 @@ public class ActivationKeyFactory extends HibernateFactory {
      */
     public static ActivationKey lookupById(Long id, Org org) {
         return ActivationKeyFactory.lookupByToken(TokenFactory.lookup(id, org));
+    }
+
+    /**
+     * Gets a list of activation keys referring to a base channel
+     * @param channelId the base channel id
+     * @return a list of activation keys referring to a base channel
+     */
+    public static List<ActivationKey> lookupByBaseChannelId(long channelId) {
+        //rhnRegTokenChannels has no correspondent object, so we need a native query
+        return getSession().createNativeQuery(
+                        """
+                        SELECT ak.*
+                        FROM rhnActivationKey ak
+                            JOIN rhnRegToken rt ON rt.id = ak.reg_token_id
+                            JOIN rhnRegTokenChannels rtc ON rtc.token_id = ak.reg_token_id
+                            JOIN rhnChannel rc ON rc.id = rtc.channel_id
+                        WHERE rc.parent_channel IS NULL
+                        AND rc.id = :channelId
+                        """, ActivationKey.class)
+                .setParameter("channelId", channelId)
+                .addSynchronizedEntityClass(Token.class)
+                .addSynchronizedEntityClass(Channel.class)
+                .getResultList();
+    }
+
+    /**
+     * Counts the activation keys referring to a base channel
+     * @param channelId the base channel id
+     * @return the activation keys count
+     */
+    public static long countActivationKeysWithBaseChannel(long channelId) {
+        //rhnRegTokenChannels has no correspondent object, so we need a native query
+        return getSession().createNativeQuery(
+                        """
+                        SELECT COUNT(*)
+                        FROM rhnActivationKey ak
+                            JOIN rhnRegToken rt ON rt.id = ak.reg_token_id
+                            JOIN rhnRegTokenChannels rtc ON rtc.token_id = ak.reg_token_id
+                            JOIN rhnChannel rc ON rc.id = rtc.channel_id
+                        WHERE rc.parent_channel IS NULL
+                        AND rc.id = :channelId
+                        """, Long.class)
+                .setParameter("channelId", channelId, StandardBasicTypes.LONG)
+                .addSynchronizedEntityClass(Token.class)
+                .addSynchronizedEntityClass(Channel.class)
+                .uniqueResult();
+    }
+
+    /**
+     * Deletes the activation keys referring to a base channel
+     * @param channelId the base channel id
+     */
+    public static void deleteActivationKeysWithBaseChannel(long channelId) {
+        //rhnRegTokenChannels has no correspondent object, so we need a native query
+        getSession().createNativeMutationQuery(
+                        """
+                        DELETE FROM rhnActivationKey WHERE token IN
+                        (
+                            SELECT ak.token
+                            FROM rhnActivationKey ak
+                                JOIN rhnRegToken rt ON rt.id = ak.reg_token_id
+                                JOIN rhnRegTokenChannels rtc ON rtc.token_id = ak.reg_token_id
+                                JOIN rhnChannel rc ON rc.id = rtc.channel_id
+                            WHERE rc.parent_channel IS NULL
+                            AND rc.id = :channelId
+                        )
+                        """)
+                .setParameter("channelId", channelId, StandardBasicTypes.LONG)
+                .executeUpdate();
     }
 }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/manage/DeleteChannelAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/manage/DeleteChannelAction.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.domain.rhnset.RhnSet;
 import com.redhat.rhn.domain.rhnset.RhnSetFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.dto.PackageOverview;
 import com.redhat.rhn.frontend.struts.RequestContext;
@@ -72,6 +73,9 @@ public class DeleteChannelAction extends RhnAction {
         // Load the number of systems subscribed through a trust relationship to the channel
         request.setAttribute("trustedSystemsCount",
                 SystemManager.countSubscribedToChannelWithoutOrg(channel.getOrg().getId(), channelId));
+
+        // Load the number of activation keys with this channel as base class
+        request.setAttribute("activationKeysCount", ActivationKeyFactory.countActivationKeysWithBaseChannel(channelId));
 
         if (context.isSubmitted()) {
             if ((request.getParameter("unsubscribeSystems") != null) || subscribedSystemsCount == 0) {

--- a/java/core/src/main/java/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -61,6 +61,7 @@ import com.redhat.rhn.domain.server.InstalledProduct;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.action.channel.ssm.ChannelActionDAO;
 import com.redhat.rhn.frontend.dto.ChannelOverview;
@@ -717,6 +718,11 @@ public class ChannelManager extends BaseManager {
                                 environmentInUse.getContentEnvironment().getContentProject().getName(),
                                 environmentInUse.getContentEnvironment().getName())
         );
+
+        //remove all activation keys that have this as a base channel
+        if (toRemove.isBaseChannel()) {
+            ActivationKeyFactory.deleteActivationKeysWithBaseChannel(toRemove.getId());
+        }
 
         ChannelManager.queueChannelChange(label, user.getLogin(), "java::deleteChannel");
         ChannelFactory.remove(toRemove);

--- a/java/core/src/main/resources/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/core/src/main/resources/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -23291,6 +23291,25 @@ given channel.</source>
           <context context-type="sourcefile">/rhn/channels/manage/Delete.do</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="channel.delete.jsp.actkeysheader" xml:space="preserve">
+        <source>Activation Keys</source>
+            <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/channels/manage/Delete.do</context>
+        </context-group>
+      </trans-unit>
+        <trans-unit id="channel.delete.jsp.actkeysparagraph" xml:space="preserve">
+        <source>Channel deletion will remove any Activation Key that has {0} as a base channel.
+         </source>
+            <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/channels/manage/Delete.do</context>
+        </context-group>
+      </trans-unit>
+        <trans-unit id="channel.delete.jsp.actkeysaffected" xml:space="preserve">
+        <source>Activation Keys Affected:</source>
+            <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/channels/manage/Delete.do</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="channel.delete.jsp.unsubheader" xml:space="preserve">
         <source>Unsubscribe Systems</source>
         <context-group name="ctx">

--- a/java/spacewalk-java.changes.carlo.uyuni-1233592-activation-key-on-channel-removal
+++ b/java/spacewalk-java.changes.carlo.uyuni-1233592-activation-key-on-channel-removal
@@ -1,0 +1,2 @@
+- Remove activation keys when a base channel is deleted
+  (bsc#1233592)

--- a/java/webapp/src/main/webapp/WEB-INF/pages/channel/manage/delete.jsp
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/channel/manage/delete.jsp
@@ -138,6 +138,22 @@
                     </div>
                 </div>
 
+                <!-- Activation Keys -->
+                <h2><bean:message key="channel.delete.jsp.actkeysheader"/></h2>
+                <p><bean:message key="channel.delete.jsp.actkeysparagraph" arg0="<strong>${channel.name}</strong>"/></p>
+
+                <!-- Activation Keys Affected -->
+                <div class="form-group">
+                    <label class="col-lg-3 control-label">
+                        <bean:message key="channel.delete.jsp.actkeysaffected"/>
+                    </label>
+                    <div class="col-lg-6">
+                        <div class="well well-sm">
+                            <c:out value="${activationKeysCount}"/>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Unsubscribe Option -->
                 <h2><bean:message key="channel.delete.jsp.unsubheader"/></h2>
                 <p><bean:message key="channel.delete.jsp.unsubparagraph" arg0="<strong>${channel.name}</strong>"/></p>


### PR DESCRIPTION

## What does this PR change?

This is the java part of https://github.com/SUSE/spacewalk/issues/26083

When a base channel is removed, the activation keys referring to that channel are in an inconsistent state.
Therefore, when a base channel is removed, the activation keys referring to that channel must be removed as well.
Child channels removal are not affected by this issue.

This PR fixes the problem on UI and API, when removing a custom base channel. Vendor base channel removal is not supported in UI/API at the moment


## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

Release notes details:
"When custom channels are deleted, all activation keys  referring to that channel as a base channel are removed as well."

- [x] **DONE**

## GUI diff
Before:
<img width="1365" height="552" alt="was_detail" src="https://github.com/user-attachments/assets/3aa836dd-e4e9-40ec-bf50-c11c66725aa3" />

After:

<img width="1333" height="718" alt="is_detail" src="https://github.com/user-attachments/assets/0fc0ee9c-95d3-4c05-81b6-e810735639d5" />


- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/31918
- [x] **DONE**

## Test coverage
- No tests: UI manually tested
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/26083
Port(s): 
5.2: https://github.com/SUSE/spacewalk/pull/31922
5.1: https://github.com/SUSE/spacewalk/pull/31917
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

