### PR TITLE
Accept an existing custom channel in the build validation MU stage

### DIFF
--- a/testsuite/features/build_validation/add_MU_repositories/add_maintenance_update_repositories.template
+++ b/testsuite/features/build_validation/add_MU_repositories/add_maintenance_update_repositories.template
@@ -15,7 +15,7 @@ Feature: Add a Maintenance Update custom channel and the custom repositories for
     And I select the parent channel for the "<client>" from "Parent Channel"
     And I enter "Custom channel" as "Channel Summary"
     And I click on "Create Channel"
-    Then I should see a "Channel Custom Channel for <client> created" text
+    Then I should see a "Channel Custom Channel for <client> created" text or "The channel label 'custom_channel_<client>' is already in use" text
 
   Scenario: Add the Maintenance update repositories for <client>
     When I create the MU repositories for "<client>"

--- a/testsuite/features/build_validation/add_MU_repositories/monitoring_server_add_maintenance_update_repositories.feature
+++ b/testsuite/features/build_validation/add_MU_repositories/monitoring_server_add_maintenance_update_repositories.feature
@@ -15,7 +15,7 @@ Feature: Add a Maintenance Update custom channel and the custom repositories for
     And I select the parent channel for the "sles15sp7_minion" from "Parent Channel"
     And I enter "Custom channel" as "Channel Summary"
     And I click on "Create Channel"
-    Then I should see a "Channel Custom Channel for monitoring_server created" text
+    Then I should see a "Channel Custom Channel for monitoring_server created" text or "The channel label 'custom_channel_monitoring_server' is already in use" text
 
   @head
   Scenario: Create development custom repositories to the custom channel for monitoring_server


### PR DESCRIPTION
## What does this PR change?

Lets the build validation MU stage run again on a server that already has the custom channel.

The step only looked for the "channel created" message, so a second run on the same server failed. It now also takes the "already in use" error, the same way the repository step below it does:

```gherkin
Then I should see a "Channel Custom Channel for <client> created" text or "The channel label 'custom_channel_<client>' is already in use" text
```

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s):
Manager-5.2: https://github.com/SUSE/spacewalk/pull/32009
Manager-5.1: https://github.com/SUSE/spacewalk/pull/32010

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
