### PR TITLE
Uyuni: fix on removing activation keys when a base channel is deleted (bsc#1233592)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -85,6 +85,7 @@ import com.redhat.rhn.manager.rhnpackage.PackageManager;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.ssm.SsmChannelDto;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.token.ActivationKeyManager;
 import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.taskomatic.TaskoFactory;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
@@ -721,7 +722,8 @@ public class ChannelManager extends BaseManager {
 
         //remove all activation keys that have this as a base channel
         if (toRemove.isBaseChannel()) {
-            ActivationKeyFactory.deleteActivationKeysWithBaseChannel(toRemove.getId());
+            ActivationKeyFactory.lookupByBaseChannelId(toRemove.getId())
+                                        .forEach(ak -> ActivationKeyManager.getInstance().remove(ak, user));
         }
 
         ChannelManager.queueChannelChange(label, user.getLogin(), "java::deleteChannel");

--- a/java/spacewalk-java.changes.carlo.uyuni-1233592-bis-fix-activation-key-on-channel-removal
+++ b/java/spacewalk-java.changes.carlo.uyuni-1233592-bis-fix-activation-key-on-channel-removal
@@ -1,0 +1,2 @@
+- Fix on removing activation keys when a base channel
+  is deleted (bsc#1233592)


### PR DESCRIPTION
## What does this PR change?

This is a fix for https://github.com/uyuni-project/uyuni/pull/12540. That solution was removing activation keys only from database, in a way similar to `ActivationKeyFactory.removeKey`.
This fix that takes also into consideration the cobbler profiles in the removal phase, calling `ActivationKeyManager.remove` instead.

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Fixes: https://github.com/uyuni-project/uyuni/pull/12540
Issue(s): https://github.com/SUSE/spacewalk/issues/26083
Port(s): 
5.1: https://github.com/SUSE/spacewalk/pull/32019
5.2: fixed directly on https://github.com/SUSE/spacewalk/pull/31922/changes/491b5112d4fa0aaaa0ae1da119383d676f6a6287
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

