### PR TITLE
Fix reactivation bootstrap when a Salt key already exists (gh#uyuni-project/uyuni#11261)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
@@ -389,14 +389,17 @@ public abstract class AbstractMinionBootstrapper {
             return Collections.singletonList(reactivationKeyError.get());
         }
 
+        // A reactivation key is bound to an existing system, so re-registering a host that already has a salt
+        // key is the expected flow (e.g. after the system has been reinstalled or migrated). The stale key is
+        // rotated during the bootstrap itself, see RegularMinionBootstrapper#bootstrapInternal.
+        if (params.getReactivationKey().isPresent()) {
+            return Collections.emptyList();
+        }
+
         if (saltApi.keyExists(params.getHost(), KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED)) {
             return Collections.singletonList("A salt key for this" +
                     " host (" + params.getHost() +
                     ") seems to already exist, please check!");
-        }
-
-        if (params.getReactivationKey().isPresent()) {
-            return Collections.emptyList();
         }
 
         return MinionServerFactory.findByMinionId(params.getHost())

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/bootstrap/RegularMinionBootstrapper.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/bootstrap/RegularMinionBootstrapper.java
@@ -100,6 +100,17 @@ public class RegularMinionBootstrapper extends AbstractMinionBootstrapper {
         String minionId = input.getHost();
         MinionPendingRegistrationService.addMinion(user, minionId, defaultContactMethod);
 
+        // A reactivation re-registers a system that may still have a stale key on the master, for instance
+        // after the system has been reinstalled or migrated. Such a key does not match the key of the
+        // reinstalled minion anymore, so the master denies the minion and the id ends up both accepted and
+        // denied. Drop the stale key here, otherwise generateKeysAndAccept() below would find an accepted key
+        // and return no key pair at all, leaving the minion with its own denied key.
+        if (input.getReactivationKey().isPresent() &&
+                saltApi.keyExists(minionId, KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED)) {
+            LOG.info("Reactivating {}, deleting the salt key that already exists for it", minionId);
+            saltApi.deleteKey(minionId);
+        }
+
         // If a key is pending for this minion, temporarily reject it
         boolean weRejectedIt = false;
         if (saltApi.keyExists(minionId, KeyStatus.UNACCEPTED)) {

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/utils/RegularMinionBootstrapperTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/utils/RegularMinionBootstrapperTest.java
@@ -17,6 +17,7 @@ package com.suse.manager.webui.controllers.utils;
 
 import static java.util.Optional.of;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.role.RoleFactory;
@@ -46,6 +47,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,6 +104,95 @@ public class RegularMinionBootstrapperTest extends AbstractMinionBootstrapperTes
         BootstrapParameters params = bootstrapper.createBootstrapParams(input);
         BootstrapResult bootstrap = bootstrapper.bootstrap(params, user, getDefaultContactMethod());
         assertFalse(bootstrap.isSuccess());
+    }
+
+    /**
+     * A system that is re-registered with a reactivation key, for instance after it has been reinstalled or
+     * migrated, still has a salt key on the master. Bootstrap must not be refused in that case, and the stale
+     * key has to be dropped so that a fresh key pair is generated and handed to the minion. Otherwise
+     * generateKeysAndAccept() finds the accepted key and returns nothing, and the reinstalled minion keeps
+     * its own key, which the master then denies.
+     *
+     * @throws Exception if something goes wrong
+     */
+    @Test
+    public void testStaleKeyDeletedWhenReactivating() throws Exception {
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+        ActivationKey reactKey = ActivationKeyTest.createTestActivationKey(user);
+
+        BootstrapHostsJson input = mockStandardInput();
+        setNoActivationKeyAndReactivationKey(input, reactKey);
+        Key.Pair keyPair = mockKeyPair();
+
+        context().checking(new Expectations() {{
+            // a key for this host is already present on the master
+            allowing(saltServiceMock).keyExists("myhost", KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED);
+            will(returnValue(true));
+            allowing(saltServiceMock).keyExists("myhost", KeyStatus.UNACCEPTED);
+            will(returnValue(false));
+
+            allowing(saltServiceMock).generateKeysAndAccept("myhost", false);
+            will(returnValue(keyPair));
+
+            MgrUtilRunner.ExecResult mockResult = new MgrUtilRunner.SshKeygenResult("key", "pubkey");
+            allowing(saltServiceMock).generateSSHKey(SaltSSHService.SSH_KEY_PATH, SaltSSHService.SUMA_SSH_PUB_KEY);
+            will(returnValue(of(mockResult)));
+
+            List<String> bootstrapMods = bootstrapMods();
+            Map<String, Object> pillarData = createPillarData(Optional.empty(), Optional.of(reactKey));
+            allowing(saltServiceMock).bootstrapMinion(with(any(BootstrapParameters.class)),
+                    with(bootstrapMods), with(pillarData));
+            Object sshResult = createSuccessResult();
+            will(returnValue(new Result<>(Xor.right(sshResult))));
+
+            // we expect the stale key to be deleted before the new one is generated
+            exactly(1).of(saltServiceMock).deleteKey("myhost");
+        }});
+
+        BootstrapParameters params = bootstrapper.createBootstrapParams(input);
+        assertTrue(bootstrapper.bootstrap(params, user, getDefaultContactMethod()).isSuccess());
+    }
+
+    /**
+     * Reactivating a system that has no salt key on the master must leave the keys alone.
+     *
+     * @throws Exception if something goes wrong
+     */
+    @Test
+    public void testNoKeyDeletedWhenReactivatingWithoutExistingKey() throws Exception {
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+        ActivationKey reactKey = ActivationKeyTest.createTestActivationKey(user);
+
+        BootstrapHostsJson input = mockStandardInput();
+        setNoActivationKeyAndReactivationKey(input, reactKey);
+        Key.Pair keyPair = mockKeyPair();
+
+        context().checking(new Expectations() {{
+            allowing(saltServiceMock).keyExists("myhost", KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED);
+            will(returnValue(false));
+            allowing(saltServiceMock).keyExists("myhost", KeyStatus.UNACCEPTED);
+            will(returnValue(false));
+
+            allowing(saltServiceMock).generateKeysAndAccept("myhost", false);
+            will(returnValue(keyPair));
+
+            MgrUtilRunner.ExecResult mockResult = new MgrUtilRunner.SshKeygenResult("key", "pubkey");
+            allowing(saltServiceMock).generateSSHKey(SaltSSHService.SSH_KEY_PATH, SaltSSHService.SUMA_SSH_PUB_KEY);
+            will(returnValue(of(mockResult)));
+
+            List<String> bootstrapMods = bootstrapMods();
+            Map<String, Object> pillarData = createPillarData(Optional.empty(), Optional.of(reactKey));
+            allowing(saltServiceMock).bootstrapMinion(with(any(BootstrapParameters.class)),
+                    with(bootstrapMods), with(pillarData));
+            Object sshResult = createSuccessResult();
+            will(returnValue(new Result<>(Xor.right(sshResult))));
+
+            // we expect no key to be deleted
+            atMost(0).of(saltServiceMock).deleteKey("myhost");
+        }});
+
+        BootstrapParameters params = bootstrapper.createBootstrapParams(input);
+        assertTrue(bootstrapper.bootstrap(params, user, getDefaultContactMethod()).isSuccess());
     }
 
     @Test
@@ -165,6 +256,17 @@ public class RegularMinionBootstrapperTest extends AbstractMinionBootstrapperTes
         pillarData.put("mgr_sudo_user", "root");
         reactKey.ifPresent(k -> pillarData.put("management_key", k.getKey()));
         return pillarData;
+    }
+
+    private void setNoActivationKeyAndReactivationKey(BootstrapHostsJson input, ActivationKey reactKey) {
+        context().checking(new Expectations() {{
+            allowing(input).getActivationKeys();
+            will(returnValue(Collections.emptyList()));
+            allowing(input).getFirstActivationKey();
+            will(returnValue(Optional.empty()));
+            allowing(input).maybeGetReactivationKey();
+            will(returnValue(Optional.of(reactKey.getKey())));
+        }});
     }
 
     private SaltError createGenericSaltError() {

--- a/java/spacewalk-java.changes.geetxnshgoyal.fix-reactivation-with-existing-salt-key
+++ b/java/spacewalk-java.changes.geetxnshgoyal.fix-reactivation-with-existing-salt-key
@@ -1,0 +1,4 @@
+- Allow bootstrap with a reactivation key when a Salt key for the
+  host already exists, and rotate that stale key so the reinstalled
+  minion is not denied by the master
+  (gh#uyuni-project/uyuni#11261)


### PR DESCRIPTION
## What does this PR change?

Fixes #11261.

Re-registering a system that already has a Salt key on the master fails in the Web UI with:

```
A salt key for this host (<host>) seems to already exist, please check!
```

This is exactly the situation a reactivation key exists for: the system was reinstalled or migrated (in the issue, a proxy moved from Leap Micro to Tumbleweed), it kept its hostname and minion ID, and the master still holds the key from before the reinstall.

### Root cause

There are two separate defects, and fixing only the first one is not enough.

**1. Validation refuses the reactivation.**

In `AbstractMinionBootstrapper.validateBootstrap()` the "key already exists" check ran *before* the reactivation-key early return, so the reactivation path was never reached:

```java
if (saltApi.keyExists(params.getHost(), ACCEPTED, DENIED, REJECTED)) {
    return List.of("A salt key for this host ... seems to already exist");
}

if (params.getReactivationKey().isPresent()) {
    return Collections.emptyList();   // unreachable when a key exists
}
```

**2. Even past validation, the key is never rotated.**

`RegularMinionBootstrapper.createPillarData()` calls:

```java
Key.Pair keyPair = saltApi.generateKeysAndAccept(input.getHost(), false);
```

Salt's `key.gen_accept` returns an empty result, without writing anything, when an accepted key for that ID already exists and `force` is false. So `getPub()` and `getPriv()` are empty, the `minion_pub` and `minion_pem` pillar entries are omitted, and `bootstrap/init.sls` skips the two `file.managed` states that would plant the key pair on the minion.

The reinstalled minion therefore keeps the key it generated for itself, which does not match the accepted key on the master. The master files it under `minions_denied`, which is the duplicate state reported in the issue:

```
Accepted Keys:
  <host>:  47:08:4d:27:...
Denied Keys:
  <host>:  85:2e:ee:ed:...
```

Bootstrap would report success while the minion stays unreachable, so simply reordering the validation would turn a visible error into a silent failure.

### Fix

1. `AbstractMinionBootstrapper.validateBootstrap()`: move the reactivation-key early return above the `keyExists` check. Bootstraps *without* a reactivation key keep the hard block, which is what prevents taking over an existing minion by bootstrapping a host with the same name.

2. `RegularMinionBootstrapper.bootstrapInternal()`: when a reactivation key is given and a key for that ID already exists (accepted, denied or rejected), delete it before the pillar is built. `generateKeysAndAccept()` then produces a real key pair, the pillar carries it, and the minion is given a key that matches what the master accepted. Salt's `key.delete` clears the denied entry too, so the duplicate in `salt-key -L` goes away.

   Nothing changes when no stale key is present, and non-reactivation bootstraps are untouched.

This supersedes #11270, which contained the reordering from point 1 only and was auto-closed as stale.

## End-User Impact & Release Notes

Bootstrapping a system from the Web UI with a reactivation key now succeeds when a Salt key for that host already exists on the master. The stale key is replaced as part of the bootstrap. This is the supported way to re-register a system that was reinstalled or migrated while keeping its hostname and minion ID.

No configuration change and no migration is required.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference. The bootstrap form is unchanged, it simply no longer rejects the request.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: this restores the documented behaviour of reactivation keys for reinstalled systems. No new option, screen or workflow is introduced.

- [x] **DONE**

## Test coverage
- Unit tests were added

Two tests in `RegularMinionBootstrapperTest`:

- `testStaleKeyDeletedWhenReactivating`: a key for the host already exists, bootstrap with a reactivation key succeeds and the stale key is deleted exactly once.
- `testNoKeyDeletedWhenReactivatingWithoutExistingKey`: reactivating a host with no existing key deletes nothing.

The existing `testBootstrapFailsWhenKeysExist` still covers the non-reactivation path, so the protection against bootstrapping over an unrelated minion is verified to be intact.

- [x] **DONE**

## Links

Issue(s): #11261
Port(s): none

- [x] **DONE**

## Changelogs

Changelog added as `java/spacewalk-java.changes.geetxnshgoyal.fix-reactivation-with-existing-salt-key`.

- [ ] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"