### PR TITLE
QE: Follow-ups on the RKE2 installation features

### DIFF
--- a/testsuite/features/kubernetes/srv_install_mlm_dependencies_on_rke2.feature
+++ b/testsuite/features/kubernetes/srv_install_mlm_dependencies_on_rke2.feature
@@ -7,7 +7,7 @@
 Feature: Install MLM dependencies on RKE2
 
   Scenario: Check the RKE2 configuration
-    And the environment variable "CERT_MANAGER_VERSION" is set on "server"
+    Then the environment variable "CERT_MANAGER_VERSION" is set on "server"
     And the environment variable "CERT_MANAGER_NAMESPACE" is set on "server"
     And the environment variable "TRAEFIK_FILE" is set on "server"
     And the environment variable "LOCAL_PATH_PROVISIONER_PATH" is set on "server"
@@ -18,7 +18,7 @@ Feature: Install MLM dependencies on RKE2
 
   ## Install helm
   Scenario: Install Helm
-    When I run "set -o pipefail; curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash" on "server"
+    When I run "set -o pipefail; curl -sfL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash" on "server"
 
   Scenario: Install cert-manager and trust-manager
     When I run "helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager --version $CERT_MANAGER_VERSION --namespace $CERT_MANAGER_NAMESPACE --create-namespace --set crds.enabled=true --timeout 10m0s --wait" on "server"

--- a/testsuite/features/kubernetes/srv_install_mlm_on_rke2.feature
+++ b/testsuite/features/kubernetes/srv_install_mlm_on_rke2.feature
@@ -7,16 +7,18 @@
 Feature: Install MLM on RKE2
 
   Scenario: Check the RKE2 configuration
-    And the environment variable "PYTHON_HELM_CHART_PATH" is set on "server"
+    Then the environment variable "PYTHON_HELM_CHART_PATH" is set on "server"
     And the environment variable "HELM_CHART_DIRECTORY" is set on "server"
+    And the environment variable "HELM_CHART_URL" is set on "server"
+    And the environment variable "HELM_CHART_NAME" is set on "server"
     And the environment variable "SELF_SIGNED_PATH" is set on "server"
     And file "/etc/rancher/rke2/config.yaml" should exist on "server"
 
   Scenario: Update OCI app version
-    And I run "python3 $PYTHON_HELM_CHART_PATH -o $HELM_CHART_URL/$HELM_CHART_NAME --chart-file $SELF_SIGNED_PATH/Chart.yaml $DEVEL_FLAG" on "server"
+    When I run "python3 $PYTHON_HELM_CHART_PATH -o $HELM_CHART_URL/$HELM_CHART_NAME --chart-file $SELF_SIGNED_PATH/Chart.yaml $DEVEL_FLAG" on "server"
 
-@install_mlm_on_rke2
+  @install_mlm_on_rke2
   Scenario: Install Uyuni
-    And I run "kubectl create namespace uyuni --dry-run=client -o yaml | kubectl apply -f -" on "server"
+    When I run "kubectl create namespace uyuni --dry-run=client -o yaml | kubectl apply -f -" on "server"
     And I run "cd $SELF_SIGNED_PATH && helm dependencies build" on "server"
     And I run "cd $HELM_CHART_DIRECTORY && helm upgrade --install uyuni ./selfsigned -f ./selfsigned/values.yaml -n uyuni" on "server"

--- a/testsuite/features/kubernetes/srv_install_rke2.feature
+++ b/testsuite/features/kubernetes/srv_install_rke2.feature
@@ -30,4 +30,3 @@ Feature: Install RKE2 on transactional systems
     When I run "ln -sf /var/lib/rancher/rke2/bin/kubectl /usr/local/bin/kubectl" on "server"
     And I run "ln -sf /var/lib/rancher/rke2/bin/crictl /usr/local/bin/crictl" on "server"
     And I run "ln -sf /var/lib/rancher/rke2/bin/ctr /usr/local/bin/ctr" on "server"
-

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -2,7 +2,8 @@
 # Licensed under the terms of the MIT license.
 
 ### This file contains the definitions for all steps concerning Cobbler.
