### PR TITLE
Uyuni: substitute ActivationKeyFactory.removeKey with ActivationKeyManager.remove 

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/token/ActivationKeyFactory.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/token/ActivationKeyFactory.java
@@ -290,6 +290,9 @@ public class ActivationKeyFactory extends HibernateFactory {
      * Remove an ActivationKey
      * @param key to remove
      */
+    // WARNING!
+    // when removing an activation key, do use instead ActivationKeyManager::remove(ActivationKey key, User user),
+    // since it takes care of removing also cobbler profiles
     public static void removeKey(ActivationKey key) {
         if (key != null) {
             WriteMode m = ModeFactory.getWriteMode("System_queries",

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/sdc/ActivationAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/systems/sdc/ActivationAction.java
@@ -62,7 +62,7 @@ public class ActivationAction extends RhnAction {
         // from old version of API. Remove them if multiple.
         if (keys.size() > 1) {
             for (ActivationKey key : keys) {
-                ActivationKeyFactory.removeKey(key);
+                ActivationKeyManager.getInstance().remove(key, user);
             }
             keys = new ArrayList<>();
         }
@@ -74,7 +74,7 @@ public class ActivationAction extends RhnAction {
 
         // if reactivation key is already used up, delete it
         if (key != null && key.isDisabled()) {
-            ActivationKeyFactory.removeKey(key);
+            ActivationKeyManager.getInstance().remove(key, user);
             key = null;
         }
 
@@ -88,7 +88,7 @@ public class ActivationAction extends RhnAction {
 
         if (ctx.isSubmitted()) {
             if (key != null) {
-                ActivationKeyFactory.removeKey(key);
+                ActivationKeyManager.getInstance().remove(key, user);
                 key = null;
             }
             if (ctx.hasParam("generate")) {

--- a/java/core/src/main/java/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -682,7 +682,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
                 log.debug("** Removing old tokens");
                 for (ActivationKey oldkey : oldkeys) {
                     log.debug("removing key.");
-                    ActivationKeyFactory.removeKey(oldkey);
+                    ActivationKeyManager.getInstance().remove(oldkey, user);
                 }
             }
         }

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-activation-key-manager-removal
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-activation-key-manager-removal
@@ -1,0 +1,3 @@
+- Substitute uses of "ActivationKeyFactory.removeKey()" with
+  "ActivationKeyManager.remove()" to take care of cobbler
+  when removing activation keys


### PR DESCRIPTION
## What does this PR change?

When removing an Activation key, there are two methods available:
1) ActivationKeyFactory.removeKey(ActivationKey key)
    only removes the key from the database
2) ActivationKeyManager.remove(ActivationKey key, User user)
   detaches the cobbler profile with that key
   removes the key from the database (calls ActivationKeyFactory.removeKey)

This PR substitutes all suitable occurrences of 1) with a call to 2), so that also the cobbler stuff is taken into consideration

## End-User Impact & Release Notes

If this PR alters behavior for end-users (WebUI, API, CLI, configs), modifies container architecture, or affects existing **migrations/upgrades**, you must add release note details to the pull request and ping the release engineers.

- [x] **DONE**

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): #
Port(s): # **add downstream PR(s), if any**
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
