### PR TITLE
Uyuni: Set default checksum type for new UI channels to sha256 (bsc#1269011)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
@@ -107,7 +107,7 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
     public static final String CHANNEL_ARCH_LABEL = "channel_arch_label";
 
     public static final String DEFAULT_ARCH = "channel-x86_64";
-    public static final String DEFAULT_CHECKSUM = "sha1";
+    public static final String DEFAULT_CHECKSUM = "sha256";
     public static final String DEFAULT_ORG_SHARING = "private";
     public static final String DEFAULT_SUBSCRIPTIONS = "all";
     public static final boolean DEFAULT_GPG_CHECK = true;

--- a/java/spacewalk-java.changes.carlo.uyuni-1269011-default-checksum-for-new-channels
+++ b/java/spacewalk-java.changes.carlo.uyuni-1269011-default-checksum-for-new-channels
@@ -1,0 +1,2 @@
+- Set default checksum type for new UI channels to sha256
+  (bsc#1269011)


### PR DESCRIPTION
## What does this PR change?

in `Software > Manage > Channels > Create channel` page, the Repository Checksum Type is set to be **sha256** by default, instead of `sha1`

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
Before:
- When creating a new software channel, the Repository Checksum Type combo box has `sha1` as default value

After:
- When creating a new software channel, the Repository Checksum Type combo box has **sha256** as default value

- [x] **DONE**

## Documentation
- No documentation needed: simply changed a default selection in a combo box
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/31113
Port(s): 
5.2: https://github.com/SUSE/spacewalk/pull/31950
5.1: https://github.com/SUSE/spacewalk/pull/31949
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
