### PR TITLE
Fixed spacewalk-data-fsck crash #12560

### DIFF
--- a/python/spacewalk/satellite_tools/spacewalk-data-fsck
+++ b/python/spacewalk/satellite_tools/spacewalk-data-fsck
@@ -52,8 +52,8 @@ def is_sha256_capable():
     try:
         h = next(mi)
         cmp = rpm.labelCompare(
-            [sstr(h["name"]), sstr(h["version"]), sstr(h["release"])],
-            [sstr(h["name"]), "0.8.1", "1"],
+            (sstr(h["name"]), sstr(h["version"]), sstr(h["release"])),
+            (sstr(h["name"]), "0.8.1", "1"),
         )
     except StopIteration:
         pass


### PR DESCRIPTION
## What does this PR change?

Fixes #12560 

`spacewalk-data-fsck` crashes on startup with a `TypeError` raised from `rpm.labelCompare()` inside `is_sha256_capable()`. 

```python
uyuni-server:/ # spacewalk-data-fsck --remove --verbose --fs-only
Checking if packages from filesystem are present in database
Traceback (most recent call last):
  File "/usr/bin/spacewalk-data-fsck", line 601, in <module>
    exit_value += check_disk_vs_db(options)
                  ~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/bin/spacewalk-data-fsck", line 396, in check_disk_vs_db
    query = package_query(options, bind_path=True)
  File "/usr/bin/spacewalk-data-fsck", line 90, in package_query
    if is_sha256_capable():
       ~~~~~~~~~~~~~~~~~^^
  File "/usr/bin/spacewalk-data-fsck", line 54, in is_sha256_capable
    cmp = rpm.labelCompare(
        [sstr(h["name"]), sstr(h["version"]), sstr(h["release"])],
        [sstr(h["name"]), "0.8.1", "1"],
    )
TypeError: EVR string or (E,V,R) tuple expected
```

### Root cause
The function passes **lists** as the EVR arguments instead of **tuples**:

```python
cmp = rpm.labelCompare(
    [sstr(h["name"]), sstr(h["version"]), sstr(h["release"])],
    [sstr(h["name"]), "0.8.1", "1"],
)
```

The `python3-rpm` bindings on this system only accept an EVR string (`"epoch:version-release"`) or an actual 3-tuple for this argument. A list satisfies neither check and is rejected with `TypeError`. This presumably used to work because older `rpm`-python bindings accepted any 3-item sequence (including lists); newer bindings  enforce the stricter tuple/str check.

### Fix
Change `/python/spacewalk/satellite_tools/spacewalk-data-fsck` to passd tuples instead of lists like so:

```python
cmp = rpm.labelCompare(
    (sstr(h["name"]), sstr(h["version"]), sstr(h["release"])),
    (sstr(h["name"]), "0.8.1", "1"),
)
```


## End-User Impact & Release Notes

Just a minor bugfix. No configuration change or migration is required
- [X] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference. Does not affect GUI.

Before:

After:

- [X] **DONE**

## Documentation
- No documentation needed: this restores the intended behaviour of spacewalk-data-fsck as already documented

- [X] **DONE**

## Test coverage
- No tests: Just a small fix, already existing tests should work

- [X] **DONE**

## Links

Issue(s): #12560 
Port(s): none

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
