### PR TITLE
QE: Raise error if file to transfer does not exist

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -600,7 +600,7 @@ def extract_logs_from_node(node, host)
     raise ScriptError, 'Download log archive failed' unless success
   rescue Errno::ECONNRESET
     $stdout.puts "⚠️ WARN: Skipping log extraction for node #{host} due to connection reset."
-  rescue RuntimeError => e
+  rescue RuntimeError, ScriptError => e
     $stdout.puts e.message
   end
 end

--- a/testsuite/features/support/remote_node.rb
+++ b/testsuite/features/support/remote_node.rb
@@ -240,6 +240,8 @@ class RemoteNode
   # @param remote_node_file [String] The path in the destination.
   # @return [Integer] The exit code.
   def inject(test_runner_file, remote_node_file)
+    raise ScriptError, "Local file #{test_runner_file} does not exist on the controller" unless File.file?(test_runner_file)
+
     if @has_mgrctl
       tmp_file = File.join('/tmp/', File.basename(test_runner_file))
       success = get_target('localhost').scp_upload(test_runner_file, tmp_file, host: @full_hostname)
@@ -259,6 +261,8 @@ class RemoteNode
   # @param test_runner_file [String] The path to the file to copy.
   # @return [Integer] The exit code.
   def extract(remote_node_file, test_runner_file)
+    raise ScriptError, "Remote file #{remote_node_file} does not exist on #{@host}" unless file_exists?(remote_node_file)
+
     if @has_mgrctl
       tmp_file = File.join('/tmp/', File.basename(remote_node_file))
       _out, code = run_local("mgrctl cp server:#{remote_node_file} #{tmp_file}", verbose: false)


### PR DESCRIPTION
## What does this PR change?

Raise error if file to transfer does not exist.

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): None.
Port(s): 
- Manager 5.2: https://github.com/SUSE/spacewalk/pull/31997

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
