### PR TITLE
proxy-helm: fix apache_tuning.conf being shadowed by spacewalk-proxy.conf

### DIFF
--- a/containers/proxy-helm/proxy-helm.changes.mbussolotto.fix-httpd-tuning-override
+++ b/containers/proxy-helm/proxy-helm.changes.mbussolotto.fix-httpd-tuning-override
@@ -1,0 +1,3 @@
+- Mount user apache_tuning conf as zz_apache_tuning conf so it
+  overrides the vendor spacewalk-proxy conf MPM settings
+  (bsc#1277719)

--- a/containers/proxy-helm/templates/deployment.yaml
+++ b/containers/proxy-helm/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               rm -f /tmp/apache2/conf.d/apache_tuning.conf
               ln -s /etc/uyuni/server.crt /tmp/apache2/ssl.crt/server.crt
               ln -s /etc/uyuni/server.key /tmp/apache2/ssl.key/server.key
-              ln -s /etc/uyuni/apache_tuning.conf /tmp/apache2/conf.d/apache_tuning.conf
+              ln -s /etc/uyuni/apache_tuning.conf /tmp/apache2/conf.d/zz_apache_tuning.conf
           volumeMounts:
           - name: etc-apache2
             mountPath: /tmp/apache2


### PR DESCRIPTION
## What does this PR change?

proxy-helm: fix apache_tuning.conf being shadowed by spacewalk-proxy.conf

The proxy httpd container ships /etc/apache2/conf.d/spacewalk-proxy.conf which hard-sets MaxRequestWorkers 150 and MaxRequestsPerChild 200 inside an <IfModule prefork.c> block.

Files under /etc/apache2/conf.d/ are included alphabetically and Apache applies "last wins" semantics for scalar server-scope directives. The init-httpd container symlinked the user tuning file to apache_tuning.conf, which sorts before spacewalk-proxy.conf, so any MPM directive set via the apache_tuning value was silently overwritten by the vendor defaults.

Symlink the user file to zz_apache_tuning.conf so it is parsed after spacewalk-proxy.conf and its directives become the effective configuration. Matches the equivalent fix in the mgrpxy podman path.

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/31911
Port(s): # needs to be created

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