-$cobbler_test = CobblerTest.new unless ENV.key?('UYUNI_NOT_INSTALLED') && ENV['UYUNI_NOT_INSTALLED'] == 'true'
+
+$cobbler_test = CobblerTest.new unless uyuni_not_installed?
 
 # cobbler daemon
 Given(/^cobblerd is running$/) do

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1761,7 +1761,7 @@ When(/^I run spacewalk-hostname-rename command on the server$/) do
 
   # Reset the API client to take the new CA into account
   log 'Resetting the API client'
-  $api_test = new_api_client unless ENV.key?('UYUNI_NOT_INSTALLED') && ENV['UYUNI_NOT_INSTALLED'] == 'true'
+  $api_test = new_api_client unless uyuni_not_installed?
 
   raise SystemCallError, 'Error while running spacewalk-hostname-rename command - see logs above' unless result_code.zero?
   raise ScriptError, 'Error in the output logs - see logs above' if out_spacewalk.include? 'No such file or directory'

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -44,12 +44,19 @@ def count_table_items
   items_label.split('of ')[1].strip
 end
 
+# Tells whether the run happens before the server has been deployed.
+#
+# @return [Boolean] True if the UYUNI_NOT_INSTALLED environment variable is set to 'true'.
+def uyuni_not_installed?
+  ENV['UYUNI_NOT_INSTALLED'] == 'true'
+end
+
 # Determines the product type (Uyuni or SUSE Manager) based on installed patterns, raises error if undetermined.
 #
 # @return [String, nil] The product name, or nil when UYUNI_NOT_INSTALLED is set.
 def product
   return $product unless $product.nil?
-  return if ENV.key?('UYUNI_NOT_INSTALLED') && ENV['UYUNI_NOT_INSTALLED'] == 'true'
+  return if uyuni_not_installed?
 
   patterns = { 'patterns-uyuni_server' => 'Uyuni', 'patterns-suma_server' => 'SUSE Manager' }
   server = get_target('server')

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -153,7 +153,8 @@ $stdout.puts "Capybara APP Host: #{Capybara.app_host}:#{Capybara.server_port}"
 World(MiniTest::Assertions)
 
 # Initialize the API client
-$api_test = new_api_client unless ENV.key?('UYUNI_NOT_INSTALLED') && ENV['UYUNI_NOT_INSTALLED'] == 'true'
+$api_test = new_api_client unless uyuni_not_installed?
+
 # Init CodeCoverage Handler
 $code_coverage = CodeCoverage.new if $code_coverage_mode
 
@@ -296,7 +297,9 @@ After('@install_mlm_on_rke2') do |scenario|
   next unless scenario.passed?
 
   bashrc_file = '/root/.bashrc'
-  get_target('localhost').run("sed -i 's/export UYUNI_NOT_INSTALLED=true/export UYUNI_NOT_INSTALLED=false/g' #{bashrc_file}")
+  localhost = get_target('localhost')
+  localhost.run("sed -i '/^export UYUNI_NOT_INSTALLED=/d' #{bashrc_file}")
+  localhost.run("echo 'export UYUNI_NOT_INSTALLED=false' >> #{bashrc_file}")
 end
 
 # get the Cobbler log output when it fails


### PR DESCRIPTION
## What does this PR change?

Follow-ups on the RKE2 installation features merged in #12529: replaces the four repeated `UYUNI_NOT_INSTALLED` environment reads with a `uyuni_not_installed?` helper, makes the Helm installer fail on a bad download, clears the flag in `.bashrc` by rewriting the line, and fixes the Gherkin keywords in the new feature files.

The flag was read as `ENV.key?('UYUNI_NOT_INSTALLED') && ENV['UYUNI_NOT_INSTALLED'] == 'true'` in four places; `ENV[]` already returns `nil` for an unset variable, so the `key?` half never changes the result. `curl` piped into `bash` had no `-f`, so an HTTP error page was executed as a shell script instead of failing the step. The `@install_mlm_on_rke2` hook substituted `true` for `false` in `.bashrc`, which is a no-op when the controller wrote the line differently or not at all — it now deletes any `export UYUNI_NOT_INSTALLED=` line and appends the new one. Three scenarios opened with `And` and one scenario tag sat at column 0; the two Helm chart variables the "Update OCI app version" scenario dereferences were also missing from the configuration check.

## End-User Impact & Release Notes

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
