### PR TITLE
QE: Change scp approach in kube tests

### DIFF
--- a/testsuite/features/step_definitions/rke2_steps.rb
+++ b/testsuite/features/step_definitions/rke2_steps.rb
@@ -238,11 +238,7 @@ When(/^I update the uyuni-ca configmap on "(.*)" with the external CA$/) do |tar
   ca_dir = get_context(:external_ca_dir)
 
   # Copy the external CA cert to the proxy node
-  success = file_extract(get_target('server'), "#{ca_dir}/ca.crt", '/tmp/external-ca.crt')
-  raise ScriptError, 'Failed to extract external CA cert from server' unless success
-
-  success = file_inject(get_target(target), '/tmp/external-ca.crt', '/tmp/external-ca.crt')
-  raise ScriptError, 'Failed to inject external CA cert into proxy' unless success
+  step %(I copy "#{ca_dir}/ca.crt" from "server" outside the container to "#{target}" via scp in the path "/tmp/external-ca.crt")
 
   # Replace the uyuni-ca configmap on the proxy cluster
   _out, code = get_target(target).run_local(


### PR DESCRIPTION
## What does this PR change?

In this PR I'm changing the scp approach in the kubernetes tests. This feature was doing an scp from the server to the controller and then to the proxy, something that was failing, so I decided to simplify it just doing the scp from the server to the proxy to make it properly work.

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): None.
Port(s): 
 - Manager 5.2: https://github.com/SUSE/spacewalk/pull/31998

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
